### PR TITLE
[TASK] Require all extensions as dev dependencies

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -304,7 +304,7 @@ fi
 
 handleDbmsOptions
 
-COMPOSER_ROOT_VERSION="4.1.x-dev"
+COMPOSER_ROOT_VERSION="1.2.x-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 USERSET=""

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,16 @@
         }
     },
     "require-dev": {
+        "fgtclb/academic-bite-jobs": "@dev",
+        "fgtclb/academic-contacts4pages": "@dev",
+        "fgtclb/academic-jobs": "@dev",
+        "fgtclb/academic-partners": "@dev",
+        "fgtclb/academic-persons": "@dev",
+        "fgtclb/academic-persons-edit": "@dev",
+        "fgtclb/academic-persons-sync": "@dev",
+        "fgtclb/academic-programs": "@dev",
+        "fgtclb/academic-projects": "@dev",
+        "fgtclb/category-types": "@dev",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-belog": "^11.5 || ^12.4",
         "typo3/cms-beuser": "^11.5 || ^12.4",
@@ -51,5 +61,11 @@
         "typo3/cms-sys-note": "^11.5 || ^12.4",
         "typo3/cms-tstemplate": "^11.5 || ^12.4",
         "typo3/cms-workspaces": "^11.5 || ^12.4"
+    },
+    "repositories": {
+        "packages": {
+            "type": "path",
+            "url": "packages/*/*"
+        }
     }
 }


### PR DESCRIPTION
The `COMPOSER_ROOT_VERSION` in `Build/Scripts/runTests.sh`
is set to suitable constraint.

Used command(s):

```shell
composer config repositories.packages path "packages/*/*" \
&& find packages/fgtclb \
    -mindepth 1 -maxdepth 1 \
    -type d -printf '%f\n' | while read -d $'\n' extension
do
    composer require --dev --no-update \
      "$( cat packages/fgtclb/${extension}/composer.json | jq -r .name )":"@dev"
done
```
