### PR TITLE
[TASK] Introduce php-cs-fixer for all extensions

### DIFF
--- a/.github/workflows/core-11.yml
+++ b/.github/workflows/core-11.yml
@@ -50,3 +50,10 @@ jobs:
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "CGL"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cgl"
+
+# @todo Disable until correct file header has been determined for extensions.
+#      - name: "CGL (header comments)"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cglHeader"

--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -50,3 +50,10 @@ jobs:
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "CGL"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+
+# @todo Disable until correct file header has been determined for extensions.
+#      - name: "CGL (header comments)"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cglHeader"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /composer.json.orig
 /composer.json.testing
 /composer.lock
+/.php-cs-fixer.cache

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -144,6 +144,8 @@ Usage: $0 [options] [file]
 Options:
     -s <...>
         Specifies which test suite to run
+            - cgl: test and fix all core php files
+            - cglHeader: test and fix file header for all core php files
             - composer: "composer" with all remaining arguments dispatched.
             - composerUpdate: "composer update", handy if host has no PHP
             - lintPhp: PHP linting
@@ -388,6 +390,26 @@ fi
 
 # Suite execution
 case ${TEST_SUITE} in
+    cgl)
+        # Active dry-run for cgl needs not "-n" but specific options
+        CSFIXER_DRYRUN=""""
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            CSFIXER_DRYRUN="--dry-run --diff"
+        fi
+        COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v ${CSFIXER_DRYRUN} --config=Build/php-cs-fixer/config.php"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name cgl-${SUFFIX} ${IMAGE_PHP} ${COMMAND}
+        SUITE_EXIT_CODE=$?
+        ;;
+    cglHeader)
+        # Active dry-run for cgl needs not "-n" but specific options
+        CSFIXER_DRYRUN=""""
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            CSFIXER_DRYRUN="--dry-run --diff"
+        fi
+        COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v ${CSFIXER_DRYRUN} --config=Build/php-cs-fixer/header-comment.php"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name cgl-header-${SUFFIX} ${IMAGE_PHP} ${COMMAND}
+        SUITE_EXIT_CODE=$?
+        ;;
     composer)
         COMMAND=(composer "$@")
         ${CONTAINER_BIN} run ${CONTAINER_SIMPLE_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * This file represents the configuration for Code Sniffing PER-related
+ * automatic checks of coding guidelines.
+ *
+ * Run it using runTests.sh, see 'runTests.sh -h' for more options.
+ *
+ * Fix entire core:
+ * > Build/Scripts/runTests.sh -s cgl
+ *
+ * Fix your current patch:
+ * > Build/Scripts/runTests.sh -s cglGit
+ */
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+// Return a Code Sniffing configuration using
+// all sniffers needed for PER
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+return (new \PhpCsFixer\Config())
+    ->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setFinder(
+        (new PhpCsFixer\Finder())
+            ->ignoreVCSIgnored(true)
+            ->in([
+                __DIR__ . '/../../packages/fgtclb/',
+                __DIR__ . '/../../Build',
+            ])
+            ->exclude([
+                '.Build/',
+                'Build/',
+                'var/',
+                'node_modules',
+            ])
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        //        'native_function_invocation' => [
+        //            'include' => ['@compiler_optimized'],
+        //            'scope' => 'all',
+        //            'strict' => true,
+        //        ],
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_nullsafe_operator' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'this'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ]);

--- a/Build/php-cs-fixer/header-comment.php
+++ b/Build/php-cs-fixer/header-comment.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+$finder = PhpCsFixer\Finder::create()
+    ->name('*.php')
+    ->in([
+        __DIR__ . '/../../packages/fgtclb/',
+        __DIR__ . '/../../Build',
+    ])
+    ->exclude('Acceptance/Support/_generated') // EXT:core
+    ->exclude('node_modules')
+    // Configuration files do not need header comments
+    ->exclude('Configuration')
+    ->notName('*locallang*.php')
+    ->notName('ext_localconf.php')
+    ->notName('ext_tables.php')
+    ->notName('ext_emconf.php')
+    // ClassAliasMap files do not need header comments
+    ->notName('ClassAliasMap.php')
+    // CodeSnippets and Examples in Documentation do not need header comments
+    ->exclude('Documentation')
+;
+
+$headerComment = <<<COMMENT
+This file is part of the fgtclb/academic extension collection.
+
+It is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License, either version 2
+of the License, or any later version.
+
+For the full copyright and license information, please read the
+LICENSE.txt file that was distributed with this source code.
+
+The TYPO3 project - inspiring people to share!
+COMMENT;
+
+return (new \PhpCsFixer\Config())
+    ->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setRiskyAllowed(false)
+    ->setRules([
+        'no_extra_blank_lines' => true,
+        'header_comment' => [
+            'header' => $headerComment,
+            'comment_type' => 'comment',
+            'separate' => 'both',
+            'location' => 'after_declare_strict',
+        ],
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "fgtclb/academic-programs": "@dev",
         "fgtclb/academic-projects": "@dev",
         "fgtclb/category-types": "@dev",
+        "friendsofphp/php-cs-fixer": "^3.57.1",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-belog": "^11.5 || ^12.4",
         "typo3/cms-beuser": "^11.5 || ^12.4",


### PR DESCRIPTION
The `friendsofphp/php-cs-fixer` is a tool to ensure
a configurable PHP coding over all extensions with
a global configuration.

Used command(s):

```shell
composer require --dev --no-update \
  'friendsofphp/php-cs-fixer':'^3.57.1'
```

Changes applied with pull-request #10 
