### PR TITLE
[TASK] Allow TYPO3 v12 for `EXT:academic_projects`

### DIFF
--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -1,4 +1,4 @@
-name: "TYPO3 v11"
+name: "TYPO3 v12"
 
 on:
   pull_request:
@@ -45,8 +45,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Prepare dependencies for TYPO3 v11"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
+      - name: "Prepare dependencies for TYPO3 v12"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -8,11 +8,11 @@
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/category-types": "^1.1.0 || 1.*.*@dev",
-        "typo3/cms-backend": "^11.5",
-        "typo3/cms-core": "^11.5",
-        "typo3/cms-extbase": "^11.5",
-        "typo3/cms-fluid": "^11.5",
-        "typo3/cms-install": "^11.5"
+        "typo3/cms-backend": "^11.5 || ^12.4",
+        "typo3/cms-core": "^11.5 || ^12.4",
+        "typo3/cms-extbase": "^11.5 || ^12.4",
+        "typo3/cms-fluid": "^11.5 || ^12.4",
+        "typo3/cms-install": "^11.5 || ^12.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
TYPO3 v12 is allowed now for `EXT:academic_projects` to
align the extension with the other extensions abeit not
tested and verified yet.

Acts as preparation to test all extensions with v12 and
fix issues for extensions not having the constrains yet.

Additionally, the TYPO3 v12 workflow is adjusted to use
TYPO3 v12 correctly.

Used command(s):

```shell
composer require --no-update \
  -d packages/fgtclb/academic-projects \
  'typo3/cms-backend':'^11.5 || ^12.4' \
  'typo3/cms-core':'^11.5 || ^12.4' \
  'typo3/cms-extbase':'^11.5 || ^12.4' \
  'typo3/cms-fluid':'^11.5 || ^12.4' \
  'typo3/cms-install':'^11.5 || ^12.4'
```
