### PR TITLE
[TASK] Enable `sort-package` for all extensions

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -21,8 +21,8 @@
         { "type": "git", "url": "https://github.com/andreaswolf/typo3-ext-migrations.git" }
     ],
 	"require": {
-		"typo3/cms-core": "^11.5 || ^12.4",
-		"php": "^8.1 || ^8.2 || ^8.3 || ^8.4"
+		"php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+		"typo3/cms-core": "^11.5 || ^12.4"
 	},
 	"require-dev": {
 		"typo3/cms-adminpanel": "^11.5 || ^12.4",
@@ -71,7 +71,8 @@
 	"config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
-        "allow-plugins": true
+        "allow-plugins": true,
+		"sort-packages": true
     },
     "extra": {
         "typo3/cms": {

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -7,8 +7,8 @@
 	],
 	"require": {
 		"php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
-		"typo3/cms-core": "^11.5 || ^12.4",
-		"fgtclb/academic-persons": "^0.2.0 || ^1.1.0 || 0.*.*@dev || 1.*.*@dev || dev-*@dev"
+		"fgtclb/academic-persons": "^0.2.0 || ^1.1.0 || 0.*.*@dev || 1.*.*@dev || dev-*@dev",
+		"typo3/cms-core": "^11.5 || ^12.4"
 	},
 	"autoload": {
 		"psr-4": {
@@ -28,6 +28,7 @@
 		"allow-plugins": {
 			"typo3/cms-composer-installers": true,
 			"typo3/class-alias-loader": true
-		}
+		},
+		"sort-packages": true
 	}
 }

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -71,7 +71,8 @@
 	"config": {
 		"vendor-dir": ".Build/vendor",
 		"bin-dir": ".Build/bin",
-		"allow-plugins": true
+		"allow-plugins": true,
+		"sort-packages": true
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
Used command(s):

```shell
find packages/fgtclb \
    -mindepth 1 -maxdepth 1 \
    -type d -printf '%f\n' | while read -d $'\n' extension
do
  composer config -d "packages/fgtclb/${extension}" \
    sort-packages true \
  && composer require --no-update \
    -d "packages/fgtclb/${extension}" \
    "php":"^8.2 || ^8.3 || ^8.4" \
  && composer require --no-update \
    -d "packages/fgtclb/${extension}" \
    "php":"^8.1 || ^8.2 || ^8.3 || ^8.4"
done
```
