### PR TITLE
[TASK] Configure and enable unit- and function tests

### DIFF
--- a/Build/php-unit/FunctionalTests.xml
+++ b/Build/php-unit/FunctionalTests.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a functional test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/FunctionalTests.xml.
+    Note FunctionalTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+    phpunit v10.1 compatible version.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+     backupGlobals="true"
+     beStrictAboutTestsThatDoNotTestAnything="false"
+     bootstrap="FunctionalTestsBootstrap.php"
+     cacheDirectory=".phpunit.cache"
+     cacheResult="false"
+     colors="true"
+     displayDetailsOnTestsThatTriggerDeprecations="true"
+     displayDetailsOnTestsThatTriggerErrors="true"
+     displayDetailsOnTestsThatTriggerNotices="true"
+     displayDetailsOnTestsThatTriggerWarnings="true"
+     failOnDeprecation="true"
+     failOnNotice="true"
+     failOnRisky="true"
+     failOnWarning="true"
+     requireCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="Functional tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../packages/*/*/Tests/Functional/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE"/>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+         -->
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Build/php-unit/FunctionalTestsBootstrap.php
+++ b/Build/php-unit/FunctionalTestsBootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a FunctionalTests.xml file.
+ *
+ * This file is defined in FunctionalTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase->defineOriginalRootPath();
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+})();

--- a/Build/php-unit/UnitTests.xml
+++ b/Build/php-unit/UnitTests.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+    phpunit v10.1 compatible version.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+     backupGlobals="true"
+     beStrictAboutTestsThatDoNotTestAnything="false"
+     bootstrap="UnitTestsBootstrap.php"
+     cacheDirectory=".phpunit.cache"
+     cacheResult="false"
+     colors="true"
+     displayDetailsOnTestsThatTriggerDeprecations="true"
+     displayDetailsOnTestsThatTriggerErrors="true"
+     displayDetailsOnTestsThatTriggerNotices="true"
+     displayDetailsOnTestsThatTriggerWarnings="true"
+     failOnDeprecation="true"
+     failOnNotice="true"
+     failOnRisky="true"
+     failOnWarning="true"
+     requireCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../packages/*/*/Tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE"/>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Build/php-unit/UnitTestsBootstrap.php
+++ b/Build/php-unit/UnitTestsBootstrap.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a unit test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a UnitTests.xml file.
+ *
+ * This file is defined in UnitTests.xml and called by phpunit
+ * before instantiating the test suites.
+ *
+ * The recommended way to execute the suite is "runTests.sh". See the
+ * according script within TYPO3 core's Build/Scripts directory and
+ * adapt to extensions needs.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+
+    // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
+    // not create the autoload-include.php file that sets these env vars and sets composer
+    // mode to true. testing-framework can not be used without composer anyway, so it is safe
+    // to do this here. This way it does not matter if 'bin/phpunit' or 'vendor/phpunit/phpunit/phpunit'
+    // is called to run the tests since the 'relative to entry script' path calculation within
+    // SystemEnvironmentBuilder is not used. However, the binary must be called from the document
+    // root since getWebRoot() uses 'getcwd()'.
+    if (!getenv('TYPO3_PATH_ROOT')) {
+        putenv('TYPO3_PATH_ROOT=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+    if (!getenv('TYPO3_PATH_WEB')) {
+        putenv('TYPO3_PATH_WEB=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+
+    $testbase->defineSitePath();
+
+    // We can use the "typo3/cms-composer-installers" constant "TYPO3_COMPOSER_MODE" to determine composer mode.
+    // This should be always true except for TYPO3 mono repository.
+    $composerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE === true;
+    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+
+    // Retrieve an instance of class loader and inject to core bootstrap
+    $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
+    \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+
+    // Initialize default TYPO3_CONF_VARS
+    $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+    $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+    $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+        'core',
+        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+    );
+
+    // Set all packages to active
+    if (interface_exists(\TYPO3\CMS\Core\Package\Cache\PackageCacheInterface::class)) {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
+    } else {
+        // v10 compatibility layer
+        // @deprecated Will be removed when v10 compat is dropped from testing-framework
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
+    }
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+
+    $testbase->dumpClassLoadingInformation();
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+})();


### PR DESCRIPTION
This change uses the PHPUnit 10.* related templates
from `typo3/testing-framework` leaving 9.x files out
and adjusting the paths.
