### PR TITLE
[TASK] Add static code analyzer `phpstan`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -469,6 +469,18 @@ case ${TEST_SUITE} in
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name lint-php-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
+    phpstan)
+        PHPSTAN_CONFIG_FILE="Build/phpstan/Core${CORE_VERSION}/phpstan.neon"
+        COMMAND=(php -dxdebug.mode=off .Build/bin/phpstan analyse -c ${PHPSTAN_CONFIG_FILE} --no-progress --no-interaction --memory-limit 4G "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstanGenerateBaseline)
+        PHPSTAN_CONFIG_FILE="Build/phpstan/Core${CORE_VERSION}/phpstan.neon"
+        COMMAND=(php -dxdebug.mode=off .Build/bin/phpstan analyse -c ${PHPSTAN_CONFIG_FILE} --no-progress --no-interaction --memory-limit 4G --allow-empty-baseline --generate-baseline=Build/phpstan/Core${CORE_VERSION}/phpstan-baseline.neon)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-baseline-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
 #    unit)
 #        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests-10.xml"
 #        # @todo Remove version switch after TYPO3 v11 / phpunit 9 support has been dropped.

--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+	ignoreErrors:

--- a/Build/phpstan/Core11/phpstan-constants.php
+++ b/Build/phpstan/Core11/phpstan-constants.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+define('ORIGINAL_ROOT', dirname(__FILE__, 2) . '/');

--- a/Build/phpstan/Core11/phpstan.neon
+++ b/Build/phpstan/Core11/phpstan.neon
@@ -1,0 +1,17 @@
+includes:
+  - phpstan-baseline.neon
+  - ../../../.Build/vendor/bnf/phpstan-psr-container/extension.neon
+  - ../../../.Build/vendor/friendsoftypo3/phpstan-typo3/extension.neon
+  - ../../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+  # Use local .cache dir instead of /tmp
+  tmpDir: ../../../.Build/.cache/phpstan
+
+  level: 8
+
+  paths:
+    - ../../../packages
+
+  excludePaths:
+    - ../../../packages/fgtclb/*/ext_emconf.php

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+	ignoreErrors:

--- a/Build/phpstan/Core12/phpstan-constants.php
+++ b/Build/phpstan/Core12/phpstan-constants.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+define('ORIGINAL_ROOT', dirname(__FILE__, 2) . '/');

--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -1,0 +1,17 @@
+includes:
+  - phpstan-baseline.neon
+  - ../../../.Build/vendor/bnf/phpstan-psr-container/extension.neon
+  - ../../../.Build/vendor/friendsoftypo3/phpstan-typo3/extension.neon
+  - ../../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+  # Use local .cache dir instead of /tmp
+  tmpDir: ../../../.Build/.cache/phpstan
+
+  level: 8
+
+  paths:
+    - ../../../packages
+
+  excludePaths:
+    - ../../../packages/fgtclb/*/ext_emconf.php

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         }
     },
     "require-dev": {
+        "bnf/phpstan-psr-container": "^1.0.1",
         "fgtclb/academic-bite-jobs": "@dev",
         "fgtclb/academic-contacts4pages": "@dev",
         "fgtclb/academic-jobs": "@dev",
@@ -41,6 +42,10 @@
         "fgtclb/academic-projects": "@dev",
         "fgtclb/category-types": "@dev",
         "friendsofphp/php-cs-fixer": "^3.57.1",
+        "friendsoftypo3/phpstan-typo3": "^0.9.0",
+        "phpstan/phpdoc-parser": "^1.29.0",
+        "phpstan/phpstan": "^1.12.21",
+        "phpstan/phpstan-phpunit": "^1.4.0",
         "phpunit/phpunit": "^10.5.45",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-belog": "^11.5 || ^12.4",


### PR DESCRIPTION
Static code analyzer is added to the repository
and configured with dual core configuration and
baseline support provided by the command wrapper
`Build/Scripts/runTests.sh`. The PHPStan level 8
is relativly high and currently reports some
errors for v11 where not all could be added to
the baseline and v12 crashes due to hard errors.

Based on that, baseline is kept empty for now to
investigate and fix most of the issues first and
enable ci pipeline when green state with a small
baseline is archieved.

It still make sense to add it so we can start to
investigate these issues.

Used command(s):

```shell
composer require --no-update --dev \
  'phpstan/phpstan':'^1.12.21' \
  'phpstan/phpdoc-parser':'^1.29.0' \
  'phpstan/phpstan-phpunit':'^1.4.0' \
  'bnf/phpstan-psr-container':'^1.0.1' \
  'friendsoftypo3/phpstan-typo3':'^0.9.0'
```
