### PR TITLE
[TASK] Add unit-testing for all packages

### DIFF
--- a/.github/workflows/core-11.yml
+++ b/.github/workflows/core-11.yml
@@ -48,12 +48,101 @@ jobs:
       - name: "Prepare dependencies for TYPO3 v11"
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
 
-      - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s lintPhp"
-
       - name: "CGL"
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cgl"
 
 # @todo Disable until correct file header has been determined for extensions.
 #      - name: "CGL (header comments)"
 #        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cglHeader"
+
+  linting:
+    name: "linting"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v11"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s lintPhp"
+
+  unit:
+    name: "unit"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+    needs: ["code-quality", "linting"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v11"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Execute unit tests"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s unit"

--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -48,12 +48,101 @@ jobs:
       - name: "Prepare dependencies for TYPO3 v12"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
 
-      - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
-
       - name: "CGL"
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
 
 # @todo Disable until correct file header has been determined for extensions.
 #      - name: "CGL (header comments)"
 #        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cglHeader"
+
+  linting:
+    name: "linting"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v12"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+
+  unit:
+    name: "unit"
+    runs-on: ubuntu-latest
+    needs: ["code-quality", "linting"]
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v12"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Execute unit tests"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s unit"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -427,10 +427,8 @@ case ${TEST_SUITE} in
         [[ -f composer.json.orig ]] && \cp -f composer.json.orig composer.json
         ;;
 #    functional)
-#        PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests-10.xml"
-#        # @todo Remove version switch after TYPO3 v11 / phpunit 9 support has been dropped.
-#        [[ "${CORE_VERSION}" -eq 11 ]] && PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests.xml"
-#        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} "$@")
+#        PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests.xml"
+#        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} --exclude-group not-core-${CORE_VERSION} "$@")
 #        case ${DBMS} in
 #            mariadb)
 #                echo "Using driver: ${DATABASE_DRIVER}"
@@ -481,22 +479,18 @@ case ${TEST_SUITE} in
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-baseline-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
-#    unit)
-#        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests-10.xml"
-#        # @todo Remove version switch after TYPO3 v11 / phpunit 9 support has been dropped.
-#        [[ "${CORE_VERSION}" -eq 11 ]] && PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
-#        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} "$@")
-#        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
-#        SUITE_EXIT_CODE=$?
-#        ;;
-#    unitRandom)
-#        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests-10.xml"
-#        # @todo Remove version switch after TYPO3 v11 / phpunit 9 support has been dropped.
-#        [[ "${CORE_VERSION}" -eq 11 ]] && PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
-#        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --order-by=random ${PHPUNIT_RANDOM} "$@")
-#        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
-#        SUITE_EXIT_CODE=$?
-#        ;;
+    unit)
+        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
+        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-core-${CORE_VERSION} "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    unitRandom)
+        PHPUNIT_CONFIG_FILE="Build/phpunit/UnitTests.xml"
+        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-core-${CORE_VERSION} --order-by=random ${PHPUNIT_RANDOM} "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
     update)
         # pull typo3/core-testing-* versions of those ones that exist locally
         echo "> pull ghcr.io/typo3/core-testing-* versions of those ones that exist locally"


### PR DESCRIPTION
This change enables the unit and randomized unit
test execution for all packages within provided
`Build/Scripts/runTests.sh` dispatcher.

The PHPUnit command used to execute the unit tests
defines exclude group for currently executed TYPO3
core version `not-core-XY` to allow disabling test
or testcases for a specific TYPO3 version.

Unit testing is now also enabled within the GitHub
action workflow definitions.
