### PR TITLE
[TASK] Add package test namespaces to root composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,15 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "autoload-dev": {
+        "psr-4": {
+            "FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/academic-bite-jobs/Tests",
+            "FGTCLB\\AcademicJobs\\Tests\\": "packages/academic-jobs/Tests",
+            "FGTCLB\\AcademicPartners\\Tests\\": "packages/academic-partners/Tests",
+            "FGTCLB\\AcademicPersons\\Tests\\": "packages/academic-persons/Tests",
+            "FGTCLB\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests",
+            "FGTCLB\\AcademicProjects\\Tests\\": "packages/academic-programs/Tests"
+        }
+    }
 }


### PR DESCRIPTION
This change adds the packages test namespace definition
directly to the root composer.json as `autoload-dev` to
have test related classes beeing autoloaded during test
execution.
