### PR TITLE
[TASK] Use correct casing for test autoload namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,9 +56,10 @@
             "FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/academic-bite-jobs/Tests",
             "FGTCLB\\AcademicJobs\\Tests\\": "packages/academic-jobs/Tests",
             "FGTCLB\\AcademicPartners\\Tests\\": "packages/academic-partners/Tests",
-            "FGTCLB\\AcademicPersons\\Tests\\": "packages/academic-persons/Tests",
             "FGTCLB\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests",
-            "FGTCLB\\AcademicProjects\\Tests\\": "packages/academic-programs/Tests"
+            "FGTCLB\\AcademicProjects\\Tests\\": "packages/academic-programs/Tests",
+            "Fgtclb\\AcademicPersons\\Tests\\": "packages/academic-persons/Tests",
+            "Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests"
         }
     }
 }


### PR DESCRIPTION
With a previous change extension test folders has been
added as `autoload-dev` to the root package, and sadly
for two extension the casing for the namespace weren't
correct. Use correct casing now.

Used command(s):

```shell
cat <<< $(jq --indent 4 'del(."autoload-dev"."psr-4"."FGTCLB\\AcademicPersons\\Tests\\")' composer.json) > composer.json.1 \
&& cat <<< $(jq --indent 4 'del(."autoload-dev"."psr-4"."FGTCLB\\Fgtclb\\Tests\\")' composer.json.1) > composer.json.2 \
&& cat <<< $(jq --indent 4 '."autoload-dev"."psr-4" += {"Fgtclb\\AcademicPersons\\Tests\\": "packages/academic-persons/Tests"}' composer.json.2) > composer.json.3 \
&& cat <<< $(jq --indent 4 '."autoload-dev"."psr-4" += {"Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests"}' composer.json.3) > composer.json \
&& rm -rf composer.json.*
```
