### PR TITLE
[TASK] Automatically register test fixture extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "allow-plugins": {
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "sbuerk/fixture-packages": true
         },
         "sort-packages": true,
         "bin-dir": ".Build/bin",
@@ -27,7 +28,10 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build"
-        }
+        },
+        "sbuerk/fixture-packages": [
+            "packages/*/Tests/Functional/Fixtures/Extensions/*"
+        ]
     },
     "require-dev": {
         "bnf/phpstan-psr-container": "^1.0.1",
@@ -37,6 +41,7 @@
         "phpstan/phpstan": "^1.12.21",
         "phpstan/phpstan-phpunit": "^1.4.0",
         "phpunit/phpunit": "^10.5.45",
+        "sbuerk/fixture-packages": "^0.0.2 <0.1",
         "typo3/testing-framework": "^7.1.1"
     },
     "repositories": {


### PR DESCRIPTION
It is a common requirement to add fixture extensions to
functional tests to test against multiple differentiating
setups, which requires that the fixture extension composer
namespaces are added to the root composer.json.

That can be a maintenance burden and a composer plugin has
been created to tackle this effort, which is still in kind
of a development phase but already usable for the subset
required in this mono repository and is added now to act
as further preparation to enable functional testing for all
extensions.

Used command(s):

```shell
mv composer.json composer.json.1 \
&& cat <<< $(jq --indent 4 '.extra."sbuerk/fixture-packages" += ["packages/*/Tests/Functional/Fixtures/Extensions/*"]' composer.json.1) > composer.json \
&& composer config allow-plugins.sbuerk/fixture-packages true \
&& COMPOSER_ROOT_VERSION='1.2.x-dev' composer require \
  --dev "sbuerk/fixture-packages":"^0.0.2 <0.1" \
&& rm -rf composer.json.*
```
