### PR TITLE
[TASK] Ensure to use correct path for extension test namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
             "app-dir": ".Build"
         },
         "sbuerk/fixture-packages": [
-            "packages/*/Tests/Functional/Fixtures/Extensions/*"
+            "packages/*/*/Tests/Functional/Fixtures/Extensions/*"
         ]
     },
     "require-dev": {
@@ -58,13 +58,13 @@
     "prefer-stable": true,
     "autoload-dev": {
         "psr-4": {
-            "FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/academic-bite-jobs/Tests",
-            "FGTCLB\\AcademicJobs\\Tests\\": "packages/academic-jobs/Tests",
-            "FGTCLB\\AcademicPartners\\Tests\\": "packages/academic-partners/Tests",
-            "FGTCLB\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests",
-            "FGTCLB\\AcademicProjects\\Tests\\": "packages/academic-programs/Tests",
-            "Fgtclb\\AcademicPersons\\Tests\\": "packages/academic-persons/Tests",
-            "Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/academic-persons-edit/Tests"
+            "FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/fgtclb/academic-bite-jobs/Tests",
+            "FGTCLB\\AcademicJobs\\Tests\\": "packages/fgtclb/academic-jobs/Tests",
+            "FGTCLB\\AcademicPartners\\Tests\\": "packages/fgtclb/academic-partners/Tests",
+            "Fgtclb\\AcademicPersons\\Tests\\": "packages/fgtclb/academic-persons/Tests",
+            "Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/fgtclb/academic-persons-edit/Tests",
+            "FGTCLB\\AcademicPrograms\\Tests\\": "packages/fgtclb/academic-programs/Tests",
+            "FGTCLB\\AcademicProjects\\Tests\\": "packages/fgtclb/academic-programs/Tests"
         }
     }
 }


### PR DESCRIPTION
Recently test folder autoload namespaces has been added to
the root `composer.json`, and already tried to fix.

It's a bad idea to work with lack of sleep, which increases
errors and happened here.

This change registers the autoload namespaces now with the
correct relative folder. Hopefully this can be simplified
with the `sbuerk/fixture-package` composer plugin in the
future also for mono repo packages.

Used command(s):

```shell
composer config --unset autoload-dev \
&& composer config --unset extra."sbuerk/fixture-packages" \
&& mv composer.json composer.json.orig \
&& cat <<< $(
 jq --indent 4 '.extra."sbuerk/fixture-packages" += ["packages/*/*/Tests/Functional/Fixtures/Extensions/*"]' composer.json.orig | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/fgtclb/academic-bite-jobs/Tests"}' |
 jq --indent 4 '."autoload-dev"."psr-4" += {"FGTCLB\\AcademicJobs\\Tests\\": "packages/fgtclb/academic-jobs/Tests"}' | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"FGTCLB\\AcademicPartners\\Tests\\": "packages/fgtclb/academic-partners/Tests"}' | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"Fgtclb\\AcademicPersons\\Tests\\": "packages/fgtclb/academic-persons/Tests"}' | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/fgtclb/academic-persons-edit/Tests"}'  | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"FGTCLB\\AcademicPrograms\\Tests\\": "packages/fgtclb/academic-programs/Tests"}' | \
 jq --indent 4 '."autoload-dev"."psr-4" += {"FGTCLB\\AcademicProjects\\Tests\\": "packages/fgtclb/academic-programs/Tests"}'
) > composer.json \
&& rm -rf composer.json.orig
```
