### PR TITLE
[TASK] Add `georgringer/numbered-pagination` dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "bnf/phpstan-psr-container": "^1.0.1",
         "friendsofphp/php-cs-fixer": "^3.57.1",
         "friendsoftypo3/phpstan-typo3": "^0.9.0",
+        "georgringer/numbered-pagination": "^1.0",
         "phpstan/phpdoc-parser": "^1.29.0",
         "phpstan/phpstan": "^1.12.21",
         "phpstan/phpstan-phpunit": "^1.4.0",

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -26,7 +26,6 @@
     "require-dev": {
         "bk2k/bootstrap-package": "^14.0",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "georgringer/numbered-pagination": "^1.0",
         "helhum/typo3-console": "^7.1 || ^8.0",
         "saschaegerer/phpstan-typo3": "^1.8",
         "typo3/cms-backend": "^11.5 || ^12.4",


### PR DESCRIPTION
The `fgtclb/academic-persons` functional tests requires
to have `georgringer/numbered-pagination` available, so
it can be loaded as extension in test instances.

This change adds this dependency now to the `composer.json`
of the mono repository and removes it from the package.

Used command(s):

```shell
composer remove --dev --no-update \
  -d packages/fgtclb/academic-persons \
  'georgringer/numbered-pagination' \
&& COMPOSER_ROOT_VERSION='1.2.x-dev' composer require \
  --dev 'georgringer/numbered-pagination':'^1.0'
```
