### PR TITLE
[TASK] Remove development dependencies from packages

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -45,11 +45,7 @@
     "typo3/cms-seo": "^11.5 || ^12.4",
     "typo3/cms-setup": "^11.5 || ^12.4",
     "typo3/cms-tstemplate": "^11.5 || ^12.4",
-    "typo3/cms-composer-installers": "^3.0 || ^5.0",
-    "helhum/typo3-console": "^6.0 || ^7.1 || ^8.0",
-    "saschaegerer/phpstan-typo3": "^1.8",
-    "friendsofphp/php-cs-fixer": "^3.14",
-    "bk2k/bootstrap-package": "^12.0 || ^14.0"
+    "typo3/cms-composer-installers": "^3.0 || ^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -45,11 +45,7 @@
 		"typo3/cms-seo": "^11.5 || ^12.4",
 		"typo3/cms-setup": "^11.5 || ^12.4",
 		"typo3/cms-tstemplate": "^11.5 || ^12.4",
-		"typo3/cms-composer-installers": "v4.0.0-RC1 || ^5",
-		"helhum/typo3-console": "^7.1 || ^8.0",
-		"saschaegerer/phpstan-typo3": "^1.8",
-		"friendsofphp/php-cs-fixer": "^3.14",
-		"bk2k/bootstrap-package": "^14.0"
+		"typo3/cms-composer-installers": "v4.0.0-RC1 || ^5"
 	},
 	"autoload": {
 		"psr-4": {
@@ -73,11 +69,5 @@
 			"app-dir": ".Build",
 			"extension-key": "academic_jobs"
 		}
-	},
-	"scripts": {
-		"cs:check": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": "@php .Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"analyze:php": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon",
-		"analyze:baseline": "@php .Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon"
 	}
 }

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -43,12 +43,9 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "helhum/typo3-console": "^7.1.6 || ^8.0.2",
         "helmich/typo3-typoscript-lint": "^3.1.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.1",
-        "saschaegerer/phpstan-typo3": "^1.8",
         "typo3/cms-extensionmanager": "^11.5 || ^12.4",
         "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
         "typo3/cms-frontend": "^11.5 || ^12.4",

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -20,10 +20,6 @@
     "typo3/cms-core": "^11.5 || ^12.4"
   },
   "require-dev": {
-    "bk2k/bootstrap-package": "^14.0",
-    "friendsofphp/php-cs-fixer": "^3.14",
-    "helhum/typo3-console": "^7.1.6 || ^8.2",
-    "saschaegerer/phpstan-typo3": "^1.8",
     "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
     "typo3/cms-felogin": "^11.5 || ^12.4",
     "typo3/testing-framework": "^7.0"

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -22,10 +22,6 @@
         "typo3/cms-extbase": "^11.5 || ^12.4"
     },
     "require-dev": {
-        "bk2k/bootstrap-package": "^14.0",
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "helhum/typo3-console": "^7.1 || ^8.0",
-        "saschaegerer/phpstan-typo3": "^1.8",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
         "typo3/cms-felogin": "^11.5 || ^12.4",

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -24,10 +24,6 @@
         "typo3/cms-rte-ckeditor": "^11.5 || ^12.4"
     },
     "require-dev": {
-        "bk2k/bootstrap-package": "^14.0",
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "helhum/typo3-console": "^7.1 || ^8.0",
-        "saschaegerer/phpstan-typo3": "^1.8",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
         "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
@@ -60,14 +56,6 @@
             "app-dir": ".Build",
             "extension-key": "academic_persons"
         }
-    },
-    "scripts": {
-        "analyze:baseline:11": "@phpstan --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
-        "analyze:baseline:12": "@phpstan --configuration=Build/phpstan/Core12/phpstan.neon --generate-baseline=Build/phpstan/Core12/phpstan-baseline.neon",
-        "analyze:php:11": "@phpstan --configuration=Build/phpstan/Core11/phpstan.neon",
-        "analyze:php:12": "@phpstan --configuration=Build/phpstan/Core12/phpstan.neon",
-        "cs:check": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-        "cs:fix": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi"
     },
     "suggest": {
         "georgringer/numbered-pagination": "Install to use numbered pagination. (~1.x)"

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -38,12 +38,9 @@
 	},
 	"require-dev": {
 		"fakerphp/faker": "^1.23",
-		"friendsofphp/php-cs-fixer": "^3.14",
-		"helhum/typo3-console": "^7.1.6 || ^8.0.2",
 		"helmich/typo3-typoscript-lint": "^3.1.0",
 		"phpstan/phpstan": "^1.10",
 		"phpunit/phpunit": "^10.1",
-		"saschaegerer/phpstan-typo3": "^1.8",
 		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
 		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
 		"typo3/cms-frontend": "^11.5 || ^12.4",
@@ -63,28 +60,6 @@
 		"psr-4": {
 			"FGTCLB\\AcademicPrograms\\Tests\\": "Tests/"
 		}
-	},
-	"scripts": {
-		"cs": "php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"tl": ".Build/bin/typoscript-lint",
-		"phpstan": ".Build/bin/phpstan",
-		"phpunit": ".Build/bin/phpunit",
-		"cs:check": "@cs --diff --verbose --dry-run",
-		"cs:fix": "@cs",
-		"analyze:php": "@phpstan analyse --ansi --no-progress --memory-limit=768M",
-		"analyze:php:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon",
-		"analyze:baseline:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
-		"analyze:php:12": "@analyze:php --configuration=Build/phpstan/Core12/phpstan.neon",
-		"analyze:baseline:12": "@analyze:php --configuration=Build/phpstan/Core12/phpstan.neon --generate-baseline=Build/phpstan/Core12/phpstan-baseline.neon",
-		"analyze:php:13": "@analyze:php --configuration=Build/phpstan/Core13/phpstan.neon",
-		"analyze:baseline:13": "@analyze:php --configuration=Build/phpstan/Core13/phpstan.neon --generate-baseline=Build/phpstan/Core12/phpstan-baseline.neon",
-		"lint:typoscript": "@tl --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
-		"test:php": [
-			"@test:php:unit",
-			"@test:php:functional"
-		],
-		"test:php:unit": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
 	},
 	"suggest": {
 		"fgtclb/page-backend-layout": "Add backend category preview"

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -15,12 +15,9 @@
         "typo3/cms-install": "^11.5 || ^12.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "helhum/typo3-console": "^5.8 || ^6.7 || ^7.1",
         "helmich/typo3-typoscript-lint": "^2.5",
         "nikic/php-parser": "^4.15.1",
         "phpstan/phpstan": "^1.3",
-        "saschaegerer/phpstan-typo3": "^1.0",
         "typo3/testing-framework": "^7.0"
     },
     "autoload": {
@@ -48,20 +45,6 @@
         "branch-alias": {
             "dev-main": "1.x.x-dev"
         }
-    },
-    "scripts": {
-        "cs:check": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-        "cs:fix": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-        "analyze:php": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon",
-        "analyze:baseline": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
-        "lint:typoscript": ".Build/bin/typoscript-lint --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
-        "lint:php": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
-        "test:php": [
-            "@test:php:unit",
-            "@test:php:functional"
-        ],
-        "test:php:unit": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-        "test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
     },
     "conflict": {
         "fgtclb/category-types": "<1.0.0 || >=2.0.0"

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -18,9 +18,7 @@
     "typo3/cms-core": "^11.5 || ^12.4"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^v3.14",
     "phpstan/phpstan": "^1.10",
-    "saschaegerer/phpstan-typo3": "^1.8",
     "typo3/testing-framework": "^7.0"
   },
   "extra": {


### PR DESCRIPTION
The extension packages (`packages/*/*`)  are splitted
and considerable readonly. Development happens within
the mono repository now and development dependencies,
tooling and tooling configuration can be removed from
each individual package and will be handled on global
level.

Used command(s):

```shell
COMPOSER_BIN="$( which composer )" \
&& find packages/fgtclb \
  -mindepth 1 -maxdepth 1 \
  -type d -printf '%f\n' | while read -d $'\n' extension
do
  ${COMPOSER_BIN} remove --dev --no-update \
    -d "packages/fgtclb/${extension}" \
      'helhum/typo3-console' \
      'saschaegerer/phpstan-typo3' \
      'friendsofphp/php-cs-fixer' \
      'bk2k/bootstrap-package' \
  && ${COMPOSER_BIN} config -d "packages/fgtclb/${extension}" \
    --unset scripts
done
```
