### PR TITLE
[TASK] Adding `typo3/cms-scheduler` dependency

### DIFF
--- a/packages-dev/monorepo-shared/composer.json
+++ b/packages-dev/monorepo-shared/composer.json
@@ -10,11 +10,21 @@
         }
     ],
     "require": {
+        "fgtclb/academic-bite-jobs": "1.2.x-dev",
+        "fgtclb/academic-contacts4pages": "1.2.x-dev",
+        "fgtclb/academic-jobs": "1.2.x-dev",
+        "fgtclb/academic-partners": "1.2.x-dev",
+        "fgtclb/academic-persons": "1.2.x-dev",
+        "fgtclb/academic-persons-edit": "1.2.x-dev",
+        "fgtclb/academic-persons-sync": "1.2.x-dev",
+        "fgtclb/academic-programs": "1.2.x-dev",
+        "fgtclb/academic-projects": "1.2.x-dev",
+        "fgtclb/category-types": "1.2.x-dev",
         "typo3/cms-backend": "^11.5 || ^12.4",
         "typo3/cms-belog": "^11.5 || ^12.4",
         "typo3/cms-beuser": "^11.5 || ^12.4",
-        "typo3/cms-core": "^11.5 || ^12.4",
         "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
+        "typo3/cms-core": "^11.5 || ^12.4",
         "typo3/cms-extbase": "^11.5 || ^12.4",
         "typo3/cms-extensionmanager": "^11.5 || ^12.4",
         "typo3/cms-felogin": "^11.5 || ^12.4",
@@ -28,19 +38,13 @@
         "typo3/cms-redirects": "^11.5 || ^12.4",
         "typo3/cms-reports": "^11.5 || ^12.4",
         "typo3/cms-rte-ckeditor": "^11.5 || ^12.4",
+        "typo3/cms-scheduler": "^11.5 || ^12.4",
         "typo3/cms-setup": "^11.5 || ^12.4",
         "typo3/cms-sys-note": "^11.5 || ^12.4",
         "typo3/cms-tstemplate": "^11.5 || ^12.4",
-        "typo3/cms-workspaces": "^11.5 || ^12.4",
-        "fgtclb/academic-bite-jobs": "1.2.x-dev",
-        "fgtclb/academic-contacts4pages": "1.2.x-dev",
-        "fgtclb/academic-jobs": "1.2.x-dev",
-        "fgtclb/academic-partners": "1.2.x-dev",
-        "fgtclb/academic-persons": "1.2.x-dev",
-        "fgtclb/academic-persons-edit": "1.2.x-dev",
-        "fgtclb/academic-persons-sync": "1.2.x-dev",
-        "fgtclb/academic-programs": "1.2.x-dev",
-        "fgtclb/academic-projects": "1.2.x-dev",
-        "fgtclb/category-types": "1.2.x-dev"
+        "typo3/cms-workspaces": "^11.5 || ^12.4"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -69,6 +69,7 @@
         "fgtclb/category-types": "<1.0.0 || >=2.0.0"
     },
     "suggest": {
-        "fgtclb/page-backend-layout": "Provides backend category preview"
+        "fgtclb/page-backend-layout": "Provides backend category preview",
+        "typo3/cms-scheduler": "Install EXT:scheduler for the automatic geocoding"
     }
 }

--- a/packages/fgtclb/academic-partners/ext_localconf.php
+++ b/packages/fgtclb/academic-partners/ext_localconf.php
@@ -41,9 +41,11 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
     );
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][GeocodeTask::class] = [
-        'extension' => 'academic_partners',
-        'title' => 'Academic Partners: Geocode',
-        'description' => 'Fetches geocoding information for academic partners',
-    ];
+    if (ExtensionManagementUtility::isLoaded('scheduler')) {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][GeocodeTask::class] = [
+            'extension' => 'academic_partners',
+            'title' => 'Academic Partners: Geocode',
+            'description' => 'Fetches geocoding information for academic partners',
+        ];
+    }
 })();


### PR DESCRIPTION
`academic-partners` provides a `EXT:scheduler` task
to automatically geocode entities used to display
in a map.

This change adds `EXT:scheduler` as suggestion to
the academic extensions and as dependency to the
mono repository to test (late) the functionality.

Used command(s):

```shell
COMPOSER_BIN="$( which composer )" \
&& ${COMPOSER_BIN} config \
  -d packages/fgtclb/academic-partners \
  suggest."typo3/cms-scheduler" \
  "Install EXT:scheduler for the automatic geocoding" \
&& ${COMPOSER_BIN} config \
  -d packages-dev/monorepo-shared \
  sort-packages true \
&& ${COMPOSER_BIN} require --no-update \
  -d packages-dev/monorepo-shared \
  'typo3/cms-scheduler':'^11.5 || ^12.4'
```
