### PR TITLE
[DOCS] Streamline root and extension `README.md` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,36 @@
-# TYPO3 academic extensions
+# TYPO3 academic extension collection (mono repository)
 
 ## Description
 
-This repository actas as mono repository to centrelaize the development
-of academic related extension, which may also depends on each other.
+`academic-extensions` is a mono repository to develop a couple of academic related TYPO3 extensions,
+which may depend on others. To keep the maintenance burden across the set of extension small while
+increasing the cross-over development and testing experience.
 
+## Repository version support
 
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
+
+> [!IMPORTANT]
+> The 1.x TYPO3 v12 support is not guaranteed over all extensions
+> yet and will most likely not get it. It has only been allowed
+> to install all of them with 1.x also in a TYPO3 v12 to combining
+> them in the mono repository.
+> Upcoming `2.x.x` moves support to TYPO3 v12 and v13 and full support
+> over all extension will is planned until the release of `2.0.0`.
+
+## List of TYPO3 extension and the split repositories (READ ONLY)
+
+| Composer                       | TYPO3                   | Path                                                                                       | Split Repository                                                                  |
+|--------------------------------|-------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| fgtclb/academic-bite-jobs      | academic_bite_jobs      | [packages/fgtclb/academic-bite-jobs](packages/fgtclb/academic-bite-jobs/README.md)         | [fgtclb/academic-bite-jobs](https://github.com/fgtclb/academic-bite-jobs)         |
+| fgtclb/academic-contacts4pages | academic_contacts4pages | [packages/fgtclb/academic-contact4pages](packages/fgtclb/academic-contact4pages/README.md) | [fgtclb/academic-contact4pages](https://github.com/fgtclb/academic-contact4pages) |
+| fgtclb/academic-jobs           | academic_jobs           | [packages/fgtclb/academic-jobs](packages/fgtclb/academic-jobs/README.md)                   | [fgtclb/academic-jobs](https://github.com/fgtclb/academic-jobs)                   |
+| fgtclb/academic-partners       | academic_partners       | [packages/fgtclb/academic-partners](packages/fgtclb/academic-partners/README.md)           | [fgtclb/academic-partners](https://github.com/fgtclb/academic-partners)           |
+| fgtclb/academic-persons        | academic_persons        | [packages/fgtclb/academic-persons](packages/fgtclb/academic-persons/README.md)             | [fgtclb/academic-persons](https://github.com/fgtclb/academic-persons)             |
+| fgtclb/academic-persons-edit   | academic_persons_edit   | [packages/fgtclb/academic-persons-edit](packages/fgtclb/academic-persons-edit/README.md)   | [fgtclb/academic-persons-edit](https://github.com/fgtclb/academic-persons-edit)   |
+| fgtclb/academic-persons-sync   | academic_persons_sync   | [packages/fgtclb/academic-persons-sync](packages/fgtclb/academic-persons-sync/README.md)   | [fgtclb/academic-persons-sync](https://github.com/fgtclb/academic-persons-sync)   |
+| fgtclb/academic-programs       | academic_programs       | [packages/fgtclb/academic-programs](packages/fgtclb/academic-programs/README.md)           | [fgtclb/academic-bite-jogs](https://github.com/fgtclb/academic-programs)          |
+| fgtclb/academic-projects       | academic_projects       | [packages/fgtclb/academic-projects](packages/fgtclb/academic-projects/README.md)           | [fgtclb/academic-bite-jogs](https://github.com/fgtclb/academic-projects)          |
+| fgtclb/category-types          | category_types          | [packages/fgtclb/typo3-category-types](packages/fgtclb/typo3-category-types/README.md)     | [fgtclb/academic-bite-jogs](https://github.com/fgtclb/typo3-category-types)       |

--- a/packages/fgtclb/academic-bite-jobs/README.md
+++ b/packages/fgtclb/academic-bite-jobs/README.md
@@ -1,31 +1,43 @@
-# Academic Bite Jobs
+# TYPO3 Extension `Academic Bite Jobs` (READ-ONLY)
+
+|                  | URL                                                                     |
+|------------------|-------------------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-bite-jobs                            |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-bite-jobs/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_bite_jobs/              |
+
+## Description
 
 This extension provides a basic structure for academic B-ite jobs.
 
-German:
+As part of the bundling of requirements for the FGTCLB Academic Extensions, the TYPO3 extension "Academic Jobs b-ite"
+was created, which only requires the b-ite key to seamlessly display job adverts from the b-ite platform on a TYPO3
+website. The developed plug-in currently supports different categorisations, which are read from b-ite, e.g. appointment
+procedures, academic staff, non-scientific staff, training positions. List view, tile view and table view are currently
+available as display modes. There are also options for grouping and sorting as well as a limit for the number of job
+adverts to be displayed.
 
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
 
-Im Rahmen der Bedarfsbündelung für die FGTCLB Academic Extensions ist die TYPO3 Extension “Academic Jobs b-ite” entstanden, welche lediglich den b-ite Schlüssel benötigt, um Stellenanzeigen der b-ite Plattform nahtlos in einer TYPO3 Website anzuzeigen.
-Das entwickelte Plug-in unterstützt derzeit unterschiedliche Zuordnungen, welche aus b-ite ausgelesen werden, z.B. Berufungsverfahren, Wissenschaftliches Personal, Nicht-wissenschaftliches Personal, Ausbildungsstellen.
-Als Darstellungsmodi sind derzeit Listenansicht, Kachelansicht und Tabellensicht verfügbar.
-Weiterhin stehen Optionen zur Gruppierung und Sortierung sowie ein Limit für die Anzahl der darzustellenden Stellenanzeigen zur Verfügung.
+## Compatibility
 
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
-English:
-
-
-As part of the bundling of requirements for the FGTCLB Academic Extensions, the TYPO3 extension "Academic Jobs b-ite" was created, which only requires the b-ite key to seamlessly display job adverts from the b-ite platform on a TYPO3 website.
-The developed plug-in currently supports different categorisations, which are read from b-ite, e.g. appointment procedures, academic staff, non-scientific staff, training positions.
-List view, tile view and table view are currently available as display modes.
-There are also options for grouping and sorting as well as a limit for the number of job adverts to be displayed.
-
-
-**This extension is currently in beta state - please notice that there might be changes to the structure**
 
 ## Installation
 
-```shell
-composer require fgtclb/academic-bite-jobs
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_bite_jobs/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclbfgtclb/academic-bite-jobs
 ```
 
 ## Credits

--- a/packages/fgtclb/academic-contact4pages/README.md
+++ b/packages/fgtclb/academic-contact4pages/README.md
@@ -1,1 +1,35 @@
-# Academic Contacts For Pages
+# TYPO3 Extension `Academic Contacts For Pages` (READ-ONLY)
+
+## Description
+
+> @todo
+
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
+
+
+## Installation
+
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_contacts4pages/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclbfgtclb/academic-contacts4pages
+```
+
+## Credits
+
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
+
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+

--- a/packages/fgtclb/academic-jobs/README.md
+++ b/packages/fgtclb/academic-jobs/README.md
@@ -1,75 +1,39 @@
-# Academic Jobs
+# TYPO3 Extension `Academic Jobs` (READ-ONLY)
+
+|                  | URL                                                                |
+|------------------|--------------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-jobs                            |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-jobs/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_jobs/              |
+
+## Description
 
 This extension provides a basic structure for academic jobs.
 
-**This extension is currently in beta state - please notice that there might be changes to the structure**
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
-```shell
-composer require fgtclb/academic-jobs
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_jobs/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclb/academic-jobs
 ```
 
 ## Credits
 
-This extension was created the [FGTCLB GmbH](https://www.fgtclb.com/).
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
-
-## Create a release (maintainers only)
-
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '0.1.4'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='0.1.4' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[TASK] Prepare release ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[TASK] Prepare release for ${RELEASE_VERSION} on ${RELEASE_BRANCH}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `0.1.4` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='0.1.4' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.

--- a/packages/fgtclb/academic-partners/README.md
+++ b/packages/fgtclb/academic-partners/README.md
@@ -1,4 +1,23 @@
-# TYPO3 extension `academic_partners`
+# TYPO3 extension `Academic Partners` (READ-ONLY)
+
+|                  | URL                                                           |
+|------------------|---------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-partners                   |
+| **TER:**         | https://extensions.typo3.org/extension/academic_partners/     |
+
+
+## Description
+
+> @todo
+
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
@@ -9,71 +28,13 @@ Install with your flavour:
 * composer
 
 We prefer composer installation:
+
 ```bash
 composer req fgtclb/academic-partners
 ```
 
-|                  | URL                                                           |
-|------------------|---------------------------------------------------------------|
-| **Repository:**  | https://github.com/fgtclb/academic-partners                   |
-| **Read online:** | https://docs.typo3.org/p/fgtclb/academic-partners/main/en-us/ |
-| **TER:**         | https://extensions.typo3.org/extension/academic_partners/     |
+## Credits
 
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-## Create a release (maintainers only)
-
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '0.1.4'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='1.1.0' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='1.1.0' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/academic-persons-edit/README.md
+++ b/packages/fgtclb/academic-persons-edit/README.md
@@ -1,70 +1,40 @@
-# Academic person database - frontend editing
+# TYPO3 Extension `Academic person database - frontend editing` (READ-ONLY)
+
+|                  | URL                                                                        |
+|------------------|----------------------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-persons-edit                            |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-persons-edit/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_persons_edit/              |
+
+## Description
 
 This extension extends the `academic_persons` extension by the option to edit profiles in the frontend.
 Profiles get connected with a frontend user and the frontend user is allow to edit its assigned profiles.
 
-**This extension is currently in beta state - please notice that there might be changes to the structure**
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
-```shell
-composer require fgtclb/academic-persons-edit
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_persons_edit/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclb/academic-persons-edit
 ```
 
-## Create a release (maintainers only)
+## Credits
 
-Prerequisites:
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '1.1.0'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='1.1.0' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='1.1.0' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/academic-persons-sync/README.md
+++ b/packages/fgtclb/academic-persons-sync/README.md
@@ -1,71 +1,40 @@
-# Academic person database - Sync
+# TYPO3 Extension `Academic person database - Sync` (READ-ONLY)
+
+|                  | URL                                                                        |
+|------------------|----------------------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-persons-sync                            |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-persons-sync/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_persons_sync/              |
+
+## Description
 
 This extension extends the `academic_persons_edit` extension.
 It adds a new user type for external users and can be used when users are imported from external sources.
 
-**This extension is currently in beta state - please notice that there might be changes to the structure**
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
-```shell
-composer require fgtclb/academic-persons-sync
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_persons_sync/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclb/academic-persons-sync
 ```
 
+## Credits
 
-## Create a release (maintainers only)
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '1.1.0'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='1.1.0' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='1.1.0' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/academic-persons/README.md
+++ b/packages/fgtclb/academic-persons/README.md
@@ -1,71 +1,41 @@
-# Academic person database
+# TYPO3 Extension `Academic person database` (READ-ONLY)
+
+|                  | URL                                                                   |
+|------------------|-----------------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-persons                            |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-persons/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_persons/              |
+
+## Description
 
 This extension adds an academic person database to TYPO3.
 Records can be created, edit and displayed in the frontend.
 There is a list and a detail view for the frontend .
 
-**This extension is currently in beta state - please notice that there might be changes to the structure**
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
-```shell
-composer require fgtclb/academic-persons
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_persons/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclb/academic-persons
 ```
 
-## Create a release (maintainers only)
+## Credits
 
-Prerequisites:
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '0.4.0'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='0.4.0' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[TASK] Prepare release ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[TASK] Prepare release for ${RELEASE_VERSION} on ${RELEASE_BRANCH}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `0.4.0` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='0.4.0' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/academic-programs/README.md
+++ b/packages/fgtclb/academic-programs/README.md
@@ -1,4 +1,22 @@
-# TYPO3 extension `academic_programs`
+# TYPO3 extension `academic_programs` (READ-ONLY)
+
+|                  | URL                                                           |
+|------------------|---------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-programs                   |
+| **TER:**         | https://extensions.typo3.org/extension/academic_programs/     |
+
+## Description
+
+> @todo
+
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
@@ -13,67 +31,8 @@ We prefer composer installation:
 composer req fgtclb/academic-programs
 ```
 
-|                  | URL                                                           |
-|------------------|---------------------------------------------------------------|
-| **Repository:**  | https://github.com/fgtclb/academic-programs                   |
-| **Read online:** | https://docs.typo3.org/p/fgtclb/academic-programs/main/en-us/ |
-| **TER:**         | https://extensions.typo3.org/extension/academic_programs/     |
+## Credits
 
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-## Create a release (maintainers only)
-
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '0.1.4'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='0.1.4' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `0.1.4` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='0.1.4' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/academic-projects/README.md
+++ b/packages/fgtclb/academic-projects/README.md
@@ -1,4 +1,23 @@
-# TYPO3 extension `academic_projects`
+# TYPO3 extension `academic_projects` (READ-ONLY)
+
+|                  | URL                                                           |
+|------------------|---------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-projects                   |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic-projects/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_projects/     |
+
+## Description
+
+> @todo
+
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
+
+## Compatibility
+
+| Branch | Version   | TYPO3      | PHP                |
+|--------|-----------|------------|--------------------|
+| main   | 1.2.x-dev | v11 + ~v12 | 8.1, 8.2, 8.3, 8.4 |
 
 ## Installation
 
@@ -13,67 +32,8 @@ We prefer composer installation:
 composer req fgtclb/academic-projects
 ```
 
-|                  | URL                                                           |
-|------------------|---------------------------------------------------------------|
-| **Repository:**  | https://github.com/fgtclb/academic-projects                   |
-| **Read online:** | https://docs.typo3.org/p/fgtclb/academic-projects/main/en-us/ |
-| **TER:**         | https://extensions.typo3.org/extension/academic_projects/     |
+## Credits
 
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-## Create a release (maintainers only)
-
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '1.1.0'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='1.1.0' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='1.1.0' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).

--- a/packages/fgtclb/typo3-category-types/README.md
+++ b/packages/fgtclb/typo3-category-types/README.md
@@ -4,12 +4,23 @@
 [![Total Downloads](https://poser.pugx.org/fgtclb/category-types/downloads.svg?style=for-the-badge)](https://packagist.org/packages/fgtclb/category-types)
 [![Monthly Downloads](https://poser.pugx.org/fgtclb/category-types/d/monthly?style=for-the-badge)](https://packagist.org/packages/fgtclb/category-types)
 
-# TYPO3 extension `category_types`
+# TYPO3 extension `category_types` (READ-ONLY)
+
+|                  | URL                                                        |
+|------------------|------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/typo3-category-types             |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/category-types/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/category_types/     |
+
+## Description
 
 This extension provides the basic configuration for typed categories.
 It is not recommended to use this extension alone, as it only provides a basic
 framework. In order to perform typification, an addition in a separate extension
 is required.
+
+> [!NOTE]
+> This extension is currently in beta state - please notice that there might be changes to the structure
 
 ## Installation
 
@@ -24,67 +35,8 @@ We prefer composer installation:
 composer req fgtclb/category-types
 ```
 
-|                  | URL                                                        |
-|------------------|------------------------------------------------------------|
-| **Repository:**  | https://github.com/fgtclb/typo3-category-types             |
-| **Read online:** | https://docs.typo3.org/p/fgtclb/category-types/main/en-us/ |
-| **TER:**         | https://extensions.typo3.org/extension/category_types/     |
+## Credits
 
+This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
-## Create a release (maintainers only)
-
-Prerequisites:
-
-* git binary
-* ssh key allowed to push new branches to the repository
-* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
-
-**Prepare release locally**
-
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
-> Set `RELEASE_VERSION` to release version working on, for example: '0.1.4'.
-
-```shell
-echo '>> Prepare release pull-request' ; \
-  RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='0.1.4' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  git checkout ${RELEASE_BRANCH} && \
-  git pull --rebase && \
-  git checkout -b prepare-release-${RELEASE_VERSION} && \
-  composer require --dev "typo3/tailor" && \
-  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
-  composer remove --dev "typo3/tailor" && \
-  git add . && \
-  git commit -m "[TASK] Prepare release ${RELEASE_VERSION}" && \
-  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
-  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[TASK] Prepare release for ${RELEASE_VERSION} on ${RELEASE_BRANCH}" && \
-  git checkout main && \
-  git branch -D prepare-release-${RELEASE_VERSION}
-```
-
-Check pull-request and the pipeline run.
-
-**Merge approved pull-request and push version tag**
-
-> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
-> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
-> Set `RELEASE_VERSION` to release version working on, for example: `0.1.4` (same as in previous step).
-
-```shell
-RELEASE_BRANCH='main' ; \
-RELEASE_VERSION='0.1.4' ; \
-RELEASE_PR_NUMBER='123' ; \
-  git checkout main && \
-  git fetch --all && \
-  git pull --rebase && \
-  gh pr checkout ${RELEASE_PR_NUMBER} && \
-  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
-  git tag ${RELEASE_VERSION} && \
-  git push --tags
-```
-
-This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
-creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.
+[Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).


### PR DESCRIPTION
This change fills the mono repository root `README.md`
file with first information and also hops through all
of the extension `README.md` files to:

* Align the structure of the `README.md` to a shared
  build up.
* Add compatibility information.
* Add TYPO3 knwon extension link box at the top.
* Align installation intstructions towards the same
  way in all extensions.
* Ensure missing fgctclb credits in the files.
