### PR TITLE
[TASK] Remove dev-dependencies from extensions

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -21,32 +21,6 @@
     "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
     "typo3/cms-core": "^11.5 || ^12.4"
   },
-  "require-dev": {
-    "typo3/cms-adminpanel": "^11.5 || ^12.4",
-    "typo3/cms-backend": "^11.5 || ^12.4",
-    "typo3/cms-belog": "^11.5 || ^12.4",
-    "typo3/cms-beuser": "^11.5 || ^12.4",
-    "typo3/cms-dashboard": "^11.5 || ^12.4",
-    "typo3/cms-extbase": "^11.5 || ^12.4",
-    "typo3/cms-extensionmanager": "^11.5 || ^12.4",
-    "typo3/cms-felogin": "^11.5 || ^12.4",
-    "typo3/cms-filelist": "^11.5 || ^12.4",
-    "typo3/cms-filemetadata": "^11.5 || ^12.4",
-    "typo3/cms-fluid": "^11.5 || ^12.4",
-    "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-    "typo3/cms-form": "^11.5 || ^12.4",
-    "typo3/cms-frontend": "^11.5 || ^12.4",
-    "typo3/cms-impexp": "^11.5 || ^12.4",
-    "typo3/cms-indexed-search": "^11.5 || ^12.4",
-    "typo3/cms-info": "^11.5 || ^12.4",
-    "typo3/cms-install": "^11.5 || ^12.4",
-    "typo3/cms-linkvalidator": "^11.5 || ^12.4",
-    "typo3/cms-lowlevel": "^11.5 || ^12.4",
-    "typo3/cms-seo": "^11.5 || ^12.4",
-    "typo3/cms-setup": "^11.5 || ^12.4",
-    "typo3/cms-tstemplate": "^11.5 || ^12.4",
-    "typo3/cms-composer-installers": "^3.0 || ^5.0"
-  },
   "autoload": {
     "psr-4": {
       "FGTCLB\\AcademicBiteJobs\\": "Classes/"

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -21,32 +21,6 @@
 		"typo3/cms-core": "^11.5 || ^12.4",
 		"typo3/cms-rte-ckeditor": "^11.5 || ^12.4"
 	},
-	"require-dev": {
-		"typo3/cms-adminpanel": "^11.5 || ^12.4",
-		"typo3/cms-backend": "^11.5 || ^12.4",
-		"typo3/cms-belog": "^11.5 || ^12.4",
-		"typo3/cms-beuser": "^11.5 || ^12.4",
-		"typo3/cms-dashboard": "^11.5 || ^12.4",
-		"typo3/cms-extbase": "^11.5 || ^12.4",
-		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
-		"typo3/cms-felogin": "^11.5 || ^12.4",
-		"typo3/cms-filelist": "^11.5 || ^12.4",
-		"typo3/cms-filemetadata": "^11.5 || ^12.4",
-		"typo3/cms-fluid": "^11.5 || ^12.4",
-		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-		"typo3/cms-form": "^11.5 || ^12.4",
-		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"typo3/cms-impexp": "^11.5 || ^12.4",
-		"typo3/cms-indexed-search": "^11.5 || ^12.4",
-		"typo3/cms-info": "^11.5 || ^12.4",
-		"typo3/cms-install": "^11.5 || ^12.4",
-		"typo3/cms-linkvalidator": "^11.5 || ^12.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4",
-		"typo3/cms-seo": "^11.5 || ^12.4",
-		"typo3/cms-setup": "^11.5 || ^12.4",
-		"typo3/cms-tstemplate": "^11.5 || ^12.4",
-		"typo3/cms-composer-installers": "v4.0.0-RC1 || ^5"
-	},
 	"autoload": {
 		"psr-4": {
 			"FGTCLB\\AcademicJobs\\": "Classes/"

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -41,20 +41,6 @@
         "typo3/cms-extbase": "^11.5 || ^12.4",
         "typo3/cms-fluid": "^11.5 || ^12.4"
     },
-    "require-dev": {
-        "fakerphp/faker": "^1.23",
-        "helmich/typo3-typoscript-lint": "^3.1.0",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.1",
-        "typo3/cms-extensionmanager": "^11.5 || ^12.4",
-        "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-        "typo3/cms-frontend": "^11.5 || ^12.4",
-        "typo3/cms-info": "^11.5 || ^12.4",
-        "typo3/cms-lowlevel": "^11.5 || ^12.4",
-        "typo3/cms-tstemplate": "^11.5 || ^12.4",
-        "typo3/coding-standards": "^0.7.1",
-        "typo3/testing-framework": "^7.0"
-    },
     "autoload": {
         "psr-4": {
             "FGTCLB\\AcademicPartners\\": "Classes/"

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -19,11 +19,6 @@
     "fgtclb/academic-persons": "1.2.*@dev",
     "typo3/cms-core": "^11.5 || ^12.4"
   },
-  "require-dev": {
-    "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
-    "typo3/cms-felogin": "^11.5 || ^12.4",
-    "typo3/testing-framework": "^7.0"
-  },
   "autoload": {
     "psr-4": {
       "Fgtclb\\AcademicPersonsEdit\\": "Classes/"

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -21,14 +21,6 @@
         "typo3/cms-core": "^11.5 || ^12.4",
         "typo3/cms-extbase": "^11.5 || ^12.4"
     },
-    "require-dev": {
-        "typo3/cms-backend": "^11.5 || ^12.4",
-        "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
-        "typo3/cms-felogin": "^11.5 || ^12.4",
-        "typo3/cms-fluid": "^11.5 || ^12.4",
-        "typo3/cms-frontend": "^11.5 || ^12.4",
-        "typo3/cms-install": "^11.5 || ^12.4"
-    },
     "autoload": {
         "psr-4": {
             "Fgtclb\\AcademicPersonsSync\\": "Classes/"

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -23,13 +23,6 @@
         "typo3/cms-frontend": "^11.5 || ^12.4",
         "typo3/cms-rte-ckeditor": "^11.5 || ^12.4"
     },
-    "require-dev": {
-        "typo3/cms-backend": "^11.5 || ^12.4",
-        "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
-        "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-        "typo3/cms-install": "^11.5 || ^12.4",
-        "typo3/testing-framework": "^7.0"
-    },
     "autoload": {
         "psr-4": {
             "Fgtclb\\AcademicPersons\\": "Classes/"

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -36,21 +36,6 @@
 		"typo3/cms-fluid": "^11.5 || ^12.4",
 		"typo3/cms-frontend": "^11.5 || ^12.4"
 	},
-	"require-dev": {
-		"fakerphp/faker": "^1.23",
-		"helmich/typo3-typoscript-lint": "^3.1.0",
-		"phpstan/phpstan": "^1.10",
-		"phpunit/phpunit": "^10.1",
-		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
-		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"typo3/cms-info": "^11.5 || ^12.4",
-		"typo3/cms-install": "^11.5 || ^12.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4",
-		"typo3/cms-tstemplate": "^11.5 || ^12.4",
-		"typo3/coding-standards": "^0.7.1",
-		"typo3/testing-framework": "^7.0"
-	},
 	"autoload": {
 		"psr-4": {
 			"FGTCLB\\AcademicPrograms\\": "Classes/"

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -14,12 +14,6 @@
         "typo3/cms-fluid": "^11.5 || ^12.4",
         "typo3/cms-install": "^11.5 || ^12.4"
     },
-    "require-dev": {
-        "helmich/typo3-typoscript-lint": "^2.5",
-        "nikic/php-parser": "^4.15.1",
-        "phpstan/phpstan": "^1.3",
-        "typo3/testing-framework": "^7.0"
-    },
     "autoload": {
         "psr-4": {
             "FGTCLB\\AcademicProjects\\": "Classes/"

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -17,10 +17,6 @@
     "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
     "typo3/cms-core": "^11.5 || ^12.4"
   },
-  "require-dev": {
-    "phpstan/phpstan": "^1.10",
-    "typo3/testing-framework": "^7.0"
-  },
   "extra": {
 	"branch-alias": {
 	  "dev-main": "1.x.x-dev",


### PR DESCRIPTION
Extensions are splitted and soley developed within
this mono repository, which means that there is no
need to maintain development dependencies in each
extension `composer.json`. Let's clean that up.

Used command(s):

```shell
COMPOSER_BIN="$( which composer2-81 )" \
&& find packages/fgtclb \
  -mindepth 1 -maxdepth 1 \
  -type d -printf '%f\n' | while read -d $'\n' extension
do
  ${COMPOSER_BIN} config --unset require-dev \
    -d "packages/fgtclb/${extension}"
done
```
