### PR TITLE
[TASK] Ensure branch alias settings for split extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
             "paths": [
                 "packages/*/*/Tests/Functional/Fixtures/Extensions/*"
             ]
+        },
+        "branch-alias": {
+            "dev-main": "1.2.x-dev"
         }
     },
     "require-dev": {

--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -42,6 +42,9 @@
       "web-dir": ".Build/Web",
       "app-dir": ".Build",
       "extension-key": "academic_bite_jobs"
+    },
+    "branch-alias": {
+      "dev-main": "1.2.x-dev"
     }
   }
 }

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -20,8 +20,7 @@
 			"extension-key": "academic_contacts4pages"
 		},
 		"branch-alias": {
-			"dev-main": "1.x.x-dev",
-			"dev-compatibility": "2.x.x-dev"
+			"dev-main": "1.2.x-dev"
 		}
 	},
 	"config": {

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -42,6 +42,9 @@
 			"web-dir": ".Build/Web",
 			"app-dir": ".Build",
 			"extension-key": "academic_jobs"
+		},
+		"branch-alias": {
+			"dev-main": "1.2.x-dev"
 		}
 	}
 }

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -21,16 +21,15 @@
         }
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.x.x-dev",
-            "dev-compatibility": "2.x.x-dev"
-        },
         "typo3/cms": {
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "extension-key": "academic_partners",
             "ignore-as-root": false,
             "web-dir": ".Build/public",
             "app-dir": ".Build"
+        },
+        "branch-alias": {
+            "dev-main": "1.2.x-dev"
         }
     },
     "require": {

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -42,7 +42,7 @@
       "extension-key": "academic_persons_edit"
     },
     "branch-alias": {
-      "dev-main": "1.x.x-dev"
+      "dev-main": "1.2.x-dev"
     }
   }
 }

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -39,7 +39,7 @@
             "extension-key": "academic_persons_sync"
         },
         "branch-alias": {
-            "dev-main": "1.x.x-dev"
+            "dev-main": "1.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -40,14 +40,13 @@
         "sort-packages": true
     },
     "extra": {
-		"branch-alias": {
-            "dev-main": "1.x.x-dev",
-            "dev-compatibility": "2.x.x-dev"
-        },
-        "typo3/cms": {
+		"typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
             "extension-key": "academic_persons"
+        },
+        "branch-alias": {
+            "dev-main": "1.2.x-dev"
         }
     },
     "suggest": {

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -23,8 +23,7 @@
 			"app-dir": ".Build"
 		},
 		"branch-alias": {
-			"dev-main": "1.x.x-dev",
-			"dev-compatibility": "2.x.x-dev"
+			"dev-main": "1.2.x-dev"
 		}
 	},
 	"require": {

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -37,7 +37,7 @@
             "extension-key": "academic_projects"
         },
         "branch-alias": {
-            "dev-main": "1.x.x-dev"
+            "dev-main": "1.2.x-dev"
         }
     },
     "conflict": {

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -18,16 +18,15 @@
     "typo3/cms-core": "^11.5 || ^12.4"
   },
   "extra": {
-	"branch-alias": {
-	  "dev-main": "1.x.x-dev",
-	  "dev-compatibility": "2.x.x-dev"
-	},
-    "typo3/cms": {
+	"typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "extension-key": "category_types",
       "ignore-as-root": false,
       "web-dir": ".Build/Web",
       "app-dir": ".Build"
+    },
+    "branch-alias": {
+      "dev-main": "1.2.x-dev"
     }
   },
   "config": {


### PR DESCRIPTION
Used command(s):

```shell
COMPOSER_BIN="$( which composer2-81 )" \
&& find packages/fgtclb \
  -mindepth 1 -maxdepth 1 \
  -type d -printf '%f\n' | while read -d $'\n' extension
do
  ${COMPOSER_BIN} config -d "packages/fgtclb/${extension}" \
    --unset extra.branch-alias
  ${COMPOSER_BIN} config -d "packages/fgtclb/${extension}" \
    extra.branch-alias."dev-main" "1.2.x-dev"
done \
&& ( ${COMPOSER_BIN} config --unset extra.branch-alias | true ) \
&& ( ${COMPOSER_BIN} config extra.branch-alias."dev-main" "1.2.x-dev" )
