### PR TITLE
[TASK] Normalize `license` field in `composer.json` files

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -3,9 +3,7 @@
     "type": "typo3-cms-extension",
     "description": "",
     "minimum-stability": "beta",
-    "license": [
-        "GPL-2.0-or-later"
-    ],
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "FGTCLB GmbH",

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -2,9 +2,7 @@
     "name": "fgtclb/academic-contacts4pages",
     "description": "Role based relations between profiles and pages",
     "type": "typo3-cms-extension",
-    "license": [
-        "GPL-2.0-or-later"
-    ],
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-persons": "1.2.*@dev",

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -2,9 +2,7 @@
     "name": "fgtclb/academic-jobs",
     "description": "The Academic Jobs extension allows users to create and manage job postings.",
     "type": "typo3-cms-extension",
-    "license": [
-        "GPL-2.0-or-later"
-    ],
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "FGTCLB GmbH",

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -2,9 +2,7 @@
     "name": "fgtclb/academic-projects",
     "description": "Research project page for universities. Ships structured data preparation",
     "type": "typo3-cms-extension",
-    "license": [
-        "GPL-2.0-or-later"
-    ],
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/category-types": "^1.1.0 || 1.*.*@dev",


### PR DESCRIPTION
Used command(s):

```shell
COMPOSER_BIN="$( which composer2-81 )" \
&& find packages/fgtclb \
  -mindepth 1 -maxdepth 1 \
  -type d -printf '%f\n' | while read -d $'\n' extension
do
  cat <<< $(
    jq --indent 4 '."license" = "GPL-2.0-or-later"' "packages/fgtclb/${extension}/composer.json"
  ) > "packages/fgtclb/${extension}/composer.json"
done \
&& cat <<< $(
    jq --indent 4 '."license" = "GPL-2.0-or-later"' "packages-dev/monorepo-shared/composer.json"
  ) > "packages-dev/monorepo-shared/composer.json" \
&& cat <<< $(
    jq --indent 4 '."license" = "GPL-2.0-or-later"' "composer.json"
  ) > "composer.json"
```
