### PR TITLE
[TASK] Prefer installing selected system extensions from source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,13 @@
         },
         "sort-packages": true,
         "bin-dir": ".Build/bin",
-        "vendor-dir": ".Build/vendor"
+        "vendor-dir": ".Build/vendor",
+        "preferred-install": {
+            "typo3/cms-extbase": "source",
+            "typo3/cms-core": "source",
+            "typo3/cms-frontend": "source",
+            "*": "dist"
+        }
     },
     "extra": {
         "typo3/cms": {


### PR DESCRIPTION
This change configure the mono repository root `composer.json`
to prefer TYPO3 system extension installed from source instead
if dist packages for following reasons:

* It elimates to maintain a own `SiteBasedTestTrait` as we can
  use the TYPO3 Core Team maintained version instead and also
  mitigates to deal with multi-core version support.
* We have also the development resources from the TYPO3 core
  in the system, except stuff only included within the TYPO3
  core mono repository (sadly). At least we have easy access
  to TYPO3 core tests to look things up as inspiration. That
  reduces possible excuses **not** to implement tests during
  on-going work literally invalid.

Note that we still pull only released versions of the TYPO3
system extension, but without stripped resources like the
test folder along with fixtures data.

Only following system extension are pulled from source, having
the most interessting parts for functional test lookups along
with additional helpers (and fixture extensions):

* typo3/cms-core
* typo3/cms-extbase
* typo3/cms-backend
* typo3/cms-frontend

Used command(s):

```shell
BIN_COMPOSER="$( which composer )" \
&& ${BIN_COMPOSER} config \
  "preferred-install"."typo3/cms-extbase" "source" \
&& ${BIN_COMPOSER} config \
  "preferred-install"."typo3/cms-core" "source" \
&& ${BIN_COMPOSER} config \
  "preferred-install"."typo3/cms-extbase" "source" \
&& ${BIN_COMPOSER} config \
  "preferred-install"."typo3/cms-frontend" "source" \
&& ${BIN_COMPOSER} config \
  "preferred-install"."*" "dist"
```
