### PR TITLE
[TASK] Update `typo3/testing-framework` and `phpunit` setup

### DIFF
--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -153,70 +153,65 @@ jobs:
       - name: "Execute unit tests"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
 
-# @todo Functional tests disabled in pipeline due to a lot of errors with TYPO3 v13. After resolving them, enable
-# @todo the pipeline again. Notable errors are:
-# @todo - Update SiteBasedTestTrait to TYPO3 v12 + v13 compatible version (once),
-#         move it to a central/global place and remove duplicate implementations
-#         from academic extensions.
+
 # @todo - Mitigate automatic TCA migrations within all extensions properly and avoid deprecation messages,
 #         which breaks functional test executions
-#
-#  functional:
-#    name: "functional"
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        php-version: [ "8.2", "8.3", "8.4" ]
-#        typo3: ["13"]
-#    needs: ["code-quality", "linting", "unit"]
-#    permissions:
-#      # actions: read|write|none
-#      actions: none
-#      # checks: read|write|none
-#      checks: none
-#      # contents: read|write|none
-#      contents: read
-#      # deployments: read|write|none
-#      deployments: none
-#      # id-token: read|write|none
-#      id-token: none
-#      # issues: read|write|none
-#      issues: none
-#      # discussions: read|write|none
-#      discussions: none
-#      # packages: read|write|none
-#      packages: read
-#      # pages: read|write|none
-#      pages: none
-#      # pull-requests: read|write|none
-#      pull-requests: none
-#      # repository-projects: read|write|none
-#      repository-projects: read
-#      # security-events: read|write|none
-#      security-events: none
-#      # statuses: read|write|none
-#      statuses: none
-#
-#    steps:
-#
-#      - name: "Checkout"
-#        uses: actions/checkout@v4
-#
-#      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
-#
-#      - name: "functional with SQLite"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
-#
-#      - name: "functional with MySQL 8.0"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -s functional"
-#
-#      - name: "functional with MariaDB 10.4"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.4 -s functional"
-#
-#      - name: "functional with MariaDB 10.6"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.6 -s functional"
-#
-#      - name: "functional with Postgres 10"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d postgres -i 10 -s functional"
+  functional:
+    name: "functional"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.2", "8.3", "8.4" ]
+        typo3: ["13"]
+    needs: ["code-quality", "linting", "unit"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "functional with SQLite"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
+
+      - name: "functional with MySQL 8.0"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -s functional"
+
+      - name: "functional with MariaDB 10.4"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.4 -s functional"
+
+      - name: "functional with MariaDB 10.6"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.6 -s functional"
+
+      - name: "functional with Postgres 10"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d postgres -i 10 -s functional"

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -40,19 +40,9 @@
                 test location path needs to be given to phpunit.
             -->
             <directory>../../packages/*/*/Tests/Functional/</directory>
-            <exclude>academic_programs/Tests/Functional/</exclude>
         </testsuite>
     </testsuites>
     <php>
-        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
-        <const name="TYPO3_MODE" value="BE"/>
-        <!--
-            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
-                         with TYPO3 core v11 and up.
-                         Will always be done with next major version.
-                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
-         -->
-        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
         <ini name="display_errors" value="1"/>
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -49,6 +49,7 @@
         // ^^ END-OF-WORKAROUND
         $adopter->adoptFixtureExtensions();
     }
+
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
     $testbase->defineOriginalRootPath();
     //var_dump(getenv('TYPO3_PATH_ROOT'));var_dump(getenv('TYPO3_PATH_WEB'));var_dump(ORIGINAL_ROOT);die();

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -43,8 +43,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
-        <const name="TYPO3_MODE" value="BE"/>
         <ini name="display_errors" value="1"/>
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -48,8 +49,15 @@
     // We can use the "typo3/cms-composer-installers" constant "TYPO3_COMPOSER_MODE" to determine composer mode.
     // This should be always true except for TYPO3 mono repository.
     $composerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE === true;
-    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+
+    // @todo: Remove else branch when dropping support for v12
+    $hasConsolidatedHttpEntryPoint = class_exists(CoreHttpApplication::class);
+    if ($hasConsolidatedHttpEntryPoint) {
+        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI, $composerMode);
+    } else {
+        $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+    }
 
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
@@ -68,15 +76,10 @@
         'core',
         new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
     );
-
-    // Set all packages to active
-    if (interface_exists(\TYPO3\CMS\Core\Package\Cache\PackageCacheInterface::class)) {
-        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
-    } else {
-        // v10 compatibility layer
-        // @deprecated Will be removed when v10 compat is dropped from testing-framework
-        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
-    }
+    $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(
+        \TYPO3\CMS\Core\Package\UnitTestPackageManager::class,
+        \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache)
+    );
 
     \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);


### PR DESCRIPTION
With the recent change to move towards `2.x.x` and changing
the supported TYPO3 version to `v12/v13` the testing related
dependency `typo3/testing-framework` has been updated.

This change aligns now the mono repository configuration to
the provided examples within the package, removing obsolete
stuff from the configuration.

Functional tests are now enabled in the GitHub workflow for
TYPO3 v13.
