### PR TITLE
[TASK] Streamlining codebase to PHP 8.1

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -316,11 +316,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 
 		-
-			message: "#^Property Fgtclb\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$profiles with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
 			message: "#^Property Fgtclb\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$view has unknown class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface as its type\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -406,11 +406,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 
 		-
-			message: "#^Property Fgtclb\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$profiles with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
 			message: "#^Property Fgtclb\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$view has unknown class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface as its type\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!defined('TYPO3')) {
-    die(__CLASS__);
+    die('Not authorized');
 }
 
 (static function (): void {

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -5,9 +5,7 @@ if (!defined('TYPO3')) {
 }
 
 (static function (): void {
-    $ll = function (string $langKey): string {
-        return 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:' . $langKey;
-    };
+    $ll = fn(string $langKey): string => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:' . $langKey;
 
     $columns = [
         'tx_academiccontacts4pages_contacts' => [

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!defined('TYPO3')) {
-    die(__CLASS__);
+    die('Not authorized');
 }
 
 (static function (): void {

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
@@ -5,9 +5,7 @@ if (!defined('TYPO3')) {
 }
 
 (static function (): void {
-    $ll = function (string $langKey): string {
-        return 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:' . $langKey;
-    };
+    $ll = fn(string $langKey): string => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:' . $langKey;
 
     $columns = [
         'tx_academiccontacts4pages_contacts' => [

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!defined('TYPO3')) {
-    die(__CLASS__);
+    die('Not authorized');
 }
 
 (static function (): void {

--- a/packages/fgtclb/academic-jobs/ext_localconf.php
+++ b/packages/fgtclb/academic-jobs/ext_localconf.php
@@ -4,7 +4,7 @@ use FGTCLB\AcademicJobs\Controller\JobController;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 if (!defined('TYPO3')) {
-    die(__CLASS__);
+    die('Not authorized');
 }
 
 (static function (): void {

--- a/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
@@ -14,8 +14,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class DemandFactory
 {
     public function __construct(
-        private CategoryRepository $categoryRepository,
-        private CategoryTypeRegistry $categoryTypeRegistry
+        private readonly CategoryRepository $categoryRepository,
+        private readonly CategoryTypeRegistry $categoryTypeRegistry
     ) {}
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Classes/Command/CreateProfilesCommand.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Command/CreateProfilesCommand.php
@@ -24,14 +24,8 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 final class CreateProfilesCommand extends Command
 {
-    private FrontendUserProvider $frontendUserProvider;
-
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(FrontendUserProvider $frontendUserProvider, EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly FrontendUserProvider $frontendUserProvider, private readonly EventDispatcherInterface $eventDispatcher)
     {
-        $this->frontendUserProvider = $frontendUserProvider;
-        $this->eventDispatcher = $eventDispatcher;
         parent::__construct();
     }
 

--- a/packages/fgtclb/academic-persons-edit/Classes/Context/ProfileAspect.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Context/ProfileAspect.php
@@ -17,20 +17,9 @@ use TYPO3\CMS\Core\Context\Exception\AspectPropertyNotFoundException;
 final class ProfileAspect implements AspectInterface
 {
     /**
-     * @var list<int>
-     */
-    private array $profileUids;
-
-    private int $activeProfileUid;
-
-    /**
      * @param list<int> $profileUids
      */
-    public function __construct(array $profileUids, int $activeProfileUid)
-    {
-        $this->profileUids = $profileUids;
-        $this->activeProfileUid = $activeProfileUid;
-    }
+    public function __construct(private readonly array $profileUids, private readonly int $activeProfileUid) {}
 
     /**
      * @return bool|int|int[]
@@ -43,7 +32,7 @@ final class ProfileAspect implements AspectInterface
             'allProfileUids' => $this->profileUids,
             'activeProfileUid' => empty($this->profileUids) ? 0 : $this->activeProfileUid,
             default => throw new AspectPropertyNotFoundException(
-                'Property "' . $name . '" not found in Aspect "' . __CLASS__ . '".',
+                'Property "' . $name . '" not found in Aspect "' . self::class . '".',
                 1689845908
             )
         };

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -50,33 +50,7 @@ final class ProfileController extends ActionController
 {
     public const FLASH_MESSAGE_QUEUE_IDENTIFIER = 'academic_profile';
 
-    private Context $context;
-
-    private ProfileRepository $profileRepository;
-
-    private PersistenceManagerInterface $persistenceManager;
-
-    private AddressRepository $addressRepository;
-
-    private ProfileTranslator $profileTranslator;
-
-    private LocationRepository $locationRepository;
-
-    public function __construct(
-        Context $context,
-        ProfileRepository $profileRepository,
-        PersistenceManagerInterface $persistenceManager,
-        AddressRepository $addressRepository,
-        ProfileTranslator $profileTranslator,
-        LocationRepository $locationRepository
-    ) {
-        $this->context = $context;
-        $this->profileRepository = $profileRepository;
-        $this->persistenceManager = $persistenceManager;
-        $this->addressRepository = $addressRepository;
-        $this->profileTranslator = $profileTranslator;
-        $this->locationRepository = $locationRepository;
-    }
+    public function __construct(private readonly Context $context, private readonly ProfileRepository $profileRepository, private readonly PersistenceManagerInterface $persistenceManager, private readonly AddressRepository $addressRepository, private readonly ProfileTranslator $profileTranslator, private readonly LocationRepository $locationRepository) {}
 
     public function initializeAction(): void
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Event/AddProfileInformationEvent.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Event/AddProfileInformationEvent.php
@@ -16,15 +16,7 @@ use Fgtclb\AcademicPersonsEdit\Domain\Model\Profile;
 
 final class AddProfileInformationEvent
 {
-    private Profile $profile;
-
-    private ProfileInformation $profileInformation;
-
-    public function __construct(Profile $profile, ProfileInformation $profileInformation)
-    {
-        $this->profile = $profile;
-        $this->profileInformation = $profileInformation;
-    }
+    public function __construct(private readonly Profile $profile, private readonly ProfileInformation $profileInformation) {}
 
     public function getProfile(): Profile
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Event/AfterProfileUpdateEvent.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Event/AfterProfileUpdateEvent.php
@@ -15,12 +15,7 @@ use Fgtclb\AcademicPersonsEdit\Domain\Model\Profile;
 
 final class AfterProfileUpdateEvent
 {
-    private Profile $profile;
-
-    public function __construct(Profile $profile)
-    {
-        $this->profile = $profile;
-    }
+    public function __construct(private readonly Profile $profile) {}
 
     public function getProfile(): Profile
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Event/ChooseProfileFactoryEvent.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Event/ChooseProfileFactoryEvent.php
@@ -18,12 +18,7 @@ final class ChooseProfileFactoryEvent
 {
     private ?ProfileFactoryInterface $profileFactory = null;
 
-    private FrontendUserAuthentication $frontendUserAuthentication;
-
-    public function __construct(FrontendUserAuthentication $frontendUserAuthentication)
-    {
-        $this->frontendUserAuthentication = $frontendUserAuthentication;
-    }
+    public function __construct(private readonly FrontendUserAuthentication $frontendUserAuthentication) {}
 
     public function getFrontendUserAuthentication(): FrontendUserAuthentication
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Event/RemoveProfileInformationEvent.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Event/RemoveProfileInformationEvent.php
@@ -16,15 +16,7 @@ use Fgtclb\AcademicPersonsEdit\Domain\Model\Profile;
 
 final class RemoveProfileInformationEvent
 {
-    private Profile $profile;
-
-    private ProfileInformation $profileInformation;
-
-    public function __construct(Profile $profile, ProfileInformation $profileInformation)
-    {
-        $this->profile = $profile;
-        $this->profileInformation = $profileInformation;
-    }
+    public function __construct(private readonly Profile $profile, private readonly ProfileInformation $profileInformation) {}
 
     public function getProfile(): Profile
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/EventListener/GenerateSlugForProfile.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/EventListener/GenerateSlugForProfile.php
@@ -18,12 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class GenerateSlugForProfile
 {
-    private ConnectionPool $connectionPool;
-
-    public function __construct(ConnectionPool $connectionPool)
-    {
-        $this->connectionPool = $connectionPool;
-    }
+    public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     public function __invoke(AfterProfileUpdateEvent $event): void
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
@@ -15,10 +15,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class SyncChangesToTranslations
 {
-    private int $defaultLanguage;
+    private readonly int $defaultLanguage;
 
     /** @var int[] */
-    private array $allowedLanguages;
+    private readonly array $allowedLanguages;
 
     public function __construct(
         ProfileTranslator $profileTranslator

--- a/packages/fgtclb/academic-persons-edit/Classes/Middleware/ProfileLoader.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Middleware/ProfileLoader.php
@@ -31,21 +31,7 @@ final class ProfileLoader implements MiddlewareInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    private Context $context;
-
-    private ProfileProvider $profileProvider;
-
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(
-        Context $context,
-        ProfileProvider $profileProvider,
-        EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->context = $context;
-        $this->profileProvider = $profileProvider;
-        $this->eventDispatcher = $eventDispatcher;
-    }
+    public function __construct(private Context $context, private ProfileProvider $profileProvider, private EventDispatcherInterface $eventDispatcher) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Profile/AbstractProfileFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Profile/AbstractProfileFactory.php
@@ -25,21 +25,7 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 abstract class AbstractProfileFactory implements ProfileFactoryInterface
 {
-    protected PersistenceManagerInterface $persistenceManager;
-
-    protected ExtensionConfiguration $extensionConfiguration;
-
-    protected EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(
-        PersistenceManagerInterface $persistenceManager,
-        ExtensionConfiguration $extensionConfiguration,
-        EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->extensionConfiguration = $extensionConfiguration;
-        $this->eventDispatcher = $eventDispatcher;
-    }
+    public function __construct(protected PersistenceManagerInterface $persistenceManager, protected ExtensionConfiguration $extensionConfiguration, protected EventDispatcherInterface $eventDispatcher) {}
 
     public function shouldCreateProfileForUser(FrontendUserAuthentication $frontendUserAuthentication): bool
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Profile/ProfileTranslator.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Profile/ProfileTranslator.php
@@ -19,12 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class ProfileTranslator
 {
-    protected ExtensionConfiguration $extensionConfiguration;
-
-    public function __construct(ExtensionConfiguration $extensionConfiguration)
-    {
-        $this->extensionConfiguration = $extensionConfiguration;
-    }
+    public function __construct(protected ExtensionConfiguration $extensionConfiguration) {}
 
     /**
      * @return int The uid of the transalted profile

--- a/packages/fgtclb/academic-persons-edit/Classes/Property/TypeConverter/ProfileImageUploadConverter.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Property/TypeConverter/ProfileImageUploadConverter.php
@@ -44,12 +44,7 @@ final class ProfileImageUploadConverter extends AbstractTypeConverter implements
 
     protected $priority = 10;
 
-    protected ResourceFactory $resourceFactory;
-
-    public function __construct(ResourceFactory $resourceFactory)
-    {
-        $this->resourceFactory = $resourceFactory;
-    }
+    public function __construct(protected ResourceFactory $resourceFactory) {}
 
     /**
      * Actually convert from $source to $targetType, taking into account the fully

--- a/packages/fgtclb/academic-persons-edit/Classes/Provider/FrontendUserProvider.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Provider/FrontendUserProvider.php
@@ -16,12 +16,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 
 final class FrontendUserProvider
 {
-    private ConnectionPool $connectionPool;
-
-    public function __construct(ConnectionPool $connectionPool)
-    {
-        $this->connectionPool = $connectionPool;
-    }
+    public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     /**
      * @return array<int, array<string, mixed>>

--- a/packages/fgtclb/academic-persons-edit/Classes/Provider/ProfileProvider.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Provider/ProfileProvider.php
@@ -23,12 +23,7 @@ final class ProfileProvider implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    private ConnectionPool $connectionPool;
-
-    public function __construct(ConnectionPool $connectionPool)
-    {
-        $this->connectionPool = $connectionPool;
-    }
+    public function __construct(private ConnectionPool $connectionPool) {}
 
     public function userHasProfile(int $userUid): bool
     {

--- a/packages/fgtclb/academic-persons/Classes/DemandValues/AbstractDemandValues.php
+++ b/packages/fgtclb/academic-persons/Classes/DemandValues/AbstractDemandValues.php
@@ -16,16 +16,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 abstract class AbstractDemandValues implements DemandValuesInterface
 {
-    private ExtensionConfiguration $extensionConfiguration;
-
     /**
      * @var array<string, string>
      */
     protected array $values;
 
-    public function __construct(ExtensionConfiguration $extensionConfiguration)
+    public function __construct(private readonly ExtensionConfiguration $extensionConfiguration)
     {
-        $this->extensionConfiguration = $extensionConfiguration;
         $this->values = [];
         $this->initialize();
     }

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
@@ -17,27 +17,21 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 
 final class ModifyDetailProfileEvent
 {
-    private Profile $profile;
-
-    /**
-     * The Extbase ViewInterface has been deprecated in TYPO3 v11.5 and has to be replaced with the TYPO3Fluid ViewInterface.
-     * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html
-     *
-     * @var ViewInterface|DeprecatedExtbaseViewInterface
-     * @todo Add native type when v11 support is dropped.
-     */
-    private $view;
-
     /**
      * @param Profile $profile
      * @param ViewInterface|DeprecatedExtbaseViewInterface $view
      * @todo Add ViewInterface as type for $view when TYPO3 v11 support is dropped.
      */
-    public function __construct(Profile $profile, $view)
-    {
-        $this->profile = $profile;
-        $this->view = $view;
-    }
+    public function __construct(
+        private Profile $profile,
+        /**
+         * The Extbase ViewInterface has been deprecated in TYPO3 v11.5 and has to be replaced with the TYPO3Fluid ViewInterface.
+         * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html
+         *
+         * @todo Add native type when v11 support is dropped.
+         */
+        private $view
+    ) {}
 
     public function getProfile(): Profile
     {

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
@@ -19,29 +19,20 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 final class ModifyListProfilesEvent
 {
     /**
-     * @var QueryResultInterface<Profile>
-     */
-    private QueryResultInterface $profiles;
-
-    /**
-     * The Extbase ViewInterface has been deprecated in TYPO3 v11.5 and has to be replaced with the TYPO3Fluid ViewInterface.
-     * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html
-     *
-     * @var ViewInterface|DeprecatedExtbaseViewInterface
-     * @todo Add native type when v11 support is dropped.
-     */
-    private $view;
-
-    /**
      * @param QueryResultInterface<Profile> $profiles
      * @param ViewInterface|DeprecatedExtbaseViewInterface $view
      * @todo Add ViewInterface as type for $view when TYPO3 v11 support is dropped.
      */
-    public function __construct(QueryResultInterface $profiles, $view)
-    {
-        $this->profiles = $profiles;
-        $this->view = $view;
-    }
+    public function __construct(
+        private QueryResultInterface $profiles,
+        /**
+         * The Extbase ViewInterface has been deprecated in TYPO3 v11.5 and has to be replaced with the TYPO3Fluid ViewInterface.
+         * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html
+         *
+         * @todo Add native type when v11 support is dropped.
+         */
+        private $view
+    ) {}
 
     /**
      * @return QueryResultInterface<Profile>

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileDemandEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileDemandEvent.php
@@ -15,12 +15,7 @@ use Fgtclb\AcademicPersons\Domain\Model\Dto\DemandInterface;
 
 final class ModifyProfileDemandEvent
 {
-    private DemandInterface $demand;
-
-    public function __construct(DemandInterface $demand)
-    {
-        $this->demand = $demand;
-    }
+    public function __construct(private DemandInterface $demand) {}
 
     public function setDemand(DemandInterface $demand): void
     {

--- a/packages/fgtclb/academic-persons/Classes/Hook/DataHandlerHooks.php
+++ b/packages/fgtclb/academic-persons/Classes/Hook/DataHandlerHooks.php
@@ -57,7 +57,7 @@ final class DataHandlerHooks
                     continue;
                 }
 
-                $data[$alphaColumnName] = strtolower(mb_substr($data[$correspondingFieldName], 0, 1));
+                $data[$alphaColumnName] = strtolower(mb_substr((string)$data[$correspondingFieldName], 0, 1));
             }
         }
     }

--- a/packages/fgtclb/academic-persons/Classes/Types/AbstractTypes.php
+++ b/packages/fgtclb/academic-persons/Classes/Types/AbstractTypes.php
@@ -16,16 +16,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 abstract class AbstractTypes implements TypesInterface
 {
-    private ExtensionConfiguration $extensionConfiguration;
-
     /**
      * @var array<string, string>
      */
     protected array $types;
 
-    public function __construct(ExtensionConfiguration $extensionConfiguration)
+    public function __construct(private readonly ExtensionConfiguration $extensionConfiguration)
     {
-        $this->extensionConfiguration = $extensionConfiguration;
         $this->types = [];
         $this->initialize();
     }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Frontend/PhpError.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Frontend/PhpError.php
@@ -28,17 +28,9 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 class PhpError implements PageErrorHandlerInterface
 {
     /**
-     * @var int
-     */
-    private $statusCode;
-
-    /**
      * @param int $statusCode
      */
-    public function __construct(int $statusCode)
-    {
-        $this->statusCode = $statusCode;
-    }
+    public function __construct(private readonly int $statusCode) {}
 
     /**
      * @param ServerRequestInterface $request

--- a/packages/fgtclb/academic-programs/Classes/Collection/CategoryCollection.php
+++ b/packages/fgtclb/academic-programs/Classes/Collection/CategoryCollection.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @implements ArrayAccess<string, Category[]>
  * @implements Iterator<int, Category>
  */
-class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
+class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \Stringable
 {
     /**
      * @var Category[]
@@ -143,13 +143,12 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
         try {
             $enum = new CategoryTypes($lowerName);
             return true;
-        } catch (InvalidEnumerationValueException $e) {
+        } catch (InvalidEnumerationValueException) {
             return false;
         }
     }
 
     /**
-     * @param mixed $offset
      * @return Category[]|false
      */
     public function offsetGet(mixed $offset): array|false

--- a/packages/fgtclb/academic-programs/Classes/Collection/FilterCollection.php
+++ b/packages/fgtclb/academic-programs/Classes/Collection/FilterCollection.php
@@ -10,7 +10,7 @@ use FGTCLB\AcademicPrograms\Domain\Model\Category;
 /**
  * @implements ArrayAccess<string, Category[]>
  */
-class FilterCollection implements \ArrayAccess
+class FilterCollection implements \ArrayAccess, \Stringable
 {
     protected CategoryCollection $filterCategories;
 
@@ -37,21 +37,20 @@ class FilterCollection implements \ArrayAccess
     {
         try {
             $this->filterCategories->getCategoriesByTypeName($offset);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException) {
             return false;
         }
         return true;
     }
 
     /**
-     * @param mixed $offset
      * @return array<int, Category>|false
      */
     public function offsetGet(mixed $offset): array|false
     {
         try {
             $categories = $this->filterCategories->getCategoriesByTypeName($offset);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException) {
             return false;
         }
         return $categories;

--- a/packages/fgtclb/academic-programs/Classes/Domain/Model/Category.php
+++ b/packages/fgtclb/academic-programs/Classes/Domain/Model/Category.php
@@ -9,30 +9,19 @@ use FGTCLB\AcademicPrograms\Domain\Repository\CategoryRepository;
 use FGTCLB\AcademicPrograms\Enumeration\CategoryTypes;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class Category
+class Category implements \Stringable
 {
-    protected int $uid;
-
-    protected int $parentId;
-
     protected ?CategoryTypes $type;
-
-    protected string $title;
-
-    protected bool $disabled = false;
 
     protected ?CategoryCollection $children = null;
 
     public function __construct(
-        int $uid,
-        int $parentId,
-        string $title,
+        protected int $uid,
+        protected int $parentId,
+        protected string $title,
         string $type = '',
-        bool $disabled = false
+        protected bool $disabled = false
     ) {
-        $this->uid = $uid;
-        $this->parentId = $parentId;
-
         if ($type === 'default' || $type === '') {
             $type = null;
         } else {
@@ -40,8 +29,6 @@ class Category
         }
 
         $this->type = $type;
-        $this->title = $title;
-        $this->disabled = $disabled;
 
         /** @var CategoryRepository $categoryRepository */
         $categoryRepository = GeneralUtility::makeInstance(CategoryRepository::class);

--- a/packages/fgtclb/academic-programs/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/academic-programs/Classes/Domain/Repository/CategoryRepository.php
@@ -412,9 +412,7 @@ class CategoryRepository
     {
         return $queryBuilder->expr()->in(
             'sys_category.type',
-            array_map(function (string $value) {
-                return '\'' . $value . '\'';
-            }, array_values(CategoryTypes::getConstants()))
+            array_map(fn(string $value) => '\'' . $value . '\'', array_values(CategoryTypes::getConstants()))
         );
     }
 

--- a/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class DemandFactory
 {
     public function __construct(
-        private CategoryRepository $categoryRepository
+        private readonly CategoryRepository $categoryRepository
     ) {}
 
     /**

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Be/CategoryViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Be/CategoryViewHelper.php
@@ -68,7 +68,7 @@ class CategoryViewHelper extends AbstractViewHelper
             } else {
                 throw new CategoryTypeException(sprintf('The category type "%s" not exist', $arguments['type']), 1694770343759);
             }
-        } catch (\Exception $exception) {
+        } catch (\Exception) {
             $categories = $repository->findAllByPageId($arguments['page']);
         }
 

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -182,10 +182,9 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     /**
      * Get the option value for an object
      *
-     * @param mixed $valueElement
      * @return string
      */
-    protected function getOptionValueScalar($valueElement)
+    protected function getOptionValueScalar(mixed $valueElement)
     {
         if (is_object($valueElement)) {
             if ($this->hasArgument('optionValueField')) {
@@ -206,7 +205,7 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
      * @param mixed $value Value to check for
      * @return bool TRUE if the value should be marked a s selected; FALSE otherwise
      */
-    protected function isSelected($value)
+    protected function isSelected(mixed $value)
     {
         if (in_array((string)$value, $this->selectedValues)) {
             return true;

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -42,9 +42,7 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         if ($this->arguments['groupByParent'] !== false) {

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -80,9 +80,7 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         return $options;

--- a/packages/fgtclb/academic-projects/Classes/Collection/CategoryCollection.php
+++ b/packages/fgtclb/academic-projects/Classes/Collection/CategoryCollection.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @implements ArrayAccess<string, Category[]>
  * @implements Iterator<int, Category>
  */
-class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
+class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \Stringable
 {
     /**
      * @var Category[]
@@ -143,13 +143,12 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
         try {
             $enum = new CategoryTypes($lowerName);
             return true;
-        } catch (InvalidEnumerationValueException $e) {
+        } catch (InvalidEnumerationValueException) {
             return false;
         }
     }
 
     /**
-     * @param mixed $offset
      * @return Category[]|false
      */
     public function offsetGet(mixed $offset): array|false

--- a/packages/fgtclb/academic-projects/Classes/Collection/FilterCollection.php
+++ b/packages/fgtclb/academic-projects/Classes/Collection/FilterCollection.php
@@ -10,7 +10,7 @@ use FGTCLB\AcademicProjects\Domain\Model\Category;
 /**
  * @implements ArrayAccess<string, Category[]>
  */
-class FilterCollection implements \ArrayAccess
+class FilterCollection implements \ArrayAccess, \Stringable
 {
     protected CategoryCollection $filterCategories;
 
@@ -37,21 +37,20 @@ class FilterCollection implements \ArrayAccess
     {
         try {
             $this->filterCategories->getCategoriesByTypeName($offset);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException) {
             return false;
         }
         return true;
     }
 
     /**
-     * @param mixed $offset
      * @return array<int, Category>|false
      */
     public function offsetGet(mixed $offset): array|false
     {
         try {
             $categories = $this->filterCategories->getCategoriesByTypeName($offset);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException) {
             return false;
         }
         return $categories;

--- a/packages/fgtclb/academic-projects/Classes/Domain/Model/Category.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Model/Category.php
@@ -9,30 +9,19 @@ use FGTCLB\AcademicProjects\Domain\Repository\CategoryRepository;
 use FGTCLB\AcademicProjects\Enumeration\CategoryTypes;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class Category
+class Category implements \Stringable
 {
-    protected int $uid;
-
-    protected int $parentId;
-
     protected ?CategoryTypes $type;
-
-    protected string $title;
-
-    protected bool $disabled = false;
 
     protected ?CategoryCollection $children = null;
 
     public function __construct(
-        int $uid,
-        int $parentId,
-        string $title,
+        protected int $uid,
+        protected int $parentId,
+        protected string $title,
         string $type = '',
-        bool $disabled = false
+        protected bool $disabled = false
     ) {
-        $this->uid = $uid;
-        $this->parentId = $parentId;
-
         if ($type === 'default' || $type === '') {
             $type = null;
         } else {
@@ -40,8 +29,6 @@ class Category
         }
 
         $this->type = $type;
-        $this->title = $title;
-        $this->disabled = $disabled;
 
         /** @var CategoryRepository $categoryRepository */
         $categoryRepository = GeneralUtility::makeInstance(CategoryRepository::class);

--- a/packages/fgtclb/academic-projects/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Repository/CategoryRepository.php
@@ -363,9 +363,7 @@ class CategoryRepository
     {
         return $queryBuilder->expr()->in(
             'sys_category.type',
-            array_map(function (string $value) {
-                return '\'' . $value . '\'';
-            }, array_values(CategoryTypes::getConstants()))
+            array_map(fn(string $value) => '\'' . $value . '\'', array_values(CategoryTypes::getConstants()))
         );
     }
 

--- a/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class DemandFactory
 {
     public function __construct(
-        private CategoryRepository $categoryRepository
+        private readonly CategoryRepository $categoryRepository
     ) {}
 
     /**

--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Be/CategoryViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Be/CategoryViewHelper.php
@@ -63,7 +63,7 @@ class CategoryViewHelper extends AbstractViewHelper
         try {
             $categoryType = CategoryTypes::cast($arguments['type']);
             $attributes = $repository->findByType($arguments['page'], $categoryType);
-        } catch (InvalidEnumerationValueException $e) {
+        } catch (InvalidEnumerationValueException) {
             $attributes = $repository->findAllByPageId($arguments['page']);
         }
 

--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -42,9 +42,7 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         if ($this->arguments['groupByParent'] !== false) {

--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -80,9 +80,7 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         return $options;
@@ -115,7 +113,7 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
             $labelKey
         );
 
-        $extensionName = $this->arguments['extensionName'] === null ? 'academic_programs' : $this->arguments['extensionName'];
+        $extensionName = $this->arguments['extensionName'] ?? 'academic_programs';
 
         $translatedLabel = LocalizationUtility::translate(
             $key,

--- a/packages/fgtclb/academic-projects/Configuration/Icons.php
+++ b/packages/fgtclb/academic-projects/Configuration/Icons.php
@@ -11,12 +11,10 @@ $sourceString = static fn(string $icon): string => sprintf(
     GeneralUtility::underscoredToUpperCamelCase($icon)
 );
 
-$identifierString = static function (string $identifier) {
-    return sprintf(
-        'academic-project-%s',
-        $identifier
-    );
-};
+$identifierString = static fn(string $identifier) => sprintf(
+    'academic-project-%s',
+    $identifier
+);
 
 return [
     $identifierString(CategoryTypes::TYPE_COMPETENCE_FIELD) => [

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
@@ -6,7 +6,7 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 if (!defined('TYPO3')) {
-    die(__CLASS__);
+    die('Not authorized');
 }
 
 (static function (): void {

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
@@ -10,9 +10,7 @@ if (!defined('TYPO3')) {
 }
 
 (static function (): void {
-    $ll = function (string $langKey): string {
-        return 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_db.xlf:' . $langKey;
-    };
+    $ll = fn(string $langKey): string => 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_db.xlf:' . $langKey;
 
     // Create new item group for academic doktype items
     // TODO: Harmonize this with all academic extensions

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/sys_category.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/sys_category.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 use FGTCLB\AcademicProjects\Enumeration\CategoryTypes;
 
 (static function (): void {
-    $ll = static function (string $label) {
-        return sprintf(
-            'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:sys_category.type.%s',
-            $label
-        );
-    };
+    $ll = static fn(string $label) => sprintf(
+        'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:sys_category.type.%s',
+        $label
+    );
 
-    $iconType = static function (string $iconType) {
-        return sprintf(
-            'academic-project-%s',
-            $iconType
-        );
-    };
+    $iconType = static fn(string $iconType) => sprintf(
+        'academic-project-%s',
+        $iconType
+    );
 
     // Create new select item group for category types
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup(

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 (static function (): void {
-    $ll = function (string $langKey): string {
-        return 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_db.xlf:' . $langKey;
-    };
+    $ll = fn(string $langKey): string => 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_db.xlf:' . $langKey;
 
     // Configure list plugin
 


### PR DESCRIPTION
- **[TASK] Do not expose class names to the public**

  In classic modes sensible files are exposed to the
  public, usually guarded by `.htaccess` rules, which
  is not the in composer mode. We support both modes
  for the extension and need to guard access to the
  files.

  Following construct is used to guard these cases:

  ```php
  if (!defined('TYPO3')) {
    die(__CLASS__);
  }
  ```

  This exposes eventually class names to the public
  and is not what TYPO3 recommends to use gurding
  these files for class mode installation.

  This change replaces these construct with a more
  generic message:

  ```php
  if (!defined('TYPO3')) {
    die('Not authorized');
  }
  ```

  Granted, the message is literally wrong and no status
  code returned matching the message, but that way we
  keep the nuts safe and warm.

- **[TASK] Modernize extension code base using modern PHP**

  * Properties initilized soley within the constructor,
    not written other wise and not passed as parameter
    to the constructore are made readonly making this
    now a string requirement.

  * Constructor parameters assigned to properties with
    the same name are replaced using the native PHP
    `constructor parameter promotion` technique and on
    top of that set as readonly where possible.

  * Replace magic `__CLASS_` constant using the self
    class constant instead: `self::class`.

  * Migrate `clousure` to `arrow` function.

  * Add the `\Stringable` interface implementation to
    classes providing a `__toString()` method matching
    PHP recommendations to make this really expectable
    and easier to detect using instanceof instead of
    `method_exist()` using costly reclection API under
    the hood.

  * Unused variables are removed, for example when the
    exception is not used in an catch block.

  * Replace null or not set array key tenary checks or
    handling using the null-coalsce operator to reduce
    cognitve load.

  Used command(s):

  ```shell
  Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate \
  && Build/Scripts/runTests.sh -t 12 -p 8.1 -s cgl \
  && Build/Scripts/runTests.sh -t 12 -p 8.1 \
    -s phpstanGenerateBaseline \
  && Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate \
  && Build/Scripts/runTests.sh -t 13 -p 8.2 \
    -s phpstanGenerateBaseline
  ```
