### PR TITLE
[TASK] Add composer autoload configuration for `fgtclb/category-types`

### DIFF
--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -37,6 +37,11 @@
             "php-http/discovery": true
         }
     },
+    "autoload": {
+        "psr-4": {
+            "FGTCLB\\CategoryTypes\\": "Classes/"
+        }
+    },
     "support": {
         "issues": "https://github.com/fgtclb/academic-extensions/issues",
         "source": "https://github.com/fgtclb/academic-extensions",


### PR DESCRIPTION
The autoload configuration was errornous removed from composer configuration.