### PR TITLE
[TASK] Upgrade `sbuerk/fixture-packages`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,109 +1,110 @@
 {
-    "name": "fgtclb/academic-extensions",
-    "description": "Centralized mono repository for academic extension development",
-    "type": "project",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "FGTCLB GmbH",
-            "email": "hello@fgtclb.com"
+  "name": "fgtclb/academic-extensions",
+  "description": "Centralized mono repository for academic extension development",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "FGTCLB GmbH",
+      "email": "hello@fgtclb.com"
+    }
+  ],
+  "require": {
+    "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+    "fgtclb/academics-monorepo-shared": "2.0.*@dev"
+  },
+  "config": {
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true,
+      "php-http/discovery": true,
+      "sbuerk/fixture-packages": true
+    },
+    "sort-packages": true,
+    "bin-dir": ".Build/bin",
+    "vendor-dir": ".Build/vendor",
+    "preferred-install": {
+      "typo3/cms-extbase": "source",
+      "typo3/cms-core": "source",
+      "typo3/cms-frontend": "source",
+      "*": "dist"
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "web-dir": ".Build/Web",
+      "app-dir": ".Build"
+    },
+    "sbuerk/fixture-packages": {
+      "paths": {
+        "packages/*/*/Tests/Functional/Fixtures/Extensions/*": [
+          "autoload",
+          "autoload-dev"
+        ],
+        "packages/*/*": [
+          "autoload-dev"
+        ]
+      }
+    },
+    "branch-alias": {
+      "dev-main": "2.0.x-dev"
+    }
+  },
+  "require-dev": {
+    "bnf/phpstan-psr-container": "^1.0.1",
+    "friendsofphp/php-cs-fixer": "^3.57.1",
+    "friendsoftypo3/phpstan-typo3": "^0.9.0",
+    "georgringer/numbered-pagination": "^2.1",
+    "phpstan/phpdoc-parser": "^1.29.0",
+    "phpstan/phpstan": "^1.12.21",
+    "phpstan/phpstan-phpunit": "^1.4.0",
+    "phpunit/phpunit": "^10.5.45",
+    "sbuerk/fixture-packages": ">=0.1.1 < 2.0.0",
+    "typo3/tailor": "^1.6",
+    "typo3/testing-framework": "^8.2.7"
+  },
+  "repositories": {
+    "packages-dev": {
+      "type": "path",
+      "url": "packages-dev/*",
+      "options": {
+        "versions": {
+          "fgtclb/academics-monorepo-shared": "2.0.0-dev"
         }
-    ],
-    "require": {
-        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
-        "fgtclb/academics-monorepo-shared": "2.0.*@dev"
+      }
     },
-    "config": {
-        "allow-plugins": {
-            "typo3/class-alias-loader": true,
-            "typo3/cms-composer-installers": true,
-            "php-http/discovery": true,
-            "sbuerk/fixture-packages": true
-        },
-        "sort-packages": true,
-        "bin-dir": ".Build/bin",
-        "vendor-dir": ".Build/vendor",
-        "preferred-install": {
-            "typo3/cms-extbase": "source",
-            "typo3/cms-core": "source",
-            "typo3/cms-frontend": "source",
-            "*": "dist"
+    "packages": {
+      "type": "path",
+      "url": "packages/*/*",
+      "options": {
+        "versions": {
+          "fgtclb/academic-bite-jobs": "2.0.0-dev",
+          "fgtclb/academic-contacts4pages": "2.0.0-dev",
+          "fgtclb/academic-jobs": "2.0.0-dev",
+          "fgtclb/academic-partners": "2.0.0-dev",
+          "fgtclb/academic-persons": "2.0.0-dev",
+          "fgtclb/academic-persons-edit": "2.0.0-dev",
+          "fgtclb/academic-persons-sync": "2.0.0-dev",
+          "fgtclb/academic-programs": "2.0.0-dev",
+          "fgtclb/academic-projects": "2.0.0-dev",
+          "fgtclb/category-types": "2.0.0-dev"
         }
-    },
-    "extra": {
-        "typo3/cms": {
-            "web-dir": ".Build/Web",
-            "app-dir": ".Build"
-        },
-        "sbuerk/fixture-packages": {
-            "paths": [
-                "packages/*/*/Tests/Functional/Fixtures/Extensions/*"
-            ]
-        },
-        "branch-alias": {
-            "dev-main": "2.0.x-dev"
-        }
-    },
-    "require-dev": {
-        "bnf/phpstan-psr-container": "^1.0.1",
-        "friendsofphp/php-cs-fixer": "^3.57.1",
-        "friendsoftypo3/phpstan-typo3": "^0.9.0",
-        "georgringer/numbered-pagination": "^2.1",
-        "phpstan/phpdoc-parser": "^1.29.0",
-        "phpstan/phpstan": "^1.12.21",
-        "phpstan/phpstan-phpunit": "^1.4.0",
-        "phpunit/phpunit": "^10.5.45",
-        "sbuerk/fixture-packages": "^0.0.2 <0.1",
-        "typo3/tailor": "^1.6",
-        "typo3/testing-framework": "^8.2.7"
-    },
-    "repositories": {
-        "packages-dev": {
-            "type": "path",
-            "url": "packages-dev/*",
-            "options": {
-                "versions": {
-                    "fgtclb/academics-monorepo-shared": "2.0.0-dev"
-                }
-            }
-        },
-        "packages": {
-            "type": "path",
-            "url": "packages/*/*",
-            "options": {
-                "versions": {
-                    "fgtclb/academic-bite-jobs": "2.0.0-dev",
-                    "fgtclb/academic-contacts4pages": "2.0.0-dev",
-                    "fgtclb/academic-jobs": "2.0.0-dev",
-                    "fgtclb/academic-partners": "2.0.0-dev",
-                    "fgtclb/academic-persons": "2.0.0-dev",
-                    "fgtclb/academic-persons-edit": "2.0.0-dev",
-                    "fgtclb/academic-persons-sync": "2.0.0-dev",
-                    "fgtclb/academic-programs": "2.0.0-dev",
-                    "fgtclb/academic-projects": "2.0.0-dev",
-                    "fgtclb/category-types": "2.0.0-dev"
-                }
-            }
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "autoload-dev": {
-        "psr-4": {
-            "FGTCLB\\AcademicBiteJobs\\Tests\\": "packages/fgtclb/academic-bite-jobs/Tests",
-            "FGTCLB\\AcademicJobs\\Tests\\": "packages/fgtclb/academic-jobs/Tests",
-            "FGTCLB\\AcademicPartners\\Tests\\": "packages/fgtclb/academic-partners/Tests",
-            "Fgtclb\\AcademicPersons\\Tests\\": "packages/fgtclb/academic-persons/Tests",
-            "Fgtclb\\AcademicPersonsEdit\\Tests\\": "packages/fgtclb/academic-persons-edit/Tests",
-            "FGTCLB\\AcademicPrograms\\Tests\\": "packages/fgtclb/academic-programs/Tests",
-            "FGTCLB\\AcademicProjects\\Tests\\": "packages/fgtclb/academic-programs/Tests",
-            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms-core/Tests"
-        }
-    },
-    "support": {
-        "issues": "https://github.com/fgtclb/academic-extensions/issues",
-        "source": "https://github.com/fgtclb/academic-extensions",
-        "email": "hello@fgtclb.com"
-    },
-    "homepage": "https://www.fgtclb.com/"
+      }
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "support": {
+    "issues": "https://github.com/fgtclb/academic-extensions/issues",
+    "source": "https://github.com/fgtclb/academic-extensions",
+    "email": "hello@fgtclb.com"
+  },
+  "homepage": "https://www.fgtclb.com/",
+  "autoload": {
+    "psr-4": {
+      "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms-core/Tests/",
+      "TYPO3\\CMS\\Extbase\\Tests\\": ".Build/vendor/typo3/cms-extbase/Tests/",
+      "TYPO3\\CMS\\Frontend\\Tests\\": ".Build/vendor/typo3/cms-frontend/Tests/"
+    }
+  }
 }


### PR DESCRIPTION
[TASK] Upgrade `sbuerk/fixture-packages`

A new versiono `sbuerk/fixture-packages` has been released,
including the fixed static path for fetching the fixture
packages within the class to adopt fixture packages for the
`typo3/testing-framework` functional tests and the ability
to select `autoload` and/or `autoload-dev` to be adopted
per path configuration.

This change now updates this package, removes the workaround
using PHP reflection API in the `FunctionalTestsBootstrap`,
removes the manual test namespace registration for our own
academic mono-repository packages. Sadly, TYPO3 does not
declare the test namespaces within the system extension
`composer.json` yet and the automatic adoption does not
work using this composer plugin. We will see what the
future brings.

For the future, this means that new packages or added test
folders are automatically reconized during a normal and simple
`composer dump-autoload` without the need to add them somewhere,
except within the package `composer.json` as namespace already.

Same counts for test-fixture extensions.

Used command(s):

```shell
BIN_COMPOSER="$( which composer2-81 )" \
&& ${BIN_COMPOSER} config --unset \
  extra."sbuerk/fixture-packages"."paths" \
&& ${BIN_COMPOSER} config --unset "autoload-dev" \
&& cat <<< $(
  jq '.extra."sbuerk/fixture-packages"."paths"."packages/*/*/Tests/Functional/Fixtures/Extensions/*" = ["autoload", "autoload-dev"]' \
    composer.json | \
  jq '.extra."sbuerk/fixture-packages"."paths"."packages/*/*" = ["autoload-dev"]'
) > composer.json \
&& cat <<< $(
  jq '.autoload."psr-4"."TYPO3\\CMS\\Core\\Tests\\" = ".Build/vendor/typo3/cms-core/Tests/"' \
    composer.json | \
  jq '.autoload."psr-4"."TYPO3\\CMS\\Extbase\\Tests\\"  = ".Build/vendor/typo3/cms-extbase/Tests/"' | \
  jq '.autoload."psr-4"."TYPO3\\CMS\\Frontend\\Tests\\"  = ".Build/vendor/typo3/cms-frontend/Tests/"' 
) > composer.json \
&& ${BIN_COMPOSER} require --dev -vv \
  'sbuerk/fixture-packages':'>=0.1.1 < 2.0.0'
```