### PR TITLE
[FEATURE] Introduce view mode selection and additional backend filter

### DIFF
--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -262,6 +262,26 @@ final class ProfileController extends ActionController
      */
     private function adoptSettings(ProfileDemand $demand): void
     {
+        if (isset($this->settings['functionTypes'])
+            && is_string($this->settings['functionTypes'])
+            && $this->settings['functionTypes'] !== ''
+        ) {
+            $functionTypeUids = GeneralUtility::intExplode(',', $this->settings['functionTypes'], true);
+            if (!empty($functionTypeUids)) {
+                $demand->setFunctionTypes($functionTypeUids);
+            }
+        }
+
+        if (isset($this->settings['organisationalUnits'])
+            && is_string($this->settings['organisationalUnits'])
+            && $this->settings['organisationalUnits'] !== ''
+        ) {
+            $organisationalUnitUids = GeneralUtility::intExplode(',', $this->settings['organisationalUnits'], true);
+            if (!empty($organisationalUnitUids)) {
+                $demand->setOrganisationalUnits($organisationalUnitUids);
+            }
+        }
+
         $contentObjectData = $this->getContentObject()?->data;
         $hasStoragePids = (
             is_array($contentObjectData)
@@ -271,6 +291,7 @@ final class ProfileController extends ActionController
         if ($hasStoragePids) {
             $demand->setStoragePages($contentObjectData['pages']);
         }
+
         /**
          * Introduced with https://github.com/fgtclb/academic-persons/pull/30 to have the option to display profiles in
          * fallback mode even when site language (non-default) is configured to be in strict mode.

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/ProfileDemand.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/ProfileDemand.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Domain\Model\Dto;
 
-use Fgtclb\AcademicPersons\Domain\Repository\ProfileRepository;
-
 class ProfileDemand implements DemandInterface
 {
     protected string $groupBy = '';
@@ -23,6 +21,16 @@ class ProfileDemand implements DemandInterface
     protected string $profileList = '';
     private string $storagePages = '';
     private int $fallbackForNonTranslated = 0;
+
+    /**
+     * @var int[]
+     */
+    protected array $functionTypes = [];
+
+    /**
+     * @var int[]
+     */
+    protected array $organisationalUnits = [];
 
     /**
      * Does not have any effect when {@see self::getProfileList()} is not empty.
@@ -106,6 +114,42 @@ class ProfileDemand implements DemandInterface
     public function setAlphabetFilter(string $alphabetFilter): self
     {
         $this->alphabetFilter = $alphabetFilter;
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getFunctionTypes(): array
+    {
+        return $this->functionTypes;
+    }
+
+    /**
+     * @param int[] $functionTypes
+     * @return ProfileDemand
+     */
+    public function setFunctionTypes(array $functionTypes): ProfileDemand
+    {
+        $this->functionTypes = $functionTypes;
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getOrganisationalUnits(): array
+    {
+        return $this->organisationalUnits;
+    }
+
+    /**
+     * @param int[] $organisationalUnits
+     * @return ProfileDemand
+     */
+    public function setOrganisationalUnits(array $organisationalUnits): ProfileDemand
+    {
+        $this->organisationalUnits = $organisationalUnits;
         return $this;
     }
 

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
@@ -148,9 +148,21 @@ class ProfileRepository extends Repository
     private function setFilters(QueryInterface $query, DemandInterface $demand): ?ConstraintInterface
     {
         $filters = [];
+
+        if (method_exists($demand, 'getFunctionTypes')
+            && $demand->getFunctionTypes() !== []) {
+            $filters[] = $query->in('contracts.functionType', $demand->getFunctionTypes());
+        }
+
+        if (method_exists($demand, 'getOrganisationalUnits')
+            && $demand->getOrganisationalUnits() !== []) {
+            $filters[] = $query->in('contracts.organisationalUnit', $demand->getOrganisationalUnits());
+        }
+
         if ($demand->getAlphabetFilter() != '') {
             $filters[] = $query->like('last_name', $demand->getAlphabetFilter() . '%');
         }
+
         return ($filters === [])
             ? null
             : $query->logicalAnd(...$filters);

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/List.xml
@@ -138,6 +138,42 @@
                             </config>
                         </TCEforms>
                     </settings.demand.profileList>
+                    <settings.viewMode.enabled>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                            <config>
+                                <type>check</type>
+                                <renderType>checkboxToggle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                                        <labelChecked>Enabled</labelChecked>
+                                        <labelUnchecked>Disabled</labelUnchecked>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.enabled>
+                    <settings.viewMode.default>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                                        <numIndex index="1">list</numIndex>
+                                    </numIndex>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                                        <numIndex index="1">table</numIndex>
+                                    </numIndex>
+                                </items>
+                                <default>asc</default>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.default>
                     <settings.fallbackForNonTranslated>
                         <TCEforms>
                             <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.label</label>
@@ -171,6 +207,32 @@
                             </config>
                         </TCEforms>
                     </settings.showFields>
+                    <settings.organisationalUnits>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.organisationalUnits.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectMultipleSideBySide</renderType>
+                                <foreign_table>tx_academicpersons_domain_model_organisational_unit</foreign_table>
+                                <foreign_table_where>AND tx_academicpersons_domain_model_organisational_unit.sys_language_uid IN (-1,0)</foreign_table_where>
+                                <maxitems>99</maxitems>
+                                <size>3</size>
+                            </config>
+                        </TCEforms>
+                    </settings.organisationalUnits>
+                    <settings.functionTypes>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.functionTypes.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectMultipleSideBySide</renderType>
+                                <foreign_table>tx_academicpersons_domain_model_function_type</foreign_table>
+                                <foreign_table_where>AND tx_academicpersons_domain_model_function_type.sys_language_uid IN (-1,0)</foreign_table_where>
+                                <maxitems>99</maxitems>
+                                <size>3</size>
+                            </config>
+                        </TCEforms>
+                    </settings.functionTypes>
                 </el>
             </ROOT>
         </sDEF>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/SelectedContracts.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/SelectedContracts.xml
@@ -48,6 +48,42 @@
                             </config>
                         </TCEforms>
                     </settings.showFields>
+                    <settings.viewMode.enabled>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                            <config>
+                                <type>check</type>
+                                <renderType>checkboxToggle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                                        <labelChecked>Enabled</labelChecked>
+                                        <labelUnchecked>Disabled</labelUnchecked>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.enabled>
+                    <settings.viewMode.default>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                                        <numIndex index="1">list</numIndex>
+                                    </numIndex>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                                        <numIndex index="1">table</numIndex>
+                                    </numIndex>
+                                </items>
+                                <default>asc</default>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.default>
                 </el>
             </ROOT>
         </sDEF>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/SelectedProfiles.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core11/SelectedProfiles.xml
@@ -49,6 +49,42 @@
                             </config>
                         </TCEforms>
                     </settings.showFields>
+                    <settings.viewMode.enabled>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                            <config>
+                                <type>check</type>
+                                <renderType>checkboxToggle</renderType>
+                                <items>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                                        <labelChecked>Enabled</labelChecked>
+                                        <labelUnchecked>Disabled</labelUnchecked>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.enabled>
+                    <settings.viewMode.default>
+                        <TCEforms>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                                        <numIndex index="1">list</numIndex>
+                                    </numIndex>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                                        <numIndex index="1">table</numIndex>
+                                    </numIndex>
+                                </items>
+                                <default>asc</default>
+                            </config>
+                        </TCEforms>
+                    </settings.viewMode.default>
                 </el>
             </ROOT>
         </sDEF>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/List.xml
@@ -118,6 +118,38 @@
                     </suggestOptions>
                 </config>
             </settings.demand.profileList>
+            <settings.viewMode.enabled>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                <config>
+                    <type>check</type>
+                    <renderType>checkboxToggle</renderType>
+                    <items>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <labelChecked>Enabled</labelChecked>
+                            <labelUnchecked>Disabled</labelUnchecked>
+                        </numIndex>
+                    </items>
+                </config>
+            </settings.viewMode.enabled>
+            <settings.viewMode.default>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                <config>
+                    <type>select</type>
+                    <renderType>selectSingle</renderType>
+                    <items>
+                        <numIndex index="1" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                            <numIndex index="1">list</numIndex>
+                        </numIndex>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                            <numIndex index="1">table</numIndex>
+                        </numIndex>
+                    </items>
+                    <default>asc</default>
+                </config>
+            </settings.viewMode.default>
             <settings.fallbackForNonTranslated>
                 <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.label</label>
                 <config>
@@ -147,6 +179,28 @@
                     <size>3</size>
                 </config>
             </settings.showFields>
+            <settings.organisationalUnits>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.organisationalUnits.label</label>
+                <config>
+                    <type>select</type>
+                    <renderType>selectMultipleSideBySide</renderType>
+                    <foreign_table>tx_academicpersons_domain_model_organisational_unit</foreign_table>
+                    <foreign_table_where>AND tx_academicpersons_domain_model_organisational_unit.sys_language_uid IN (-1,0)</foreign_table_where>
+                    <maxitems>99</maxitems>
+                    <size>3</size>
+                </config>
+            </settings.organisationalUnits>s
+            <settings.functionTypes>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.functionTypes.label</label>
+                <config>
+                    <type>select</type>
+                    <renderType>selectMultipleSideBySide</renderType>
+                    <foreign_table>tx_academicpersons_domain_model_function_type</foreign_table>
+                    <foreign_table_where>AND tx_academicpersons_domain_model_function_type.sys_language_uid IN (-1,0)</foreign_table_where>
+                    <maxitems>99</maxitems>
+                    <size>3</size>
+                </config>
+            </settings.functionTypes>
         </el>
     </ROOT>
 </T3DataStructure>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/SelectedContracts.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/SelectedContracts.xml
@@ -38,6 +38,38 @@
                     <size>3</size>
                 </config>
             </settings.showFields>
+<settings.viewMode.enabled>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                <config>
+                    <type>check</type>
+                    <renderType>checkboxToggle</renderType>
+                    <items>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <labelChecked>Enabled</labelChecked>
+                            <labelUnchecked>Disabled</labelUnchecked>
+                        </numIndex>
+                    </items>
+                </config>
+            </settings.viewMode.enabled>
+            <settings.viewMode.default>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                <config>
+                    <type>select</type>
+                    <renderType>selectSingle</renderType>
+                    <items>
+                        <numIndex index="1" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                            <numIndex index="1">list</numIndex>
+                        </numIndex>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                            <numIndex index="1">table</numIndex>
+                        </numIndex>
+                    </items>
+                    <default>asc</default>
+                </config>
+            </settings.viewMode.default>
         </el>
     </ROOT>
 </T3DataStructure>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/SelectedProfiles.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/SelectedProfiles.xml
@@ -41,6 +41,38 @@
                     <size>3</size>
                 </config>
             </settings.showFields>
+<settings.viewMode.enabled>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.label</label>
+                <config>
+                    <type>check</type>
+                    <renderType>checkboxToggle</renderType>
+                    <items>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <labelChecked>Enabled</labelChecked>
+                            <labelUnchecked>Disabled</labelUnchecked>
+                        </numIndex>
+                    </items>
+                </config>
+            </settings.viewMode.enabled>
+            <settings.viewMode.default>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.label</label>
+                <config>
+                    <type>select</type>
+                    <renderType>selectSingle</renderType>
+                    <items>
+                        <numIndex index="1" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
+                            <numIndex index="1">list</numIndex>
+                        </numIndex>
+                        <numIndex index="0" type="array">
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
+                            <numIndex index="1">table</numIndex>
+                        </numIndex>
+                    </items>
+                    <default>asc</default>
+                </config>
+            </settings.viewMode.default>
         </el>
     </ROOT>
 </T3DataStructure>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
@@ -28,6 +28,10 @@
                 <target>Nach Werten sortieren: Kommagetrennte Liste von zulässigen Sortierwerten</target>
             </trans-unit>
 
+            <trans-unit id="content.ctype.group.label">
+                <source>Academic</source>
+                <target>Academic</target>
+            </trans-unit>
             <trans-unit id="plugin.list.label">
                 <source>Profiles: List of profiles</source>
                 <target>Profile: Liste von Profilen</target>
@@ -78,7 +82,10 @@
                 <target>Fügt ein oder mehrere Kontakte hinzu</target>
             </trans-unit>
 
-
+            <trans-unit id="element.tab.configuration">
+                <source>Configuration</source>
+                <target>Konfiguration</target>
+            </trans-unit>
             <trans-unit id="flexform.tab.settings">
                 <source>Settings</source>
                 <target>Einstellungen</target>
@@ -90,6 +97,10 @@
             <trans-unit id="flexform.el.listPid.label">
                 <source>List Page</source>
                 <target>Listen Seite</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.functionTypes.label">
+                <source>Function Types</source>
+                <target>Funktionstypen</target>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
                 <source>Group By (is given priority in sorting if activ)</source>
@@ -106,6 +117,10 @@
             <trans-unit id="flexform.el.groupBy.items.last_name">
                 <source>First Letter of Last Name</source>
                 <target>Erster Buchstabe des Nachnamens</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.organisationalUnits.label">
+                <source>Organisational Units</source>
+                <target>Organisationseinheiten</target>
             </trans-unit>
             <trans-unit id="flexform.el.sortBy.label">
                 <source>Sort By (sorting of activated grouping has priority)</source>
@@ -190,6 +205,26 @@
             <trans-unit id="flexform.el.fallbackForNonTranslated.label">
                 <source>Fallback to default language for non translated profiles</source>
                 <target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.enabled.label">
+                <source>View Mode Toggle</source>
+                <target>Ansichtsmodus-Umschalter</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.enabled.items.0.label">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.label">
+                <source>View Mode Default</source>
+                <target>Standard für Ansichtsmodus</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.I.list">
+                <source>List</source>
+                <target>Liste</target>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.I.table">
+                <source>Table</source>
+                <target>Tabelle</target>
             </trans-unit>
         </body>
     </file>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
@@ -22,6 +22,9 @@
                 <source>Sort By Values: Comma-separated list of allowed sort by values</source>
             </trans-unit>
 
+            <trans-unit id="content.ctype.group.label">
+                <source>Academic</source>
+            </trans-unit>
             <trans-unit id="plugin.list.label">
                 <source>Profiles: List of profiles</source>
             </trans-unit>
@@ -66,6 +69,9 @@
                 <source>Adds one or more contacts</source>
             </trans-unit>
 
+            <trans-unit id="element.tab.configuration">
+                <source>Configuration</source>
+            </trans-unit>
             <trans-unit id="flexform.tab.settings">
                 <source>Settings</source>
             </trans-unit>
@@ -74,6 +80,9 @@
             </trans-unit>
             <trans-unit id="flexform.el.listPid.label">
                 <source>List Page</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.functionTypes.label">
+                <source>Function Types</source>
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.label">
                 <source>Group By (is given priority in sorting if activ)</source>
@@ -86,6 +95,9 @@
             </trans-unit>
             <trans-unit id="flexform.el.groupBy.items.last_name">
                 <source>First Letter of Last Name</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.organisationalUnits.label">
+                <source>Organisational Units</source>
             </trans-unit>
             <trans-unit id="flexform.el.selectedContracts.label">
                 <source>Selected Contracts</source>
@@ -146,6 +158,21 @@
             </trans-unit>
             <trans-unit id="flexform.el.fallbackForNonTranslated.label">
                 <source>Fallback to default language for non translated profiles</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.enabled.label">
+                <source>View Mode Toggle</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.enabled.items.0.label">
+                <source>Enabled</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.label">
+                <source>View Mode Default</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.I.list">
+                <source>List</source>
+            </trans-unit>
+            <trans-unit id="flexform.el.viewMode.default.I.table">
+                <source>Table</source>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
This pull-requests introduces a additional view mode selection,
which allows to define the presentation mode per plugin usage.
That means, switching between list or grid view.

Further, organizational units and function types are selectable
per plugin placement acting as filter for the frontend retrivale
of the dataset.