### PR TITLE
[TASK] Streamlining code base to modern PHP language features

### DIFF
--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Config;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+use PhpCsFixer\Finder;
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -40,10 +44,10 @@ if (PHP_SAPI !== 'cli') {
 //  - Remove unused use statements in the PHP source code
 //  - Ensure Concatenation to have at least one whitespace around
 //  - Remove trailing whitespace at the end of blank lines.
-return (new \PhpCsFixer\Config())
-    ->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setFinder(
-        (new PhpCsFixer\Finder())
+        (new Finder())
             ->ignoreVCSIgnored(true)
             ->in([
                 __DIR__ . '/../../packages/fgtclb/',

--- a/Build/php-cs-fixer/header-comment.php
+++ b/Build/php-cs-fixer/header-comment.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Finder;
+use PhpCsFixer\Config;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -19,7 +23,7 @@ if (PHP_SAPI !== 'cli') {
     die('This script supports command line usage only. Please check your command.');
 }
 
-$finder = PhpCsFixer\Finder::create()
+$finder = Finder::create()
     ->name('*.php')
     ->in([
         __DIR__ . '/../../packages/fgtclb/',
@@ -52,8 +56,8 @@ LICENSE.txt file that was distributed with this source code.
 The TYPO3 project - inspiring people to share!
 COMMENT;
 
-return (new \PhpCsFixer\Config())
-    ->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(false)
     ->setRules([
         'no_extra_blank_lines' => true,

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -1,5 +1,8 @@
 <?php
 
+use SBUERK\AvailableFixturePackages;
+use TYPO3\TestingFramework\Core\Testbase;
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -12,7 +15,6 @@
  *
  * The TYPO3 project - inspiring people to share!
  */
-
 /**
  * Boilerplate for a functional test phpunit boostrap file.
  *
@@ -30,8 +32,8 @@
      * allow composer package name or extension keys of fixture extension in
      * {@see \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase::$testExtensionToLoad}.
      */
-    if (class_exists(\SBUERK\AvailableFixturePackages::class)) {
-        $adopter = (new \SBUERK\AvailableFixturePackages());
+    if (class_exists(AvailableFixturePackages::class)) {
+        $adopter = (new AvailableFixturePackages());
         /**
          * Property {@see \SBUERK\AvailableFixturePackages::$dataFile} contains an invalid path,
          * missing one slash to separate vendor name from the data file and failing to read the
@@ -51,7 +53,7 @@
         $adopter->adoptFixtureExtensions();
     }
 
-    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase = new Testbase();
     $testbase->defineOriginalRootPath();
     //var_dump(getenv('TYPO3_PATH_ROOT'));var_dump(getenv('TYPO3_PATH_WEB'));var_dump(ORIGINAL_ROOT);die();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -23,7 +23,7 @@
  * This file is defined in FunctionalTests.xml and called by phpunit
  * before instantiating the test suites.
  */
-(static function () {
+(static function (): void {
     /**
      * Automatically add fixture extensions to the `typo3/testing-framework`
      * {@see \TYPO3\TestingFramework\Composer\ComposerPackageManager} to

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -27,7 +27,7 @@
  * according script within TYPO3 core's Build/Scripts directory and
  * adapt to extensions needs.
  */
-(static function () {
+(static function (): void {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,5 +1,17 @@
 <?php
 
+use TYPO3\TestingFramework\Core\Testbase;
+use TYPO3\TestingFramework\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Configuration\ConfigurationManager;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Package\UnitTestPackageManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -12,7 +24,6 @@
  *
  * The TYPO3 project - inspiring people to share!
  */
-
 /**
  * Boilerplate for a unit test phpunit boostrap file.
  *
@@ -28,7 +39,7 @@
  * adapt to extensions needs.
  */
 (static function (): void {
-    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase = new Testbase();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
     // not create the autoload-include.php file that sets these env vars and sets composer
@@ -53,38 +64,38 @@
     // @todo: Remove else branch when dropping support for v12
     $hasConsolidatedHttpEntryPoint = class_exists(CoreHttpApplication::class);
     if ($hasConsolidatedHttpEntryPoint) {
-        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI, $composerMode);
+        SystemEnvironmentBuilder::run(0, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI, $composerMode);
     } else {
         $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+        SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
     }
 
-    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
-    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
-    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
-    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+    $testbase->createDirectory(Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(Environment::getPublicPath() . '/typo3temp/var/transient');
 
     // Retrieve an instance of class loader and inject to core bootstrap
     $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
-    \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+    Bootstrap::initializeClassLoader($classLoader);
 
     // Initialize default TYPO3_CONF_VARS
-    $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+    $configurationManager = new ConfigurationManager();
     $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
 
-    $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+    $cache = new PhpFrontend(
         'core',
-        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+        new NullBackend('production', [])
     );
-    $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(
-        \TYPO3\CMS\Core\Package\UnitTestPackageManager::class,
-        \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache)
+    $packageManager = Bootstrap::createPackageManager(
+        UnitTestPackageManager::class,
+        Bootstrap::createPackageCache($cache)
     );
 
-    \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+    GeneralUtility::setSingletonInstance(PackageManager::class, $packageManager);
+    ExtensionManagementUtility::setPackageManager($packageManager);
 
     $testbase->dumpClassLoadingInformation();
 
-    \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+    GeneralUtility::purgeInstances();
 })();

--- a/packages/fgtclb/academic-bite-jobs/Configuration/Icons.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/Icons.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
 return [
     'bitejobs_list' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_bite_jobs/Resources/Public/Icons/jobs_bite_icon.svg',
     ],
 ];

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/sys_template.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/sys_template.php
@@ -1,8 +1,10 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 defined('TYPO3') || die();
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+ExtensionManagementUtility::addStaticFile(
     'academic_bite_jobs',
     'Configuration/TypoScript',
     'Academic Bite Jobs'

--- a/packages/fgtclb/academic-contact4pages/Configuration/Services.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/Services.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return function (ContainerConfigurator $containerConfigurator) {
+return function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator
         ->services()
         ->defaults()

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
@@ -1,5 +1,8 @@
 <?php
 
+use FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContactLabels;
+use FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContractItemsProcFunc;
+
 if (!defined('TYPO3')) {
     die('Not authorized');
 }
@@ -8,7 +11,7 @@ return [
     'ctrl' => [
         'title' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact',
         'label' => 'uid',
-        'label_userFunc' => \FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContactLabels::class . '->getTitle',
+        'label_userFunc' => ContactLabels::class . '->getTitle',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
@@ -69,7 +72,7 @@ return [
                         'value' => 0,
                     ],
                 ],
-                'itemsProcFunc' => FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContractItemsProcFunc::class . '->itemsProcFunc',
+                'itemsProcFunc' => ContractItemsProcFunc::class . '->itemsProcFunc',
                 'minitems' => 1,
                 'default' => 0,
             ],

--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Controller;
 
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use FGTCLB\AcademicJobs\DateTime\IsoDateTime;
 use FGTCLB\AcademicJobs\Domain\Model\Job;
 use FGTCLB\AcademicJobs\Domain\Repository\JobRepository;
@@ -84,7 +85,7 @@ class JobController extends ActionController
     }
 
     /**
-     * @param \TYPO3\CMS\Extbase\Domain\Model\FileReference|null $imageObject
+     * @param FileReference|null $imageObject
      */
     public function getImageUri($imageObject): ?string
     {

--- a/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
+++ b/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Domain\Model;
 
+use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -15,13 +16,13 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Job extends AbstractEntity
 {
     /**
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected string $title;
 
     /**
      * @var \DateTime
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected $employmentStartDate;
 
@@ -33,7 +34,7 @@ class Job extends AbstractEntity
     protected ?FileReference $image = null;
 
     /**
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected string $companyName;
 
@@ -51,7 +52,7 @@ class Job extends AbstractEntity
      * employmentType
      *
      * @var int
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected int $employmentType;
 
@@ -69,13 +70,13 @@ class Job extends AbstractEntity
 
     /**
      * @var \DateTime
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected $starttime;
 
     /**
      * @var \DateTime
-     * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
+     * @Validate("NotEmpty")
      */
     protected $endtime;
 

--- a/packages/fgtclb/academic-jobs/Configuration/Extbase/Persistence/Classes.php
+++ b/packages/fgtclb/academic-jobs/Configuration/Extbase/Persistence/Classes.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicJobs\Domain\Model\Job;
+use FGTCLB\AcademicJobs\Domain\Model\Contact;
+
 return [
-    \FGTCLB\AcademicJobs\Domain\Model\Job::class => [
+    Job::class => [
         'tableName' => 'tx_academicjobs_domain_model_job',
-        'recordType' => \FGTCLB\AcademicJobs\Domain\Model\Job::class,
+        'recordType' => Job::class,
     ],
-    \FGTCLB\AcademicJobs\Domain\Model\Contact::class => [
+    Contact::class => [
         'tableName' => 'tx_academicjobs_domain_model_contact',
-        'recordType' => \FGTCLB\AcademicJobs\Domain\Model\Contact::class,
+        'recordType' => Contact::class,
     ],
 ];

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/sys_template.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/sys_template.php
@@ -1,8 +1,10 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 defined('TYPO3') || die();
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+ExtensionManagementUtility::addStaticFile(
     'academic_jobs',
     'Configuration/TypoScript',
     'Academic Jobs'

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -1,24 +1,28 @@
 <?php
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 if (!defined('TYPO3')) {
     die('Not authorized');
 }
 
 (static function (): void {
-    $typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
+    ExtensionUtility::registerPlugin(
         'AcademicJobs',
         'NewJobForm',
         'Academic Jobs: New Job Form',
         'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg'
     );
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    ExtensionUtility::registerPlugin(
         'AcademicJobs',
         'List',
         'Academic Jobs: List Jobs',
         'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg'
     );
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    ExtensionUtility::registerPlugin(
         'AcademicJobs',
         'Detail',
         'Academic Jobs: Detail',
@@ -31,11 +35,11 @@ if (!defined('TYPO3')) {
     $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_list'] = 'pi_flexform';
     $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_newjobform'] = 'pi_flexform';
 
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    ExtensionManagementUtility::addPiFlexFormValue(
         'academicjobs_list',
         sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/PluginList.xml', $typo3MajorVersion)
     );
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    ExtensionManagementUtility::addPiFlexFormValue(
         'academicjobs_newjobform',
         sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/Plugin_NewJobForm.xml', $typo3MajorVersion)
     );

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicPartners\Backend\FormEngine\CountryItems;
 use FGTCLB\AcademicPartners\Enumeration\PageTypes;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -120,7 +121,7 @@ defined('TYPO3') or die;
                         'value' => '',
                     ],
                 ],
-                'itemsProcFunc' => FGTCLB\AcademicPartners\Backend\FormEngine\CountryItems::class . '->itemsProcFunc',
+                'itemsProcFunc' => CountryItems::class . '->itemsProcFunc',
             ],
         ],
         'address_additional' => [

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
-    $typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+    $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
     ExtensionManagementUtility::addTcaSelectItemGroup(
         'tt_content',
         'CType',

--- a/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -14,9 +14,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-partners',
     ];
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPartners\Tests\Functional\CategoryTypes;
 
+use PHPUnit\Framework\Attributes\Test;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -14,7 +15,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-partners',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-partners/ext_localconf.php
+++ b/packages/fgtclb/academic-partners/ext_localconf.php
@@ -15,12 +15,12 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     // Starting with TYPO3 v13.0 Configuration/user.tsconfig in an Extension is automatically loaded during build time
     // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101807-ExtensionManagementUtilityaddUserTSConfig.html
     if ($versionInformation->getMajorVersion() < 13) {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
+        ExtensionManagementUtility::addUserTSConfig('
             @import \'EXT:academic_partners/Configuration/user.tsconfig\'
         ');
     }
 
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+    ExtensionUtility::configurePlugin(
         'AcademicPartners',
         'List',
         [

--- a/packages/fgtclb/academic-persons-edit/Configuration/Extbase/Persistence/Classes.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Fgtclb\AcademicPersonsEdit\Domain\Model\Profile;
+use Fgtclb\AcademicPersonsEdit\Domain\Model\Address;
+use Fgtclb\AcademicPersonsEdit\Domain\Model\FrontendUser;
+use Fgtclb\AcademicPersonsEdit\Domain\Model\Location;
+
 /*
  * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
  *
@@ -10,16 +15,16 @@ declare(strict_types=1);
  */
 
 return [
-    \Fgtclb\AcademicPersonsEdit\Domain\Model\Profile::class => [
+    Profile::class => [
         'tableName' => 'tx_academicpersons_domain_model_profile',
     ],
-    \Fgtclb\AcademicPersonsEdit\Domain\Model\Address::class => [
+    Address::class => [
         'tableName' => 'tx_academicpersons_domain_model_address',
     ],
-    \Fgtclb\AcademicPersonsEdit\Domain\Model\FrontendUser::class => [
+    FrontendUser::class => [
         'tableName' => 'fe_users',
     ],
-    \Fgtclb\AcademicPersonsEdit\Domain\Model\Location::class => [
+    Location::class => [
         'tableName' => 'tx_academicpersons_domain_model_location',
     ],
 ];

--- a/packages/fgtclb/academic-persons-edit/Configuration/Icons.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/Icons.php
@@ -1,15 +1,16 @@
 <?php
 
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
 /*
  * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-
 return [
     'persons_edit_icon' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons_edit/Resources/Public/Icons/persons_edit_icon.svg',
     ],
 ];

--- a/packages/fgtclb/academic-persons-edit/Configuration/RequestMiddlewares.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/RequestMiddlewares.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Fgtclb\AcademicPersonsEdit\Middleware\ProfileLoader;
+
 /*
  * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
  *
@@ -12,7 +14,7 @@ declare(strict_types=1);
 return [
     'frontend' => [
         'fgtclb/academic-persons-edit/profile-loader' => [
-            'target' => \Fgtclb\AcademicPersonsEdit\Middleware\ProfileLoader::class,
+            'target' => ProfileLoader::class,
             'after' => [
                 'typo3/cms-frontend/authentication',
                 'typo3/cms-frontend/prepare-tsfe-rendering',

--- a/packages/fgtclb/academic-persons-edit/Configuration/Services.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/Services.php
@@ -15,6 +15,6 @@ use Fgtclb\AcademicPersonsEdit\Profile\ProfileFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
+return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder): void {
     $containerBuilder->registerForAutoconfiguration(ProfileFactoryInterface::class)->setPublic(true);
 };

--- a/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/sys_template.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/sys_template.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 /*
  * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
  *
@@ -9,7 +11,7 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+ExtensionManagementUtility::addStaticFile(
     'academic_persons_edit',
     'Configuration/TypoScript/',
     'Academic Persons Edit Settings'

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Context/ProfileAspectTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Context/ProfileAspectTest.php
@@ -11,14 +11,16 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersonsEdit\Tests\Unit\Context;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Fgtclb\AcademicPersonsEdit\Context\ProfileAspect;
 use TYPO3\CMS\Core\Context\Exception\AspectPropertyNotFoundException;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
-#[\PHPUnit\Framework\Attributes\CoversClass(\Fgtclb\AcademicPersonsEdit\Context\ProfileAspect::class)]
+#[CoversClass(ProfileAspect::class)]
 class ProfileAspectTest extends UnitTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function emptyProfileUidsWillResultInNotHavingProfile(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -26,7 +28,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertFalse($subject->get('hasProfile'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function givenProfileUidsWillResultInHavingProfile(): void
     {
         $subject = new ProfileAspect([1], 1);
@@ -34,7 +36,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertTrue($subject->get('hasProfile'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function emptyProfileUidsWillReturnEmptyArray(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -42,7 +44,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame([], $subject->get('allProfileUids'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function givenProfileUidsWillReturnUids(): void
     {
         $subject = new ProfileAspect([1, 2], 1);
@@ -50,7 +52,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame([1, 2], $subject->get('allProfileUids'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function emptyProfileUidsAndGivenActiveProfileUidWillReturnZero(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -58,7 +60,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(0, $subject->get('activeProfileUid'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function givenProfileUidsAndGivenActiveProfileUidWillReturnActiveProfileUid(): void
     {
         $subject = new ProfileAspect([1], 1);
@@ -66,7 +68,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(1, $subject->get('activeProfileUid'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function givenProfileUidsAndNoActiveProfileUidWillReturnZero(): void
     {
         $subject = new ProfileAspect([1], 0);
@@ -74,7 +76,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(0, $subject->get('activeProfileUid'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gettingInvalidValueWillResultInException(): void
     {
         $subject = new ProfileAspect([1], 1);

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Context/ProfileAspectTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Context/ProfileAspectTest.php
@@ -15,14 +15,10 @@ use Fgtclb\AcademicPersonsEdit\Context\ProfileAspect;
 use TYPO3\CMS\Core\Context\Exception\AspectPropertyNotFoundException;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
-/**
- * @covers \Fgtclb\AcademicPersonsEdit\Context\ProfileAspect
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(\Fgtclb\AcademicPersonsEdit\Context\ProfileAspect::class)]
 class ProfileAspectTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function emptyProfileUidsWillResultInNotHavingProfile(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -30,9 +26,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertFalse($subject->get('hasProfile'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function givenProfileUidsWillResultInHavingProfile(): void
     {
         $subject = new ProfileAspect([1], 1);
@@ -40,9 +34,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertTrue($subject->get('hasProfile'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function emptyProfileUidsWillReturnEmptyArray(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -50,9 +42,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame([], $subject->get('allProfileUids'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function givenProfileUidsWillReturnUids(): void
     {
         $subject = new ProfileAspect([1, 2], 1);
@@ -60,9 +50,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame([1, 2], $subject->get('allProfileUids'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function emptyProfileUidsAndGivenActiveProfileUidWillReturnZero(): void
     {
         $subject = new ProfileAspect([], 1);
@@ -70,9 +58,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(0, $subject->get('activeProfileUid'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function givenProfileUidsAndGivenActiveProfileUidWillReturnActiveProfileUid(): void
     {
         $subject = new ProfileAspect([1], 1);
@@ -80,9 +66,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(1, $subject->get('activeProfileUid'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function givenProfileUidsAndNoActiveProfileUidWillReturnZero(): void
     {
         $subject = new ProfileAspect([1], 0);
@@ -90,9 +74,7 @@ class ProfileAspectTest extends UnitTestCase
         $this->assertSame(0, $subject->get('activeProfileUid'));
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function gettingInvalidValueWillResultInException(): void
     {
         $subject = new ProfileAspect([1], 1);

--- a/packages/fgtclb/academic-persons-sync/Configuration/Extbase/Persistence/Classes.php
+++ b/packages/fgtclb/academic-persons-sync/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Fgtclb\AcademicPersonsSync\Domain\Model\FrontendUser;
+
 /*
  * This file is part of the "academic_persons_sync" Extension for TYPO3 CMS.
  *
@@ -10,7 +12,7 @@ declare(strict_types=1);
  */
 
 return [
-    \Fgtclb\AcademicPersonsSync\Domain\Model\FrontendUser::class => [
+    FrontendUser::class => [
         'tableName' => 'fe_users',
     ],
 ];

--- a/packages/fgtclb/academic-persons-sync/Configuration/TCA/Overrides/fe_users.php
+++ b/packages/fgtclb/academic-persons-sync/Configuration/TCA/Overrides/fe_users.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 /*
  * This file is part of the "academic_persons_sync" Extension for TYPO3 CMS.
  *
@@ -9,7 +11,7 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
+ExtensionManagementUtility::addTcaSelectItem(
     'fe_users',
     'tx_extbase_type',
     [

--- a/packages/fgtclb/academic-persons/Configuration/Extbase/Persistence/Classes.php
+++ b/packages/fgtclb/academic-persons/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+use Fgtclb\AcademicPersons\Domain\Model\Address;
+use Fgtclb\AcademicPersons\Domain\Model\Contract;
+use Fgtclb\AcademicPersons\Domain\Model\Email;
+use Fgtclb\AcademicPersons\Domain\Model\FunctionType;
+use Fgtclb\AcademicPersons\Domain\Model\Location;
+use Fgtclb\AcademicPersons\Domain\Model\OrganisationalUnit;
+use Fgtclb\AcademicPersons\Domain\Model\PhoneNumber;
+use Fgtclb\AcademicPersons\Domain\Model\Profile;
+use Fgtclb\AcademicPersons\Domain\Model\ProfileInformation;
+
 /*
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
@@ -10,56 +20,56 @@ declare(strict_types=1);
  */
 
 return [
-    \Fgtclb\AcademicPersons\Domain\Model\Address::class => [
+    Address::class => [
         'tableName' => 'tx_academicpersons_domain_model_address',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\Address::class,
+        'recordType' => Address::class,
         'properties' => [
             'employeeType' => [
                 'fieldName' => 'employee_type',
             ],
         ],
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\Contract::class => [
+    Contract::class => [
         'tableName' => 'tx_academicpersons_domain_model_contract',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\Contract::class,
+        'recordType' => Contract::class,
         'properties' => [
             'employeeType' => [
                 'fieldName' => 'employee_type',
             ],
         ],
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\Email::class => [
+    Email::class => [
         'tableName' => 'tx_academicpersons_domain_model_email',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\Email::class,
+        'recordType' => Email::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\FunctionType::class => [
+    FunctionType::class => [
         'tableName' => 'tx_academicpersons_domain_model_function_type',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\FunctionType::class,
+        'recordType' => FunctionType::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\Location::class => [
+    Location::class => [
         'tableName' => 'tx_academicpersons_domain_model_location',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\Location::class,
+        'recordType' => Location::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\OrganisationalUnit::class => [
+    OrganisationalUnit::class => [
         'tableName' => 'tx_academicpersons_domain_model_organisational_unit',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\OrganisationalUnit::class,
+        'recordType' => OrganisationalUnit::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\PhoneNumber::class => [
+    PhoneNumber::class => [
         'tableName' => 'tx_academicpersons_domain_model_phone_number',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\PhoneNumber::class,
+        'recordType' => PhoneNumber::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\Profile::class => [
+    Profile::class => [
         'tableName' => 'tx_academicpersons_domain_model_profile',
-        'recordType' => \Fgtclb\AcademicPersons\Domain\Model\Profile::class,
+        'recordType' => Profile::class,
     ],
-    \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class => [
+    ProfileInformation::class => [
         'tableName' => 'tx_academicpersons_domain_model_profile_information',
         'subclasses' => [
-            'curriculum_vitae' => \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class,
-            'membership' => \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class,
-            'cooperation' => \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class,
-            'publication' => \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class,
-            'lecture' => \Fgtclb\AcademicPersons\Domain\Model\ProfileInformation::class,
+            'curriculum_vitae' => ProfileInformation::class,
+            'membership' => ProfileInformation::class,
+            'cooperation' => ProfileInformation::class,
+            'publication' => ProfileInformation::class,
+            'lecture' => ProfileInformation::class,
         ],
     ],
 ];

--- a/packages/fgtclb/academic-persons/Configuration/Icons.php
+++ b/packages/fgtclb/academic-persons/Configuration/Icons.php
@@ -1,51 +1,52 @@
 <?php
 
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
 /*
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-
 return [
     'tx_academicpersons_domain_model_address' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_address.svg',
     ],
     'tx_academicpersons_domain_model_contract' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_contract.svg',
     ],
     'tx_academicpersons_domain_model_email' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_email.svg',
     ],
     'tx_academicpersons_domain_model_function_type' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_function_type.svg',
     ],
     'tx_academicpersons_domain_model_organisational_unit' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_organisational_unit.svg',
     ],
     'tx_academicpersons_domain_model_phone_number' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_phone_number.svg',
     ],
     'tx_academicpersons_domain_model_profile' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_profile.svg',
     ],
     'tx_academicpersons_domain_model_location' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_location.svg',
     ],
     'tx_academicpersons_domain_model_profile_information' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/tx_academicpersons_domain_model_profile_information.svg',
     ],
     'persons_icon' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/persons_icon.svg',
     ],
 ];

--- a/packages/fgtclb/academic-persons/Configuration/Services.php
+++ b/packages/fgtclb/academic-persons/Configuration/Services.php
@@ -16,7 +16,7 @@ use Fgtclb\AcademicPersons\Types\TypesInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
+return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder): void {
     $containerBuilder->registerForAutoconfiguration(TypesInterface::class)->setPublic(true);
     $containerBuilder->registerForAutoconfiguration(DemandValuesInterface::class)->setPublic(true);
 };

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+use Fgtclb\AcademicPersons\Tca\RecordTypes;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 
@@ -173,7 +176,7 @@ return [
                         $selectValueKey => '',
                     ],
                 ],
-                'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getPhysicalAddressTypes',
+                'itemsProcFunc' => RecordTypes::class . '->getPhysicalAddressTypes',
             ],
         ],
     ],

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+use Fgtclb\AcademicPersons\Tca\ContractLabels;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 
@@ -16,7 +19,7 @@ return [
     'ctrl' => [
         'title' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_contract.ctrl.label',
         'label' => 'profile',
-        'label_userFunc' => \Fgtclb\AcademicPersons\Tca\ContractLabels::class . '->getTitle',
+        'label_userFunc' => ContractLabels::class . '->getTitle',
         'default_sortby' => 'sorting',
         'hideTable' => true,
         'origUid' => 't3_origuid',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+use Fgtclb\AcademicPersons\Tca\RecordTypes;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 return [
@@ -107,7 +110,7 @@ return [
                         $selectValueKey => '',
                     ],
                 ],
-                'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getEmailAddressTypes',
+                'itemsProcFunc' => RecordTypes::class . '->getEmailAddressTypes',
             ],
         ],
     ],

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_location.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_location.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 return [

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+use Fgtclb\AcademicPersons\Tca\RecordTypes;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 
@@ -110,7 +113,7 @@ return [
                         $selectValueKey => '',
                     ],
                 ],
-                'itemsProcFunc' => \Fgtclb\AcademicPersons\Tca\RecordTypes::class . '->getPhoneNumberTypes',
+                'itemsProcFunc' => RecordTypes::class . '->getPhoneNumberTypes',
             ],
         ],
     ],

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
+
 /**
  * This file is part of the "academic_persons" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-$typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+$typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
 $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Hook;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,7 +47,7 @@ class DataHandlerHooksTest extends FunctionalTestCase
         $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function insertingNewRecordWillGenerateAndSaveAlphaFieldValues(): void
     {
         $dataMap = [
@@ -69,7 +70,7 @@ class DataHandlerHooksTest extends FunctionalTestCase
         $this->assertSame('d', $records[1]['last_name_alpha']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updatingRecordWillGenerateAndSaveNewAlphaFieldValues(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/MinimumProfile.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
@@ -46,9 +46,7 @@ class DataHandlerHooksTest extends FunctionalTestCase
         $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function insertingNewRecordWillGenerateAndSaveAlphaFieldValues(): void
     {
         $dataMap = [
@@ -71,9 +69,7 @@ class DataHandlerHooksTest extends FunctionalTestCase
         $this->assertSame('d', $records[1]['last_name_alpha']);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function updatingRecordWillGenerateAndSaveNewAlphaFieldValues(): void
     {
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/MinimumProfile.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
@@ -43,7 +45,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         'SC_OPTIONS' => [
             'Core/TypoScript/TemplateService' => [
                 'runThroughTemplatesPostProcessing' => [
-                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                    'FunctionalTest' => TypoScriptInstructionModifier::class . '->apply',
                 ],
             ],
         ],
@@ -87,7 +89,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageDisplayProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv');
@@ -118,7 +120,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedDisplaysLocalizedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv');
@@ -150,7 +152,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
@@ -186,7 +188,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
     /**
      * @todo Really ?
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageStrict(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
@@ -87,9 +87,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageDisplayProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv');
@@ -120,9 +118,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedDisplaysLocalizedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv');
@@ -154,9 +150,7 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
@@ -190,9 +184,9 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
     }
 
     /**
-     * @test
      * @todo Really ?
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageStrict(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -44,7 +46,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         'SC_OPTIONS' => [
             'Core/TypoScript/TemplateService' => [
                 'runThroughTemplatesPostProcessing' => [
-                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                    'FunctionalTest' => TypoScriptInstructionModifier::class . '->apply',
                 ],
             ],
         ],
@@ -88,7 +90,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaysAllProfiles(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
@@ -112,7 +114,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(2): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageDisplayProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
@@ -144,7 +146,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaySingleSelectedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -168,7 +170,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv');
@@ -192,7 +194,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedDisplaysLocalizedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -225,7 +227,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
@@ -258,7 +260,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -283,7 +285,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -308,7 +310,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -333,7 +335,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -358,7 +360,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -383,7 +385,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
@@ -414,7 +416,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
      * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
      *       test for v12 when enabling it again.
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
         if ((new Typo3Version())->getMajorVersion() >= 12) {
@@ -444,7 +446,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -471,7 +473,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -88,9 +88,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaysAllProfiles(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
@@ -114,9 +112,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(2): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageDisplayProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
@@ -148,9 +144,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaySingleSelectedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -174,9 +168,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv');
@@ -200,9 +192,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedDisplaysLocalizedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -235,9 +225,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function localizedPagesAndTtContentWithNotLocalizedProfileDisplayDefaultLanguageWhenLanguageFallback(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
@@ -270,9 +258,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -297,9 +283,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
@@ -324,9 +308,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -351,12 +333,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Horst Huber', $content);
     }
 
-    /**
-     * @test
-     *
-     * Cover `fallbackForNonTranslated` option introduced with https://github.com/fgtclb/academic-persons/pull/30 to
-     * have an option to get default language profiles for non-translated profiled when siteLanguage is in strict mode.
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -381,9 +358,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -408,9 +383,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
@@ -438,10 +411,10 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
     }
 
     /**
-     * @test
      * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
      *       test for v12 when enabling it again.
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
         if ((new Typo3Version())->getMajorVersion() >= 12) {
@@ -471,9 +444,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -500,9 +471,7 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -44,7 +46,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         'SC_OPTIONS' => [
             'Core/TypoScript/TemplateService' => [
                 'runThroughTemplatesPostProcessing' => [
-                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                    'FunctionalTest' => TypoScriptInstructionModifier::class . '->apply',
                 ],
             ],
         ],
@@ -88,7 +90,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaysAllProfiles(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv');
@@ -112,7 +114,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(2): Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaySingleSelectedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -136,7 +138,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv');
@@ -160,7 +162,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
@@ -185,7 +187,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
@@ -210,7 +212,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -235,7 +237,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -260,7 +262,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -285,7 +287,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
@@ -316,7 +318,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
      * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
      *       test for v12 when enabling it again.
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
         if ((new Typo3Version())->getMajorVersion() >= 12) {
@@ -346,7 +348,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -373,7 +375,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -88,9 +88,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaysAllProfiles(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv');
@@ -114,9 +112,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(2): Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaySingleSelectedProfile(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -140,9 +136,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageListDisplaysSelectedProfilesInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv');
@@ -166,9 +160,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysDefaultLanguageProfilesForRequestedDefaultLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
@@ -193,9 +185,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedProfilesForRequestedLanguage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
@@ -220,9 +210,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -247,12 +235,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Horst Huber', $content);
     }
 
-    /**
-     * @test
-     *
-     * Cover `fallbackForNonTranslated` option introduced with https://github.com/fgtclb/academic-persons/pull/30 to
-     * have an option to get default language profiles for non-translated profiled when siteLanguage is in strict mode.
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysOnlyLocalizedProfilesForRequestedLanguageWithNotAllProfilesLocalizedInStrictModeWithFallbackForNonTranslatedSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -277,9 +260,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedPagesAndTtContentListDisplaysLocalizedProfileAndDefaultLanguageProfileForRequestedLanguageWithNotAllProfilesLocalizedInFallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
@@ -304,9 +285,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrder(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
@@ -334,10 +313,10 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
     }
 
     /**
-     * @test
      * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
      *       test for v12 when enabling it again.
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
         if ((new Typo3Version())->getMajorVersion() >= 12) {
@@ -367,9 +346,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalizedButPluginFallbackSet(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
@@ -396,9 +373,7 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -87,9 +87,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         );
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageOnly_allContractsSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv');
@@ -113,9 +111,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringContainsString('#1(1): Worker', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageOnly_oneContractSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv');
@@ -139,9 +135,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('Worker', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_allContractsSelected_allContractsLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv');
@@ -169,9 +163,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('[EN] Worker', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_allContractsSelected_notAllContractsLocalized_strictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
@@ -198,9 +190,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('[EN] Worker', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
@@ -43,7 +45,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         'SC_OPTIONS' => [
             'Core/TypoScript/TemplateService' => [
                 'runThroughTemplatesPostProcessing' => [
-                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                    'FunctionalTest' => TypoScriptInstructionModifier::class . '->apply',
                 ],
             ],
         ],
@@ -87,7 +89,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageOnly_allContractsSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv');
@@ -111,7 +113,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringContainsString('#1(1): Worker', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageOnly_oneContractSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv');
@@ -135,7 +137,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('Worker', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_allContractsSelected_allContractsLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv');
@@ -163,7 +165,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('[EN] Worker', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_allContractsSelected_notAllContractsLocalized_strictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
@@ -190,7 +192,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
         $this->assertStringNotContainsString('[EN] Worker', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -87,9 +87,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageOnly_allProfilesSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv');
@@ -113,9 +111,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function defaultLanguageOnly_oneProfileSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -139,9 +135,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_allProfilesSelected_allProfilesLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv');
@@ -169,9 +163,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_allProfilesSelected_notAllProfilesLocalized_strictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
@@ -198,9 +190,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
@@ -43,7 +45,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         'SC_OPTIONS' => [
             'Core/TypoScript/TemplateService' => [
                 'runThroughTemplatesPostProcessing' => [
-                    'FunctionalTest' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook\TypoScriptInstructionModifier::class . '->apply',
+                    'FunctionalTest' => TypoScriptInstructionModifier::class . '->apply',
                 ],
             ],
         ],
@@ -87,7 +89,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageOnly_allProfilesSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv');
@@ -111,7 +113,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function defaultLanguageOnly_oneProfileSelected(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv');
@@ -135,7 +137,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_allProfilesSelected_allProfilesLocalized(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv');
@@ -163,7 +165,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_allProfilesSelected_notAllProfilesLocalized_strictMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
@@ -190,7 +192,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');

--- a/packages/fgtclb/academic-persons/ext_localconf.php
+++ b/packages/fgtclb/academic-persons/ext_localconf.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */
-
+use Fgtclb\AcademicPersons\Hook\DataHandlerHooks;
 use Fgtclb\AcademicPersons\Controller\ProfileController;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
@@ -83,5 +83,5 @@ defined('TYPO3') or die;
     );
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['academicPersons']
-        = \Fgtclb\AcademicPersons\Hook\DataHandlerHooks::class;
+        = DataHandlerHooks::class;
 })();

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -81,9 +81,7 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         return $options;

--- a/packages/fgtclb/academic-programs/Configuration/Icons.php
+++ b/packages/fgtclb/academic-programs/Configuration/Icons.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
 return [
     'academic-programs' => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_programs/Resources/Public/Icons/Extension.svg',
     ],
 ];

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
-    $typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+    $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
     ExtensionManagementUtility::addTcaSelectItemGroup(
         'tt_content',
         'CType',

--- a/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -14,9 +14,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-programs',
     ];
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPrograms\Tests\Functional\CategoryTypes;
 
+use PHPUnit\Framework\Attributes\Test;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -14,7 +15,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-programs',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -81,9 +81,7 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         return $options;

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
-    $typo3MajorVersion = (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+    $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
 
     // ------------------------------------------------------------------------
     // Add custom content element group for acadmic plugins

--- a/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -18,9 +18,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-projects',
     ];
 
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\Tests\Functional\CategoryTypes;
 
+use PHPUnit\Framework\Attributes\Test;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -18,7 +19,7 @@ final class CategoryTypesTest extends FunctionalTestCase
         'fgtclb/academic-projects',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {
         /** @var CategoryTypeRegistry $categoryTypeRegistry */

--- a/packages/fgtclb/academic-projects/ext_localconf.php
+++ b/packages/fgtclb/academic-projects/ext_localconf.php
@@ -1,11 +1,13 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use FGTCLB\AcademicProjects\Controller\ProjectController;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 (static function (): void {
-    $versionInformation = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
 
     // Starting with TYPO3 v13.0 Configuration/user.tsconfig in an Extension is automatically loaded during build time
     // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101807-ExtensionManagementUtilityaddUserTSConfig.html

--- a/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @implements \Iterator<int, Category>
  * @todo Only "offsetGet" implemented, consider to change from array access to ContainerInterface (get/has only).
  */
-class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
+class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \Stringable
 {
     /**
      * @var Category[]
@@ -184,7 +184,6 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
 
     /**
      * ArrayAccess method offsetExists
-     * @param mixed $offset
      * @return bool
      */
     public function offsetExists(mixed $offset): bool
@@ -198,7 +197,6 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
 
     /**
      * ArrayAccess method offsetGet
-     * @param mixed $offset
      * @return Category[]|false
      */
     public function offsetGet(mixed $offset): array|false
@@ -211,8 +209,6 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
 
     /**
      * ArrayAccess method offsetSet is not implemented
-     * @param mixed $offset
-     * @param mixed $value
      */
     public function offsetSet(mixed $offset, mixed $value): void
     {
@@ -224,7 +220,6 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess
 
     /**
      * ArrayAccess method offsetUnset is not implemented
-     * @param mixed $offset
      */
     public function offsetUnset(mixed $offset): void
     {

--- a/packages/fgtclb/typo3-category-types/Classes/Collection/FilterCollection.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Collection/FilterCollection.php
@@ -11,9 +11,9 @@ use FGTCLB\CategoryTypes\Domain\Model\Category;
  * @implements ArrayAccess<string, Category[]>
  * @todo Only "offsetGet" implemented, consider to change from array access to ContainerInterface (get/has only).
  */
-class FilterCollection implements \ArrayAccess
+class FilterCollection implements \ArrayAccess, \Stringable
 {
-    private CategoryCollection $filterCategories;
+    private readonly CategoryCollection $filterCategories;
 
     public function __construct(
         ?CategoryCollection $categoryCollection = null,
@@ -36,7 +36,6 @@ class FilterCollection implements \ArrayAccess
     }
 
     /**
-     * @param mixed $offset
      * @return array<int, Category>|false
      */
     public function offsetGet(mixed $offset): array|false

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/Category.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/Category.php
@@ -9,7 +9,7 @@ use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class Category
+class Category implements \Stringable
 {
     protected ?CategoryType $type;
     protected ?CategoryCollection $children = null;

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\CategoryTypes\Domain\Model;
 
-class CategoryType implements \JsonSerializable
+class CategoryType implements \JsonSerializable, \Stringable
 {
     public function __construct(
         private readonly string $identifier,

--- a/packages/fgtclb/typo3-category-types/Classes/ServiceProvider.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ServiceProvider.php
@@ -39,7 +39,7 @@ class ServiceProvider extends AbstractServiceProvider
 
     public static function addIcons(ContainerInterface $container): \Closure
     {
-        return static function (BootCompletedEvent $event) use ($container) {
+        return static function (BootCompletedEvent $event) use ($container): void {
             $iconRegistry = $container->get(IconRegistry::class);
 
             $categoryTypeRegistry = $container->get(CategoryTypeRegistry::class);

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -182,10 +182,9 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     /**
      * Get the option value for an object
      *
-     * @param mixed $valueElement
      * @return string
      */
-    protected function getOptionValueScalar($valueElement)
+    protected function getOptionValueScalar(mixed $valueElement)
     {
         if (is_object($valueElement)) {
             if ($this->hasArgument('optionValueField')) {
@@ -219,7 +218,7 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
      * @param mixed $value Value to check for
      * @return bool TRUE if the value should be marked a s selected; FALSE otherwise
      */
-    protected function isSelected($value)
+    protected function isSelected(mixed $value)
     {
         if (in_array((string)$value, $this->selectedValues)) {
             return true;

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -42,9 +42,7 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
         }
 
         if ($this->arguments['sortByOptionLabel'] !== false) {
-            usort($options, function ($a, $b) {
-                return strcoll($a['label'], $b['label']);
-            });
+            usort($options, fn($a, $b) => strcoll((string)$a['label'], (string)$b['label']));
         }
 
         if ($this->arguments['groupByParent'] !== false) {

--- a/packages/fgtclb/typo3-category-types/Configuration/TCA/Overrides/sys_category.php
+++ b/packages/fgtclb/typo3-category-types/Configuration/TCA/Overrides/sys_category.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -47,12 +49,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
         ],
     ];
 
-    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
+    ArrayUtility::mergeRecursiveWithOverrule(
         $GLOBALS['TCA']['sys_category'],
         $sysCategoryTca
     );
 
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    ExtensionManagementUtility::addToAllTCAtypes(
         'sys_category',
         'type',
         '',

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
@@ -9,9 +9,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class CategoryCollectionTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function canBeCreatedUsingNew(): void
     {
         $subject = new CategoryCollection();

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace FGTCLB\CategoryTypes\Tests\Unit\Collection;
 
+use PHPUnit\Framework\Attributes\Test;
 use FGTCLB\CategoryTypes\Collection\CategoryCollection;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class CategoryCollectionTest extends UnitTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function canBeCreatedUsingNew(): void
     {
         $subject = new CategoryCollection();


### PR DESCRIPTION
- **[TASK] Streamline code base**
  This change streamlines the code base towards PHP 8.1
  as minimum version using newer language syntax, for
  example readonly properties where possible, adding
  type declarations instead of annotations and so on.
  

- **[TASK] Change phpunit annotation with PHP attributes**
  Switch to the newer PHP Attributes for PHPUnit
  declarations.
  

- **[TASK] Streamline PHP namespace handling**
  This change streamlines the whole code base related
  to PHP Namespace handling, which includes:
  
  * Adding namespace imports for long namespaces (use statements),
    excluding short (root) namespaces (global namespace).
  * Import PHPDoc namespaces and replace with short variants to allow
    proper cross linking in IDE's like PHPStorm.
  * Remove unused namespace imports.
  