### PR TITLE
[TASK] Add upgrade wizard for renamed plugin of `contacts4pages`

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
@@ -32,6 +32,8 @@ class ContactsProcessor implements DataProcessorInterface
         $contactRepository = GeneralUtility::makeInstance(ContactRepository::class);
         $contacts = $contactRepository->findByPid($currentRecordUid);
 
+        $processedData['contacts'] = $contacts;
+
         $roles = [];
         foreach ($contacts as $contact) {
             $role = $contact->getRole();

--- a/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Upgrades;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+#[UpgradeWizard('academicContact4pages_pluginUpgradeWizard')]
+final class PluginUpgradeWizard implements UpgradeWizardInterface
+{
+    private const MIGRATE_CONTENT_TYPES_LIST = [
+        'academiccontact4pages_contactslist' => 'academiccontacts4pages_list',
+    ];
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    public function getTitle(): string
+    {
+        return 'Migrate academic_contacts4pages plugins from "academiccontact4pages_contactslist" to "academiccontacts4pages_list".';
+    }
+
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function executeUpdate(): bool
+    {
+        foreach (self::MIGRATE_CONTENT_TYPES_LIST as $oldName => $newName) {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+            $queryBuilder->getRestrictions()->removeAll();
+            $queryBuilder->update('tt_content')
+                ->set('CType', $newName)
+                ->where(
+                    $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter($oldName))
+                )->executeStatement();
+        }
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+        return (bool)$queryBuilder
+            ->count('uid')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'list_type',
+                    $queryBuilder->quoteArrayBasedValueListToStringList(array_keys(self::MIGRATE_CONTENT_TYPES_LIST))
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+}


### PR DESCRIPTION
This pull-requests provides the missing TYPO3 UpgradeWizard
for the renamed `EXT:academic_contacts4pages` plugin completed
with pull-request #60 .

Readding missing context data full-filled by related `DataProcessor`
is done as a side-change, masked as TASK albeit fixing a bug.