### PR TITLE
[TASK] Allow budget field to be nullable

### DIFF
--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
@@ -109,6 +109,7 @@ if (!defined('TYPO3')) {
             'config' => [
                 'type' => 'number',
                 'format' => 'decimal',
+                'nullable' => true,
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],


### PR DESCRIPTION
Due to the fields database registration in ext_tables.sql the budget field is set to be NULL by default. Whenever a page is copied, this field is processed by the DataHandler to set a correct value in the database. When trying to resolve the value the DataHandler crashes because it can't preg_replace on NULL (see https://github.com/TYPO3/typo3/blob/45a64eb0329655690ec087fceb0bf60c250e60ff/typo3/sysext/core/Classes/DataHandling/DataHandler.php#L1564).

Therefore either the DEFAULT value in ext_tables.sql needs to be changed to 0 or the field is "nullable" which converts the NULL value to an empty string. The number field type probably cannot be NULL by default, which is why the issue is occurring. It was decided to add the nullable checkbox to the field to still be able to differentiate between no value set and the actual value 0.