### PR TITLE
[TASK] Remove TYPO3 v11 content object compat in `contacts4pages`

### DIFF
--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
 
 		-
-			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Configuration\\\\ConfigurationManagerInterface\\:\\:getContentObject\\(\\)\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
-
-		-
 			message: "#^Parameter \\#1 \\$pid of method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php


### PR DESCRIPTION
The `EXT:academic_contacts4pages` extension still contains some
TYPO3 v11 compatibility code branches, which are no longer needed.

This change removes the old way to retrieve the content object by
dropping the conditional TYPO3 v11 branch from the controller. [1]

Makes one PHPStan error ignorePattern obsolete for TYPO3 v13 and
is removed in the same step.

Used command(s):

```shell
Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate \
&& Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstanGenerateBaseline
```


[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100662-ConfigurationManager-getContentObject.html
