### PR TITLE
[TASK] Use cgl check mode with TYPO3 v13

### DIFF
--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -50,7 +50,7 @@ jobs:
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "CGL"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
 
 # @todo Disable until correct file header has been determined for extensions.
 #      - name: "CGL (header comments)"


### PR DESCRIPTION
It is essential to execute the `cgl` check based on
the `php-cs-fixer` in dry-run mode, controlled with
the `-n` flag of `Build/Scripts/runTests.sh` to get
failing error code when cgl fixes should be applied.

This has been missed, and for TYPO3 v12 already added
in recent change. Let's make the same change for TYPO3
v13 to have a double check in place.
