### PR TITLE
[TASK] Remove vanished `cruser_id` from TCA

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
@@ -14,7 +14,6 @@ return [
         'label_userFunc' => ContactLabels::class . '->getTitle',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'origUid' => 't3_origuid',
         'sortby' => 'sorting',

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_role.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_role.php
@@ -10,7 +10,6 @@ return [
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',


### PR DESCRIPTION
The `cruser_id` setting and field for TCA managed tables
has been removed breaking in TYPO3 v12.0 and setting TCA
ctrl section option leads to automatic TCA migration and
emits `E_USER_DEPRECATED` notices. [1]

No need to keep it in anyway, remove it.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98024-TCA-option-cruserid-removed.html
