### PR TITLE
[TASK] Mitigate removed FAL related behaviour for `TCA type=inline`

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -38,8 +38,6 @@ if (!defined('TYPO3')) {
                             'localize' => true,
                         ],
                         'showPossibleRecordsSelector' => false,
-                        'fileUploadAllowed' => false,
-                        'fileByUrlAllowed' => false,
                         'elementBrowserEnabled' => false,
                     ],
                     'enableCascadingDelete' => true,

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
@@ -37,8 +37,6 @@ if (!defined('TYPO3')) {
                             'localize' => true,
                         ],
                         'showPossibleRecordsSelector' => false,
-                        'fileUploadAllowed' => false,
-                        'fileByUrlAllowed' => false,
                         'elementBrowserEnabled' => false,
                         'newRecordLinkTitle' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button',
                     ],


### PR DESCRIPTION
TYPO3 v12 removed some FAL related behaviour TCA settings
for TCA type=inline, providing automatic TCA migration and
emitting `E_USER_DEPRECATED` errors.

Since TYPO3 v12 is the minimal supported TYPO3 version,
related TCA configuration are now dropped aggordingly
to the TYPO3 changelog entry [1].

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98479-RemovedFileReferenceRelatedFunctionality.html
