### PR TITLE
[TASK] Mitigate extension scanner matches in `academic-projects`

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -1,21 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Variable \\$biteJobsService on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
-
-		-
-			message: "#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
-
-		-
-			message: "#^Variable \\$requestFactory on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
-
-		-
 			message: "#^Parameter \\#1 \\$pid of method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,26 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Variable \\$biteJobsService on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
-
-		-
-			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Configuration\\\\ConfigurationManager\\:\\:getContentObject\\(\\)\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
-
-		-
-			message: "#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
-
-		-
-			message: "#^Variable \\$requestFactory on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php
-
-		-
 			message: "#^Parameter \\#1 \\$pid of method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php

--- a/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
+++ b/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
@@ -6,20 +6,18 @@ namespace FGTCLB\AcademicBiteJobs\Controller;
 
 use FGTCLB\AcademicBiteJobs\Services\BiteJobsService;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class BiteJobsController extends ActionController
 {
-    protected BiteJobsService $biteJobsService;
-    public function __construct(BiteJobsService $biteJobsService)
-    {
-        $this->biteJobsService = $biteJobsService ?? GeneralUtility::makeInstance(BiteJobsService::class);
-    }
+    public function __construct(
+        protected readonly BiteJobsService $biteJobsService
+    ) {}
+
     public function listAction(): ResponseInterface
     {
         $this->view->assignMultiple([
-            'jobs' => $this->biteJobsService->fetchBiteJobs(),
+            'jobs' => $this->biteJobsService->fetchBiteJobs($this->request),
             'jobRelations' => $this->biteJobsService->findCustomjobRelations(),
         ]);
 

--- a/packages/fgtclb/academic-partners/Classes/Controller/PartnerController.php
+++ b/packages/fgtclb/academic-partners/Classes/Controller/PartnerController.php
@@ -25,8 +25,8 @@ class PartnerController extends ActionController
      */
     public function listAction(?array $demand = null): ResponseInterface
     {
-        /** @var array<string, mixed> */
-        $contentElementData = $this->getContentObject()?->data ?? [];
+        /** @var array<string, mixed> $contentElementData */
+        $contentElementData = $this->getCurrentContentObjectRenderer()?->data ?? [];
         $demandObject = $this->partnerDemandFactory->createDemandObject(
             $demand,
             $this->settings,
@@ -46,7 +46,7 @@ class PartnerController extends ActionController
         return $this->htmlResponse();
     }
 
-    private function getContentObject(): ?ContentObjectRenderer
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->request->getAttribute('currentContentObject');
     }

--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -113,7 +113,7 @@ final class ProfileController extends ActionController
         }
 
         $this->view->assignMultiple([
-            'data' => $this->getContentObject()?->data,
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profiles' => $profiles,
             'demand' => $demand,
         ]);
@@ -156,7 +156,7 @@ final class ProfileController extends ActionController
         // @todo Add enforced sorting based on selected uid's order, similar to listAction/selectedProfilesAction ?
 
         $this->view->assignMultiple([
-            'data' => $this->getContentObject()?->data,
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profiles' => $profiles,
         ]);
 
@@ -218,7 +218,7 @@ final class ProfileController extends ActionController
         }
 
         $this->view->assignMultiple([
-            'data' => $this->getContentObject()?->data,
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profiles' => $sortedProfiles,
         ]);
 
@@ -250,7 +250,7 @@ final class ProfileController extends ActionController
         }
 
         $this->view->assignMultiple([
-            'data' => $this->getContentObject()?->data,
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'contracts' => $sortedContracts,
         ]);
 
@@ -282,7 +282,8 @@ final class ProfileController extends ActionController
             }
         }
 
-        $contentObjectData = $this->getContentObject()?->data;
+        /** @var array<string, mixed> $contentObjectData */
+        $contentObjectData = $this->getCurrentContentObjectRenderer()?->data;
         $hasStoragePids = (
             is_array($contentObjectData)
             && !empty($contentObjectData['pages'])
@@ -320,7 +321,7 @@ final class ProfileController extends ActionController
     {
         // @todo Remove if-block when dropping `typo3/cms-*` v12 support
         if (!class_exists(CacheDataCollector::class)) {
-            $this->getContentObject()?->getTypoScriptFrontendController()?->addCacheTags($tags);
+            $this->getCurrentContentObjectRenderer()?->getTypoScriptFrontendController()?->addCacheTags($tags);
             return;
         }
         // TYPO3 v13+
@@ -330,7 +331,7 @@ final class ProfileController extends ActionController
         }
     }
 
-    private function getContentObject(): ?ContentObjectRenderer
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->request->getAttribute('currentContentObject');
     }

--- a/packages/fgtclb/academic-programs/Classes/Controller/DetailsController.php
+++ b/packages/fgtclb/academic-programs/Classes/Controller/DetailsController.php
@@ -22,7 +22,8 @@ class DetailsController extends ActionController
      */
     public function showAction(): ResponseInterface
     {
-        $contentElementData = $this->getContentObject()?->data ?? [];
+        /** @var array<string, mixed> $contentElementData */
+        $contentElementData = $this->getCurrentContentObjectRenderer()?->data ?? [];
         $program = $this->programRepository->findByUid((int)($contentElementData['pid'] ?? 0));
 
         $this->view->assignMultiple([
@@ -33,7 +34,7 @@ class DetailsController extends ActionController
         return $this->htmlResponse();
     }
 
-    private function getContentObject(): ?ContentObjectRenderer
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->request->getAttribute('currentContentObject');
     }

--- a/packages/fgtclb/academic-programs/Classes/Controller/ProgramController.php
+++ b/packages/fgtclb/academic-programs/Classes/Controller/ProgramController.php
@@ -25,8 +25,8 @@ class ProgramController extends ActionController
      */
     public function listAction(?array $demand = null): ResponseInterface
     {
-        /** @var array<string, mixed> */
-        $contentElementData = $this->getContentObject()?->data ?? [];
+        /** @var array<string, mixed> $contentElementData */
+        $contentElementData = $this->getCurrentContentObjectRenderer()?->data ?? [];
         $demandObject = $this->programDemandFactory->createDemandObject(
             $demand,
             $this->settings,
@@ -46,7 +46,7 @@ class ProgramController extends ActionController
         return $this->htmlResponse();
     }
 
-    private function getContentObject(): ?ContentObjectRenderer
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->request->getAttribute('currentContentObject');
     }

--- a/packages/fgtclb/academic-projects/Classes/Controller/ProjectController.php
+++ b/packages/fgtclb/academic-projects/Classes/Controller/ProjectController.php
@@ -25,8 +25,8 @@ class ProjectController extends ActionController
      */
     public function listAction(?array $demand = null): ResponseInterface
     {
-        /** @var array<string, mixed> */
-        $contentElementData = $this->getContentObject()?->data ?? [];
+        /** @var array<string, mixed> $contentElementData */
+        $contentElementData = $this->getCurrentContentObjectRenderer()?->data ?? [];
         $demandObject = $this->demandFactory->createDemandObject(
             $demand,
             $this->settings,
@@ -48,7 +48,7 @@ class ProjectController extends ActionController
         return $this->htmlResponse();
     }
 
-    private function getContentObject(): ?ContentObjectRenderer
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->request->getAttribute('currentContentObject');
     }


### PR DESCRIPTION
During the upgrade towards new TYPO3 version support, the
retrieval of the current object renderer has been aligned
multiple times and capsulated into a dedicate method. The
name is picked up by the extension leading to fals-positives,
which may be disturbing to consumers.

This change replaces these places by using a method name
not picked up by the extension scanner and allows us to
remove more PHPStan error ignore patterns from the baseline.

Used command(s):

```shell
Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s cgl \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstanGenerateBaseline \
; Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate \
; Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstanGenerateBaseline \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate
```

