### PR TITLE
[TASK] Replace removed `$GLOBALS['PAGES_TYPES']`

### DIFF
--- a/packages/fgtclb/academic-partners/ext_tables.php
+++ b/packages/fgtclb/academic-partners/ext_tables.php
@@ -3,12 +3,12 @@
 defined('TYPO3') || die();
 
 use FGTCLB\AcademicPartners\Enumeration\PageTypes;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 (static function (): void {
-    $projectDokType = PageTypes::ACADEMIC_PARTNERS;
-
-    $GLOBALS['PAGES_TYPES'][$projectDokType] = [
-        'type' => 'web',
-        'allowedTables' => '*',
-    ];
+    GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+        ->add(PageTypes::ACADEMIC_PARTNERS, [
+            'allowedTables' => '*',
+        ]);
 })();

--- a/packages/fgtclb/academic-programs/ext_tables.php
+++ b/packages/fgtclb/academic-programs/ext_tables.php
@@ -1,12 +1,12 @@
 <?php
 
 use FGTCLB\AcademicPrograms\Enumeration\PageTypes;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 (static function (): void {
-    $studyProgrammeDokType = PageTypes::TYPE_ACADEMIC_PROGRAM;
-
-    $GLOBALS['PAGES_TYPES'][$studyProgrammeDokType] = [
-        'type' => 'web',
-        'allowedTables' => '*',
-    ];
+    GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+        ->add(PageTypes::TYPE_ACADEMIC_PROGRAM, [
+            'allowedTables' => '*',
+        ]);
 })();

--- a/packages/fgtclb/academic-projects/ext_tables.php
+++ b/packages/fgtclb/academic-projects/ext_tables.php
@@ -1,12 +1,12 @@
 <?php
 
 use FGTCLB\AcademicProjects\Enumeration\PageTypes;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 (static function (): void {
-    $projectDokType = PageTypes::TYPE_ACEDEMIC_PROJECT;
-
-    $GLOBALS['PAGES_TYPES'][$projectDokType] = [
-        'type' => 'web',
-        'allowedTables' => '*',
-    ];
+    GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+        ->add(PageTypes::TYPE_ACEDEMIC_PROJECT, [
+            'allowedTables' => '*',
+        ]);
 })();


### PR DESCRIPTION
TYPO3 v12.0 removed `$GLOBALS['PAGES_TYPES']` [1] in
favour of the new `PageDoktypeRegistry` [2] class.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98487-GLOBALSPAGES_TYPESRemoved.html
[2] https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/PageTypes/CreateNewPageType.html
