### PR TITLE
[!!!][TASK] Remove TYPO3 v11 related code from `academic-jobs`

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
 
 		-
-			message: "#^Method FGTCLB\\\\AcademicJobs\\\\Controller\\\\JobController\\:\\:addFlashMessageToQueue\\(\\) has parameter \\$severity with no type specified\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
 			message: "#^Parameter \\#1 \\$recordId of method FGTCLB\\\\AcademicJobs\\\\Controller\\\\JobController\\:\\:sendEmail\\(\\) expects int, int\\<1, max\\>\\|null given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -46,27 +46,7 @@ parameters:
 			path: ../../../packages/fgtclb/academic-contact4pages/ext_tables.php
 
 		-
-			message: "#^Access to undefined constant TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage\\:\\:ERROR\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
-			message: "#^Access to undefined constant TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage\\:\\:OK\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
-			message: "#^Access to undefined constant TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\FlashMessage\\:\\:WARNING\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
 			message: "#^Binary operation \"\\.\" between array\\<string, bool\\|string\\|null\\>\\|bool\\|string\\|null and Psr\\\\Http\\\\Message\\\\UriInterface results in an error\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
-			message: "#^Method FGTCLB\\\\AcademicJobs\\\\Controller\\\\JobController\\:\\:addFlashMessageToQueue\\(\\) has parameter \\$severity with no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
 

--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -12,7 +12,6 @@ use FGTCLB\AcademicJobs\Property\TypeConverter\JobAvatarImageUploadConverter;
 use FGTCLB\AcademicJobs\SaveForm\FlashMessageCreationMode;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
@@ -49,8 +48,7 @@ class JobController extends ActionController
             $this->addFlashMessage(
                 $this->translateAlert('job_not_found.body', 'Job not found.'),
                 '',
-                // @todo FlashMessage constants deprecated since TYPO3 v12 in favour of Native Enum.
-                (((new Typo3Version())->getMajorVersion() < 12) ? FlashMessage::ERROR : ContextualFeedbackSeverity::ERROR),
+                ContextualFeedbackSeverity::ERROR,
                 true
             );
             return $this->htmlResponse();
@@ -183,8 +181,7 @@ class JobController extends ActionController
             $this->addFlashMessage(
                 $this->translateAlert('job_not_created.body', 'Something went wrong.'),
                 $this->translateAlert('job_not_created.title', 'Job not created'),
-                // @todo FlashMessage constants deprecated since TYPO3 v12 in favour of Native Enum.
-                (((new Typo3Version())->getMajorVersion() < 12) ? FlashMessage::ERROR : ContextualFeedbackSeverity::ERROR),
+                ContextualFeedbackSeverity::ERROR,
                 true
             );
             $this->redirect('newJobForm');
@@ -246,16 +243,14 @@ class JobController extends ActionController
                 $this->addFlashMessageToQueue(
                     $this->translateAlert('job_created.body', 'Job created and email sent.'),
                     $this->translateAlert('job_created.title', 'Job created'),
-                    // @todo FlashMessage constants deprecated since TYPO3 v12 in favour of Native Enum.
-                    (((new Typo3Version())->getMajorVersion() < 12) ? FlashMessage::OK : ContextualFeedbackSeverity::OK),
+                    ContextualFeedbackSeverity::OK,
                     true
                 );
             } else {
                 $this->addFlashMessageToQueue(
                     $this->translateAlert('job_created_no_email.body', 'Job created, but email could not be sent.'),
                     $this->translateAlert('job_created_no_email.title', 'Job created'),
-                    // @todo FlashMessage constants deprecated since TYPO3 v12 in favour of Native Enum.
-                    (((new Typo3Version())->getMajorVersion() < 12) ? FlashMessage::WARNING : ContextualFeedbackSeverity::WARNING),
+                    ContextualFeedbackSeverity::WARNING,
                     true
                 );
             }
@@ -392,11 +387,11 @@ class JobController extends ActionController
     private function addFlashMessageToQueue(
         string $messageBody,
         string $messageTitle = '',
-        $severity = null,
+        ?ContextualFeedbackSeverity $severity = null,
         bool $storeInSession = true,
         ?string $queueIdentifier = null,
     ): void {
-        $severity ??= (((new Typo3Version())->getMajorVersion() < 12) ? FlashMessage::OK : ContextualFeedbackSeverity::OK);
+        $severity ??= ContextualFeedbackSeverity::OK;
         if ($queueIdentifier === null) {
             $this->addFlashMessage($messageBody, $messageTitle, $severity, $storeInSession);
             return;


### PR DESCRIPTION
TYPO3 v11 support has been dropped, remove some traces of
compatibility code not needed anymore and clean the house.

This change also allows us to get rid of a couple of phpstan
error ignore patterns in baseline for both TYPO3 versions.

Used command(s):

```shell
Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s cgl \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstanGenerateBaseline \
; Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate \
; Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstanGenerateBaseline \
; Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate
```
