### PR TITLE
[BUGFIX] Fix template errors in URL generation and pagination in `academic_persons`

### DIFF
--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/List/AlphabetPagination.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/List/AlphabetPagination.html
@@ -10,28 +10,26 @@
         <ul>
             <f:for each="{alphabets}" as="alphabet">
                 <li class="page-item">
-					<f:if condition="{demand.alphabetFilter} == {alphabet}">
-						<f:then>
-							<f:link.action
-								action="list"
-								arguments="{demand: '{alphabetFilter: \'{}\'}'}"
-								class="page-link active"
-								rel="nofollow"
-							>
-								<span>{alphabet -> f:format.case()}</span>
-							</f:link.action>
-						</f:then>
-						<f:else>
-							<f:link.action
-								action="list"
-								arguments="{demand: '{alphabetFilter: alphabet}'}"
-								class="page-link"
-								rel="nofollow"
-							>
-								<span>{alphabet -> f:format.case()}</span>
-							</f:link.action>
-						</f:else>
-					</f:if>
+                    <f:if condition="{demand.alphabetFilter} == {alphabet}">
+                        <f:then>
+                            <f:link.action
+                                arguments="{demand: '{alphabetFilter: \'{}\'}'}"
+                                class="page-link active"
+                                rel="nofollow"
+                            >
+                                <span>{alphabet -> f:format.case()}</span>
+                            </f:link.action>
+                        </f:then>
+                        <f:else>
+                            <f:link.action
+                                arguments="{demand: '{alphabetFilter: alphabet}'}"
+                                class="page-link"
+                                rel="nofollow"
+                            >
+                                <span>{alphabet -> f:format.case()}</span>
+                            </f:link.action>
+                        </f:else>
+                    </f:if>
                 </li>
             </f:for>
         </ul>

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/List/ListItem.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/List/ListItem.html
@@ -2,208 +2,215 @@
     data-namespace-typo3-fluid="true"
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<f:variable
-    name="targetPlugin"
-    value="{f:if(
-        condition: '{settings.detailPid} > 0 && {settings.detailPid} != {data.pid}',
-        then: 'Detail',
-        else: 'ListAndDetail'
-    )}"
-/>
-
-<li>
-    <f:link.action
-        pageUid="{settings.detailPid}"
-        action="detail"
-        pluginName="{targetPlugin}"
-        arguments="{profile: profile}"
-    >
-        {profile.firstName}
-        {f:if(condition: profile.middleName, then: ' {profile.middleName}')}
-        {profile.lastName}
-    </f:link.action>
-    <br>
-    <f:if condition="{profile.contracts}">
+    <f:if condition="{CType} = 'academicpersons_listanddetail'">
+        <f:then>
+            <f:variable
+                name="detailUri"
+                value="{f:uri.action(
+                    action: 'detail',
+                    arguments: {
+                        profile: profile
+                    }
+                )}"
+            />
+        </f:then>
+        <f:else>
+            <f:variable
+                name="detailUri"
+                value="{f:uri.action(
+                    pageUid: settings.detailPid,
+                    action: 'detail',
+                    arguments: {
+                        profile: profile
+                    }
+                )}"
+            />
+        </f:else>
+    </f:if>
+    <li>
+        <a href="{detailUri}">
+            {profile.firstName}
+            {f:if(condition: profile.middleName, then: ' {profile.middleName}')}
+            {profile.lastName}
+        </a>
+        <br>
+        <f:if condition="{profile.contracts}">
+            <f:for
+                each="{profile.contracts}"
+                as="contract"
+            >
+                <f:if condition="{settings.showFields}">
+                    <f:then>
+                        <f:render
+                            section="ContractSelected"
+                            arguments="{
+                                contract: contract,
+                                settings: settings
+                            }"
+                        />
+                    </f:then>
+                    <f:else>
+                        <f:render
+                            section="ContractFull"
+                            arguments="{
+                                contract: contract,
+                                settings: settings
+                            }"
+                        />
+                    </f:else>
+                </f:if>
+            </f:for>
+        </f:if>
+    </li>
+    <f:section name="ContractSelected">
         <f:for
-            each="{profile.contracts}"
-            as="contract"
+            each="{settings.showFields}"
+            as="showField"
         >
-            <f:if condition="{settings.showFields}">
-                <f:then>
-                    <f:render
-                        section="ContractSelected"
-                        arguments="{
-                            contract: contract,
-                            settings: settings
-                        }"
-                    />
-                </f:then>
-                <f:else>
-                    <f:render
-                        section="ContractFull"
-                        arguments="{
-                            contract: contract,
-                            settings: settings
-                        }"
-                    />
-                </f:else>
-            </f:if>
-        </f:for>
-    </f:if>
-</li>
-
-<f:section name="ContractSelected">
-    <f:for
-        each="{settings.showFields}"
-        as="showField"
-    >
-        <f:switch expression="{showField}">
-            <f:case value="contracts.position">
-                <f:if condition="{contract.position}">
-                    {contract.position}<br>
-                </f:if>
-            </f:case>
-            <f:case value="contracts.room">
-                <f:if condition="{contract.room}">
-                    {contract.room}<br>
-                </f:if>
-            </f:case>
-            <f:case value="contracts.officeHours">
-                <f:if condition="{contract.officeHours}">
-                    {contract.officeHours}<br>
-                </f:if>
-            </f:case>
-            <f:case value="contracts.emailAddresses">
-                <f:if condition="{contract.emailAddresses}">
-                    <strong>
-                    {f:translate(
-                        key: 'contracts.email',
-                        extensionName: 'academic_persons',
-                        default: 'Email'
-                    )}:
-                    </strong>
-                    <ul>
-                        <f:for as="item" each="{contract.emailAddresses}">
-                            <li>
-                                <f:link.email email="{item.email}" />
-                            </li>
-                        </f:for>
-                    </ul>
-                </f:if>
-            </f:case>
-            <f:case value="contracts.phoneNumbers">
-                <f:if condition="{contract.phoneNumbers}">
-                    <strong>
+            <f:switch expression="{showField}">
+                <f:case value="contracts.position">
+                    <f:if condition="{contract.position}">
+                        {contract.position}<br>
+                    </f:if>
+                </f:case>
+                <f:case value="contracts.room">
+                    <f:if condition="{contract.room}">
+                        {contract.room}<br>
+                    </f:if>
+                </f:case>
+                <f:case value="contracts.officeHours">
+                    <f:if condition="{contract.officeHours}">
+                        {contract.officeHours}<br>
+                    </f:if>
+                </f:case>
+                <f:case value="contracts.emailAddresses">
+                    <f:if condition="{contract.emailAddresses}">
+                        <strong>
                         {f:translate(
-                            key: 'contracts.phone',
+                            key: 'contracts.email',
                             extensionName: 'academic_persons',
-                            default: 'Phone'
+                            default: 'Email'
                         )}:
-                    </strong>
-                    <f:for as="item" each="{contract.phoneNumbers}">
-                        <a href="tel:{item.phone}">{item.phone}</a>
-                    </f:for>
-                </f:if>
-            </f:case>
-            <f:case value="contracts.physicalAddresses">
-                <f:if condition="{contract.physicalAddresses}">
-                    <strong>
-                        {f:translate(
-                            key: 'contracts.address',
-                            extensionName: 'academic_persons',
-                            default: 'Address'
-                        )}:
-                    </strong>
-                    <ul>
-                        <f:for as="item" each="{contract.physicalAddresses}">
-                            <li>
-                                <f:if condition="{item.zip} || {item.city}">
-                                    {item.zip} {item.city}
-                                </f:if>
-                                <f:if condition="{item.street} || {item.streetNumber}">
-                                    | {item.street} {item.streetNumber}
-                                </f:if>
-                                <f:if condition="{item.country}">
-                                    | {item.country}
-                                </f:if>
-                                <f:if condition="{item.state}">
-                                    | {item.state}
-                                </f:if>
-                            </li>
+                        </strong>
+                        <ul>
+                            <f:for as="item" each="{contract.emailAddresses}">
+                                <li>
+                                    <f:link.email email="{item.email}" />
+                                </li>
+                            </f:for>
+                        </ul>
+                    </f:if>
+                </f:case>
+                <f:case value="contracts.phoneNumbers">
+                    <f:if condition="{contract.phoneNumbers}">
+                        <strong>
+                            {f:translate(
+                                key: 'contracts.phone',
+                                extensionName: 'academic_persons',
+                                default: 'Phone'
+                            )}:
+                        </strong>
+                        <f:for as="item" each="{contract.phoneNumbers}">
+                            <a href="tel:{item.phone}">{item.phone}</a>
                         </f:for>
-                    </ul>
-                </f:if>
-            </f:case>
-        </f:switch>
-    </f:for>
-</f:section>
-
-<f:section name="ContractFull">
-    <f:if condition="{contract.position}">
-        {contract.position}<br>
-    </f:if>
-    <f:if condition="{contract.room}">
-        {contract.room}<br>
-    </f:if>
-    <f:if condition="{contract.officeHours}">
-        {contract.officeHours}<br>
-    </f:if>
-    <f:if condition="{contract.emailAddresses}">
-        <strong>
-        {f:translate(
-            key: 'contracts.email',
-            extensionName: 'academic_persons',
-            default: 'Email'
-        )}:
-        </strong>
-        <ul>
-            <f:for as="item" each="{contract.emailAddresses}">
-                <li>
-                    <f:link.email email="{item.email}" />
-                </li>
-            </f:for>
-        </ul>
-    </f:if>
-    <f:if condition="{contract.phoneNumbers}">
-        <strong>
-            {f:translate(
-                key: 'contracts.phone',
-                extensionName: 'academic_persons',
-                default: 'Phone'
-            )}:
-        </strong>
-        <f:for as="item" each="{contract.phoneNumbers}">
-            <a href="tel:{item.phone}">{item.phone}</a>
+                    </f:if>
+                </f:case>
+                <f:case value="contracts.physicalAddresses">
+                    <f:if condition="{contract.physicalAddresses}">
+                        <strong>
+                            {f:translate(
+                                key: 'contracts.address',
+                                extensionName: 'academic_persons',
+                                default: 'Address'
+                            )}:
+                        </strong>
+                        <ul>
+                            <f:for as="item" each="{contract.physicalAddresses}">
+                                <li>
+                                    <f:if condition="{item.zip} || {item.city}">
+                                        {item.zip} {item.city}
+                                    </f:if>
+                                    <f:if condition="{item.street} || {item.streetNumber}">
+                                        | {item.street} {item.streetNumber}
+                                    </f:if>
+                                    <f:if condition="{item.country}">
+                                        | {item.country}
+                                    </f:if>
+                                    <f:if condition="{item.state}">
+                                        | {item.state}
+                                    </f:if>
+                                </li>
+                            </f:for>
+                        </ul>
+                    </f:if>
+                </f:case>
+            </f:switch>
         </f:for>
-    </f:if>
-    <f:if condition="{contract.physicalAddresses}">
-        <strong>
+    </f:section>
+    <f:section name="ContractFull">
+        <f:if condition="{contract.position}">
+            {contract.position}<br>
+        </f:if>
+        <f:if condition="{contract.room}">
+            {contract.room}<br>
+        </f:if>
+        <f:if condition="{contract.officeHours}">
+            {contract.officeHours}<br>
+        </f:if>
+        <f:if condition="{contract.emailAddresses}">
+            <strong>
             {f:translate(
-                key: 'contracts.address',
+                key: 'contracts.email',
                 extensionName: 'academic_persons',
-                default: 'Address'
+                default: 'Email'
             )}:
-        </strong>
-        <ul>
-            <f:for as="item" each="{contract.physicalAddresses}">
-                <li>
-                    <f:if condition="{item.zip} || {item.city}">
-                        {item.zip} {item.city}
-                    </f:if>
-                    <f:if condition="{item.street} || {item.streetNumber}">
-                        | {item.street} {item.streetNumber}
-                    </f:if>
-                    <f:if condition="{item.country}">
-                        | {item.country}
-                    </f:if>
-                    <f:if condition="{item.state}">
-                        | {item.state}
-                    </f:if>
-                </li>
+            </strong>
+            <ul>
+                <f:for as="item" each="{contract.emailAddresses}">
+                    <li>
+                        <f:link.email email="{item.email}" />
+                    </li>
+                </f:for>
+            </ul>
+        </f:if>
+        <f:if condition="{contract.phoneNumbers}">
+            <strong>
+                {f:translate(
+                    key: 'contracts.phone',
+                    extensionName: 'academic_persons',
+                    default: 'Phone'
+                )}:
+            </strong>
+            <f:for as="item" each="{contract.phoneNumbers}">
+                <a href="tel:{item.phone}">{item.phone}</a>
             </f:for>
-        </ul>
-    </f:if>
-</f:section>
-
+        </f:if>
+        <f:if condition="{contract.physicalAddresses}">
+            <strong>
+                {f:translate(
+                    key: 'contracts.address',
+                    extensionName: 'academic_persons',
+                    default: 'Address'
+                )}:
+            </strong>
+            <ul>
+                <f:for as="item" each="{contract.physicalAddresses}">
+                    <li>
+                        <f:if condition="{item.zip} || {item.city}">
+                            {item.zip} {item.city}
+                        </f:if>
+                        <f:if condition="{item.street} || {item.streetNumber}">
+                            | {item.street} {item.streetNumber}
+                        </f:if>
+                        <f:if condition="{item.country}">
+                            | {item.country}
+                        </f:if>
+                        <f:if condition="{item.state}">
+                            | {item.state}
+                        </f:if>
+                    </li>
+                </f:for>
+            </ul>
+        </f:if>
+    </f:section>
 </html>

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/List/Pagination.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/List/Pagination.html
@@ -1,89 +1,85 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-<nav class="f3-widget-paginator">
-	<ul>
-		<f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
-			<li class="page-item first">
-				<f:link.action
-					action="{actionName}"
-					arguments="{demand: '{currentPage: 1}'}"
-					title="{f:translate(key:'widget.pagination.first', extensionName: 'fluid')}"
-					class="page-link"
-				>
-					<span>{f:translate(key:'widget.pagination.first', extensionName: 'fluid')}</span>
-				</f:link.action>
-			</li>
-
-			<li class="page-item previous">
-				<f:link.action
-					action="{actionName}"
-					arguments="{demand: '{currentPage: pagination.previousPageNumber}'}"
-					title="{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}"
-					class="page-link"
-				>
-					<span>{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}</span>
-				</f:link.action>
-			</li>
-		</f:if>
-
-		<f:if condition="{pagination.hasLessPages}">
-			<li class="page-item">
-				<span>…</span>
-			</li>
-		</f:if>
-
-		<f:for each="{pagination.allPageNumbers}" as="page">
-			<f:if condition="{page} == {paginator.currentPageNumber}">
-				<f:then>
-					<li class="page-item current">
-						<span>{page}</span>
-					</li>
-				</f:then>
-				<f:else>
-					<li class="page-item">
-						<f:link.action
-							action="{actionName}"
-							arguments="{demand: '{currentPage: page}'}"
-							class="page-link"
-						>
-							<span>{page}</span>
-						</f:link.action>
-					</li>
-				</f:else>
-			</f:if>
-		</f:for>
-
-		<f:if condition="{pagination.hasMorePages}">
-			<li class="page-item">
-				<span>…</span>
-			</li>
-		</f:if>
-
-		<f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
-			<li class="page-item next">
-				<f:link.action
-					action="{actionName}"
-					arguments="{demand: '{currentPage: pagination.nextPageNumber}'}"
-					title="{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}"
-					class="page-link"
-				>
-					<span>{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}</span>
-				</f:link.action>
-			</li>
-
-			<li class="page-item last">
-				<f:link.action
-					action="{actionName}"
-					arguments="{demand: '{currentPage: pagination.lastPageNumber}'}"
-					title="{f:translate(key:'widget.pagination.last', extensionName: 'fluid')}"
-					class="page-link"
-				>
-					<span>{f:translate(key:'widget.pagination.last', extensionName: 'fluid')}</span>
-				</f:link.action>
-			</li>
-		</f:if>
-	</ul>
-</nav>
-
+    <nav class="f3-widget-paginator">
+        <ul>
+            <f:comment><!-- Link to first page --></f:comment>
+            <f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
+                <li class="page-item first">
+                    <f:link.action
+                        arguments="{demand: '{currentPage: 1}'}"
+                        title="{f:translate(key:'widget.pagination.first', extensionName: 'fluid')}"
+                        class="page-link"
+                    >
+                        <span>{f:translate(key:'widget.pagination.first', extensionName: 'fluid')}</span>
+                    </f:link.action>
+                </li>
+                <f:comment><!-- Link to previous page --></f:comment>
+                <li class="page-item previous">
+                    <f:link.action
+                        arguments="{demand: '{currentPage: pagination.previousPageNumber}'}"
+                        title="{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}"
+                        class="page-link"
+                    >
+                        <span>{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}</span>
+                    </f:link.action>
+                </li>
+            </f:if>
+            <f:comment><!-- Ellipse --></f:comment>
+            <f:if condition="{pagination.hasLessPages}">
+                <li class="page-item">
+                    <span>…</span>
+                </li>
+            </f:if>
+            <f:comment><!-- Link to pages --></f:comment>
+            <f:for each="{pagination.allPageNumbers}" as="page">
+                <f:if condition="{page} == {paginator.currentPageNumber}">
+                    <f:then>
+                        <li class="page-item current">
+                            <span>{page}</span>
+                        </li>
+                    </f:then>
+                    <f:else>
+                        <li class="page-item">
+                            <f:link.action
+                                arguments="{demand: '{currentPage: page}'}"
+                                class="page-link"
+                            >
+                                <span>{page}</span>
+                            </f:link.action>
+                        </li>
+                    </f:else>
+                </f:if>
+            </f:for>
+            <f:comment><!-- Ellipse --></f:comment>
+            <f:if condition="{pagination.hasMorePages}">
+                <li class="page-item">
+                    <span>…</span>
+                </li>
+            </f:if>
+            <f:comment><!-- Link to next page --></f:comment>
+            <f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
+                <li class="page-item next">
+                    <f:link.action
+                        arguments="{demand: '{currentPage: pagination.nextPageNumber}'}"
+                        title="{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}"
+                        class="page-link"
+                    >
+                        <span>{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}</span>
+                    </f:link.action>
+                </li>
+                <f:comment><!-- Link to last page --></f:comment>
+                <li class="page-item last">
+                    <f:link.action
+                        arguments="{demand: '{currentPage: pagination.lastPageNumber}'}"
+                        title="{f:translate(key:'widget.pagination.last', extensionName: 'fluid')}"
+                        class="page-link"
+                    >
+                        <span>{f:translate(key:'widget.pagination.last', extensionName: 'fluid')}</span>
+                    </f:link.action>
+                </li>
+            </f:if>
+        </ul>
+    </nav>
 </html>

--- a/packages/fgtclb/academic-persons/Resources/Private/Templates/Profile/List.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Templates/Profile/List.html
@@ -1,61 +1,73 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-<div class="academic-persons-list">
-    <f:if condition="{settings.alphabetPaginationEnabled}">
-        <f:render partial="List/AlphabetPagination" arguments="{demand: demand}" />
+    <f:variable name="profilesToList" value="{profiles}" />
+    <f:if condition="{settings.paginationEnabled} && {paginator.paginatedItems}">
+        <f:variable name="profilesToList" value="{paginator.paginatedItems}" />
     </f:if>
-
-    <f:if condition="{profiles}">
-        <f:then>
-            <f:variable name="profilesToList" value="{profiles}" />
-
-            <f:if condition="{settings.paginationEnabled} && {pagination.paginator.paginatedItems}">
-                <f:variable name="profilesToList" value="{pagination.paginator.paginatedItems}" />
-            </f:if>
-
-            <f:if condition="{demand.groupBy}">
-                <f:then>
-                    <f:groupedFor as="groupedProfiles" groupBy="{demand.groupBy}" each="{profilesToList}">
-                        <h3>{groupKey -> f:format.case()}</h3>
-
+    <div class="academic-persons-list">
+        <f:if condition="{settings.alphabetPaginationEnabled}">
+            <f:render
+                partial="List/AlphabetPagination"
+                arguments="{demand: demand}"
+            />
+        </f:if>
+        <f:if condition="{profilesToList}">
+            <f:then>
+                <f:if condition="{demand.groupBy}">
+                    <f:then>
+                        <f:groupedFor
+                            as="groupedProfiles"
+                            groupBy="{demand.groupBy}"
+                            each="{profilesToList}"
+                        >
+                            <h3>{groupKey -> f:format.case()}</h3>
+                            <ul class="profile-list">
+                                <f:for each="{groupedProfiles}" as="profile">
+                                    <f:render
+                                        partial="List/ListItem"
+                                        arguments="{
+                                            profile: profile,
+                                            demand: demand,
+                                            settings: settings,
+                                            CType: data.CType
+                                        }"
+                                    />
+                                </f:for>
+                            </ul>
+                        </f:groupedFor>
+                    </f:then>
+                    <f:else>
                         <ul class="profile-list">
-                            <f:for each="{groupedProfiles}" as="profile">
+                            <f:for each="{profilesToList}" as="profile">
                                 <f:render
-									partial="List/ListItem"
-									arguments="{
-										profile: profile,
-										demand: demand,
-										settings: settings
-									}"
-								/>
+                                    partial="List/ListItem"
+                                    arguments="{
+                                        profile: profile,
+                                        demand: demand,
+                                        settings: settings,
+                                        CType: data.CType
+                                    }"
+                                />
                             </f:for>
                         </ul>
-                    </f:groupedFor>
-                </f:then>
-                <f:else>
-                    <ul class="profile-list">
-                        <f:for each="{profilesToList}" as="profile">
-                            <f:render
-								partial="List/ListItem"
-								arguments="{
-									profile: profile,
-									demand: demand,
-									settings: settings
-								}"
-							/>
-                        </f:for>
-                    </ul>
-                </f:else>
-            </f:if>
-
-            <f:if condition="{settings.paginationEnabled} && {pagination.paginator.paginatedItems}">
-                <f:render partial="List/Pagination" arguments="{paginator: paginator, pagination: pagination}" />
-            </f:if>
-        </f:then>
-        <f:else>
-            <p>{f:translate(key: 'list.noProfilesFound', extensionName: 'academic_persons')}</p>
-        </f:else>
-    </f:if>
-</div>
+                    </f:else>
+                </f:if>
+                <f:if condition="{settings.paginationEnabled} && {paginator.paginatedItems}">
+                    <f:render
+                        partial="List/Pagination"
+                        arguments="{
+                            demand: demand,
+                            paginator: paginator,
+                            pagination: pagination
+                        }"
+                    />
+                </f:if>
+            </f:then>
+            <f:else>
+                <p>{f:translate(key: 'list.noProfilesFound', extensionName: 'academic_persons')}</p>
+            </f:else>
+        </f:if>
+    </div>
 </html>


### PR DESCRIPTION
* Access paginated items from `QueryResultPaginator` instead from `SimplePagination`, which is supported by the Georg Ringer's `NumberedPagination` but not by the `SimplePagination`
* Generate detail link depending on the selected plugin instead of "guessing" it by checking other settings
* Inherit action argument in links from plugin instead of setting them explicitly
* Add comments to pagination
* Switch intendation from tabs to spaces