### PR TITLE
[BUGFIX] Adopt required contacts handling changes for TYPO3 requirements (`contacts4pages`)

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
 
 		-
-			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\QuerySettingsInterface\\:\\:setLanguageOverlayMode\\(\\)\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
-
-		-
 			message: "#^Method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
 
 		-
-			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\QuerySettingsInterface\\:\\:setLanguageOverlayMode\\(\\)\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
-
-		-
 			message: "#^Method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php

--- a/packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
@@ -6,8 +6,6 @@ namespace FGTCLB\AcademicContacts4pages\Domain\Repository;
 
 use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
 use TYPO3\CMS\Core\Context\LanguageAspect;
-use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -21,25 +19,18 @@ class ContactRepository extends Repository
      */
     public function findByPid(int $pid): QueryResultInterface
     {
-        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-
         $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
 
-        // With version TYPO3 v12.0 some the method setLanguageOverlayMode() is removed.
-        // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97926-ExtbaseQuerySettingsMethodsRemoved.html
-        if ($versionInformation->getMajorVersion() >= 12) {
-            $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
-            $changedLanguageAspect = new LanguageAspect(
-                $currentLanguageAspect->getId(),
-                $currentLanguageAspect->getContentId(),
-                LanguageAspect::OVERLAYS_ON,
-                $currentLanguageAspect->getFallbackChain()
-            );
-            $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
-        } else {
-            $query->getQuerySettings()->setLanguageOverlayMode(true);
-        }
+        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
+        $changedLanguageAspect = new LanguageAspect(
+            $currentLanguageAspect->getId(),
+            $currentLanguageAspect->getContentId(),
+            LanguageAspect::OVERLAYS_ON,
+            $currentLanguageAspect->getFallbackChain()
+        );
+        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $query->getQuerySettings()->setRespectStoragePage(false);
 
         $query->matching(
             $query->equals('page', $pid)

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -40,7 +40,9 @@ if (!defined('TYPO3')) {
                         'showPossibleRecordsSelector' => false,
                         'elementBrowserEnabled' => false,
                     ],
-                    'enableCascadingDelete' => true,
+                    'behavior' => [
+                        'enableCascadingDelete' => true,
+                    ],
                     'foreign_field' =>  'page',
                     'foreign_sortby' => 'sorting',
                     'foreign_table' => 'tx_academiccontacts4pages_domain_model_contact',

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
@@ -40,7 +40,9 @@ if (!defined('TYPO3')) {
                         'elementBrowserEnabled' => false,
                         'newRecordLinkTitle' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button',
                     ],
-                    'enableCascadingDelete' => true,
+                    'behavior' => [
+                        'enableCascadingDelete' => true,
+                    ],
                     'foreign_field' =>  'contract',
                     'foreign_sortby' => 'sorting',
                     'foreign_table' => 'tx_academiccontacts4pages_domain_model_contact',

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
@@ -12,6 +12,7 @@ return [
         'title' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact',
         'label' => 'uid',
         'label_userFunc' => ContactLabels::class . '->getTitle',
+        'hideTable' => true,
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'versioningWS' => true,
@@ -21,6 +22,10 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'languageField' => 'sys_language_uid',
+        'translationSource' => 'l10n_source',
         'typeicon_classes' => [
             'default' => 'tx_academiccontacts4pages_domain_model_contact',
         ],
@@ -34,12 +39,17 @@ return [
                 'page',
                 'contract',
                 'role',
+                'hidden',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                'sys_language_uid',
+                'l10n_parent',
             ]),
         ],
     ],
     'columns' => [
         'hidden' => [
             'exclude' => true,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
@@ -60,6 +70,7 @@ return [
         ],
         'contract' => [
             'exclude' => true,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.contract',
             'config' => [
                 'type' => 'select',
@@ -78,6 +89,7 @@ return [
         ],
         'role' => [
             'exclude' => false,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.role',
             'config' => [
                 'type' => 'select',
@@ -90,7 +102,7 @@ return [
                     ],
                 ],
                 'foreign_table' => 'tx_academiccontacts4pages_domain_model_role',
-                'foreign_table_where' => 'AND {#tx_academiccontacts4pages_domain_model_role}.{#sys_language_uid} = ###REC_FIELD_sys_language_uid### ORDER BY tx_academiccontacts4pages_domain_model_role.name ASC',
+                'foreign_table_where' => 'AND {#tx_academiccontacts4pages_domain_model_role}.{#sys_language_uid} = 0 ORDER BY tx_academiccontacts4pages_domain_model_role.name ASC',
                 'minitems' => 1,
                 'default' => 0,
             ],


### PR DESCRIPTION
All contact records are edited in the default language only, therefore
the loading of the contact records might not be very intuitive. The
data handler enforces a translation of inline records for which "l10n_mode"
is set to "exclude".

To keep this record in sync with the record in the default language, all
relevant contact fields must have set "l10n_mode" to "exclude", too. We
need an additional "page" field to store the relation between the page
and the contact records in the respective language.

Finally, the handling in the extbase repository adds the missing piece
to configure extbase towards proper language overlay handling combined  
with constraints based on backend selected record ids, which are always
in default language to mitigate side effects recieving records from the
database using `Extbase ORM`.

* Make records in the `tx_academiccontacts4pages_domain_model_contact`
  table translatable.
* Hide `tx_academiccontacts4pages_domain_model_contact` table in lits
  view as editing of contacts should only be done in the page properties.
* Exclude hidden, role and contract columns from translation.
* Show only records in default language in role selection.
* Ensure correct cascading delete setting for pages and contracts.