### PR TITLE
[BUGFIX] Use suiting translation keys in TCA   

### DIFF
--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -84,6 +84,7 @@ return [
             ],
         ],
         'profile' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.ctrl.label',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_tca.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_tca.xlf
@@ -172,6 +172,9 @@
             <trans-unit id="tx_academicpersons_domain_model_organisational_unit.ctrl.label">
                 <source>Organisational Unit</source>
             </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.contracts.label">
+                <source>Employee Contracts</source>
+            </trans-unit>
 
             <!-- Phone Numbers -->
 


### PR DESCRIPTION
`EXT:academic_persons` uses now correct localization    
key for contracts column TCA definition, and adds an
missing key for profile field in another TCA config.
