### PR TITLE
[BUGFIX] Use correct service namespace in `Services.yaml`

### DIFF
--- a/packages/fgtclb/academic-projects/Configuration/Services.yaml
+++ b/packages/fgtclb/academic-projects/Configuration/Services.yaml
@@ -11,7 +11,7 @@ services:
   FGTCLB\AcademicProjects\Domain\Repository\ProjectRepository:
     public: true
 
-  FGTCLB\AcademicPrograms\DataProcessing\ProjectProcessor:
+  FGTCLB\AcademicProjects\DataProcessing\ProjectProcessor:
     tags:
       - {
           name: 'data.processor',

--- a/packages/fgtclb/academic-projects/Configuration/TypoScript/Content/ContentLoad.typoscript
+++ b/packages/fgtclb/academic-projects/Configuration/TypoScript/Content/ContentLoad.typoscript
@@ -1,0 +1,6 @@
+styles.content {
+  getContent < styles.content.get
+  getContent {
+    select.where = {#colPos}=0
+  }
+}

--- a/packages/fgtclb/academic-projects/Configuration/TypoScript/setup.typoscript
+++ b/packages/fgtclb/academic-projects/Configuration/TypoScript/setup.typoscript
@@ -1,10 +1,5 @@
+@import 'EXT:academic_projects/Configuration/TypoScript/Content/'
 @import 'EXT:academic_projects/Configuration/TypoScript/Page/'
-
-plugin.tx_academicprojects {
-  features {
-    skipDefaultArguments = 1
-  }
-}
 
 plugin.tx_academicprojects {
   view {

--- a/packages/fgtclb/academic-projects/Resources/Private/Pages/AcademicProject.html
+++ b/packages/fgtclb/academic-projects/Resources/Private/Pages/AcademicProject.html
@@ -6,20 +6,76 @@
     <f:layout name="Default"/>
     <f:section name="Main">
         <section>
-            <h1>{project.title}</h1>
-            <h2>{project.projectTitle}</h2>
-            <h2>Project runtime</h2>
-            <p>{project.startDate -> f:format.date(format: '%m/%Y')}-{project.endDate -> f:format.date(format: '%m/%Y')}</p>
-            <h2>Project budget</h2>
-            <p>{project.budget -> f:format.currency(thousandsSeparator: '.', currencySign: 'EURO')}</p>
-            <h2>Project description</h2>
-            <f:format.raw>
-                {project.shortDescription}
-            </f:format.raw>
-            <h2>Project funders</h2>
-            <f:format.raw>
-                {project.funders}
-            </f:format.raw>
+            <f:comment><!-- The page title --></f:comment>
+            <h1>[PAGE TITLE] {project.title}</h1>
+        </section>
+        <hr />
+        <section>
+            <f:comment><!-- The project title --></f:comment>
+            <h2>[PROJECT TITLE] {project.projectTitle}</h2>
+        </section>
+        <hr />
+        <section>
+            <h2>[IMAGES]</h2>
+            <f:comment><!-- Provide images referenced in the media field by standard files data processor --></f:comment>
+            <f:if condition="{images}">
+                <f:then>
+                    <div class="row">
+                        <f:for
+                            each="{images}"
+                            as="image"
+                        >
+                            <f:image
+                                image="{image}"
+                                alt="{image.alternative}"
+                                title="{image.title}"
+                                style="width: 100%; height: auto;"
+                            />
+                        </f:for>
+                    </div>
+                </f:then>
+                <f:else>
+                    <p>No images found.</p>
+                </f:else>
+            </f:if>
+        </section>
+        <hr />
+        <section>
+            <f:comment><!-- The assigned categories grouped by type --></f:comment>
+            <h2>[CATEGORIES]</h2>
+            <aside>
+                <f:render
+                    partial="Categories"
+                    arguments="{_all}"
+                />
+            </aside>
+        </section>
+        <hr />
+        <section>
+            <f:comment><!-- Information from text fields added by the academic partners extension --></f:comment>
+            <h2>[INFO FROM PAGE PROPERTIES]</h2>
+            <div>
+                <h3>Project Runtime</h3>
+                {project.startDate -> f:format.date(format: '%m/%Y')}-{project.endDate -> f:format.date(format: '%m/%Y')}
+            </div>
+            <div>
+                <h3>Project Budget</h3>
+                {project.budget -> f:format.currency(thousandsSeparator: '.', currencySign: 'EURO')}
+            </div>
+            <div>
+                <h3>Project Description</h3>
+                {project.shortDescription -> f:format.raw()}
+            </div>
+            <div>
+                <h3>Project Funders</h3>
+                {project.funders -> f:format.raw()}
+            </div>
+        </section>
+        <hr />
+        <section>
+            <f:comment><!-- Render the content of colPos 0 --></f:comment>
+            <h2>[CONTENT]</h2>
+            <f:cObject typoscriptObjectPath="styles.content.getContent"/>
         </section>
     </f:section>
 </html>

--- a/packages/fgtclb/academic-projects/Resources/Private/Partials/Categories.html
+++ b/packages/fgtclb/academic-projects/Resources/Private/Partials/Categories.html
@@ -1,0 +1,51 @@
+<html
+    lang="en"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+    <f:if condition="{project.attributes}">
+        <f:then>
+            <f:variable
+                name="cateoriesByType"
+                value="{project.attributes.allCategoriesByType}"
+            />
+        </f:then>
+        <f:else>
+            <f:variable
+                name="cateoriesByType"
+                value="{project.categories.allCategoriesByType}"
+            />
+        </f:else>
+    </f:if>
+    <f:if condition="{cateoriesByType}">
+        <dl>
+            <f:for
+                each="{cateoriesByType}"
+                key="type"
+                as="categories"
+            >
+                <f:if condition="{categories}">
+                    <dt>
+                        <core:icon identifier="category_types.projects.{type}"/>
+                        {f:translate(
+                            key: 'sys_category.academic_projects.{type}',
+                            extensionName: 'academic_projects'
+                        )}:
+                    </dt>
+                    <dd>
+                        <f:for
+                            each="{categories}"
+                            as="category"
+                            iteration="categoryIteration"
+                        >
+                            {category.title}{f:if(
+                                condition="{categoryIteration.isLast} == false",
+                                then: ','
+                            )}
+                        </f:for>
+                    </dd>
+                </f:if>
+            </f:for>
+        </dl>
+    </f:if>
+</html>


### PR DESCRIPTION
This pull-request ensures that `EXT:academic_projects`
data processor works by using the correct namespace in
the `Services.yaml`, which has not been adjusted after
copy & pasting from another extension.

Minor tasks are done as dedicated changes around this,
mainly targeting deprecated stuff.



* Use correct service namespace in `Services.yaml`.
* Remove deprecated skipDefaultArguments setting
  in TS setup.
* Add TS configuration to load page content for
  default page template.
* Update project page template to display all
  project related data:
  * Add output for title, images, page properties
    and content elements.
  * Add categories partial to output assigned system
    catgeories in the page template.