### PR TITLE
[BUGFIX] Adopt required contacts handling changes for TYPO3 requirements

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
@@ -7,7 +7,6 @@ namespace FGTCLB\AcademicContacts4pages\Domain\Repository;
 use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -21,25 +20,24 @@ class ContactRepository extends Repository
      */
     public function findByPid(int $pid): QueryResultInterface
     {
-        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-
         $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
 
         // With version TYPO3 v12.0 some the method setLanguageOverlayMode() is removed.
         // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97926-ExtbaseQuerySettingsMethodsRemoved.html
-        if ($versionInformation->getMajorVersion() >= 12) {
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
             $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
             $changedLanguageAspect = new LanguageAspect(
-                $currentLanguageAspect->getId(),
-                $currentLanguageAspect->getContentId(),
-                LanguageAspect::OVERLAYS_ON,
-                $currentLanguageAspect->getFallbackChain()
-            );
+                    $currentLanguageAspect->getId(),
+                    $currentLanguageAspect->getContentId(),
+                    LanguageAspect::OVERLAYS_ON,
+                    $currentLanguageAspect->getFallbackChain()
+                );
             $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
         } else {
             $query->getQuerySettings()->setLanguageOverlayMode(true);
         }
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $query->getQuerySettings()->setRespectStoragePage(false);
 
         $query->matching(
             $query->equals('page', $pid)

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -42,6 +42,9 @@ if (!defined('TYPO3')) {
                     'fileByUrlAllowed' => false,
                     'elementBrowserEnabled' => false,
                 ],
+                'behavior' => [
+                    'enableCascadingDelete' => true,
+                ],
                 'enableCascadingDelete' => true,
                 'foreign_field' =>  'page',
                 'foreign_sortby' => 'sorting',

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tx_academicpersons_domain_model_contract.php
@@ -42,7 +42,9 @@ if (!defined('TYPO3')) {
                     'elementBrowserEnabled' => false,
                     'newRecordLinkTitle' => $ll('tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button'),
                 ],
-                'enableCascadingDelete' => true,
+                'behavior' => [
+                    'enableCascadingDelete' => true,
+                ],
                 'foreign_field' =>  'contract',
                 'foreign_sortby' => 'sorting',
                 'foreign_table' => 'tx_academiccontacts4pages_domain_model_contact',

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
@@ -9,6 +9,7 @@ return [
         'title' => $ll . 'tx_academiccontacts4pages_domain_model_contact',
         'label' => 'uid',
         'label_userFunc' => \FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContactLabels::class . '->getTitle',
+        'hideTable' => true,
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
@@ -19,6 +20,10 @@ return [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'languageField' => 'sys_language_uid',
+        'translationSource' => 'l10n_source',
         'typeicon_classes' => [
             'default' => 'tx_academiccontacts4pages_domain_model_contact',
         ],
@@ -34,12 +39,17 @@ return [
                 'page',
                 'contract',
                 'role',
+                'hidden',
+                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
+                'sys_language_uid',
+                'l10n_parent',
             ]),
         ],
     ],
     'columns' => [
         'hidden' => [
             'exclude' => true,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
@@ -60,21 +70,23 @@ return [
         ],
         'contract' => [
             'exclude' => true,
-            'label' => $ll . 'tx_academiccontacts4pages_domain_model_contact.contract',
+            'l10n_mode' => 'exclude',
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.contract',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
                     ['', 0],
                 ],
-                'itemsProcFunc' => FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContractItemsProcFunc::class . '->itemsProcFunc',
+                'itemsProcFunc' => \FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContractItemsProcFunc::class . '->itemsProcFunc',
                 'minitems' => 1,
                 'default' => 0,
             ],
         ],
         'role' => [
             'exclude' => false,
-            'label' => $ll . 'tx_academiccontacts4pages_domain_model_contact.role',
+            'l10n_mode' => 'exclude',
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.role',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -82,7 +94,7 @@ return [
                     ['', 0],
                 ],
                 'foreign_table' => 'tx_academiccontacts4pages_domain_model_role',
-                'foreign_table_where' => 'AND {#tx_academiccontacts4pages_domain_model_role}.{#sys_language_uid} = ###REC_FIELD_sys_language_uid### ORDER BY tx_academiccontacts4pages_domain_model_role.name ASC',
+                'foreign_table_where' => 'AND {#tx_academiccontacts4pages_domain_model_role}.{#sys_language_uid} = 0 ORDER BY tx_academiccontacts4pages_domain_model_role.name ASC',
                 'minitems' => 1,
                 'default' => 0,
             ],


### PR DESCRIPTION
All contact records are edited in the default language only, therefore
the loading of the contact records might not be very intuitive. The
data handler enforces a translation of inline records for which "l10n_mode"
is set to "exclude".

To keep this record in sync with the record in the default language, all
relevant contact fields must have set "l10n_mode" to "exclude", too. We
need an additional "page" field to store the relation between the page
and the contact records in the respective language.

Finally, the handling in the extbase repository adds the missing piece
to configure extbase towards proper language overlay handling combined
with constraints based on backend selected record ids, which are always
in default language to mitigate side effects recieving records from the
database using `Extbase ORM`.

* Make records in the `tx_academiccontacts4pages_domain_model_contact`
  table translatable.
* Hide `tx_academiccontacts4pages_domain_model_contact` table in lits
  view as editing of contacts should only be done in the page properties.
* Exclude hidden, role and contract columns from translation.
* Show only records in default language in role selection.
* Ensure correct cascading delete setting for pages and contracts.
