### PR TITLE
[BUGFIX] Display assigned hidden system categories in backend views

### DIFF
--- a/packages/fgtclb/academic-partners/Resources/Private/Backend/Partials/PageLayout/Doktype40.html
+++ b/packages/fgtclb/academic-partners/Resources/Private/Backend/Partials/PageLayout/Doktype40.html
@@ -6,7 +6,6 @@
     data-namespace-typo3-fluid="true"
 >
 <f:if condition="{context.pageRecord.doktype} == 40">
-    <f:comment><!--<div class="callout callout-warning">--></f:comment>
     <div>
         <table class="table table-striped">
             <tbody>
@@ -39,7 +38,10 @@
                                                 each="{categories}"
                                                 as="category"
                                             >
-                                                <li>{category.title}</li>
+                                            <li>
+                                                <core:icon identifier="{f:if(condition: '{category.hidden}  == 1', then: 'overlay-hidden', else: 'category_types.partners.{type}')}" />
+                                                {category.title}
+                                            </li>
                                             </f:for>
                                         </ul>
                                     </f:then>

--- a/packages/fgtclb/academic-programs/Resources/Private/Backend/Partials/PageLayout/Doktype20.html
+++ b/packages/fgtclb/academic-programs/Resources/Private/Backend/Partials/PageLayout/Doktype20.html
@@ -6,7 +6,6 @@
     data-namespace-typo3-fluid="true"
 >
 <f:if condition="{context.pageRecord.doktype} == 20">
-    <f:comment><!--<div class="callout callout-warning">--></f:comment>
     <div>
         <table class="table table-striped">
             <tbody>
@@ -39,7 +38,10 @@
                                                 each="{categories}"
                                                 as="category"
                                             >
-                                                <li>{category.title}</li>
+                                                <li>
+                                                    <core:icon identifier="{f:if(condition: '{category.hidden}  == 1', then: 'overlay-hidden', else: 'category_types.programs.{type}')}" />
+                                                    {category.title}
+                                                </li>
                                             </f:for>
                                         </ul>
                                     </f:then>

--- a/packages/fgtclb/academic-projects/Resources/Private/Backend/Partials/PageLayout/Doktype30.html
+++ b/packages/fgtclb/academic-projects/Resources/Private/Backend/Partials/PageLayout/Doktype30.html
@@ -6,7 +6,6 @@
     data-namespace-typo3-fluid="true"
 >
 <f:if condition="{context.pageRecord.doktype} == 30">
-    <f:comment><!--<div class="callout callout-warning">--></f:comment>
     <div>
         <table class="table table-striped">
             <tbody>
@@ -39,7 +38,10 @@
                                                 each="{categories}"
                                                 as="category"
                                             >
-                                                <li>{category.title}</li>
+                                                <li>
+                                                    <core:icon identifier="{f:if(condition: '{category.hidden}  == 1', then: 'overlay-hidden', else: 'category_types.projects.{type}')}" />
+                                                    {category.title}
+                                                </li>
                                             </f:for>
                                         </ul>
                                     </f:then>

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/Category.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/Category.php
@@ -20,6 +20,7 @@ class Category implements \Stringable
         protected string $title,
         string $type = 'default',
         string $typeGroup = 'default',
+        protected bool $hidden = false,
         protected bool $disabled = false
     ) {
         $this->type = null;
@@ -49,6 +50,11 @@ class Category implements \Stringable
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    public function getHidden(): bool
+    {
+        return $this->hidden;
     }
 
     public function getChildren(): ?CategoryCollection

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
@@ -59,7 +59,7 @@ class CategoryViewHelper extends AbstractViewHelper
 
         /** @var CategoryRepository $repository */
         $repository = GeneralUtility::makeInstance(CategoryRepository::class);
-        $categories = $repository->findByGroupAndPageId($arguments['group'], $arguments['page']);
+        $categories = $repository->findByGroupAndPageId($arguments['group'], $arguments['page'], true);
 
         $templateVariableContainer->add($arguments['as'], $categories);
         $output = $renderChildrenClosure();


### PR DESCRIPTION
Hidden system categories assigned to consuming records are not
display in the backend and are considerable a `UX` fail within
the backend context and does not follow known TYPO3 behaviour
related to backend system category handling.

To align the behaviour towards known handling in backend context,
this change ...

* Add a `hidden` property to category model to make it available
  in backend templates.
* Remove the hidden restriction for loading categories in backend
  even if the parent page or the category is hidden.
* Display hidden categories in the backend with hidden icon to
  show the hidden status.