### PR TITLE
[BUGFIX] Restore selected pages plugin setting handling

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
@@ -71,6 +71,15 @@ class DemandFactory
             $demand->setFilterCollection(new FilterCollection($categoryCollection));
         }
 
+        // Set demand properties, which are always defined by plugin settings
+        $demand->setPages([]);
+        if (isset($contentElementData['pages'])
+            && is_string($contentElementData['pages'])
+            && $contentElementData['pages'] !== ''
+        ) {
+            $demand->setPages(GeneralUtility::intExplode(',', $contentElementData['pages']));
+        }
+
         return $demand;
     }
 }

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
@@ -10,6 +10,7 @@ defined('TYPO3') or die;
 
 (static function (): void {
     $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
+
     ExtensionManagementUtility::addTcaSelectItemGroup(
         'tt_content',
         'CType',
@@ -27,9 +28,14 @@ defined('TYPO3') or die;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_partners'
     );
+
     ExtensionManagementUtility::addToAllTCAtypes(
         'tt_content',
-        '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_list.configuration,pi_flexform,',
+        implode(',', [
+            '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_list.configuration',
+            'pi_flexform',
+            'pages',
+        ]),
         'academicpartners_list',
         'after:subheader',
     );

--- a/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
@@ -71,6 +71,15 @@ class DemandFactory
             $demand->setFilterCollection(new FilterCollection($categoryCollection));
         }
 
+        // Set demand properties, which are always defined by plugin settings
+        $demand->setPages([]);
+        if (isset($contentElementData['pages'])
+            && is_string($contentElementData['pages'])
+            && $contentElementData['pages'] !== ''
+        ) {
+            $demand->setPages(GeneralUtility::intExplode(',', $contentElementData['pages']));
+        }
+
         return $demand;
     }
 }

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
@@ -27,12 +27,18 @@ defined('TYPO3') or die;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_programs'
     );
+
     ExtensionManagementUtility::addToAllTCAtypes(
         'tt_content',
-        '--div--;LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:plugin.program_list.configuration,pi_flexform,',
+        implode(',', [
+            '--div--;LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:plugin.program_list.configuration',
+            'pi_flexform',
+            'pages',
+        ]),
         'academicprograms_programlist',
         'after:subheader',
     );
+
     ExtensionManagementUtility::addPiFlexFormValue(
         '*',
         sprintf('FILE:EXT:academic_programs/Configuration/FlexForms/Core%s/ProgramListSettings.xml', $typo3MajorVersion),

--- a/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
@@ -75,13 +75,15 @@ class DemandFactory
         }
 
         // Set demand properties, which are always defined by plugin settings
-        $demand->setPages(
-            $contentElementData['pages'] !== ''
-                ? GeneralUtility::intExplode(',', $contentElementData['pages'])
-                : []
-        );
+        $demand->setPages([]);
+        if (isset($contentElementData['pages'])
+            && is_string($contentElementData['pages'])
+            && $contentElementData['pages'] !== ''
+        ) {
+            $demand->setPages(GeneralUtility::intExplode(',', $contentElementData['pages']));
+        }
         $demand->setShowSelected(
-            $contentElementData['list_type'] === 'academicprojects_projectlistsingle'
+            ($contentElementData['list_type'] ?? '') === 'academicprojects_projectlistsingle'
         );
 
         return $demand;

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -44,6 +44,7 @@ defined('TYPO3') or die;
         implode(',', [
             '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:element.tab.configuration',
             'pi_flexform',
+            'pages',
         ]),
         'academicprojects_projectlist',
         'after:header'


### PR DESCRIPTION
* Respect that database tt_content field `pages` is nullable 
  by streamlining the check if explodable page ids are set
  or not while setting the demand setting in `DemandFactory`.
* Add `pages` field in TCA showitem definition for the plugins
  again to allow selecting pages for them.
