### PR TITLE
[TASK] Fix backend labels of partnerships

### DIFF
--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
@@ -198,7 +198,7 @@ defined('TYPO3') or die;
         ],
         'tx_academicpartners_partnerships' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:pages.tx_academicpartners_partnerships',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:columns.tx_academicpartners_partnerships.label',
             'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'inline',
@@ -278,7 +278,7 @@ defined('TYPO3') or die;
     ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
         implode(',', [
-            '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:pages.tx_academicpartners_partnerships',
+            '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership',
             'tx_academicpartners_partnerships',
         ]),
         '',
@@ -289,7 +289,7 @@ defined('TYPO3') or die;
     ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
         implode(',', [
-            '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang.xlf:pages.div.partner_information',
+            '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:pages.div.partner_information',
             '--palette--;;address',
             '--palette--;;geocode',
         ]),

--- a/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_partnership.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_partnership.php
@@ -9,7 +9,7 @@ if (!defined('TYPO3')) {
 
 return [
     'ctrl' => [
-        'title' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_partnership',
+        'title' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership',
         'label' => 'uid',
         'label_userFunc' => PartnershipLabels::class . '->getTitle',
         'hideTable' => false,
@@ -58,7 +58,7 @@ return [
         ],
         'page' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_partnership.page',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership.page',
             'config' => [
                 'type' => 'group',
                 'allowed' => 'pages',
@@ -71,7 +71,7 @@ return [
         'partner' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_partnership.partner',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership.partner',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -90,7 +90,7 @@ return [
         'role' => [
             'exclude' => false,
             'l10n_mode' => 'exclude',
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_partnership.role',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership.role',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
@@ -6,7 +6,7 @@ if (!defined('TYPO3')) {
 
 return [
     'ctrl' => [
-        'title' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_role',
+        'title' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_role',
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
@@ -92,7 +92,7 @@ return [
         ],
         'name' => [
             'exclude' => false,
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_role.name',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_role.name',
             'config' => [
                 'type' => 'input',
                 'size' => 30,
@@ -102,7 +102,7 @@ return [
         ],
         'description' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_role.description',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_role.description',
             'config' => [
                 'type' => 'text',
                 'cols' => 30,
@@ -112,7 +112,7 @@ return [
         'partnerships' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
-            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_db.xlf:tx_academicpartners_domain_model_role.partnerships',
+            'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_role.partnerships',
             'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academicpartners_domain_model_partnership',

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang_be.xlf
@@ -257,6 +257,56 @@
                 <source>Show on map</source>
                 <target>Auf Karte zeigen</target>
             </trans-unit>
+			<trans-unit id="columns.tx_academicpartners_partnerships.label">
+                <source>Partnerships</source>
+				<target>Partnerschaften</target>
+            </trans-unit>
+
+            <!-- Partnership table: TCA columns -->
+
+            <trans-unit id="tx_academicpartners_domain_model_partnership">
+                <source>Partnership</source>
+				<target>Partnerschaft</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
+                <source>Create new linked page</source>
+				<target>Neue verlinkte Seite anlegen</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_partnership.page">
+                <source>Page</source>
+				<target>Seite</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_partnership.partner">
+                <source>Partner</source>
+				<target>Partner</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_partnership.role">
+                <source>Role</source>
+				<target>Rolle</target>
+            </trans-unit>
+
+            <!-- Role table: TCA columns -->
+
+            <trans-unit id="tx_academicpartners_domain_model_role">
+                <source>Role</source>
+				<target>Rolle</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_role.name">
+                <source>Name</source>
+				<target>Name</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_role.description">
+                <source>Description</source>
+				<target>Beschreibung</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_role.doktypes">
+                <source>Page types</source>
+				<target>Seitentypen</target>
+            </trans-unit>
+            <trans-unit id="tx_academicpartners_domain_model_role.partnerships">
+                <source>Contacts</source>
+				<target>Kontakte</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
@@ -210,7 +210,7 @@
                 <source>Partnership</source>
             </trans-unit>
             <trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
-                <source>Create new Linked page</source>
+                <source>Create new linked page</source>
             </trans-unit>
             <trans-unit id="tx_academicpartners_domain_model_partnership.page">
                 <source>Page</source>


### PR DESCRIPTION
While implementing partnerships and integrating them into the page configuration the language keys for the backend fields were searched for inside the locallang_db file. This file does not exist but the labels were added to the locallang_be file. Therefore the target files were adjusted.