### PR TITLE
[FEATURE] Introduce `remove` and `useExisting` category type options

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Loader/CategoryTypeLoader.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Loader/CategoryTypeLoader.php
@@ -58,8 +58,63 @@ class CategoryTypeLoader
                 }
                 if (array_key_exists('types', $configArray) && is_array($configArray['types'])) {
                     foreach ($configArray['types'] as $categoryType) {
+                        // @todo Consider to introduce a extracted, more complete validation/normalization method and
+                        //       cover this format handling finally with tests.
+                        // Check if the identifier and group of the category type to ensure it is unambiguous
+                        $categoryTypeIdentifier = $categoryType['identifier'] ?? null;
+                        if (!is_string($categoryTypeIdentifier) || trim($categoryTypeIdentifier, ' ') === '') {
+                            throw new \Exception(
+                                'Category type identifier has to be defined as a non-empty string.',
+                                1678979375330
+                            );
+                        }
+                        // @todo Validate $categoryTypeIdentifier against invalid characters, for example dots (`.`).
+
+                        $categoryTypeGroup = $categoryType['group'] ?? null;
+                        if (!is_string($categoryTypeGroup) || trim($categoryTypeGroup, ' ') === '') {
+                            throw new \Exception(
+                                'Category type group has to be defined as a non-empty string.',
+                                1678979375330
+                            );
+                        }
+                        // @todo Validate $categoryTypeGroup against invalid characters, for example dots (`.`).
+
+                        // Generate an unambiguous array key for the category type
+                        $categoryKey = sprintf(
+                            '%s.%s',
+                            trim($categoryTypeGroup, ' '),
+                            trim($categoryTypeIdentifier, ' '),
+                        );
+
+                        // Remove a (default) category type if not needed in a project
+                        $shouldBeRemoved = (bool)($categoryType['remove'] ?? false);
+                        if ($shouldBeRemoved) {
+                            unset($loadedCategoryTypes[$categoryKey]);
+                            continue;
+                        }
+
+                        // The extension is added for debugging purposes
+                        // @todo Temporarily ? Or should this maybe be hidden behind some kind of "context" switch ?
                         $categoryType['extensionKey'] = $extensionKey;
-                        $loadedCategoryTypes[] = CategoryType::fromArray($categoryType);
+
+                        // Override a (default) category type with a custom configuration
+                        $useExisting = (bool)($categoryType['useExisting'] ?? false);
+                        if ($useExisting) {
+                            if (!(($loadedCategoryTypes[$categoryKey] ?? null) instanceof CategoryType)) {
+                                throw new \Exception(
+                                    'Category type does not exist for override.',
+                                    1678979375330
+                                );
+                            }
+                            // Combine existing categoryType options with override values.
+                            $categoryType = array_merge(
+                                $loadedCategoryTypes[$categoryKey]->toArray(),
+                                $categoryType
+                            );
+                        }
+
+                        // Add category type to the list
+                        $loadedCategoryTypes[$categoryKey] = CategoryType::fromArray($categoryType);
                     }
                 }
             }


### PR DESCRIPTION
* Add a new configuration option `remove` to remove category
  types defined earlier in the configuartion chain.
* Add a new configuration option `useExisting` to override
  settings like title or icon for category types defined
  earlier in the configuartion chain.
