### PR TITLE
[TASK] Update `academic_persons_edit` for v12/v13

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -71,11 +71,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$constraints of method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Model\\\\Address\\>\\:\\:logicalAnd\\(\\) expects TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ConstraintInterface, array\\<int, TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ComparisonInterface\\> given\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
-
-		-
 			message: "#^Method Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Repository\\\\ProfileRepository\\:\\:findByUids\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/ProfileRepository.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -81,22 +81,12 @@ parameters:
 			path: ../../../packages/fgtclb/academic-partners/Classes/Domain/Repository/PartnershipRepository.php
 
 		-
-			message: "#^Access to undefined constant TYPO3\\\\CMS\\\\Core\\\\Messaging\\\\AbstractMessage\\:\\:OK\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
-
-		-
 			message: "#^Method Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Model\\\\Profile\\:\\:getLanguageUid\\(\\) should return int but returns int\\<\\-1, max\\>\\|null\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Profile.php
 
 		-
 			message: "#^Method Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Repository\\\\AddressRepository\\:\\:getAddressFromOrganisation\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$constraints of method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Model\\\\Address\\>\\:\\:logicalAnd\\(\\) expects TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ConstraintInterface, array\\<int, TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ComparisonInterface\\> given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
 

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -38,8 +38,8 @@ use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Response;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Annotation\Validate;
@@ -225,7 +225,7 @@ final class ProfileController extends ActionController
             FlashMessage::class,
             (string)$successMessageBody,
             (string)$successMessageTitle,
-            AbstractMessage::OK,
+            ContextualFeedbackSeverity::OK,
             true
         );
         $this->getFlashMessageQueue(self::FLASH_MESSAGE_QUEUE_IDENTIFIER)->addMessage($flashMessage);

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Repository/AddressRepository.php
@@ -34,10 +34,10 @@ class AddressRepository extends Repository
         $query->getQuerySettings()->setRespectStoragePage(false);
 
         $query->matching(
-            $query->logicalAnd([
+            $query->logicalAnd(
                 $query->equals('employee_type', $employeeType),
                 $query->equals('organisational_unit', $organizationalUnit),
-            ])
+            )
         );
         $query->setOrderings([
             'zip' => QueryInterface::ORDER_ASCENDING,

--- a/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/sys_template.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/sys_template.php
@@ -13,6 +13,6 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 ExtensionManagementUtility::addStaticFile(
     'academic_persons_edit',
-    'Configuration/TypoScript/',
+    'Configuration/TypoScript',
     'Academic Persons Edit Settings'
 );

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
@@ -73,7 +73,7 @@
 			</trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.employeeContracts">
 				<source>Employee contracts</source>
-				<target>Mitarbeiter Verträge</target>
+				<target>Mitarbeiterverträge</target>
 			</trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.contractInformation">
 				<source>Contract information</source>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
@@ -10,164 +10,184 @@
                 <source>Your profile was updated.</source>
             </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.save">
-				<source>Save profile data</source>
-			</trans-unit>
+                <source>Save profile data</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.error.no_translation">
-				<source>Profile ist not translated for current language.</source>
-			</trans-unit>
+                <source>Profile ist not translated for current language.</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.translate">
-				<source>Translate profile</source>
-			</trans-unit>
+                <source>Translate profile</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.switchChoose">
-				<source>Choose profile</source>
-			</trans-unit>
+                <source>Choose profile</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.switch.btn.switch">
-				<source>Switch Profile</source>
-			</trans-unit>
+                <source>Switch Profile</source>
+            </trans-unit>
+
+            <trans-unit id="tx_academicpersonsedit.fe.title.profileData">
+                <source>Profile data</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.title.additionalProfileData">
+                <source>Additional profile data</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.title">
+                <source>Title</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.firstName">
+                <source>First name</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.middleName">
+                <source>Middle name</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.lastName">
+                <source>Last name</source>
+            </trans-unit>
+
             <trans-unit id="tx_academicpersonsedit.fe.legend.image">
-				<source>Profile Image</source>
-			</trans-unit>
+                <source>Profile Image</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.removeImage">
-				<source>Remove image</source>
-			</trans-unit>
+                <source>Remove image</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.update_image">
-				<source>Update profile image</source>
-			</trans-unit>
+                <source>Update profile image</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.publicationsLinksTitle">
-				<source>Website link title</source>
-			</trans-unit>
+                <source>Website link title</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.website">
-				<source>Website</source>
-			</trans-unit>
+                <source>Website</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.coreCompetences">
-				<source>Core competences</source>
-			</trans-unit>
+                <source>Core competences</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.supervisedThesis">
-				<source>Supervised thesis</source>
-			</trans-unit>
+                <source>Supervised thesis</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.supervisedDoctoralThesis">
-				<source>Supervised doctoral thesis</source>
-			</trans-unit>
+                <source>Supervised doctoral thesis</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.miscellaneous">
-				<source>Miscellaneous information</source>
-			</trans-unit>
+                <source>Miscellaneous information</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.publish">
-				<source>Publish?</source>
-			</trans-unit>
+                <source>Publish?</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.employeeContracts">
-				<source>Employee contracts</source>
-			</trans-unit>
+                <source>Employee contracts</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.contractInformation">
-				<source>Contract information</source>
-			</trans-unit>
+                <source>Contract information</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.position">
-				<source>Position/Specialty/Function</source>
-			</trans-unit>
+                <source>Position/Specialty/Function</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.location">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersonsedit.fe.label.room">
-				<source>Room</source>
-			</trans-unit>
+                <source>Location</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.room">
+                <source>Room</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.officeHours">
-				<source>Office Hours</source>
-			</trans-unit>
+                <source>Office Hours</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.addPhysicalAddress">
-				<source>Add new physical address</source>
-			</trans-unit>
+                <source>Add new physical address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.enterAdress">
-				<source>Enter address</source>
-			</trans-unit>
+                <source>Enter address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.type">
-				<source>Type</source>
-			</trans-unit>
+                <source>Type</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.street">
-				<source>Street</source>
-			</trans-unit>
+                <source>Street</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.number">
-				<source>Street number</source>
-			</trans-unit>
+                <source>Street number</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.additional">
-				<source>Additional information</source>
-			</trans-unit>
+                <source>Additional information</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.zip">
-				<source>ZIP</source>
-			</trans-unit>
+                <source>ZIP</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.city">
-				<source>City</source>
-			</trans-unit>
+                <source>City</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.state">
-				<source>State</source>
-			</trans-unit>
+                <source>State</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.physicalAddress.country">
-				<source>Country</source>
-			</trans-unit>
+                <source>Country</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.removePhysicalAddress">
-				<source>Remove physical address</source>
-			</trans-unit>
+                <source>Remove physical address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.emailAddresses">
-				<source>Email addresses</source>
-			</trans-unit>
+                <source>Email addresses</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.addEmailAddress">
-				<source>Add new email address</source>
-			</trans-unit>
+                <source>Add new email address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.emailAddress">
-				<source>Email address</source>
-			</trans-unit>
+                <source>Email address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.removeEmailAddress">
-				<source>Remove email address</source>
-			</trans-unit>
+                <source>Remove email address</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.addPhoneNumber">
-				<source>Add new phone number</source>
-			</trans-unit>
+                <source>Add new phone number</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.phoneNumbers">
-				<source>Phone numbers</source>
-			</trans-unit>
+                <source>Phone numbers</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.phoneNumber">
-				<source>Phone number</source>
-			</trans-unit>
+                <source>Phone number</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.removePhoneNumber">
-				<source>Remove phone number</source>
-			</trans-unit>
+                <source>Remove phone number</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.cooperations">
-				<source>Cooperations</source>
-			</trans-unit>
+                <source>Cooperations</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.addEntry">
-				<source>Add new entry</source>
-			</trans-unit>
+                <source>Add new entry</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.field.year">
-				<source>Year</source>
-			</trans-unit>
+                <source>Year</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.field.title">
-				<source>Title</source>
-			</trans-unit>
+                <source>Title</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.field.text">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersonsedit.fe.label.field.link">
-				<source>Link</source>
-			</trans-unit>
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="tx_academicpersonsedit.fe.label.field.link">
+                <source>Link</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.profile.btn.removeEntry">
-				<source>Remove entry</source>
-			</trans-unit>
+                <source>Remove entry</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersons.fe.title.vita">
-				<source>Vita</source>
-			</trans-unit>
+                <source>Vita</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.lectures">
-				<source>Lectures</source>
-			</trans-unit>
+                <source>Lectures</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.memberships">
-				<source>Memberships and committee activities</source>
-			</trans-unit>
+                <source>Memberships and committee activities</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.field.publication_external_link">
-				<source>Link to external publications</source>
-			</trans-unit>
+                <source>Link to external publications</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.label.field.publication_external_link_title">
-				<source>Publication Link Title</source>
-			</trans-unit>
+                <source>Publication Link Title</source>
+            </trans-unit>
             <trans-unit id="tx_academicpersonsedit.fe.title.publications">
-				<source>Publications</source>
-			</trans-unit>
+                <source>Publications</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/Addresses.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/Addresses.html
@@ -1,132 +1,159 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<f:if condition="!{contract.physicalAddresses}">
-<div class="row mb-3">
-    <div class="col-12">
-        <h4>
-					<f:translate key="tx_academicpersonsedit.fe.profile.btn.enterAdress" extensionName="academic_persons_edit"/>
-				</h4>
-        <f:link.action action="addPhysicalAddress" arguments="{profile: profile, contract: contract}" class="btn btn-primary">
-						<f:translate key="tx_academicpersonsedit.fe.profile.btn.addPhysicalAddress" extensionName="academic_persons_edit"/>
-				</f:link.action>
-    </div>
-</div>
-</f:if>
-<f:for each="{contract.physicalAddresses}" as="physicalAddress" iteration="physicalAddressIterator">
     <div class="row mb-3">
         <div class="col-12">
-            <label for="address-{physicalAddressIterator.index}-type" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.type" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.select
-                    property="physicalAddresses.{physicalAddressIterator.index}.type"
+            <h3>
+                {f:translate(
+                    key:'tx_academicpersonsedit.fe.profile.btn.enterAdress',
+                    extensionName:'academic_persons_edit'
+                )}                
+            </h3>
+            <f:link.action
+                action="addPhysicalAddress"
+                arguments="{profile: profile, contract: contract}" 
+                class="btn btn-primary"
+            >
+                {f:translate(
+                    key:'tx_academicpersonsedit.fe.profile.btn.addPhysicalAddress',
+                    extensionName:'academic_persons_edit'
+                )}
+            </f:link.action>
+        </div>
+    </div>
+    <f:for each="{contract.physicalAddresses}" as="physicalAddress" iteration="physicalAddressIterator">
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="address-{physicalAddressIterator.index}-type" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.type",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.select
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.type"
                     id="address-{physicalAddressIterator.index}-type"
                     class="form-select"
                     options="{addressTypes}"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-md-9">
-            <label for="address-{physicalAddressIterator.index}-street" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.street" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.street"
+        <div class="row mb-3">
+            <div class="col-md-9">
+                <label for="address-{physicalAddressIterator.index}-street" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.street",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.street"
                     id="address-{physicalAddressIterator.index}-street"
                     class="form-control"
-                    maxlength="120"
-                    required="1"
-            />
-        </div>
-        <div class="col-md-3">
-            <label for="address-{physicalAddressIterator.index}-street-number" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.number" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.streetNumber"
+                />
+            </div>
+            <div class="col-md-3">
+                <label for="address-{physicalAddressIterator.index}-street-number" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.number",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.streetNumber"
                     id="address-{physicalAddressIterator.index}-street-number"
                     class="form-control"
-                    maxlength="6"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="address-{physicalAddressIterator.index}-additional" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.additional" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.additional"
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="address-{physicalAddressIterator.index}-additional" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.additional",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.additional"
                     id="address-{physicalAddressIterator.index}-additional"
                     class="form-control"
-                    maxlength="120"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-md-4">
-            <label for="address-{physicalAddressIterator.index}-zip" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.zip" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.zip"
+        <div class="row mb-3">
+            <div class="col-md-4">
+                <label for="address-{physicalAddressIterator.index}-zip" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.zip",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.zip"
                     id="address-{physicalAddressIterator.index}-zip"
                     class="form-control"
-                    maxlength="10"
-                    required="1"
-            />
-        </div>
-        <div class="col-md-8">
-            <label for="address-{physicalAddressIterator.index}-city" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.city" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.city"
+                />
+            </div>
+            <div class="col-md-8">
+                <label for="address-{physicalAddressIterator.index}-city" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.city",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.city"
                     id="address-{physicalAddressIterator.index}-city"
                     class="form-control"
-                    maxlength="100"
-                    required="1"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-md-4">
-            <label for="address-{physicalAddressIterator.index}-state" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.state" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.state"
+        <div class="row mb-3">
+            <div class="col-md-4">
+                <label for="address-{physicalAddressIterator.index}-state" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.state",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.state"
                     id="address-{physicalAddressIterator.index}-state"
                     class="form-control"
-                    maxlength="60"
-            />
-        </div>
-        <div class="col-md-8">
-            <label for="address-{physicalAddressIterator.index}-country" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.physicalAddress.country" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
-                    property="physicalAddresses.{physicalAddressIterator.index}.country"
+                />
+            </div>
+            <div class="col-md-8">
+                <label for="address-{physicalAddressIterator.index}-country" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.physicalAddress.country",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
+                    property="contracts.{contractIterator.index}.physicalAddresses.{physicalAddressIterator.index}.country"
                     id="address-{physicalAddressIterator.index}-country"
                     class="form-control"
-                    maxlength="100"
-                    required="1"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <f:link.action action="removePhysicalAddress" arguments="{profile: profile, contract: contract, address: physicalAddress}" class="btn btn-danger">
-								<f:translate key="tx_academicpersonsedit.fe.profile.btn.removePhysicalAddress" extensionName="academic_persons_edit"/>
-						</f:link.action>
+        <div class="row mb-3">
+            <div class="col-12">
+                <f:link.action
+                    action="removePhysicalAddress"
+                    arguments="{profile: profile, contract: contract, address: physicalAddress}"
+                    class="btn btn-danger"
+                >
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.btn.removePhysicalAddress",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </f:link.action>
+            </div>
         </div>
-    </div>
-    <f:if condition="!{physicalAddressIterator.isLast}">
-        <hr class="mb-3" />
-    </f:if>
-</f:for>
-
+        <f:if condition="!{physicalAddressIterator.isLast}">
+            <hr />
+        </f:if>
+    </f:for>
 </html>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/EmailAddresses.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/EmailAddresses.html
@@ -1,56 +1,71 @@
 <html data-namespace-typo3-fluid="true"
       xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<div class="row mb-3">
-    <div class="col-12">
-        <h2>
-						<f:translate key="tx_academicpersonsedit.fe.title.emailAddresses" extensionName="academic_persons_edit"/>
-				</h2>
-        <f:link.action action="addEmailAddress" arguments="{profile: profile, contract: contract}" class="btn btn-primary">
-						<f:translate key="tx_academicpersonsedit.fe.profile.btn.addEmailAddress" extensionName="academic_persons_edit"/>
-				</f:link.action>
-    </div>
-</div>
-<f:for each="{contract.emailAddresses}" as="emailAddress" iteration="emailAddressIterator">
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="email-address-{emailAddressIterator.index}-type" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.type" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.select
+    <h3>
+        {f:translate(
+            key:'tx_academicpersonsedit.fe.title.emailAddresses',
+            extensionName:'academic_persons_edit'
+        )}
+    </h3>
+    <f:link.action
+        action="addEmailAddress"
+        arguments="{profile: profile, contract: contract}"
+        class="btn btn-primary"
+    >
+        {f:translate(
+            key:'tx_academicpersonsedit.fe.profile.btn.addEmailAddress',
+            extensionName:'academic_persons_edit'
+        )}
+    </f:link.action>
+    <f:for
+        each="{contract.emailAddresses}"
+        as="emailAddress"
+        iteration="emailAddressIterator"
+    >
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="email-address-{emailAddressIterator.index}-type" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.type",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.select
                     property="contracts.{contractIterator.index}.emailAddresses.{emailAddressIterator.index}.type"
                     id="email-address-{emailAddressIterator.index}-type"
                     class="form-select"
                     options="{emailAddressTypes}"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="email-address-{emailAddressIterator.index}-email" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.profile.emailAddress" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="email-address-{emailAddressIterator.index}-email" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.emailAddress",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
                     type="email"
                     property="contracts.{contractIterator.index}.emailAddresses.{emailAddressIterator.index}.email"
                     id="email-address-{emailAddressIterator.index}-email"
                     class="form-control"
-                    maxlength="255"
-                    required="1"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <f:link.action action="removeEmailAddress" arguments="{profile: profile, contract: contract, emailAddress: emailAddress}" class="btn btn-danger">
-								<f:translate key="tx_academicpersonsedit.fe.profile.btn.removeEmailAddress" extensionName="academic_persons_edit"/>
-						</f:link.action>
+        <div class="row mb-3">
+            <div class="col-12">
+                <f:link.action action="removeEmailAddress" arguments="{profile: profile, contract: contract, emailAddress: emailAddress}" class="btn btn-danger">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.btn.removeEmailAddress",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </f:link.action>
+            </div>
         </div>
-    </div>
-    <f:if condition="!{emailAddressIterator.isLast}">
-        <hr class="mb-3" />
-    </f:if>
-</f:for>
-
+        <f:if condition="!{emailAddressIterator.isLast}">
+            <hr />
+        </f:if>
+    </f:for>
 </html>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/PhoneNumbers.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/Contract/PhoneNumbers.html
@@ -1,55 +1,79 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<div class="row mb-3">
-    <div class="col-12">
-        <h2>
-					  <f:translate key="tx_academicpersonsedit.fe.title.phoneNumbers" extensionName="academic_persons_edit"/>
-				</h2>
-        <f:link.action action="addPhoneNumber" arguments="{profile: profile, contract: contract}" class="btn btn-primary">
-						<f:translate key="tx_academicpersonsedit.fe.profile.btn.addPhoneNumber" extensionName="academic_persons_edit"/>
-				</f:link.action>
-    </div>
-</div>
-<f:for each="{contract.phoneNumbers}" as="phoneNumber" iteration="phoneNumbersterator">
     <div class="row mb-3">
         <div class="col-12">
-            <label for="phone-number-{phoneNumbersterator.index}-type" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.profile.type" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.select
+            <h3>
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.title.phoneNumbers",
+                    extensionName: "academic_persons_edit"
+                )}
+            </h3>
+            <f:link.action
+                action="addPhoneNumber"
+                arguments="{profile: profile, contract: contract}"
+                class="btn btn-primary"
+            >
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.profile.btn.addPhoneNumber",
+                    extensionName: "academic_persons_edit"
+                )}
+            </f:link.action>
+        </div>
+    </div>
+    <f:for
+        each="{contract.phoneNumbers}"
+        as="phoneNumber"
+        iteration="phoneNumbersterator"
+    >
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="phone-number-{phoneNumbersterator.index}-type" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.type",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.select
                     property="contracts.{contractIterator.index}.phoneNumbers.{phoneNumbersterator.index}.type"
                     id="phone-number-{phoneNumbersterator.index}-type"
                     class="form-select"
                     options="{phoneNumberTypes}"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="phone-number-{phoneNumbersterator.index}-phone-number" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.label.phoneNumber" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="phone-number-{phoneNumbersterator.index}-phone-number" class="form-label">
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.phoneNumber",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </label>
+                <f:form.textfield
                     property="contracts.{contractIterator.index}.phoneNumbers.{phoneNumbersterator.index}.phoneNumber"
                     id="phone-number-{phoneNumbersterator.index}-phone-number"
                     class="form-control"
-                    maxlength="255"
-                    required="1"
-            />
+                />
+            </div>
         </div>
-    </div>
-    <div class="row mb-3">
-        <div class="col-12">
-            <f:link.action action="removePhoneNumber" arguments="{profile: profile, contract: contract, phoneNumber: phoneNumber}" class="btn btn-danger">
-							  <f:translate key="tx_academicpersonsedit.fe.profile.btn.removePhoneNumber" extensionName="academic_persons_edit"/>
-						</f:link.action>
+        <div class="row mb-3">
+            <div class="col-12">
+                <f:link.action
+                    action="removePhoneNumber"
+                    arguments="{profile: profile, contract: contract, phoneNumber: phoneNumber}"
+                    class="btn btn-danger"
+                >
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.profile.btn.removePhoneNumber",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </f:link.action>
+            </div>
         </div>
-    </div>
-    <f:if condition="!{phoneNumbersterator.isLast}">
-        <hr class="mb-3" />
-    </f:if>
-</f:for>
-
+        <f:if condition="!{phoneNumbersterator.isLast}">
+            <hr />
+        </f:if>
+    </f:for>
 </html>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileContract.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileContract.html
@@ -1,86 +1,115 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<div class="row mt-5 mb-3">
-		<div class="col-12">
-				<h2>
-						<f:translate key="tx_academicpersonsedit.fe.label.employeeContracts" extensionName="academic_persons_edit"/>
-				</h2>
-		</div>
-</div>
-
-<f:for each="{profile.contracts}" as="contract" iteration="contractIterator">
-		<div class="row mb-3">
-				<div class="col-12">
-					<h3>
-							<f:translate key="tx_academicpersonsedit.fe.label.contractInformation" extensionName="academic_persons_edit"/>
-					</h3>
-					<f:form.checkbox value="1"
-														class="form-check-inpu"
-														id="contract-{contract.uid}-publish"
-														property="contracts.{contractIterator.index}.publish" />
-					<label for="contract-{contract.uid}-publish" class="form-check-label">
-							<f:translate key="tx_academicpersonsedit.fe.label.publish" extensionName="academic_persons_edit"/>
-					</label>
+    <div class="row mt-5 mb-3">
+        <div class="col-12">
+            <h2>
+                {f:translate(
+                    key:'tx_academicpersonsedit.fe.label.employeeContracts',
+                    extensionName:'academic_persons_edit'
+                )}
+            </h2>
         </div>
     </div>
-
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="contract-{contract.uid}-position" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.label.position" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
+    <f:for
+        each="{profile.contracts}"
+        as="contract"
+        iteration="contractIterator"
+    >
+        <div class="row mb-3">
+            <div class="col-12">
+                <h3>
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.contract',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </h3>
+                <f:form.checkbox
+                    value="1"
+                    class="form-check-inpu"
+                    id="contract-{contract.uid}-publish"
+                    property="contracts.{contractIterator.index}.publish"
+                />
+                <label for="contract-{contract.uid}-publish" class="form-check-label">
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.publish',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </label>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="contract-{contract.uid}-position" class="form-label">
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.position',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </label>
+                <f:form.textfield
                     property="contracts.{contractIterator.index}.position"
                     id="contract-{contract.uid}-position"
                     class="form-control"
-                    maxlength="100"
-            />
-        </div>
-        <div class="col-6">
-            <label for="contract-{contract.uid}-location" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.label.location" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.select property="contracts.{contractIterator.index}.location"
-                           id="contract-{contract.uid}-location"
-                           class="form-select"
-                           prependOptionLabel="Please choose"
-                           options="{availableLocations}"
-                           optionLabelField="title"
-           />
-        </div>
-        <div class="col-6">
-            <label for="contract-{contract.uid}-room" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.label.room" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textfield
+                />
+            </div>
+            <div class="col-6">
+                <label for="contract-{contract.uid}-location" class="form-label">
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.location',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </label>
+                <f:form.select
+                    property="contracts.{contractIterator.index}.location"
+                    id="contract-{contract.uid}-location"
+                    class="form-select"
+                    prependOptionLabel="Please choose"
+                    prependOptionValue="0"
+                    options="{availableLocations}"
+                    optionLabelField="title"
+                />
+            </div>
+            <div class="col-6">
+                <label for="contract-{contract.uid}-room" class="form-label">
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.room',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </label>
+                <f:form.textfield
                     property="contracts.{contractIterator.index}.room"
                     id="contract-{contract.uid}-room"
                     class="form-control"
-                    maxlength="100"
-            />
+                />
+            </div>
         </div>
-    </div>
-
-    <f:if condition="!{constrat.physicalAddressesFromOrganisation}">
-        <f:render partial="ProfileEdit/Contract/Addresses" arguments="{_all}"/>
-    </f:if>
-    <f:render partial="ProfileEdit/Contract/EmailAddresses" arguments="{_all}"/>
-    <f:render partial="ProfileEdit/Contract/PhoneNumbers" arguments="{_all}"/>
-
-    <div class="row mb-3">
-        <div class="col-12">
-            <label for="contract-{contract.uid}-office-hours" class="form-label">
-								<f:translate key="tx_academicpersonsedit.fe.label.officeHours" extensionName="academic_persons_edit"/>
-						</label>
-            <f:form.textarea
+        <div class="row mb-3">
+            <div class="col-12">
+                <label for="contract-{contract.uid}-office-hours" class="form-label">
+                    {f:translate(
+                        key:'tx_academicpersonsedit.fe.label.officeHours',
+                        extensionName:'academic_persons_edit'
+                    )}
+                </label>
+                <f:form.textarea
                     property="contracts.{contractIterator.index}.officeHours"
                     id="contract-{contract.uid}-office-hours"
                     class="form-control"
-            />
+                />
+            </div>
         </div>
-    </div>
-</f:for>
-
+        <f:render
+            partial="ProfileEdit/Contract/Addresses"
+            arguments="{_all}"
+        />
+        <f:render
+            partial="ProfileEdit/Contract/EmailAddresses"
+            arguments="{_all}"
+        />
+        <f:render
+            partial="ProfileEdit/Contract/PhoneNumbers"
+            arguments="{_all}"
+        />
+    </f:for>
 </html>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileData.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileData.html
@@ -1,102 +1,185 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<f:render partial="ProfileEdit/ProfileInformation/CurriculumVitae" arguments="{_all}" />
-<f:render partial="ProfileEdit/ProfileInformation/Membership" arguments="{_all}" />
-<f:render partial="ProfileEdit/ProfileInformation/Cooperation" arguments="{_all}" />
-<f:render partial="ProfileEdit/ProfileInformation/Publication" arguments="{_all}" />
-<f:render partial="ProfileEdit/ProfileInformation/Lecture" arguments="{_all}" />
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-website-title" class="form-label">
-						<f:translate key="tx_academicpersonsedit.fe.label.publicationsLinksTitle" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textfield
+    <h2>
+        {f:translate(
+            key: 'tx_academicpersonsedit.fe.title.profileData',
+            extensionName: 'academic_persons_edit'
+        )}
+    </h2>
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-title" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.title",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
+                property="title"
+                id="profile-title"
+                class="form-control"
+            />
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-first-name" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.firstName",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
+                property="firstName"
+                id="profile-first-name"
+                class="form-control"
+            />
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-middle-name" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.middleName",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
+                property="middleName"
+                id="profile-middle-name"
+                class="form-control"
+            />
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-last-name" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.lastName",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
+                property="lastName"
+                id="profile-last-name"
+                class="form-control"
+            />
+        </div>
+    </div>
+    <h2>
+        <h2>
+            {f:translate(
+                key: 'tx_academicpersonsedit.fe.title.additionalProfileData',
+                extensionName: 'academic_persons_edit'
+            )}
+        </h2>
+    </h2>
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-website-title" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.publicationsLinksTitle",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
                 property="websiteTitle"
                 id="profile-website-title"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-website" class="form-label">
-						<f:translate key="tx_academicpersonsedit.fe.label.website" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textfield
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-website" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.website",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textfield
                 property="website"
                 id="profile-website"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-teaching-area" class="form-label">
-					  <f:translate key="tx_academicpersons.fe.text.teaching_area" extensionName="academic_persons"/>
-				</label>
-        <f:form.textarea
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-teaching-area" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersons.fe.label.teachingArea",
+                    extensionName: "academic_persons"
+                )}
+            </label>
+            <f:form.textarea
                 property="teachingArea"
                 id="profile-teaching-area"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
 
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-core-competences" class="form-label">
-					  <f:translate key="tx_academicpersonsedit.fe.label.coreCompetences" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textarea
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-core-competences" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.coreCompetences",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textarea
                 property="coreCompetences"
                 id="profile-core-competences"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-supervised-thesis" class="form-label">
-					  <f:translate key="tx_academicpersonsedit.fe.label.supervisedThesis" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textarea
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-supervised-thesis" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.supervisedThesis",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textarea
                 property="supervisedThesis"
                 id="profile-supervised-thesis"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-supervised-doctoral-thesis" class="form-label">
-					  <f:translate key="tx_academicpersonsedit.fe.label.supervisedDoctoralThesis" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textarea
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-supervised-doctoral-thesis" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.supervisedDoctoralThesis",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textarea
                 property="supervisedDoctoralThesis"
                 id="profile-supervised-doctoral-thesis"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
-<div class="row mb-3">
-    <div class="col-12">
-        <label for="profile-miscellaneous" class="form-label">
-					  <f:translate key="tx_academicpersonsedit.fe.label.miscellaneous" extensionName="academic_persons_edit"/>
-				</label>
-        <f:form.textarea
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="profile-miscellaneous" class="form-label">
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.miscellaneous",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
+            <f:form.textarea
                 property="miscellaneous"
                 id="profile-miscellaneous"
                 class="form-control"
-        />
+            />
+        </div>
     </div>
-</div>
-
 </html>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileImage.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileImage.html
@@ -5,8 +5,11 @@
     <div class="row mb-1">
         <div class="col-12">
             <h2>
-								<f:translate key="tx_academicpersonsedit.fe.legend.image" extensionName="academic_persons_edit" />
-						</h2>
+                {f:translate(
+                    key: 'tx_academicpersonsedit.fe.legend.image',
+                    extensionName: 'academic_persons_edit'
+                )}
+            </h2>
         </div>
         <div class="col-md-4">
             <f:if condition="{profile.image}">
@@ -21,7 +24,10 @@
                         arguments="{profile: profile}"
                         class="btn btn-danger"
                     >
-												<f:translate key="tx_academicpersonsedit.fe.profile.btn.removeImage" extensionName="academic_persons_edit" />
+                        {f:translate(
+                            key: 'tx_academicpersonsedit.fe.profile.btn.removeImage',
+                            extensionName: 'academic_persons_edit'
+                        )}
                     </f:link.action>
                 </f:then>
                 <f:else>
@@ -37,6 +43,7 @@
                                         each="{errors}"
                                         as="error"
                                     >
+                                        <f:debug>{error}</f:debug>
                                         <li>{error}</li>
                                     </f:for>
                                 </f:for>
@@ -47,7 +54,10 @@
                         for="profile-image"
                         class="visually-hidden"
                     >
-												<f:translate key="tx_academicpersonsedit.fe.label.update_image" extensionName="academic_persons_edit" />
+                        {f:translate(
+                            key: 'tx_academicpersonsedit.fe.label.update_image',
+                            extensionName: 'academic_persons_edit'
+                        )}
                     </label>
                     <f:form.upload
                         property="image"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileInformation/Cooperation.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/ProfileEdit/ProfileInformation/Cooperation.html
@@ -1,76 +1,105 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
 <div class="row mb-3">
     <div class="col-12">
         <h2>
-					  <f:translate key="tx_academicpersonsedit.fe.title.cooperations" extensionName="academic_persons_edit"/>
-				</h2>
-        <f:link.action action="addProfileInformation" arguments="{profile: profile, type: 'cooperation'}" class="btn btn-primary">
-					  <f:translate key="tx_academicpersonsedit.fe.profile.btn.addEntry" extensionName="academic_persons_edit"/>
-				</f:link.action>
+            {f:translate(
+                key: 'tx_academicpersonsedit.fe.title.cooperations',
+                extensionName: 'academic_persons_edit'
+            )}
+        </h2>
+        <f:link.action
+            action="addProfileInformation"
+            arguments="{profile: profile, type: 'cooperation'}"
+            class="btn btn-primary"
+        >
+            {f:translate(
+                key: 'tx_academicpersonsedit.fe.profile.btn.addEntry',
+                extensionName: 'academic_persons_edit'
+            )}
+        </f:link.action>
     </div>
 </div>
 <f:for each="{profile.cooperation}" as="entry" iteration="entryIterator">
     <div class="row mb-3">
         <div class="col-12">
             <label for="cooperation-{entryIterator.index}-year" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.label.field.year" extensionName="academic_persons_edit"/>
-						</label>
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.field.year",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
             <f:form.textfield
-                    type="number"
-                    property="cooperation.{entryIterator.index}.year"
-                    id="cooperation-{entryIterator.index}-year"
-                    class="form-control"
+                type="number"
+                property="cooperation.{entryIterator.index}.year"
+                id="cooperation-{entryIterator.index}-year"
+                class="form-control"
             />
         </div>
     </div>
     <div class="row mb-3">
         <div class="col-12">
             <label for="cooperation-{entryIterator.index}-title" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.label.field.title" extensionName="academic_persons_edit"/>
-						</label>
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.field.title",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
             <f:form.textfield
-                    property="cooperation.{entryIterator.index}.title"
-                    id="cooperation-{entryIterator.index}-title"
-                    class="form-control"
+                property="cooperation.{entryIterator.index}.title"
+                id="cooperation-{entryIterator.index}-title"
+                class="form-control"
             />
         </div>
     </div>
     <div class="row mb-3">
         <div class="col-12">
             <label for="cooperation-{entryIterator.index}-bodytext" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.label.field.text" extensionName="academic_persons_edit"/>
-						</label>
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.field.text",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
             <f:form.textarea
-                    property="cooperation.{entryIterator.index}.bodytext"
-                    id="cooperation-{entryIterator.index}-bodytext"
-                    class="form-control"
+                property="cooperation.{entryIterator.index}.bodytext"
+                id="cooperation-{entryIterator.index}-bodytext"
+                class="form-control"
             />
         </div>
     </div>
     <div class="row mb-3">
         <div class="col-12">
             <label for="cooperation-{entryIterator.index}-link" class="form-label">
-							  <f:translate key="tx_academicpersonsedit.fe.label.field.link" extensionName="academic_persons_edit"/>
-						</label>
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.label.field.link",
+                    extensionName: "academic_persons_edit"
+                )}
+            </label>
             <f:form.textfield
-                    property="cooperation.{entryIterator.index}.link"
-                    id="cooperation-{entryIterator.index}-link"
-                    class="form-control"
+                property="cooperation.{entryIterator.index}.link"
+                id="cooperation-{entryIterator.index}-link"
+                class="form-control"
             />
         </div>
     </div>
     <div class="row mb-3">
         <div class="col-12">
-            <f:link.action action="removeProfileInformation" arguments="{profile: profile, profileInformation: entry}" class="btn btn-danger">
-								<f:translate key="tx_academicpersonsedit.fe.profile.btn.removeEntry" extensionName="academic_persons_edit"/>
-						</f:link.action>
+            <f:link.action
+                action="removeProfileInformation"
+                arguments="{profile: profile, profileInformation: entry}"
+                class="btn btn-danger"
+            >
+                {f:translate(
+                    key: "tx_academicpersonsedit.fe.profile.btn.removeEntry",
+                    extensionName: "academic_persons_edit"
+                )}
+            </f:link.action>
         </div>
     </div>
     <f:if condition="!{entryIterator.isLast}">
-        <hr class="mb-3" />
+        <hr />
     </f:if>
 </f:for>
 

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/ShowProfileEditingForm.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/ShowProfileEditingForm.html
@@ -1,70 +1,102 @@
-<html data-namespace-typo3-fluid="true"
-      xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
-
-<f:layout name="Default" />
-
-<f:section name="Content">
-    <f:if condition="{profile.languageUid} == {currentLanguageUid}">
-        <f:then>
-            <f:asset.script identifier="ckeditor" src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js" async="1" defer="1" />
-            <f:asset.script identifier="frontend-editor" src="EXT:academic_persons_edit/Resources/Public/JavaScript/FrontendEditor.js" async="1" defer="1" />
-
-            <f:flashMessages queueIdentifier="academic_profile" />
-
-            <f:form action="saveProfile" object="{profile}" name="profile" enctype="multipart/form-data" class="mt-5">
-
-                <div class="row mb-5">
-                    <div class="col">
-                        <f:form.validationResults for="profile">
-                            <f:if condition="{validationResults.flattenedErrors}">
-                                <ul class="errors">
-                                    <f:for each="{validationResults.flattenedErrors}" as="errors" key="propertyPath">
-                                        <li>{propertyPath}
-                                            <ul>
-                                                <f:for each="{errors}" as="error">
-                                                    <li>{error}</li>
-                                                </f:for>
-                                            </ul>
-                                        </li>
-                                    </f:for>
-                                </ul>
-                            </f:if>
-                        </f:form.validationResults>
+    <f:layout name="Default" />
+    <f:section name="Content">
+        <f:if condition="{profile.languageUid} == {currentLanguageUid}">
+            <f:then>
+                <f:asset.script
+                    identifier="ckeditor"
+                    src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js"
+                    async="1"
+                    defer="1"
+                />
+                <f:asset.script
+                    identifier="frontend-editor"
+                    src="EXT:academic_persons_edit/Resources/Public/JavaScript/FrontendEditor.js"
+                    async="1"
+                    defer="1"
+                />
+                <f:flashMessages queueIdentifier="academic_profile" />
+                <f:form
+                    action="saveProfile"
+                    object="{profile}"
+                    name="profile"
+                    enctype="multipart/form-data"
+                    class="mt-5"
+                >
+                    <div class="row mb-5">
+                        <div class="col">
+                            <f:form.validationResults for="profile">
+                                <f:if condition="{validationResults.flattenedErrors}">
+                                    <ul class="errors">
+                                        <f:for
+                                            each="{validationResults.flattenedErrors}"
+                                            as="errors"
+                                            key="propertyPath"
+                                        >
+                                            <li>{propertyPath}
+                                                <ul>
+                                                    <f:for each="{errors}" as="error">
+                                                        <li>{error}</li>
+                                                    </f:for>
+                                                </ul>
+                                            </li>
+                                        </f:for>
+                                    </ul>
+                                </f:if>
+                            </f:form.validationResults>
+                        </div>
                     </div>
-                </div>
-
-                <f:render partial="ProfileEdit/ProfileImage" arguments="{_all}"/>
-
-                <f:for each="{profile.contracts}" as="contract" iteration="contractIterator">
-                    <f:render partial="ProfileEdit/ProfileContract" arguments="{_all}"/>
-                </f:for>
-
-                <f:render partial="ProfileEdit/ProfileData" arguments="{_all}"/>
-
-                <div class="row mb-5">
-                    <div class="col">
-                        <f:form.button class="btn btn-primary mb-3">
-														<f:translate key="tx_academicpersonsedit.fe.profile.btn.save" extensionName="academic_persons_edit" />
-												</f:form.button>
+                    <f:render
+                        partial="ProfileEdit/ProfileImage"
+                        arguments="{_all}"
+                    />
+                    <f:render
+                        partial="ProfileEdit/ProfileData"
+                        arguments="{_all}"
+                    />
+                    <f:for
+                        each="{profile.contracts}"
+                        as="contract"
+                        iteration="contractIterator"
+                    >
+                        <f:render partial="ProfileEdit/ProfileContract" arguments="{_all}"/>
+                    </f:for>
+                    <f:render partial="ProfileEdit/ProfileInformation/CurriculumVitae" arguments="{_all}" />
+                    <f:render partial="ProfileEdit/ProfileInformation/Membership" arguments="{_all}" />
+                    <f:render partial="ProfileEdit/ProfileInformation/Cooperation" arguments="{_all}" />
+                    <f:render partial="ProfileEdit/ProfileInformation/Publication" arguments="{_all}" />
+                    <f:render partial="ProfileEdit/ProfileInformation/Lecture" arguments="{_all}" />
+                    <div class="row mb-5">
+                        <div class="col">
+                            <f:form.button class="btn btn-primary mb-3">
+                                {f:translate(
+                                    key: 'tx_academicpersonsedit.fe.profile.btn.save',
+                                    extensionName: 'academic_persons_edit'
+                                )}
+                            </f:form.button>
+                        </div>
                     </div>
-                </div>
-
-            </f:form>
-        </f:then>
-        <f:else>
-            <p>
-								<f:translate key="tx_academicpersonsedit.fe.error.no_translation" extensionName="academic_persons_edit" />
-            </p>
-            <f:if condition="{translationAllowed}">
-                <f:link.action action="translate" arguments="{profileUid: profile.uid, languageUid: currentLanguageUid}" class="btn btn-primary">
-										<f:translate key="tx_academicpersonsedit.fe.profile.btn.translate" extensionName="academic_persons_edit" />
-                </f:link.action>
-            </f:if>
-        </f:else>
-    </f:if>
-
-
-</f:section>
-
+                </f:form>
+            </f:then>
+            <f:else>
+                <p>
+                    {f:translate(
+                        key: "tx_academicpersonsedit.fe.error.no_translation",
+                        extensionName: "academic_persons_edit"
+                    )}
+                </p>
+                <f:if condition="{translationAllowed}">
+                    <f:link.action action="translate" arguments="{profileUid: profile.uid, languageUid: currentLanguageUid}" class="btn btn-primary">
+                        {f:translate(
+                            key: "tx_academicpersonsedit.fe.profile.btn.translate",
+                            extensionName="academic_persons_edit"
+                        )}
+                    </f:link.action>
+                </f:if>
+            </f:else>
+        </f:if>
+    </f:section>
 </html>

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
@@ -139,7 +139,7 @@ class Contract extends AbstractEntity
         return $this->position;
     }
 
-    public function setLocation(Location $location): void
+    public function setLocation(?Location $location): void
     {
         $this->location = $location;
     }

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -253,7 +253,7 @@ return [
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'file',
-                'maxitems' => 6,
+                'maxitems' => 1,
                 'allowed' => 'common-image-types',
             ],
         ],

--- a/packages/fgtclb/academic-persons/ext_tables.sql
+++ b/packages/fgtclb/academic-persons/ext_tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE tx_academicpersons_domain_model_contract (
 
     employee_type int(11) unsigned DEFAULT '0' NOT NULL,
     position varchar(255) DEFAULT '' NOT NULL,
-    location int(11) unsigned DEFAULT '0' NOT NULL,
+    location int(11) unsigned  DEFAULT NULL,
 
     room varchar(255) DEFAULT '' NOT NULL,
     office_hours text,


### PR DESCRIPTION
* Change image property mapping and upload from raw `array` access to `TYPO3\CMS\Core\Http\UploadedFile` handling introduced with TYPO3 v12. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97214-UseUploadedFileObjectsInsteadOf_FILES.html#breaking-97214
* Use enums for severities introduced with TYPO3 v12. See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97787-EnumForSeveritiesIntroduced.html
* Make location in contracts nullable to avoid error when no location was seleceted in the frontend form.
* Add missing editing fields for personal data (e.g. first and last name) to templates and partials.
* Optimize templates and partials for better readability.