### PR TITLE
[DOCS] Migrate documentation to php-based rendering

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Documentation/guides.xml
+++ b/packages/fgtclb/academic-bite-jobs/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-bite-jobs" project-issues="https://github.com/fgtclb/academic-bite-jobs/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-bite-jobs" typo3-core-preferred="stable"/>
+  <project title="Academic Bite Jobs" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/academic-jobs/Documentation/guides.xml
+++ b/packages/fgtclb/academic-jobs/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-jobs" project-issues="https://github.com/fgtclb/academic-jobs/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-jobs" typo3-core-preferred="stable"/>
+  <project title="Academic Jobs" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/academic-persons-edit/Documentation/guides.xml
+++ b/packages/fgtclb/academic-persons-edit/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-persons-edit" project-issues="https://github.com/fgtclb/academic-persons-edit/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-persons-edit" typo3-core-preferred="stable"/>
+  <project title="Academic Profiles Edit" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/academic-persons-sync/Documentation/guides.xml
+++ b/packages/fgtclb/academic-persons-sync/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-persons-sync" project-issues="https://github.com/fgtclb/academic-persons-sync/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-persons-sync" typo3-core-preferred="stable"/>
+  <project title="Academic Profiles Sync" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/academic-persons/Documentation/guides.xml
+++ b/packages/fgtclb/academic-persons/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-persons" project-issues="https://github.com/fgtclb/academic-persons/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-persons" typo3-core-preferred="stable"/>
+  <project title="Academic Profiles" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/academic-projects/Documentation/guides.xml
+++ b/packages/fgtclb/academic-projects/Documentation/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/academic-projects" project-issues="https://github.com/fgtclb/academic-projects/issues" edit-on-github-branch="main" edit-on-github="fgtclb/academic-projects" typo3-core-preferred="stable"/>
+  <project title="Academic Projects" release="2.0.2" copyright="since 2023 by FGTCLB GmbH"/>
+  <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+  <inventory id="t3install" url="https://docs.typo3.org/m/typo3/guide-installation/main/en-us/"/>
+  <inventory id="t3sitepackage" url="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"/>
+  <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
+</guides>

--- a/packages/fgtclb/typo3-category-types/Documentation/guides.xml
+++ b/packages/fgtclb/typo3-category-types/Documentation/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
+  <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-repository="https://github.com/fgtclb/typo3-category-types" project-issues="https://github.com/fgtclb/typo3-category-types/issues" edit-on-github-branch="main" edit-on-github="fgtclb/typo3-category-types" edit-on-github-directory="Documentation" typo3-core-preferred="stable"/>
+  <project title="FGTCLB Category Types" release="2.0.2" version="2.0.2" copyright="2023"/>
+  <inventory id="t3tsref" url="http://docs.typo3.org/typo3cms/TyposcriptReference/"/>
+  <inventory id="t3editors" url="http://docs.typo3.org/typo3cms/EditorsTutorial/"/>
+  <inventory id="t3start" url="http://docs.typo3.org/typo3cms/GettingStartedTutorial/"/>
+</guides>


### PR DESCRIPTION
This change migrates existing extension documentation
to new php based renderer using the provided migration
command.

Used command(s) for each extension:

```shell
docker run --rm --pull always -v $(pwd):/project \
  -it ghcr.io/typo3-documentation/render-guides:latest \
  migrate Documentation
```

[1] https://docs.typo3.org/other/t3docs/render-guides/main/en-us/Migration/Index.html
