### PR TITLE
[TASK] Streamline extbase domain model implementation

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Contact.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Contact.php
@@ -10,10 +10,18 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Contact extends AbstractEntity
 {
     protected int $page = 0;
-
     protected ?Contract $contract = null;
-
     protected ?Role $role = null;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getPage(): int
     {

--- a/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Role.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Role.php
@@ -9,8 +9,23 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Role extends AbstractEntity
 {
     protected string $name = '';
-
     protected string $description = '';
+    protected int $page = 0;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
 
     public function getName(): string
     {

--- a/packages/fgtclb/academic-jobs/Classes/Domain/Model/Contact.php
+++ b/packages/fgtclb/academic-jobs/Classes/Domain/Model/Contact.php
@@ -8,73 +8,56 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class Contact extends AbstractEntity
 {
-    protected string $name;
+    protected string $name = '';
+    protected string $email = '';
+    protected string $phone = '';
+    protected string $additionalInformation = '';
 
-    protected string $email;
-
-    protected string $phone;
-
-    protected string $additionalInformation;
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
 
     /**
-     * @return string
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
      */
+    public function initializeObject(): void {}
+
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
     public function getEmail(): string
     {
         return $this->email;
     }
 
-    /**
-     * @param string $email
-     */
     public function setEmail(string $email): void
     {
         $this->email = $email;
     }
 
-    /**
-     * @return string
-     */
     public function getPhone(): string
     {
         return $this->phone;
     }
 
-    /**
-     * @param string $phone
-     */
     public function setPhone(string $phone): void
     {
         $this->phone = $phone;
     }
 
-    /**
-     * @return string
-     */
     public function getAdditionalInformation(): string
     {
         return $this->additionalInformation;
     }
 
-    /**
-     * @param string $additionalInformation
-     */
     public function setAdditionalInformation(string $additionalInformation): void
     {
         $this->additionalInformation = $additionalInformation;

--- a/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
+++ b/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
@@ -18,67 +18,53 @@ class Job extends AbstractEntity
     /**
      * @Validate("NotEmpty")
      */
-    protected string $title;
-
+    protected string $title = '';
     /**
-     * @var \DateTime
      * @Validate("NotEmpty")
      */
-    protected $employmentStartDate;
-
-    protected string $description;
-
+    protected ?\DateTime $employmentStartDate = null;
+    protected string $description = '';
     /**
      * @Cascade("remove")
      */
     protected ?FileReference $image = null;
-
     /**
      * @Validate("NotEmpty")
      */
-    protected string $companyName;
-
-    protected string $sector;
-
-    protected string $requiredDegree;
-
-    protected string $contractualRelationship;
-
+    protected string $companyName = '';
+    protected string $sector = '';
+    protected string $requiredDegree = '';
+    protected string $contractualRelationship = '';
     protected int $alumniRecommend = 0;
-
     protected int $internationalsWelcome = 0;
-
     /**
-     * employmentType
-     *
-     * @var int
      * @Validate("NotEmpty")
      */
-    protected int $employmentType;
-
-    protected string $workLocation;
-
-    protected string $link;
-
+    protected int $employmentType = 0;
+    protected string $workLocation = '';
+    protected string $link = '';
     protected string $slug = '';
-
-    protected int $type;
-
+    protected int $type = 0;
     protected int $hidden = 0;
-
     protected ?Contact $contact = null;
-
     /**
-     * @var \DateTime
      * @Validate("NotEmpty")
      */
-    protected $starttime;
-
+    protected ?\DateTime $starttime = null;
     /**
-     * @var \DateTime
      * @Validate("NotEmpty")
      */
-    protected $endtime;
+    protected ?\DateTime $endtime = null;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getTitle(): string
     {
@@ -90,22 +76,12 @@ class Job extends AbstractEntity
         $this->title = $title;
     }
 
-    /**
-     * Returns the employmentStartDate
-     *
-     * @return \DateTime
-     */
-    public function getEmploymentStartDate()
+    public function getEmploymentStartDate(): ?\DateTime
     {
         return $this->employmentStartDate;
     }
 
-    /**
-     * Sets the employmentStartDate
-     *
-     * @param \DateTime $employmentStartDate
-     */
-    public function setEmploymentStartDate(\DateTime $employmentStartDate): void
+    public function setEmploymentStartDate(?\DateTime $employmentStartDate = null): void
     {
         $this->employmentStartDate = $employmentStartDate;
     }
@@ -230,56 +206,32 @@ class Job extends AbstractEntity
         $this->contact = $contact;
     }
 
-    /**
-     * employmentType
-     *
-     * @return int
-     */
     public function getEmploymentType(): int
     {
         return $this->employmentType;
     }
 
-    /**
-     * employmentType
-     *
-     * @param int $employmentType employmentType
-     * @return self
-     */
-    public function setEmploymentType(int $employmentType): self
+    public function setEmploymentType(int $employmentType): void
     {
         $this->employmentType = $employmentType;
-        return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getStarttime()
+    public function getStarttime(): ?\DateTime
     {
         return $this->starttime;
     }
 
-    /**
-     * @param \DateTime $starttime
-     */
-    public function setStarttime($starttime): void
+    public function setStarttime(?\DateTime $starttime = null): void
     {
         $this->starttime = $starttime;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getEndtime()
+    public function getEndtime(): ?\DateTime
     {
         return $this->endtime;
     }
 
-    /**
-     * @param \DateTime $endtime
-     */
-    public function setEndtime($endtime): void
+    public function setEndtime(?\DateTime $endtime = null): void
     {
         $this->endtime = $endtime;
     }
@@ -289,10 +241,9 @@ class Job extends AbstractEntity
         return $this->hidden;
     }
 
-    public function setHidden(int $hidden): self
+    public function setHidden(int $hidden): void
     {
         $this->hidden = $hidden;
-        return $this;
     }
 
     public function getImage(): ?FileReference
@@ -300,9 +251,8 @@ class Job extends AbstractEntity
         return $this->image;
     }
 
-    public function setImage(?FileReference $image): self
+    public function setImage(?FileReference $image): void
     {
         $this->image = $image;
-        return $this;
     }
 }

--- a/packages/fgtclb/academic-partners/Classes/Domain/Model/Dto/PartnerDemand.php
+++ b/packages/fgtclb/academic-partners/Classes/Domain/Model/Dto/PartnerDemand.php
@@ -11,16 +11,20 @@ class PartnerDemand
 {
     /** @var int[] */
     protected array $pages = [];
-
     protected ?FilterCollection $filterCollection = null;
-
     protected string $sorting = '';
-
     protected string $sortingField = '';
-
     protected string $sortingDirection = '';
 
     public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
     {
         $this->setSorting(SortingOptions::__default);
     }

--- a/packages/fgtclb/academic-partners/Classes/Domain/Model/Partner.php
+++ b/packages/fgtclb/academic-partners/Classes/Domain/Model/Partner.php
@@ -16,41 +16,38 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Partner extends AbstractEntity implements GetCategoryCollectionInterface
 {
     protected int $doktype = 0;
-
     protected string $title = '';
-
     protected string $abstract = '';
-
     protected string $description = '';
-
     protected string $addressStreet = '';
-
     protected string $addressStreetNumber = '';
-
     protected string $addressAdditional = '';
-
     protected string $addressZip = '';
-
     protected string $addressCity = '';
-
     protected string $addressCountry = '';
-
     protected float $geocodeLongitude = 0;
-
     protected float $geocodeLatitude = 0;
-
     protected ?\DateTime $geocodeLastRun = null;
-
     protected string $geocodeStatus = 'open';
-
     protected string $geocodeMessage = '';
-
     protected bool $showOnMap = true;
-
     protected ?CategoryCollection $attributes = null;
 
     /** @var ObjectStorage<FileReference> */
-    protected $media;
+    protected ObjectStorage $media;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
+        $this->media = new ObjectStorage();
+    }
 
     /**
      * @return int<0, max>|null

--- a/packages/fgtclb/academic-partners/Classes/Domain/Model/Partnership.php
+++ b/packages/fgtclb/academic-partners/Classes/Domain/Model/Partnership.php
@@ -9,10 +9,18 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Partnership extends AbstractEntity
 {
     protected int $page = 0;
-
     protected ?Partner $partner = null;
-
     protected ?Role $role = null;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getPage(): int
     {

--- a/packages/fgtclb/academic-partners/Classes/Domain/Model/Role.php
+++ b/packages/fgtclb/academic-partners/Classes/Domain/Model/Role.php
@@ -9,8 +9,17 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Role extends AbstractEntity
 {
     protected string $name = '';
-
     protected string $description = '';
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getName(): string
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Address.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Address.php
@@ -11,4 +11,19 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersonsEdit\Domain\Model;
 
-class Address extends \Fgtclb\AcademicPersons\Domain\Model\Address {}
+class Address extends \Fgtclb\AcademicPersons\Domain\Model\Address
+{
+    public function __construct()
+    {
+        // parent constructor needs to call $this->initializeObject().
+        parent::__construct();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
+        parent::initializeObject();
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/FrontendUser.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/FrontendUser.php
@@ -17,6 +17,16 @@ class FrontendUser extends AbstractEntity
 {
     protected string $username = '';
 
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
     public function getUsername(): string
     {
         return $this->username;

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Location.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Location.php
@@ -11,4 +11,19 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersonsEdit\Domain\Model;
 
-class Location extends \Fgtclb\AcademicPersons\Domain\Model\Location {}
+class Location extends \Fgtclb\AcademicPersons\Domain\Model\Location
+{
+    public function __construct()
+    {
+        // parent constructor needs to call $this->initializeObject().
+        parent::__construct();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
+        parent::initializeObject();
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Profile.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Profile.php
@@ -26,7 +26,16 @@ class Profile extends \Fgtclb\AcademicPersons\Domain\Model\Profile
 
     public function __construct()
     {
+        // parent constructor needs to call $this->initializeObject().
         parent::__construct();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
+        parent::initializeObject();
         $this->frontendUsers = new ObjectStorage();
     }
 

--- a/packages/fgtclb/academic-persons-sync/Classes/Domain/Model/FrontendUser.php
+++ b/packages/fgtclb/academic-persons-sync/Classes/Domain/Model/FrontendUser.php
@@ -13,4 +13,15 @@ namespace Fgtclb\AcademicPersonsSync\Domain\Model;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
-class FrontendUser extends AbstractEntity {}
+class FrontendUser extends AbstractEntity
+{
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Address.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Address.php
@@ -18,9 +18,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Address extends AbstractEntity
 {
     protected ?Category $employeeType = null;
-
     protected ?OrganisationalUnit $organisationalUnit = null;
-
     protected ?FunctionType $functionType = null;
 
     /**
@@ -29,7 +27,6 @@ class Address extends AbstractEntity
     protected string $street = '';
 
     protected string $streetNumber = '';
-
     protected string $additional = '';
 
     /**
@@ -41,7 +38,6 @@ class Address extends AbstractEntity
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $city = '';
-
     protected string $state = '';
 
     /**
@@ -53,6 +49,16 @@ class Address extends AbstractEntity
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $type = '';
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getEmployeeType(): ?Category
     {

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
@@ -20,25 +20,15 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Contract extends AbstractEntity
 {
     protected ?Profile $profile = null;
-
     protected ?OrganisationalUnit $organisationalUnit = null;
-
     protected ?FunctionType $functionType = null;
-
     protected ?\DateTime $validFrom = null;
-
     protected ?\DateTime $validTo = null;
-
     protected ?Category $employeeType = null;
-
     protected string $position = '';
-
     protected ?Location $location = null;
-
     protected string $room = '';
-
     protected string $officeHours = '';
-
     protected bool $publish = false;
 
     /**
@@ -63,6 +53,14 @@ class Contract extends AbstractEntity
     protected ObjectStorage $phoneNumbers;
 
     public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
     {
         $this->physicalAddresses = new ObjectStorage();
         $this->emailAddresses = new ObjectStorage();

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Email.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Email.php
@@ -27,6 +27,16 @@ class Email extends AbstractEntity
      */
     protected string $type = '';
 
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
     public function getEmail(): string
     {
         return $this->email;

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/FunctionType.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/FunctionType.php
@@ -20,10 +20,18 @@ class FunctionType extends AbstractEntity
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $functionName = '';
-
     protected string $functionNameMale = '';
-
     protected string $functionNameFemale = '';
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function setFunctionName(string $functionName): void
     {

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Location.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Location.php
@@ -17,6 +17,16 @@ class Location extends AbstractEntity
 {
     protected string $title = '';
 
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
     public function getTitle(): string
     {
         return $this->title;

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/OrganisationalUnit.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/OrganisationalUnit.php
@@ -20,20 +20,14 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class OrganisationalUnit extends AbstractEntity
 {
     protected ?OrganisationalUnit $parent = null;
-
     /**
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $unitName = '';
-
     protected string $uniqueName = '';
-
     protected string $displayText = '';
-
     protected string $longText = '';
-
     protected ?\DateTime $validFrom = null;
-
     protected ?\DateTime $validTo = null;
 
     /**
@@ -44,6 +38,14 @@ class OrganisationalUnit extends AbstractEntity
     protected ObjectStorage $contracts;
 
     public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
     {
         $this->contracts = new ObjectStorage();
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/PhoneNumber.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/PhoneNumber.php
@@ -26,6 +26,16 @@ class PhoneNumber extends AbstractEntity
      */
     protected string $type = '';
 
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
     public function getPhoneNumber(): string
     {
         return $this->phoneNumber;

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Profile.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Profile.php
@@ -21,97 +21,73 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Profile extends AbstractEntity
 {
     protected string $gender = '';
-
     protected string $title = '';
-
     /**
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $firstName = '';
-
     protected string $firstNameAlpha = '';
-
     protected string $middleName = '';
-
     /**
      * @Validate("TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator")
      */
     protected string $lastName = '';
-
     protected string $lastNameAlpha = '';
-
     /**
      * @Cascade("remove")
      */
     protected ?FileReference $image = null;
-
     /**
      * @var ObjectStorage<Contract>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $contracts;
-
     protected string $websiteTitle = '';
-
     protected string $website = '';
-
     protected string $teachingArea = '';
-
     protected string $coreCompetences = '';
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $memberships;
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $pressMedia;
-
     protected string $supervisedThesis = '';
-
     protected string $supervisedDoctoralThesis = '';
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $vita;
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $publications;
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $scientificResearch;
-
     protected string $publicationsLink = '';
-
     protected string $publicationsLinkTitle = '';
-
     protected string $miscellaneous = '';
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
      * @Cascade("remove")
      */
     protected ObjectStorage $cooperation;
-
     /**
      * @var ObjectStorage<ProfileInformation>
      * @Lazy
@@ -120,6 +96,14 @@ class Profile extends AbstractEntity
     protected ObjectStorage $lectures;
 
     public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
     {
         $this->contracts = new ObjectStorage();
         $this->memberships = new ObjectStorage();

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/ProfileInformation.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/ProfileInformation.php
@@ -16,18 +16,22 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class ProfileInformation extends AbstractEntity
 {
     protected string $type = '';
-
     protected string $title = '';
-
     protected string $bodytext = '';
-
     protected string $link = '';
-
     protected int $year = 0;
-
     protected int $yearStart = 0;
-
     protected int $yearEnd = 0;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
 
     public function getType(): string
     {

--- a/packages/fgtclb/academic-programs/Classes/Domain/Model/Dto/ProgramDemand.php
+++ b/packages/fgtclb/academic-programs/Classes/Domain/Model/Dto/ProgramDemand.php
@@ -11,16 +11,20 @@ class ProgramDemand
 {
     /** @var int[] */
     protected array $pages = [];
-
     protected ?FilterCollection $filterCollection = null;
-
     protected string $sorting = '';
-
     protected string $sortingField = '';
-
     protected string $sortingDirection = '';
 
     public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
     {
         $this->setSorting(SortingOptions::__default);
     }

--- a/packages/fgtclb/academic-programs/Classes/Domain/Model/Program.php
+++ b/packages/fgtclb/academic-programs/Classes/Domain/Model/Program.php
@@ -14,26 +14,31 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class Program extends AbstractEntity implements GetCategoryCollectionInterface
 {
-    protected int $doktype;
-
+    protected int $doktype = 0;
     protected string $title = '';
-
     protected string $subtitle = '';
-
     protected string $abstract = '';
-
     protected int $creditPoints = 0;
-
     protected string $jobProfile = '';
-
     protected string $performanceScope = '';
-
     protected string $prerequisites = '';
-
     protected ?CategoryCollection $attributes = null;
 
     /** @var ObjectStorage<FileReference> */
-    protected $media;
+    protected ObjectStorage $media;
+
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
+        $this->media = new ObjectStorage();
+    }
 
     /**
      * @return int<0, max>|null

--- a/packages/fgtclb/academic-programs/Classes/Domain/Model/ProgramData.php
+++ b/packages/fgtclb/academic-programs/Classes/Domain/Model/ProgramData.php
@@ -21,6 +21,16 @@ class ProgramData
     protected string $performanceScope = '';
     protected string $prerequisites = '';
 
+    public function __construct()
+    {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void {}
+
     public function setPid(int $pid): void
     {
         $this->pid = $pid;

--- a/packages/fgtclb/academic-projects/Classes/Domain/Model/Dto/ProjectDemand.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Model/Dto/ProjectDemand.php
@@ -20,6 +20,14 @@ class ProjectDemand
 
     public function __construct()
     {
+        $this->initializeObject();
+    }
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
+    public function initializeObject(): void
+    {
         $this->setSorting(SortingOptions::__default);
     }
 

--- a/packages/fgtclb/academic-projects/Classes/Domain/Model/Project.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Model/Project.php
@@ -15,24 +15,15 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Project extends AbstractEntity implements GetCategoryCollectionInterface
 {
     protected int $doktype = 0;
-
     protected string $title = '';
-
     /** @var ObjectStorage<FileReference> */
     protected ObjectStorage $media;
-
     protected string $projectTitle = '';
-
     protected string $shortDescription = '';
-
     protected ?\DateTime $startDate = null;
-
     protected ?\DateTime $endDate = null;
-
     protected float $budget = 0;
-
     protected string $funders = '';
-
     protected ?CategoryCollection $attributes = null;
 
     public function __construct()
@@ -40,6 +31,9 @@ class Project extends AbstractEntity implements GetCategoryCollectionInterface
         $this->initializeObject();
     }
 
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
+     */
     public function initializeObject(): void
     {
         $this->media = new ObjectStorage();

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
@@ -7,12 +7,12 @@ namespace FGTCLB\CategoryTypes\Domain\Model;
 class CategoryType implements \JsonSerializable, \Stringable
 {
     public function __construct(
-        private readonly string $identifier,
-        private readonly string $extensionKey,
-        private readonly string $title,
-        private readonly string $group,
-        private readonly string $icon,
-        private readonly int $priority,
+        protected readonly string $identifier,
+        protected readonly string $extensionKey,
+        protected readonly string $title,
+        protected readonly string $group,
+        protected readonly string $icon,
+        protected readonly int $priority,
     ) {}
 
     /**


### PR DESCRIPTION
Extbase does not call class constructor for domain models
when hydrating (thwating) from database, but calls custom
method `public function initializeObject(): void`, which
is a long-time known construct.

In older days that was only needed for `ObjectStorage`,
but became a harder requirement for other types domain
model properties and specially when custructor property
promotion is used.

Recommended design of Extbase Domain models boils down
to:

* Use native typed properties with default assignments as
  long as it is possible.
* Keep `__construct()` clean and call `initializeObject()`.
* Use `initializeObject()` to ensure that all properties
  are initialized, mainly when objects like `ObjectStorage`
  needs to be set. Constructor and empty method are added
  to all models with code comment to make clear the use and
  to help on reviews when adding stuff and it needs to be
  added.
* Do not use `constructor property promotion` for domain
  models, which requires to assign default values for ALL
  constructor promoted parameters despite the assignment
  defined in the constructor.
* Avoid `: self` for setter.

Note that same logic is applied to extbase based DTO's, but
not used for not extbase based classes even when they resides
within `Domain/Model` folders following a bad anti-pattern.

[1] https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.html#good-use-initializeobject-for-setup
