### PR TITLE
[BUGFIX] Use named placeholder in `EXT:academic_projects` upgrade wizard

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
@@ -38,8 +38,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
             $queryBuilder->getRestrictions()->removeAll();
             $queryBuilder->update('tt_content')
                 ->set('CType', $contentType)
+                ->set('list_tyype', '')
                 ->where(
-                    $queryBuilder->expr()->eq('CType', 'list'),
+                    $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter('list')),
                     $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter($contentType))
                 )->executeStatement();
         }


### PR DESCRIPTION
The `EXT:academic_projects` upgrade wizard for `list_type` to `CType`
migration does not use correct value quoting.

To mitigate that, named placeholder are now used for the `UPDATE`
statement creation and also sets `list_type` to an empty string
now to complete the migration.
