### PR TITLE
[BUGFIX] Use correct column name in UpgradeWizard update query

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
@@ -38,7 +38,7 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
             $queryBuilder->getRestrictions()->removeAll();
             $queryBuilder->update('tt_content')
                 ->set('CType', $contentType)
-                ->set('list_tyype', '')
+                ->set('list_type', '')
                 ->where(
                     $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter('list')),
                     $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter($contentType))


### PR DESCRIPTION
`EXT:academic_projects` upgrade wizard has been modified
recently to use proper named placeholder and clearing
the `list_type` added along the way - with an typo in the
column name. This is now corrected.
