### PR TITLE
[TASK] Mitigate TCA automigration for select items

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/fe_users.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/fe_users.php
@@ -15,8 +15,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'fe_users',
     'tx_extbase_type',
     [
-        'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser',
-        'Tx_Academicpersonsedit_Domain_Model_FrontendUser',
+        'label' => 'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser',
+        'value' => 'Tx_Academicpersonsedit_Domain_Model_FrontendUser',
+        'icon' => null,
     ]
 );
 $GLOBALS['TCA']['fe_users']['types']['Tx_Academicpersonsedit_Domain_Model_FrontendUser'] = $GLOBALS['TCA']['fe_users']['types']['0'];

--- a/packages/fgtclb/academic-persons-sync/Configuration/TCA/Overrides/fe_users.php
+++ b/packages/fgtclb/academic-persons-sync/Configuration/TCA/Overrides/fe_users.php
@@ -15,9 +15,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'fe_users',
     'tx_extbase_type',
     [
-        'LLL:EXT:academic_persons_sync/Resources/Private/Language/locallang_tca.xlf:fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser',
-        'Tx_Academicpersonssync_Domain_Model_FrontendUser',
-    ]
+        'label' => 'LLL:EXT:academic_persons_sync/Resources/Private/Language/locallang_tca.xlf:fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser',
+        'value' => 'Tx_Academicpersonssync_Domain_Model_FrontendUser',
+    ],
 );
 
 $GLOBALS['TCA']['fe_users']['types']['Tx_Academicpersonssync_Domain_Model_FrontendUser'] = [


### PR DESCRIPTION
TYPO3 v12 deprecated TCA type=select items list array
items automigrating them to associative arrays while
triggering a `E_USER_DEPRECATED` notice in these cases.

`academic_persons_edit` and `academic_persons_sync`
register custom `tx_extbase_type` items using list
array style and hitting TCA automigration.

This change adopts the new associative item style for
regisered items.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html
