### PR TITLE
[TASK] Mitigate v13 flexform TCA migration

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core13/AcademicBiteJobsList.xml
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core13/AcademicBiteJobsList.xml
@@ -119,8 +119,7 @@
                 <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.jobs.limit.label</label>
                 <description>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.jobs.limit.description</description>
                 <config>
-                    <type>input</type>
-                    <eval>int</eval>
+                    <type>number</type>
                 </config>
             </settings.jobs.limit>
         </el>


### PR DESCRIPTION
With TYPO3 v12 quite some tca stuff has been deprecated and
automigrated to new structures and adopted in TYPO3 v13 for
flexform the same way.

Some issues has been already addressed working on v12/v13
dual version support and fixed with core specific flexform
definition files.

Introducing new category type handling with #56 also changed
some flexforms, but sadly introduced depcreated `type=input`
with `eval=int` for a new option not covered by functional
tests and therefore was not detected earlier. [1]

This change migrates for TYPO3 v13 flexform the field directly
to the new `TCA type=number`. [2]

[1] https://github.com/fgtclb/academic-extensions/pull/56
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97193-NewTCATypeNumber.html
