### PR TITLE
[TASK] Create release on monorepo with all extension archives

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: publish
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    env:
+      TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify tag
+        run: |
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
+            exit 1
+          fi
+
+      - name: Get version
+        id: get-version
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: intl, mbstring, json, zip, curl
+          tools: composer:v2
+
+      - name: Install tailor
+        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+
+      # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
+      - name: Create local TER package upload artifact
+        shell: bash
+        run: |
+          find packages/fgtclb \
+            -mindepth 1 -maxdepth 1 \
+            -type d -printf '%f\n' | while read -d $'\n' extension
+          do
+            extensionKey="$(cat "packages/fgtclb/${extension}/composer.json" | jq -r '.extra."typo3/cms"."extension-key"' )"
+            if [[ "${extensionKey}" != "" ]]; then
+              php ~/.composer/vendor/bin/tailor create-artefact ${{ env.version }} ${extensionKey} --path="packages/fgtclb/${extension}"
+            fi
+          done
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          generate_release_notes: true
+          files: |
+            tailor-version-artefact/*_${{ env.version }}.zip
+            LICENSE
+          fail_on_unmatched_files: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /ddev-instances/core-13/vendor
 /ddev-instances/core-13/var
 /ddev-instances/core-13/composer.lock
+
+/tailor-version-artefact/
+/tailor-version-upload/


### PR DESCRIPTION
Each extension contains a dedicated publish GitHub workflow to
create an TER artifact and upload it to TER and add it within
each extension split repository created GitHub release.

This change introduces a publish workflow similar to that used
for each extension, except that it only creates GitHub release
and attaches TER upload packages of all extensions not process
any TER (TYPO3 Extension Repository) uploads.

Acts as a central place to have extension releases in a more
communicative way and ALL extension upload archives in one
place.

Using the GitHub commandline tool `gh` helps to download all
of them in one go when required, for example with:

```shell
mkdir -p extensions-2.0.1 \
&& gh release download 2.0.1 \
  --repo fgtclb/academic-extensions \
  --pattern '*_2.0.1.zip' ./extensions-2.0.1
```

See: https://cli.github.com/manual/gh_release_download
