### PR TITLE
[TASK] Streamline CType Upgrade wizard of `academic-projects`

### DIFF
--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"list","academicprojects_projectlistsingle",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"list","academicprojects_projectlistsingle",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectListSingle_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"list","academicprojects_projectlistsingle",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"list","academicprojects_projectlist",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"list","academicprojects_projectlist",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/DataSets/onlyProjectList_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"list","academicprojects_projectlist",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"academicprojects_projectlistsingle","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"academicprojects_projectlistsingle","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectListSingle_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"academicprojects_projectlistsingle","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"academicprojects_projectlist","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"academicprojects_projectlist","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyProjectList_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"academicprojects_projectlist","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Upgrades;
+
+use FGTCLB\AcademicProjects\Upgrades\PluginUpgradeWizard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+final class PluginUpgradeWizardTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/category-types',
+        'fgtclb/academic-projects',
+    ];
+
+    #[Test]
+    public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
+    {
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertFalse($subject->updateNecessary());
+    }
+
+    public static function ttContentPluginDataSets(): \Generator
+    {
+        yield 'only projectlist - not deleted and hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectList_notDeletedOrHidden.csv',
+        ];
+        yield 'only projectlist - not deleted and but hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectList_notDeletedButHidden.csv',
+        ];
+        yield 'only projectlist - deleted but not hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectList_deletedButNotHidden.csv',
+        ];
+        yield 'only projectlistsingle - not deleted and hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectListSingle_notDeletedOrHidden.csv',
+        ];
+        yield 'only projectlistsingle - not deleted and but hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectListSingle_notDeletedButHidden.csv',
+        ];
+        yield 'only projectlistsingle - deleted but not hidden' => [
+            'fixtureDataSetFile' => 'onlyProjectListSingle_deletedButNotHidden.csv',
+        ];
+    }
+
+    #[DataProvider('ttContentPluginDataSets')]
+    #[Test]
+    public function updateNecessaryReturnsTrueWhenUpgradablePluginsExists(
+        string $fixtureDataSetFile,
+    ): void {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSets/' . $fixtureDataSetFile);
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertTrue($subject->updateNecessary(), 'updateNecessary() returns true');
+    }
+
+    #[DataProvider('ttContentPluginDataSets')]
+    #[Test]
+    public function executeUpdateMigratesContentElementsAndReturnsTrue(
+        string $fixtureDataSetFile,
+    ): void {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSets/' . $fixtureDataSetFile);
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertTrue($subject->executeUpdate(), 'updateNecessary() returns true');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Upgraded/' . $fixtureDataSetFile);
+    }
+}


### PR DESCRIPTION
This change streamlines the `list_type` to `CType` upgrade
wizard of `academic-projects` to a modern and more explicit
implementation. This includes:

* Using constructor injection for `ConnectionPool`.
* Use QueryBuilder to update records in the database.
* Use QueryBuilder to check if update is neccessary
  instead of hardcoded `true`.
* Adding tests for upgrade wizard to ensure working
  state.

