### PR TITLE
[!!!][TASK] Migrate `academic_jobs` plugins to `CType`

### DIFF
--- a/packages/fgtclb/academic-jobs/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-jobs/Classes/Upgrades/PluginUpgradeWizard.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Upgrades;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+#[UpgradeWizard('academicJobs_pluginContent')]
+final class PluginUpgradeWizard implements UpgradeWizardInterface
+{
+    private const MIGRATE_CONTENT_TYPES_LIST = [
+        // list_type => CType
+        'academicjobs_newjobform' => 'academicjobs_newjobform',
+        'academicjobs_list' => 'academicjobs_list',
+        'academicjobs_detail' => 'academicjobs_detail',
+    ];
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    public function getTitle(): string
+    {
+        return 'Migrate plugin list element from academic_jobs to normal content elements';
+    }
+
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function executeUpdate(): bool
+    {
+        foreach (self::MIGRATE_CONTENT_TYPES_LIST as $oldName => $newName) {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+            $queryBuilder->getRestrictions()->removeAll();
+            $queryBuilder
+                ->update('tt_content')
+                ->set('CType', $newName)
+                ->set('list_type', '')
+                ->where(
+                    $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter('list')),
+                    $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter($oldName)),
+                )->executeStatement();
+        }
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+        return (int)($queryBuilder
+            ->count('*')
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter('list')),
+                $queryBuilder->expr()->in(
+                    'list_type',
+                    $queryBuilder->quoteArrayBasedValueListToStringList(array_keys(self::MIGRATE_CONTENT_TYPES_LIST))
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne()) > 0;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+}

--- a/packages/fgtclb/academic-jobs/Configuration/Icons.php
+++ b/packages/fgtclb/academic-jobs/Configuration/Icons.php
@@ -1,0 +1,10 @@
+<?php
+
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+return [
+    'academic_jobs_icon' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg',
+    ],
+];

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -10,37 +10,96 @@ if (!defined('TYPO3')) {
 
 (static function (): void {
     $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
-    ExtensionUtility::registerPlugin(
-        'AcademicJobs',
-        'NewJobForm',
-        'Academic Jobs: New Job Form',
-        'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg'
-    );
-    ExtensionUtility::registerPlugin(
-        'AcademicJobs',
-        'List',
-        'Academic Jobs: List Jobs',
-        'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg'
-    );
-    ExtensionUtility::registerPlugin(
-        'AcademicJobs',
-        'Detail',
-        'Academic Jobs: Detail',
-        'EXT:academic_jobs/Resources/Public/Icons/jobs_icon.svg'
+
+    //==================================================================================================================
+    // Add custom content element group `academic`
+    //==================================================================================================================
+    ExtensionManagementUtility::addTcaSelectItemGroup(
+        'tt_content',
+        'CType',
+        'academic',
+        'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:content.ctype.group.label',
     );
 
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_detail'] = 'recursive,select_key';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_list'] = 'pages,layout,select_key,recursive';
-
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_list'] = 'pi_flexform';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_newjobform'] = 'pi_flexform';
-
-    ExtensionManagementUtility::addPiFlexFormValue(
-        'academicjobs_list',
-        sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/PluginList.xml', $typo3MajorVersion)
+    //==================================================================================================================
+    // Plugin: academicjobs_newjobform
+    //==================================================================================================================
+    ExtensionManagementUtility::addPlugin(
+        [
+            'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.newjobform.label',
+            'value' => 'academicjobs_newjobform',
+            'icon' => 'academic_jobs_icon',
+            'group' => 'academic',
+        ],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+        'academic_jobs'
+    );
+    ExtensionManagementUtility::addToAllTCAtypes(
+        'tt_content',
+        implode(',', [
+            '--div--;LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:element.tab.configuration',
+            'pi_flexform',
+        ]),
+        'academicjobs_newjobform',
+        'after:header'
     );
     ExtensionManagementUtility::addPiFlexFormValue(
         'academicjobs_newjobform',
         sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/Plugin_NewJobForm.xml', $typo3MajorVersion)
     );
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_newjobform'] = 'pi_flexform';
+
+    //==================================================================================================================
+    // Plugin: academicjobs_list
+    //==================================================================================================================
+    ExtensionManagementUtility::addPlugin(
+        [
+            'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.list.label',
+            'value' => 'academicjobs_list',
+            'icon' => 'academic_jobs_icon',
+            'group' => 'academic',
+        ],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+        'academic_jobs'
+    );
+    ExtensionManagementUtility::addToAllTCAtypes(
+        'tt_content',
+        implode(',', [
+            '--div--;LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:element.tab.configuration',
+            'pi_flexform',
+        ]),
+        'academicjobs_list',
+        'after:header'
+    );
+    ExtensionManagementUtility::addPiFlexFormValue(
+        'academicjobs_list',
+        sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/PluginList.xml', $typo3MajorVersion)
+    );
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_list'] = 'pages,layout,select_key,recursive';
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_list'] = 'pi_flexform';
+
+    //==================================================================================================================
+    // Plugin: academicjobs_detail
+    //==================================================================================================================
+    ExtensionManagementUtility::addPlugin(
+        [
+            'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.list.label',
+            'value' => 'academicjobs_list',
+            'icon' => 'academic_jobs_icon',
+            'group' => 'academic',
+        ],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+        'academic_jobs'
+    );
+    ExtensionManagementUtility::addToAllTCAtypes(
+        'tt_content',
+        implode(',', [
+            '--div--;LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:element.tab.configuration',
+            'pi_flexform',
+        ]),
+        'academicjobs_list',
+        'after:header'
+    );
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_detail'] = 'recursive,select_key';
+
 })();

--- a/packages/fgtclb/academic-jobs/Configuration/TSConfig/page.tsconfig
+++ b/packages/fgtclb/academic-jobs/Configuration/TSConfig/page.tsconfig
@@ -1,0 +1,36 @@
+mod.wizards.newContentElement.wizardItems.academic {
+  header = LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic
+  after = special
+  elements {
+    academicjobs_newjobform {
+      iconIdentifier = persons_icon
+      title = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.newjobform.title
+      description = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.newjobform.description
+      tt_content_defValues {
+        CType = academicjobs_newjobform
+      }
+    }
+
+    academicjobs_list {
+      iconIdentifier = persons_icon
+      title = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.list.title
+      description = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.list.description
+      tt_content_defValues {
+        CType = academicjobs_list
+      }
+    }
+
+    academicjobs_detail {
+      iconIdentifier = persons_icon
+      title = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.detail.title
+      description = LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.detail.description
+      tt_content_defValues {
+        CType = academicjobs_detail
+      }
+    }
+
+  }
+
+  show := addToList(academicjobs_newjobform,academicjobs_list,academicjobs_detail)
+}
+

--- a/packages/fgtclb/academic-jobs/Configuration/page.tsconfig
+++ b/packages/fgtclb/academic-jobs/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:academic_jobs/Configuration/TSconfig/page.tsconfig'

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang_be.xlf
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" product-name="academic_jobs">
+        <header/>
+        <body>
+            <!-- /* shared */ -->
+            <trans-unit id="element.tab.configuration">
+                <source>Configuration</source>
+                <target>Konfiguration</target>
+            </trans-unit>
+
+            <!-- /* CType group */ -->
+            <trans-unit id="content.ctype.group.label">
+                <source>Academic</source>
+                <target>Academic</target>
+            </trans-unit>
+
+            <!-- /* academicjobs_newjobform */ -->
+            <trans-unit id="plugin.newjobform.label">
+                <source>Academic Jobs: New Job Form</source>
+                <target>Academic Jobs: New Job Form</target>
+            </trans-unit>
+
+            <!-- /* academicjobs_list */ -->
+            <trans-unit id="plugin.list.label">
+                <source>Academic Jobs: List Jobs</source>
+                <target>Academic Jobs: List Jobs</target>
+            </trans-unit>
+
+            <!-- /* academicjobs_detail */ -->
+            <trans-unit id="plugin.detail.label">
+                <source>Academic Jobs: Detail</source>
+                <target>Academic Jobs: Detail</target>
+            </trans-unit>
+
+            <!-- /* newContentElement */ -->
+            <trans-unit id="newContentElement.wizardItems.academic">
+                <source>Academic</source>
+                <target>Akademisch</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
+                <source>Academic New Jobs Form</source>
+                <target>Academic New Jobs Form</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
+                <source>Plugin providing new jobs form</source>
+                <target>Plugin providing new jobs form</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.list.title">
+                <source>Academic Jobs List</source>
+                <target>Academic Jobs List</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.list.description">
+                <source>Plugin for listing academic jobs</source>
+                <target>Plugin for listing academic jobs</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+                <source>Academic Jobs Detail</source>
+                <target>Academic Jobs Detail</target>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+                <source>Plugin for viewing single academic job</source>
+                <target>Plugin for viewing single academic job</target>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" product-name="academic_jobs">
+        <header/>
+        <body>
+            <!-- /* shared */ -->
+            <trans-unit id="element.tab.configuration">
+                <source>Configuration</source>
+            </trans-unit>
+
+            <!-- /* CType group */ -->
+            <trans-unit id="content.ctype.group.label">
+                <source>Academic</source>
+            </trans-unit>
+
+            <!-- /* academicjobs_newjobform */ -->
+            <trans-unit id="plugin.newjobform.label">
+                <source>Academic Jobs: New Job Form</source>
+            </trans-unit>
+
+            <!-- /* academicjobs_list */ -->
+            <trans-unit id="plugin.list.label">
+                <source>Academic Jobs: List Jobs</source>
+            </trans-unit>
+
+            <!-- /* academicjobs_detail */ -->
+            <trans-unit id="plugin.detail.label">
+                <source>Academic Jobs: Detail</source>
+            </trans-unit>
+
+            <!-- /* newContentElement */ -->
+            <trans-unit id="newContentElement.wizardItems.academic">
+                <source>Academic</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
+                <source>Academic New Jobs Form</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
+                <source>Plugin providing new jobs form</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.list.title">
+                <source>Academic Jobs List</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.list.description">
+                <source>Plugin for listing academic jobs</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+                <source>Academic Jobs Detail</source>
+            </trans-unit>
+            <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+                <source>Plugin for viewing single academic job</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"list","academicjobs_detail",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"list","academicjobs_detail",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyDetail_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"list","academicjobs_detail",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"list","academicjobs_list",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"list","academicjobs_list",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyList_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"list","academicjobs_list",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"list","academicjobs_newjobform",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"list","academicjobs_newjobform",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/DataSets/onlyNewJobForm_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"list","academicjobs_newjobform",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"academicjobs_detail","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"academicjobs_detail","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyDetail_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"academicjobs_detail","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"academicjobs_list","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"academicjobs_list","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyList_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"academicjobs_list","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_deletedButNotHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_deletedButNotHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,1,"academicjobs_newjobform","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_notDeletedButHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_notDeletedButHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,1,0,"academicjobs_newjobform","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_notDeletedOrHidden.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/Fixtures/Upgraded/onlyNewJobForm_notDeletedOrHidden.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","title","slug",
+,1,0,1,"site 1","/",
+"tt_content",
+,"uid","pid","hidden","deleted","CType","list_type",
+,1,1,0,0,"academicjobs_newjobform","",
+,2,1,0,0,"list","unrelated_plugin",
+,3,1,0,0,"text","",

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Upgrades;
+
+use FGTCLB\AcademicJobs\Upgrades\PluginUpgradeWizard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+final class PluginUpgradeWizardTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-jobs',
+    ];
+
+    #[Test]
+    public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
+    {
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertFalse($subject->updateNecessary());
+    }
+
+    public static function ttContentPluginDataSets(): \Generator
+    {
+        yield 'only newjobform - not deleted and hidden' => [
+            'fixtureDataSetFile' => 'onlyNewJobForm_notDeletedOrHidden.csv',
+        ];
+        yield 'only newjobform - not deleted and but hidden' => [
+            'fixtureDataSetFile' => 'onlyNewJobForm_notDeletedButHidden.csv',
+        ];
+        yield 'only newjobform - deleted but not hidden' => [
+            'fixtureDataSetFile' => 'onlyNewJobForm_deletedButNotHidden.csv',
+        ];
+        yield 'only list - not deleted and hidden' => [
+            'fixtureDataSetFile' => 'onlyList_notDeletedOrHidden.csv',
+        ];
+        yield 'only list - not deleted and but hidden' => [
+            'fixtureDataSetFile' => 'onlyList_notDeletedButHidden.csv',
+        ];
+        yield 'only list - deleted but not hidden' => [
+            'fixtureDataSetFile' => 'onlyList_deletedButNotHidden.csv',
+        ];
+        yield 'only detail - not deleted and hidden' => [
+            'fixtureDataSetFile' => 'onlyDetail_notDeletedOrHidden.csv',
+        ];
+        yield 'only detail - not deleted and but hidden' => [
+            'fixtureDataSetFile' => 'onlyDetail_notDeletedButHidden.csv',
+        ];
+        yield 'only detail - deleted but not hidden' => [
+            'fixtureDataSetFile' => 'onlyDetail_deletedButNotHidden.csv',
+        ];
+    }
+
+    #[DataProvider('ttContentPluginDataSets')]
+    #[Test]
+    public function updateNecessaryReturnsTrueWhenUpgradablePluginsExists(
+        string $fixtureDataSetFile,
+    ): void {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSets/' . $fixtureDataSetFile);
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertTrue($subject->updateNecessary(), 'updateNecessary() returns true');
+    }
+
+    #[DataProvider('ttContentPluginDataSets')]
+    #[Test]
+    public function executeUpdateMigratesContentElementsAndReturnsTrue(
+        string $fixtureDataSetFile,
+    ): void {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSets/' . $fixtureDataSetFile);
+        $subject = $this->get(PluginUpgradeWizard::class);
+        $this->assertInstanceOf(PluginUpgradeWizard::class, $subject);
+        $this->assertTrue($subject->executeUpdate(), 'updateNecessary() returns true');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Upgraded/' . $fixtureDataSetFile);
+    }
+}

--- a/packages/fgtclb/academic-jobs/UPGRADE.md
+++ b/packages/fgtclb/academic-jobs/UPGRADE.md
@@ -2,6 +2,27 @@
 
 ## X.Y.Z
 
+### BREAKING: Migrated extbase plugins from `list_type` to `CType`
+
+TYPO3 v13 deprecated the `tt_content` sub-type feature, only used for `CType=list` sub-typing also known
+as `list_type` and mostly used based on old times for extbase based plugins. It has been possible since
+the very beginning to register Extbase Plugins directly as `CType` instead of `CType=list` sub-type, which
+has now done.
+
+Technically this is a breaking change, and instances upgrading from `1.x` version of the plugin needs to
+update corresponding `tt_content` records in the database and eventually adopt addition, adjustments or
+overrides requiring to use the correct CType.
+
+Relates to following plugins:
+
+* academicjobs_newjobform
+* academicjobs_list'
+* academicjobs_detail
+
+> [!NOTE]
+> An TYPO3 UpgradeWizard `academicJobs_pluginUpgradeWizard` is provided to migrate
+> plugins from `CType=list` to dedicated `CTypes` matching the new registration.
+
 ## 2.0.1
 
 ## 2.0.0

--- a/packages/fgtclb/academic-jobs/ext_emconf.php
+++ b/packages/fgtclb/academic-jobs/ext_emconf.php
@@ -6,6 +6,8 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
+            'rte-ckeditor' => '12.4.0-13.4.99',
+            'install' => '12.4.0-13.4.99',
         ],
     ],
     'state' => 'beta',

--- a/packages/fgtclb/academic-jobs/ext_localconf.php
+++ b/packages/fgtclb/academic-jobs/ext_localconf.php
@@ -8,7 +8,6 @@ if (!defined('TYPO3')) {
 }
 
 (static function (): void {
-    // @todo Needs to be migrated to CType due to TYPO3 v13 constraint.
     ExtensionUtility::configurePlugin(
         'AcademicJobs',
         'NewJobForm',
@@ -17,9 +16,9 @@ if (!defined('TYPO3')) {
         ],
         [
             JobController::class => 'newJobForm, saveJob',
-        ]
+        ],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
     );
-    // @todo Needs to be migrated to CType due to TYPO3 v13 constraint.
     ExtensionUtility::configurePlugin(
         'AcademicJobs',
         'List',
@@ -28,14 +27,16 @@ if (!defined('TYPO3')) {
         ],
         [
             JobController::class => 'list',
-        ]
+        ],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
     );
-    // @todo Needs to be migrated to CType due to TYPO3 v13 constraint.
     ExtensionUtility::configurePlugin(
         'AcademicJobs',
         'Detail',
         [
             JobController::class => 'show, list',
-        ]
+        ],
+        [],
+        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
     );
 })();


### PR DESCRIPTION
For a long time TYPO3 provided the sub-type feature
soley for the `tt_content` table and the core team
had to maintain a bag of painfull special cases in
the codebase without real benefit.

Right from the start it was possible to register
extbase plugins directly as `CType` instead of
the mostly used `list_type` sub-type registration.

Since TYPO3 v13 the list_type sub-type feature is
deprecated and is removed in v14, making the life
of the core team a bit easier. With the deprecation,
a migration upgrade wizard helper is provided, which
extension authors to add migrations in an easy step.

This extension needs to support TYPO3 v12 and v13
and a custom upgrade wizard is provided to process
the migration for 2.x.x directly on all suitable
TYPO3 versions.

Included in this change:

* `list_type` based plugin registration are converted
  to `CType` registration, including new content element
  wizard configuration.
* Group all plugins into a dedicated `academics` content
  element group.
* Provide a upgrade wizard to migrate existing list_type
  plugins to CType.
* Register icon in `Configuration/Icons.php`.
* Add missing language files for translation keys.
* Added basic tests for upgrade wizard.
* Added `typo3/cms-install` as hard dependency due to the
  added upgrade wizard.

Technically breaking the when upgrading in instances should
be low due to the provided upgrade wizard. Except related
extension dealing, xclassing or impacting concrete api's
need to do proper adoptions and are generally not covered
by the breaking policy.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.4/Deprecation-105213-TCASubTypes.html
