### PR TITLE
[TASK] Ensure base functional test setup for all extensions

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/AbstractAcademicBiteJobsTestCase.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/AbstractAcademicBiteJobsTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBiteJobs\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicBiteJobsTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-bite-jobs',
+    ];
+}

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBiteJobs\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicBiteJobsTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-bite-jobs', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_bite_jobs'));
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/AbstractAcademicContacts4PagesTestCase.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/AbstractAcademicContacts4PagesTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicContacts4PagesTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-persons',
+        'fgtclb/academic-contacts4pages',
+    ];
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicContacts4PagesTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-contacts4pages', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_contacts4pages'));
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -13,6 +13,11 @@
             "FGTCLB\\AcademicContacts4pages\\": "Classes/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "FGTCLB\\AcademicContacts4pages\\Tests\\": "Tests/"
+        }
+    },
     "extra": {
         "typo3/cms": {
             "extension-key": "academic_contacts4pages"

--- a/packages/fgtclb/academic-jobs/Tests/Functional/AbstractAcademicJobsTestCase.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/AbstractAcademicJobsTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicJobsTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-jobs',
+    ];
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicJobsTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-jobs', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_jobs'));
+    }
+}

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "typo3/cms-core": "^12.4 || ^13.4",
+        "typo3/cms-install": "^12.4 || ^13.4",
         "typo3/cms-rte-ckeditor": "^12.4 || ^13.4"
     },
     "autoload": {

--- a/packages/fgtclb/academic-partners/Tests/Functional/AbstractAcademicPartnersTestCase.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/AbstractAcademicPartnersTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicPartnersTestCase extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'fgtclb/category-types',
+        'fgtclb/academic-partners',
+    ];
+}

--- a/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPartners\Tests\Functional\CategoryTypes;
 
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 
-final class CategoryTypesTest extends FunctionalTestCase
+final class CategoryTypesTest extends AbstractAcademicPartnersTestCase
 {
-    protected array $testExtensionsToLoad = [
-        'fgtclb/category-types',
-        'fgtclb/academic-partners',
-    ];
-
     #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {

--- a/packages/fgtclb/academic-partners/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicPartnersTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-partners', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_partners'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/AbstractAcademicPersonsEditTestCase.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/AbstractAcademicPersonsEditTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersonsEdit\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicPersonsEditTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-persons',
+        'fgtclb/academic-persons-edit',
+    ];
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersonsEdit\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicPersonsEditTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-persons-edit', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_persons_edit'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Upgrades/PluginContentWizardTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Upgrades/PluginContentWizardTest.php
@@ -4,23 +4,13 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersonsEdit\Tests\Functional\Upgrades;
 
+use Fgtclb\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
 use Fgtclb\AcademicPersonsEdit\Upgrades\PluginContentWizard;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 
-final class PluginContentWizardTest extends FunctionalTestCase
+final class PluginContentWizardTest extends AbstractAcademicPersonsEditTestCase
 {
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'fgtclb/academic-persons',
-        'fgtclb/academic-persons-edit',
-    ];
-
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-persons": "2.0.*@dev",
-        "typo3/cms-core": "^12.4 || ^13.4"
+        "typo3/cms-core": "^12.4 || ^13.4",
+        "typo3/cms-install": "^12.4 || ^13.4"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-persons-edit/ext_emconf.php
+++ b/packages/fgtclb/academic-persons-edit/ext_emconf.php
@@ -13,6 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
+            'install' => '12.4.0-13.4.99',
             'academic_persons' => '2.0.2',
         ],
         'conflicts' => [

--- a/packages/fgtclb/academic-persons-sync/Tests/Functional/AbstractAcademicPersonsSyncTestCase.php
+++ b/packages/fgtclb/academic-persons-sync/Tests/Functional/AbstractAcademicPersonsSyncTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersonsSync\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicPersonsSyncTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-persons',
+        'fgtclb/academic-persons-edit',
+        'fgtclb/academic-persons-sync',
+    ];
+}

--- a/packages/fgtclb/academic-persons-sync/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-persons-sync/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersonsSync\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicPersonsSyncTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-persons-sync', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_persons_sync'));
+    }
+}

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -26,6 +26,11 @@
             "Fgtclb\\AcademicPersonsSync\\": "Classes/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Fgtclb\\AcademicPersonsSync\\Tests\\": "Tests/"
+        }
+    },
     "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",

--- a/packages/fgtclb/academic-persons/Tests/Functional/AbstractAcademicPersonsTestCase.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/AbstractAcademicPersonsTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicPersonsTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-persons',
+    ];
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fgtclb\AcademicPersons\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-persons', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_persons'));
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Hook/DataHandlerHooksTest.php
@@ -11,30 +11,15 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Hook;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class DataHandlerHooksTest extends FunctionalTestCase
+class DataHandlerHooksTest extends AbstractAcademicPersonsTestCase
 {
     private DataHandler $dataHandler;
-
-    /**
-     * @var list<non-empty-string>
-     */
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-    ];
-
-    /**
-     * @var list<non-empty-string>
-     */
-    protected array $testExtensionsToLoad = [
-        'fgtclb/academic-persons',
-    ];
 
     protected function setUp(): void
     {

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
@@ -4,28 +4,16 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
-final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
+final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestCase
 {
     use SiteBasedTestTrait;
-
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-        'typo3/cms-fluid-styled-content',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'georgringer/numbered-pagination',
-        'fgtclb/academic-persons',
-        'tests/plugin-templates',
-    ];
 
     protected array $configurationToUseInTestInstance = [
         'SYS' => [
@@ -52,6 +40,19 @@ final class AcademicPersonsDetailPluginTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...array_values([
+                'typo3/cms-fluid-styled-content',
+            ]),
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...array_values([
+                'georgringer/numbered-pagination',
+                'tests/plugin-templates',
+            ]),
+        ]);
         parent::setUp();
     }
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -4,29 +4,17 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
-final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
+final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPersonsTestCase
 {
     use SiteBasedTestTrait;
-
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-        'typo3/cms-fluid-styled-content',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'georgringer/numbered-pagination',
-        'fgtclb/academic-persons',
-        'tests/plugin-templates',
-    ];
 
     protected array $configurationToUseInTestInstance = [
         'SYS' => [
@@ -53,6 +41,19 @@ final class AcademicPersonsListAndDetailPluginTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...array_values([
+                'typo3/cms-fluid-styled-content',
+            ]),
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...array_values([
+                'georgringer/numbered-pagination',
+                'tests/plugin-templates',
+            ]),
+        ]);
         parent::setUp();
     }
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -4,29 +4,17 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
-final class AcademicPersonsListPluginTest extends FunctionalTestCase
+final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCase
 {
     use SiteBasedTestTrait;
-
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-        'typo3/cms-fluid-styled-content',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'georgringer/numbered-pagination',
-        'fgtclb/academic-persons',
-        'tests/plugin-templates',
-    ];
 
     protected array $configurationToUseInTestInstance = [
         'SYS' => [
@@ -53,6 +41,19 @@ final class AcademicPersonsListPluginTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...array_values([
+                'typo3/cms-fluid-styled-content',
+            ]),
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...array_values([
+                'georgringer/numbered-pagination',
+                'tests/plugin-templates',
+            ]),
+        ]);
         parent::setUp();
     }
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -4,28 +4,16 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
-final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCase
+final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicPersonsTestCase
 {
     use SiteBasedTestTrait;
-
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-        'typo3/cms-fluid-styled-content',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'georgringer/numbered-pagination',
-        'fgtclb/academic-persons',
-        'tests/plugin-templates',
-    ];
 
     protected array $configurationToUseInTestInstance = [
         'SYS' => [
@@ -52,6 +40,19 @@ final class AcademicPersonsSelectedContractsPluginTest extends FunctionalTestCas
 
     protected function setUp(): void
     {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...array_values([
+                'typo3/cms-fluid-styled-content',
+            ]),
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...array_values([
+                'georgringer/numbered-pagination',
+                'tests/plugin-templates',
+            ]),
+        ]);
         parent::setUp();
     }
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -4,28 +4,16 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Plugins;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
-final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
+final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPersonsTestCase
 {
     use SiteBasedTestTrait;
-
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-        'typo3/cms-fluid-styled-content',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'georgringer/numbered-pagination',
-        'fgtclb/academic-persons',
-        'tests/plugin-templates',
-    ];
 
     protected array $configurationToUseInTestInstance = [
         'SYS' => [
@@ -52,6 +40,19 @@ final class AcademicPersonsSelectedProfilesPluginTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...array_values([
+                'typo3/cms-fluid-styled-content',
+            ]),
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...array_values([
+                'georgringer/numbered-pagination',
+                'tests/plugin-templates',
+            ]),
+        ]);
         parent::setUp();
     }
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace Fgtclb\AcademicPersons\Tests\Functional\Upgrades;
 
+use Fgtclb\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use Fgtclb\AcademicPersons\Upgrades\PluginUpgradeWizard;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 
-final class PluginUpgradeWizardTest extends FunctionalTestCase
+final class PluginUpgradeWizardTest extends AbstractAcademicPersonsTestCase
 {
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-        'typo3/cms-rte-ckeditor',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'fgtclb/academic-persons',
-    ];
-
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {

--- a/packages/fgtclb/academic-programs/Tests/Functional/AbstractAcademicProgramsTestCase.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/AbstractAcademicProgramsTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicProgramsTestCase extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'fgtclb/category-types',
+        'fgtclb/academic-programs',
+    ];
+}

--- a/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPrograms\Tests\Functional\CategoryTypes;
 
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 
-final class CategoryTypesTest extends FunctionalTestCase
+final class CategoryTypesTest extends AbstractAcademicProgramsTestCase
 {
-    protected array $testExtensionsToLoad = [
-        'fgtclb/category-types',
-        'fgtclb/academic-programs',
-    ];
-
     #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {

--- a/packages/fgtclb/academic-programs/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicProgramsTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-programs', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_programs'));
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/AbstractAcademicProjectsTestCase.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/AbstractAcademicProjectsTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicProjectsTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/category-types',
+        'fgtclb/academic-projects',
+    ];
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/CategoryTypes/CategoryTypesTest.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\Tests\Functional\CategoryTypes;
 
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
 use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use PHPUnit\Framework\Attributes\Test;
-use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 
-final class CategoryTypesTest extends FunctionalTestCase
+final class CategoryTypesTest extends AbstractAcademicProjectsTestCase
 {
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-install',
-    ];
-
-    protected array $testExtensionsToLoad = [
-        'fgtclb/category-types',
-        'fgtclb/academic-projects',
-    ];
-
     #[Test]
     public function extensionCategoryTypesYamlIsLoaded(): void
     {

--- a/packages/fgtclb/academic-projects/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicProjectsTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-projects', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_projects'));
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/AbstractCategoryTypesTestCase.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/AbstractCategoryTypesTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractCategoryTypesTestCase extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'fgtclb/category-types',
+    ];
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractCategoryTypesTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/category-types', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('category_types'));
+    }
+}

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -45,15 +45,15 @@
       "FGTCLB\\CategoryTypes\\": "Classes/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "FGTCLB\\CategoryTypes\\Tests\\": "Tests/"
+    }
+  },
   "support": {
     "issues": "https://github.com/fgtclb/academic-extensions/issues",
     "source": "https://github.com/fgtclb/academic-extensions",
     "email": "hello@fgtclb.com"
   },
-  "homepage": "https://www.fgtclb.com/",
-  "autoload-dev": {
-    "psr-4": {
-      "FGTCLB\\CategoryTypes\\Tests\\": "Tests/"
-    }
-  }
+  "homepage": "https://www.fgtclb.com/"
 }


### PR DESCRIPTION
Functional tests are a good way to detect TYPO3 detections
early when handled as breaking within tests, which follows
the TYPO3 Core Team recommendations and preference.

This change iterates over all extensions to ensure at least
a base functional test implementation to get some deprecation
early for default extension bootstrap like TCA automigrations.

To provider basic setup for all extensions, this change ...

* Ensures to have `Tests/Functional` folder and `autoload-dev`
  configuration for all extensions in place.
* Adds an abstract testcase `Abstract<ExtensionKey>TestCase`
  to `Tests/Functional/` havint the default test extensions
  and eventually non-default TYPO3 system extension defined.
* Adds a `ExtensionLoadedTest` extending from the abstract
  test case adding two test method ensuring the abstract is
  workable in default extension can be loaded.

With that setup missed TCA migration adoption for one extension
has been revealed (TYPO3 v12) and fixed in a pre-change.

Note that existing extension functional tests are adopted to
use the new introduced abstract test case now to centralized
shared setup.
