### PR TITLE
[TASK] Align information across all academic extensions

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/ext_emconf.php
+++ b/packages/fgtclb/academic-bite-jobs/ext_emconf.php
@@ -1,23 +1,17 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'Academic Bite Jobs',
-    'description' => 'The Academic Bite Jobs extension shows jobs from the B-Ite Job Board.',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
+    'category' => 'fe,be',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
         ],
     ],
-    'state' => 'stable',
+    'description' => 'The Academic Bite Jobs extension shows jobs from the B-Ite Job Board.',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Bite Jobs',
     'version' => '2.0.2',
-    'clearCacheOnLoad' => true,
-    'category' => 'fe,be',
-    'author' => 'Riad Zejnilagic Trumic',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
-    'autoload' => [
-        'psr-4' => [
-            'Fgtclb\\AcademicBiteJobs\\' => 'Classes/',
-        ],
-    ],
 ];

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -3,6 +3,18 @@
     "description": "Role based relations between profiles and pages",
     "type": "typo3-cms-extension",
     "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "FGTCLB GmbH",
+            "email": "hello@fgtclb.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/fgtclb/academic-extensions/issues",
+        "source": "https://github.com/fgtclb/academic-extensions",
+        "email": "hello@fgtclb.com"
+    },
+    "homepage": "https://www.fgtclb.com/",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-persons": "2.0.*@dev",
@@ -32,17 +44,5 @@
             "typo3/class-alias-loader": true
         },
         "sort-packages": true
-    },
-    "authors": [
-        {
-            "name": "FGTCLB GmbH",
-            "email": "hello@fgtclb.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/fgtclb/academic-extensions/issues",
-        "source": "https://github.com/fgtclb/academic-extensions",
-        "email": "hello@fgtclb.com"
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-contact4pages/ext_emconf.php
+++ b/packages/fgtclb/academic-contact4pages/ext_emconf.php
@@ -1,11 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'Contacts for Pages',
-    'description' => 'Role based relations between profiles and pages',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'fe',
-    'state' => 'beta',
-    'version' => '2.0.2',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -14,4 +13,8 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
+    'description' => 'Role based relations between profiles and pages',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Contags for Pages',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/academic-jobs/ext_emconf.php
+++ b/packages/fgtclb/academic-jobs/ext_emconf.php
@@ -1,8 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'Academic Jobs',
-    'description' => 'The Academic Jobs extension allows users to create and manage job postings.',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
+    'category' => 'fe,be',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -10,16 +12,8 @@ $EM_CONF[$_EXTKEY] = [
             'install' => '12.4.0-13.4.99',
         ],
     ],
+    'description' => 'The Academic Jobs extension allows users to create and manage job postings.',
     'state' => 'beta',
+    'title' => 'FGTCLB: Academic Jobs',
     'version' => '2.0.2',
-    'clearCacheOnLoad' => true,
-    'category' => 'fe,be',
-    'author' => 'Riad Zejnilagic Trumic',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
-    'autoload' => [
-        'psr-4' => [
-            'Fgtclb\\AcademicJobs\\' => 'Classes/',
-        ],
-    ],
 ];

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -4,12 +4,18 @@
     "description": "Extension for showing academic partners in list and map view",
     "minimum-stability": "stable",
     "license": "GPL-2.0-or-later",
-    "author": [
+    "authors": [
         {
-            "name": "Jan-Philipp Halle",
-            "email": "p.halle@web-vision.de"
+            "name": "FGTCLB GmbH",
+            "email": "hello@fgtclb.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/fgtclb/academic-extensions/issues",
+        "source": "https://github.com/fgtclb/academic-extensions",
+        "email": "hello@fgtclb.com"
+    },
+    "homepage": "https://www.fgtclb.com/",
     "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
@@ -57,17 +63,5 @@
     "suggest": {
         "fgtclb/page-backend-layout": "Provides backend category preview",
         "typo3/cms-scheduler": "Install EXT:scheduler for the automatic geocoding"
-    },
-    "authors": [
-        {
-            "name": "FGTCLB GmbH",
-            "email": "hello@fgtclb.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/fgtclb/academic-extensions/issues",
-        "source": "https://github.com/fgtclb/academic-extensions",
-        "email": "hello@fgtclb.com"
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-partners/ext_emconf.php
+++ b/packages/fgtclb/academic-partners/ext_emconf.php
@@ -1,11 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'FGTCLB: Academic Partners',
-    'description' => 'Extension for showing academic partners in list and map view',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'fe,be',
-    'state' => 'beta',
-    'version' => '2.0.2',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -18,14 +17,8 @@ $EM_CONF[$_EXTKEY] = [
             'page_backend_layout' => '2.0.0-2.9.99',
         ],
     ],
-    'autoload' => [
-        'psr-4' => [
-            'FGTCLB\\AcademicPartners\\' => 'Classes/',
-        ],
-    ],
-    'autoload-dev' => [
-        'psr-4' => [
-            'FGTCLB\\AcademicPartners\\Tests\\' => 'Tests/',
-        ],
-    ],
+    'description' => 'Extension for showing academic partners in list and map view',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Partners',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -14,6 +14,7 @@
         "source": "https://github.com/fgtclb/academic-extensions",
         "email": "hello@fgtclb.com"
     },
+    "homepage": "https://www.fgtclb.com/",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-persons": "2.0.*@dev",
@@ -45,6 +46,5 @@
         "branch-alias": {
             "dev-main": "2.0.x-dev"
         }
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-persons-edit/ext_emconf.php
+++ b/packages/fgtclb/academic-persons-edit/ext_emconf.php
@@ -1,15 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'FGTCLB: Academic Persons Edit',
-    'description' => 'dds the option to assign frontend users to academic persons and allow editing the profiles in frontend.',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'plugin',
-    'author' => 'Tim Schreiner',
-    'author_email' => 'tim.schreiner@km2.de',
-    'author_company' => 'FGTCLB',
-    'state' => 'beta',
-    'version' => '2.0.2',
-    'clearCacheOnLoad' => true,
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -21,4 +16,8 @@ $EM_CONF[$_EXTKEY] = [
         'suggests' => [
         ],
     ],
+    'description' => 'Provides the option to assign frontend users to academic persons and allow editing the profiles in frontend.',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Persons Edit',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -14,6 +14,7 @@
         "source": "https://github.com/fgtclb/academic-extensions",
         "email": "hello@fgtclb.com"
     },
+    "homepage": "https://www.fgtclb.com/",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-persons": "2.0.*@dev",
@@ -46,6 +47,5 @@
         "branch-alias": {
             "dev-main": "2.0.x-dev"
         }
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-persons-sync/ext_emconf.php
+++ b/packages/fgtclb/academic-persons-sync/ext_emconf.php
@@ -1,15 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'FGTCLB: Academic Persons Sync',
-    'description' => 'Adds some configuration for external users providers like Active Directory.',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'plugin',
-    'author' => 'Tim Schreiner',
-    'author_email' => 'tim.schreiner@km2.de',
-    'author_company' => 'FGTCLB',
-    'state' => 'beta',
-    'version' => '2.0.2',
-    'clearCacheOnLoad' => true,
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -22,4 +17,8 @@ $EM_CONF[$_EXTKEY] = [
         'suggests' => [
         ],
     ],
+    'description' => 'Adds some configuration for external users providers like Active Directory.',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Persons Sync',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/academic-persons/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/ext_emconf.php
@@ -1,15 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'FGTCLB: Academic Persons',
-    'description' => 'Adds a person database to TYPO3 with plugins to show them in the frontend.',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'plugin',
-    'author' => 'Tim Schreiner',
-    'author_email' => 'tim.schreiner@km2.de',
-    'author_company' => 'FGTCLB',
-    'state' => 'beta',
-    'version' => '2.0.1',
-    'clearCacheOnLoad' => true,
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -25,4 +20,8 @@ $EM_CONF[$_EXTKEY] = [
             'numbered_pagination' => '2.1.0-2.99.99',
         ],
     ],
+    'description' => 'Adds a person database to TYPO3 with plugins to show them in the frontend.',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Persons',
+    'version' => '2.0.1',
 ];

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -4,6 +4,18 @@
     "description": "Add structured data for academic programs to pages",
     "minimum-stability": "stable",
     "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "FGTCLB GmbH",
+            "email": "hello@fgtclb.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/fgtclb/academic-extensions/issues",
+        "source": "https://github.com/fgtclb/academic-extensions",
+        "email": "hello@fgtclb.com"
+    },
+    "homepage": "https://www.fgtclb.com/",
     "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
@@ -51,17 +63,5 @@
     "conflict": {
         "fgtclb/category-types": "<2.0.0",
         "fgtclb/page-backend-layout": "<2.0.0 || >=3.0.0"
-    },
-    "authors": [
-        {
-            "name": "FGTCLB GmbH",
-            "email": "hello@fgtclb.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/fgtclb/academic-extensions/issues",
-        "source": "https://github.com/fgtclb/academic-extensions",
-        "email": "hello@fgtclb.com"
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-programs/ext_emconf.php
+++ b/packages/fgtclb/academic-programs/ext_emconf.php
@@ -1,11 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => '(FGTCLB) University Educational Program',
-    'description' => 'Educational Program page for TYPO3 with structured data based on sys_category',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'fe',
-    'state' => 'beta',
-    'version' => '2.0.2',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -20,4 +19,8 @@ $EM_CONF[$_EXTKEY] = [
             'page_backend_layout' => '2.0.0-2.99.99',
         ],
     ],
+    'description' => 'Educational Program page for TYPO3 with structured data based on sys_category',
+    'state' => 'beta',
+    'title' => 'FGTCLB: University Educational Program',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -3,6 +3,18 @@
     "description": "Research project page for universities. Ships structured data preparation",
     "type": "typo3-cms-extension",
     "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "FGTCLB GmbH",
+            "email": "hello@fgtclb.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/fgtclb/academic-extensions/issues",
+        "source": "https://github.com/fgtclb/academic-extensions",
+        "email": "hello@fgtclb.com"
+    },
+    "homepage": "https://www.fgtclb.com/",
     "require": {
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/category-types": "2.0.*@dev",
@@ -40,17 +52,5 @@
     },
     "conflict": {
         "fgtclb/category-types": "<2.0.0"
-    },
-    "authors": [
-        {
-            "name": "FGTCLB GmbH",
-            "email": "hello@fgtclb.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/fgtclb/academic-extensions/issues",
-        "source": "https://github.com/fgtclb/academic-extensions",
-        "email": "hello@fgtclb.com"
-    },
-    "homepage": "https://www.fgtclb.com/"
+    }
 }

--- a/packages/fgtclb/academic-projects/ext_emconf.php
+++ b/packages/fgtclb/academic-projects/ext_emconf.php
@@ -1,11 +1,10 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => '(FGTCLB) Academic Projects',
-    'description' => 'Academic project pages for TYPO3 with specific structured data and typed sys_categories',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'category' => 'fe',
-    'state' => 'beta',
-    'version' => '2.0.2',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -18,4 +17,8 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
+    'description' => 'Academic project pages for TYPO3 with specific structured data and typed sys_categories',
+    'state' => 'beta',
+    'title' => 'FGTCLB: Academic Projects',
+    'version' => '2.0.2',
 ];

--- a/packages/fgtclb/typo3-category-types/ext_emconf.php
+++ b/packages/fgtclb/typo3-category-types/ext_emconf.php
@@ -1,14 +1,11 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'title' => '(FGTCLB) Basic Typed categories',
+    'author' => 'FGTCLB',
+    'author_company' => 'FGTCLB GmbH',
+    'author_email' => 'hello@fgtclb.com',
     'description' => 'Basic extension for typed categories',
     'category' => 'misc',
-    'author' => 'FGTCLB',
-    'author_email' => 'hello@fgtclb.com',
-    'state' => 'stable',
-    'clearCacheOnLoad' => 0,
-    'version' => '2.0.2',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-13.4.99',
@@ -16,4 +13,7 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
+    'state' => 'beta',
+    'title' => 'FGTCLB: Basic Typed categories',
+    'version' => '2.0.2',
 ];


### PR DESCRIPTION
This change aligns basic information in `composer.json`
and `ext_emconf.php` files of all extensions to provide
the same setup and avoid the feeling of chaos.

That includes:

* Avoid developer names and email adresses as part of author
  information in both aforementioned files in all extensions.
* Use `FGTCLB` als company, author and support information in
  both aforementioned files over all extensions.
* Ensure having author/support information in the top of all
  extension `composer.json` files.
* Having `ext_emconf.php` array keys sorted alphabetically to
  provide the same ordering across all extensions and giving
  a more clean and precise feeling across extensions.
* Prefix all extension titles in `ext_emconf.php` files with
  `'FGTCLB: <title>'` to provide a aligned feeling across all
  extensions.
