### PR TITLE
[TASK] Further prepare ddev instances

### DIFF
--- a/ddev-instances/core-12/composer.json
+++ b/ddev-instances/core-12/composer.json
@@ -11,6 +11,7 @@
   ],
   "require": {
     "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+    "bk2k/bootstrap-package": "^15.0@dev",
     "fgtclb/academics-monorepo-shared": "2.0.*@dev",
     "typo3/minimal": "^12"
   },

--- a/ddev-instances/core-13/composer.json
+++ b/ddev-instances/core-13/composer.json
@@ -11,6 +11,7 @@
   ],
   "require": {
     "php": "^8.2 || ^8.3 || ^8.4",
+    "bk2k/bootstrap-package": "^15.0@dev",
     "fgtclb/academics-monorepo-shared": "2.0.*@dev",
     "typo3/minimal": "^13"
   },


### PR DESCRIPTION
Local development instances for supported TYPO3 Core versions
are basically available in `ddev-instances/core-*` albeit not
having currently a generated dataset available.

However, to prepare further towards a automatically startup,
generating a default dataset for the ddev instances, the one
or other preparation is required and in the making.

With this change more packages are added as composer dependencies
for the ddev instances acting as further preparations.

Used command(s):

```shell
BIN_COMPOSER="$( which composer )" \
&& ${BIN_COMPOSER} require \
    -d ddev-instances/core-12 \
    --no-update \
    "bk2k/bootstrap-package":"^15.0@dev" \
&& ${BIN_COMPOSER} require \
    -d ddev-instances/core-13 \
    --no-update \
    "bk2k/bootstrap-package":"^15.0@dev"
```
