### PR TITLE
[BUGFIX] Align database sturcture in all supported TYPO3 version

### DIFF
--- a/packages/fgtclb/academic-partners/ext_tables.sql
+++ b/packages/fgtclb/academic-partners/ext_tables.sql
@@ -1,6 +1,5 @@
 CREATE TABLE pages (
-    partner_name varchar(255) DEFAULT '' NOT NULL,
-    partner_abbreviation varchar(255) DEFAULT '' NOT NULL,
+    abbreviation varchar(255) DEFAULT '' NOT NULL,
     address_street varchar(255) DEFAULT '' NOT NULL,
     address_street_number varchar(8) DEFAULT '' NOT NULL,
     address_zip varchar(20) DEFAULT '' NOT NULL,
@@ -13,7 +12,9 @@ CREATE TABLE pages (
     geocode_status varchar(40) DEFAULT '' NOT NULL,
     geocode_message varchar(255) DEFAULT '' NOT NULL,
     show_on_map tinyint(1) unsigned DEFAULT '1' NOT NULL,
-    tx_academicpartners_partnerships int(11) DEFAULT NULL
+    tx_academicpartners_partnerships int(11) DEFAULT NULL,
+    link text NOT NULL DEFAULT '',
+    description longtext DEFAULT NULL,
 );
 
 CREATE TABLE tx_academicpartners_domain_model_partnership (


### PR DESCRIPTION
TYPO3 v13 extended automatic database schema generation based for TCA
managed tables for nearly all TCA types, which is not the case for the
older TYPO3 v12 and requires to maintain `ext_tables.sql` in this case.

With bb4c013009d3cad354d04e5c035cbb0a8bd3c1d5 `EXT:academic_projects`
has been added and as a kickoff from a development state including db
additions for the `pages` table defined in TCA Overrides.

Sadly, the required TYPO3 v12 aligned addition in `ext_tables.sql` does
not match the naming scheme, or to be precise not exists in the same
naming schema:

* `ext_tables.sql`: partner_abbreviation `TCA Overrides`.: abbreviation
* `ext_tables.sql`: partner_name `TCA Overrides`.: -
* `ext_tables.sql`:  `TCA Overrides`.: description

Extension expects to have `abbreviation` which will not be created in
TYPO3 v12 instances due to the different naming.

This change now ...

* drops `partner_abbreviation` from `ext_tables.sql`.
* addes correct `abbreviation` in `ext_tables.sql`.
* drops `partner_name` from `ext_tables.sql`.
* adds `description` to `ext_tables.sql`.

to ensure existing database field for both supported TYPO3 versions.

The aforementioned field was only a example, more fields are out of
synced or not added to `ext_tables.sql` and therefore missing, which
are corrected for all of them.

[1] https://github.com/fgtclb/academic-extensions/commit/bb4c013009d3cad354d04e5c035cbb0a8bd3c1d5
