### PR TITLE
[DOCS] Add some line breaks in documentation

### DIFF
--- a/packages/fgtclb/academic-projects/Documentation/Index.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Index.rst
@@ -32,8 +32,11 @@ Academic Projects
 ----
 
 This extension adds a new page type for research projects to your TYPO3 CMS.
-Projects can be created like any normal page, but provide additional structured data for research projects as well as suitable typed categories.
-In addition, this extension provides a list view that can be used to sort and filter research projects.
+Projects can be created like any normal page, but provide additional structured
+data for research projects as well as suitable typed categories.
+
+In addition, this extension provides a list view that can be used to sort and
+filter research projects.
 
 ----
 


### PR DESCRIPTION
This change adds some line breaks in the documentation
to avoid excessive line lengths. But to be fully honest,
the main goal is trying to get a initial documentation
rendering happen on intercept.
