### PR TITLE
[BUGFIX] Use correct icon identifier for formengine items

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/Backend/FormEngine/PartnerItems.php
+++ b/packages/fgtclb/academic-partners/Classes/Backend/FormEngine/PartnerItems.php
@@ -29,7 +29,7 @@ class PartnerItems
                 $parameters['items'][] = [
                     'label' => $partner->getTitle(),
                     'value' => $partner->getUid(),
-                    'icon' => 'tx_academicpartners_domain_model_partner',
+                    'icon' => 'tx_academicpartners_domain_model_partnership',
                 ];
             }
         }


### PR DESCRIPTION
Used icon identifier added within the TCA itemProcFunc hook
for partner items was not registered. Use the correct icon
identifier like registered in `Configuration/Icons.php`.
