### PR TITLE
[BUGFIX] Configure correct type=0 showitem field for TCA table

### DIFF
--- a/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
@@ -30,7 +30,7 @@ return [
             'showitem' => implode(',', [
                 'name',
                 'description',
-                'contacts',
+                'partnerships',
                 '--palette--;;paletteCore',
             ]),
         ],


### PR DESCRIPTION
Using copy&paste from other extension is often a source for human
errors and can slip through reviews, special when part of bigger
mono-repository and old/new version aggregation.

`academic-partners` provides `tx_academicpartners_domain_model_role`
as TCA managed table and configured `type=0` showitems for it, but
used a non-existing table column.

This change replaces the wrong column name `contacts` with the
correct `partnerships` column name to tell TYPO3 to display it.

Cherry-picked from https://github.com/fgtclb/academic-extensions/pull/120
