### PR TITLE
[BUGFIX] Use registered extension icon identifier for plugin icons

### DIFF
--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
@@ -23,7 +23,7 @@ defined('TYPO3') or die;
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_list.title',
             'value' => 'academicpartners_list',
-            'icon' => 'EXT:academic_partners/Resources/Public/Icons/Extension.svg',
+            'icon' => 'academic-partners',
             'group' => 'academic',
         ],
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
@@ -40,7 +40,7 @@ defined('TYPO3') or die;
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_map.title',
             'value' => 'academicpartners_map',
-            'icon' => 'EXT:academic_partners/Resources/Public/Icons/Extension.svg',
+            'icon' => 'academic-partners',
             'group' => 'academic',
         ],
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
@@ -72,7 +72,7 @@ defined('TYPO3') or die;
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_partnershipslist.title',
             'value' => 'academicpartners_partnershipslist',
-            'icon' => 'EXT:academic_partners/Resources/Public/Icons/Extension.svg',
+            'icon' => 'academic-partners',
             'group' => 'academic',
         ],
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
@@ -84,7 +84,7 @@ defined('TYPO3') or die;
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_partnershipsteaser.title',
             'value' => 'academicpartners_partnershipsteaser',
-            'icon' => 'EXT:academic_partners/Resources/Public/Icons/Extension.svg',
+            'icon' => 'academic-partners',
             'group' => 'academic',
         ],
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,


### PR DESCRIPTION
`academic-partners` extension icon is already registered
in `Configuration/Icons.php` and is now used instead of
dedicated `EXT`-syntax icon file for the content plugin
registration (`CType typeicon_classes`).

Cherry-picked from https://github.com/fgtclb/academic-extensions/pull/120