### PR TITLE
[BUGFIX] Used simplified fluid variable for subsequent access

### DIFF
--- a/packages/fgtclb/academic-partners/Resources/Private/Partials/Partnerships/ListItem.html
+++ b/packages/fgtclb/academic-partners/Resources/Private/Partials/Partnerships/ListItem.html
@@ -6,7 +6,7 @@
 >
     <f:variable name="partner" value="{partnership.partner}" />
     <div class="ace-item">
-        <f:if condition="{partnership.partner.media.0}">
+        <f:if condition="{partner.media.0}">
             <div class="ace-item__image">
                 <f:image
                     image="{partner.media.0}"

--- a/packages/fgtclb/academic-partners/Resources/Private/Partials/Partnerships/TeaserItem.html
+++ b/packages/fgtclb/academic-partners/Resources/Private/Partials/Partnerships/TeaserItem.html
@@ -6,7 +6,7 @@
 >
     <f:variable name="partner" value="{partnership.partner}" />
     <div class="ace-item">
-        <f:if condition="{partnership.partner.media.0}">
+        <f:if condition="{partner.media.0}">
             <div class="ace-item__image">
                 <f:image
                     image="{partner.media.0}"


### PR DESCRIPTION
Some fluid templates uses the fluid VariableViewHelper to
register variables to shorten array path accesses and make
templates easier to read.

When registering them they should be used and are now done
in some places with this change.
