### PR TITLE
[BUGFIX] Adjust data processing and template paths

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/DataProcessing/PartnerProcessor.php
+++ b/packages/fgtclb/academic-partners/Classes/DataProcessing/PartnerProcessor.php
@@ -27,8 +27,16 @@ class PartnerProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ) {
-        $partnerFactory = GeneralUtility::makeInstance(PartnerFactory::class);
-        $processedData['partner'] = $partnerFactory->get($processedData['page']->getPageRecord());
+        // Try to fetch page data for FLUIDTEMPLATE
+        $pageData = $processedData['data'] ?? [];
+        if ($pageData === []) {
+            // If no page data is available in FLUIDTEMPLATE, try to fetch page data from PAGEVIEW
+            $pageData = $processedData['page']->getPageRecord() ?? [];
+        }
+        if ($pageData !== []) {
+            $programDataFactory = GeneralUtility::makeInstance(PartnerFactory::class);
+            $processedData['partner'] = $programDataFactory->get($pageData);
+        }
         return $processedData;
     }
 }

--- a/packages/fgtclb/academic-partners/Configuration/TypoScript/Page/AcademicPartners.typoscript
+++ b/packages/fgtclb/academic-partners/Configuration/TypoScript/Page/AcademicPartners.typoscript
@@ -1,9 +1,22 @@
 [traverse(page, "doktype") == 40]
   page {
     10 {
+      // Template paths for PAGEVIEW based configurations
       paths {
-        1 = EXT:academic_partners/Resources/Private/
+        100 = EXT:academic_partners/Resources/Private/
       }
+
+      // Template paths for FLUIDTEMPLATE based configurations
+      templateRootPaths {
+        100 = EXT:academic_partners/Resources/Private/Pages/
+      }
+      layoutRootPaths {
+        100 = EXT:academic_partners/Resources/Private/Layouts/
+      }
+      partialRootPaths {
+        100 = EXT:academic_partners/Resources/Private/Partials/
+      }
+
       dataProcessing {
         100 = partner-data
         110 = files

--- a/packages/fgtclb/academic-programs/Classes/DataProcessing/ProgramDataProcessor.php
+++ b/packages/fgtclb/academic-programs/Classes/DataProcessing/ProgramDataProcessor.php
@@ -3,7 +3,6 @@
 namespace FGTCLB\AcademicPrograms\DataProcessing;
 
 use FGTCLB\AcademicPrograms\Factory\ProgramDataFactory;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
@@ -28,17 +27,16 @@ class ProgramDataProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ) {
-        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-        $programDataFactory = GeneralUtility::makeInstance(ProgramDataFactory::class);
-
-        // TODO: Check which version exactly changed this...
-        if (version_compare($versionInformation->getVersion(), '12.0.0', '>=')) {
-            $pageData = $processedData['page']->getPageRecord();
-        } else {
-            $pageData = $processedData['data'];
+        // Try to fetch page data for FLUIDTEMPLATE
+        $pageData = $processedData['data'] ?? [];
+        if ($pageData === []) {
+            // If no page data is available in FLUIDTEMPLATE, try to fetch page data from PAGEVIEW
+            $pageData = $processedData['page']->getPageRecord() ?? [];
         }
-        $processedData['program'] = $programDataFactory->get($pageData);
-
+        if ($pageData !== []) {
+            $programDataFactory = GeneralUtility::makeInstance(ProgramDataFactory::class);
+            $processedData['program'] = $programDataFactory->get($pageData);
+        }
         return $processedData;
     }
 }

--- a/packages/fgtclb/academic-programs/Configuration/TypoScript/Page/AcademicPrograms.typoscript
+++ b/packages/fgtclb/academic-programs/Configuration/TypoScript/Page/AcademicPrograms.typoscript
@@ -1,9 +1,22 @@
 [traverse(page, "doktype") == 20]
   page {
     10 {
+      // Template path for PAGEVIEW based configurations
       paths {
-        10 = EXT:academic_programs/Resources/Private/
+        100 = EXT:academic_programs/Resources/Private/
       }
+
+      // Template paths for FLUIDTEMPLATE based configurations
+      templateRootPaths {
+        100 = EXT:academic_programs/Resources/Private/Pages/
+      }
+      layoutRootPaths {
+        100 = EXT:academic_programs/Resources/Private/Layouts/
+      }
+      partialRootPaths {
+        100 = EXT:academic_programs/Resources/Private/Partials/
+      }
+
       dataProcessing {
         100 = program-data
         110 = files

--- a/packages/fgtclb/academic-projects/Classes/DataProcessing/ProjectProcessor.php
+++ b/packages/fgtclb/academic-projects/Classes/DataProcessing/ProjectProcessor.php
@@ -29,8 +29,16 @@ class ProjectProcessor implements DataProcessorInterface
         array $processorConfiguration,
         array $processedData
     ) {
-        $projectFactory = GeneralUtility::makeInstance(ProjectFactory::class);
-        $processedData['project'] = $projectFactory->get($processedData['page']->getPageRecord());
+        // Try to fetch page data for FLUIDTEMPLATE
+        $pageData = $processedData['data'] ?? [];
+        if ($pageData === []) {
+            // If no page data is available in FLUIDTEMPLATE, try to fetch page data from PAGEVIEW
+            $pageData = $processedData['page']->getPageRecord() ?? [];
+        }
+        if ($pageData !== []) {
+            $programDataFactory = GeneralUtility::makeInstance(ProjectFactory::class);
+            $processedData['project'] = $programDataFactory->get($pageData);
+        }
         return $processedData;
     }
 }

--- a/packages/fgtclb/academic-projects/Configuration/TypoScript/Page/AcademicProjects.typoscript
+++ b/packages/fgtclb/academic-projects/Configuration/TypoScript/Page/AcademicProjects.typoscript
@@ -1,9 +1,22 @@
 [traverse(page, "doktype") == 30]
   page {
     10 {
+      // Template paths for PAGEVIEW based configurations
       paths {
-        10 = EXT:academic_projects/Resources/Private/
+        100 = EXT:academic_projects/Resources/Private/
       }
+
+      // Template paths for FLUIDTEMPLATE based configurations
+      templateRootPaths {
+        100 = EXT:academic_projects/Resources/Private/Pages/
+      }
+      layoutRootPaths {
+        100 = EXT:academic_projects/Resources/Private/Layouts/
+      }
+      partialRootPaths {
+        100 = EXT:academic_projects/Resources/Private/Partials/
+      }
+
       dataProcessing {
         100 = project-data
         110 = files


### PR DESCRIPTION
This adds bugfixes to the doktype based academic extension
partners, persons and projects:

* Add template path configuration alternatives  for site templates
  based on `FLUIDTEMPLATE` configuration.
* Rename the page configuration TS files from `Fluidtemplate.typoscript`
  to extension name based names.
* Remove incorrect TYPO3 version based condition for data processing in
  `ProgramDataProcessor.php` as data processing depends on template
  configuration (`FLUIDTEMPLATE` or `PAGEVIEW`) and not on TYPO3 version.
* Check `$processedData` for provided page data in sub-array `data` used
  by FLUIDTEMPLATE configuration or `page`  used by `PAGEVIEW` configurations.