### PR TITLE
[BUGFIX] Ensure flexform for plugin ctype

### DIFF
--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -50,10 +50,6 @@ defined('TYPO3') or die;
         'after:header'
     );
 
-    // Exclude/add fields for the plugin
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicprojects_projectlist'] = 'layout,recursive';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicprojects_projectlist'] = 'pi_flexform';
-
     // Link the FlexForm configuration to the pi_flexform field
     ExtensionManagementUtility::addPiFlexFormValue(
         '*',
@@ -77,9 +73,16 @@ defined('TYPO3') or die;
         'academicprojects_projectlistsingle'
     );
 
-    // Exclude/add fields for the plugin
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicprojects_projectlistsingle'] = 'layout,recursive';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicprojects_projectlistsingle'] = 'pi_flexform';
+    ExtensionManagementUtility::addToAllTCAtypes(
+        'tt_content',
+        implode(',', [
+            '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:element.tab.configuration',
+            'pi_flexform',
+            'pages',
+        ]),
+        'academicprojects_projectlistsingle',
+        'after:header'
+    );
 
     // Link the FlexForm configuration to the pi_flexform field
     // @todo Add FlexForm options to select a list of projects


### PR DESCRIPTION
Extbase plugins has been reworked from `list_type` to
`CType` handling, which is deprecated since TYPO3 v13
and will be removed in v14.

For the `academicprojects_projectlistsingle` adding
configuration to display the `pi_flexform` and `pages`
field based on `tt_content.CType` has been missed
and is added now.

Old and obsolete subtype field mangling is removed in
the same step.
