### PR TITLE
[TASK] Allow access on protected property

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/Domain/Model/Partner.php
+++ b/packages/fgtclb/academic-partners/Classes/Domain/Model/Partner.php
@@ -75,6 +75,11 @@ class Partner extends AbstractEntity implements GetCategoryCollectionInterface
         return $this->title;
     }
 
+    public function getAbstract(): string
+    {
+        return $this->abstract;
+    }
+
     public function getDescription(): string
     {
         return $this->description;


### PR DESCRIPTION
As the "abstract" property of the "Partner" model is protected and therefore can not be accessed without an appropriate public `get` function to return the property value, accessing it in templates is not
possible.

Thus a `get` function for the "abstract" property has been added to allow usage in e.g. the list view.