### PR TITLE
[FEATURE] Introduce person detail page `ProfileTitleProvider`

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Event/ProfileTitlePlaceholderReplacementEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ProfileTitlePlaceholderReplacementEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Event;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider;
+
+/**
+ * Fired in {@see ProfileTitleProvider::dispatchReplacementEvent()} for each found pageTitleFormat
+ * placeholder value (`%%SOME_IDENTIFIER%%` => `SOME_IDENTIFER`) to allow changing the replacement
+ * value.
+ *
+ * @internal event implementation is considered experimental for now and not part of Public API.
+ */
+final class ProfileTitlePlaceholderReplacementEvent
+{
+    public function __construct(
+        private readonly Profile $profile,
+        private readonly string $placeholder,
+        private string $replacement,
+    ) {}
+
+    /**
+     * Person profile extbase model for the current detail view page.
+     */
+    public function getProfile(): Profile
+    {
+        return $this->profile;
+    }
+
+    /**
+     * Original placeholder value with removed surrounding `%` signs.
+     */
+    public function getPlaceholder(): string
+    {
+        return $this->placeholder;
+    }
+
+    /**
+     * Current set replacement value for {@see self::getPlaceholder()}.
+     */
+    public function getReplacement(): string
+    {
+        return $this->replacement;
+    }
+
+    /**
+     * Set the replacement value, which should be used to replace the
+     * placeholder {@see self::getPlaceholder()}.
+     */
+    public function setReplacement(string $replacement): void
+    {
+        $this->replacement = $replacement;
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/PageTitle/ProfileTitleProvider.php
+++ b/packages/fgtclb/academic-persons/Classes/PageTitle/ProfileTitleProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\PageTitle;
+
+use FGTCLB\AcademicPersons\Controller\ProfileController;
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\Event\ProfileTitlePlaceholderReplacementEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Concrete page title provider implementation based on {@see AbstractPageTitleProvider},
+ * providing simplified `setTitle()` method and a advanced `setFromProfile()` method to
+ * allow format based setting possible.
+ *
+ * Used in {@see ProfileController::detailAction()} to set page title for displaced profile.
+ */
+final class ProfileTitleProvider extends AbstractPageTitleProvider
+{
+    public const DETAIL_PAGE_TITLE_FORMAT = '%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%';
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Set page title based on Profile values using the specified format,
+     * supporting placeholder with syntax `%%UPPER_CASED_PROFILE_FIELD%%`
+     * converted to camel-cased model getter `getUpperCasedProfileField()`
+     * to retrieve replacement value.
+     *
+     * Note: Non-existing model getter will be not replaced and does not throw or log any errors.
+     */
+    public function setFromProfile(Profile $profile, string $format = self::DETAIL_PAGE_TITLE_FORMAT): void
+    {
+        // replace all `%%` surrounded values with model fields
+        $title = (string)preg_replace_callback(
+            pattern: '/%%([\w\d]+)%%/',
+            callback: function (array $matches) use ($profile): string {
+                $originalPlaceholder = $matches[1];
+                $placeholder = $matches[1];
+                $placeholder = $this->profileGetterPlaceholderReplacement($profile, $placeholder);
+                $placeholder = $this->dispatchProfileTitleTagPlaceholderReplacementEvent($profile, $originalPlaceholder, $placeholder);
+                return ($originalPlaceholder === $placeholder)
+                    // no replacement processed, return full placeholder with surrounding percent
+                    // signs to indicate unreplaced value
+                    ? $matches[0]
+                    // placeholder modified, return it
+                    : $placeholder;
+            },
+            subject: $format,
+        );
+        // remove all leading and tailing spaces
+        $title = trim($title, ' ');
+        // ensure keeping only single spaces in content (replacing multi spaces with single space)
+        $title = (string)preg_replace('/[[:blank:]]+/', ' ', $title);
+        $this->setTitle($title);
+    }
+
+    private function profileGetterPlaceholderReplacement(Profile $profile, string $placeholder): string
+    {
+        $getterName = 'get' . str_replace('_', '', ucwords(mb_strtolower($placeholder), '_'));
+        return method_exists($profile, $getterName)
+            ? trim($profile->{$getterName}(), ' ')
+            : $placeholder;
+    }
+
+    private function dispatchProfileTitleTagPlaceholderReplacementEvent(
+        Profile $profile,
+        string $placeholder,
+        string $replacement,
+    ): string {
+        /** @var ProfileTitlePlaceholderReplacementEvent $event */
+        $event = $this->getEventDispatcher()->dispatch(new ProfileTitlePlaceholderReplacementEvent(
+            profile: $profile,
+            placeholder: $placeholder,
+            replacement: $replacement,
+        ));
+        return $event->getReplacement();
+    }
+
+    private function getEventDispatcher(): EventDispatcherInterface
+    {
+        return GeneralUtility::makeInstance(EventDispatcherInterface::class);
+    }
+}

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/Detail.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/Detail.xml
@@ -1,0 +1,32 @@
+<T3DataStructure>
+    <ROOT>
+        <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
+        <type>array</type>
+        <el>
+            <settings.pageTitleFormat>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.label</label>
+                <config>
+                    <type>input</type>
+                    <size>100</size>
+                    <eval>trim</eval>
+                    <valuePicker>
+                        <items>
+                            <numIndex index="0" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
+                                <numIndex index="1"></numIndex>
+                            </numIndex>
+                            <numIndex index="1" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
+                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                            </numIndex>
+                            <numIndex index="2" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
+                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                            </numIndex>
+                        </items>
+                    </valuePicker>
+                </config>
+            </settings.pageTitleFormat>
+        </el>
+    </ROOT>
+</T3DataStructure>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
@@ -3,6 +3,31 @@
         <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
         <type>array</type>
         <el>
+            <settings.pageTitleFormat>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.label</label>
+                <description>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.listanddetail_description</description>
+                <config>
+                    <type>input</type>
+                    <size>100</size>
+                    <eval>trim</eval>
+                    <valuePicker>
+                        <items>
+                            <numIndex index="0" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
+                                <numIndex index="1"></numIndex>
+                            </numIndex>
+                            <numIndex index="1" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
+                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                            </numIndex>
+                            <numIndex index="2" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
+                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                            </numIndex>
+                        </items>
+                    </valuePicker>
+                </config>
+            </settings.pageTitleFormat>
             <settings.detailPid>
                 <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.detailPid.label</label>
                 <config>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/Detail.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/Detail.xml
@@ -1,0 +1,32 @@
+<T3DataStructure>
+    <ROOT>
+        <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
+        <type>array</type>
+        <el>
+            <settings.pageTitleFormat>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.label</label>
+                <config>
+                    <type>input</type>
+                    <size>100</size>
+                    <eval>trim</eval>
+                    <valuePicker>
+                        <items>
+                            <numIndex index="0" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
+                                <numIndex index="1"></numIndex>
+                            </numIndex>
+                            <numIndex index="1" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
+                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                            </numIndex>
+                            <numIndex index="2" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
+                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                            </numIndex>
+                        </items>
+                    </valuePicker>
+                </config>
+            </settings.pageTitleFormat>
+        </el>
+    </ROOT>
+</T3DataStructure>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/List.xml
@@ -3,6 +3,31 @@
         <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
         <type>array</type>
         <el>
+            <settings.pageTitleFormat>
+                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.label</label>
+                <description>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.listanddetail_description</description>
+                <config>
+                    <type>input</type>
+                    <size>100</size>
+                    <eval>trim</eval>
+                    <valuePicker>
+                        <items>
+                            <numIndex index="0" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
+                                <numIndex index="1"></numIndex>
+                            </numIndex>
+                            <numIndex index="1" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
+                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                            </numIndex>
+                            <numIndex index="2" type="array">
+                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
+                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                            </numIndex>
+                        </items>
+                    </valuePicker>
+                </config>
+            </settings.pageTitleFormat>
             <settings.detailPid>
                 <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.detailPid.label</label>
                 <config>

--- a/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
@@ -98,6 +98,11 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
+    ExtensionManagementUtility::addPiFlexFormValue(
+        '*',
+        sprintf('FILE:EXT:academic_persons/Configuration/FlexForms/Core%s/Detail.xml', $typo3MajorVersion),
+        'academicpersons_detail'
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_card

--- a/packages/fgtclb/academic-persons/Configuration/TypoScript/Default/setup.typoscript
+++ b/packages/fgtclb/academic-persons/Configuration/TypoScript/Default/setup.typoscript
@@ -27,3 +27,10 @@ plugin.tx_academicpersons {
     }
   }
 }
+
+config.pageTitleProviders {
+    profile  {
+        provider = FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider
+        before = calendarize,altPageTitle,record,seo
+    }
+}

--- a/packages/fgtclb/academic-persons/Configuration/TypoScript/Standalone/setup.typoscript
+++ b/packages/fgtclb/academic-persons/Configuration/TypoScript/Standalone/setup.typoscript
@@ -15,3 +15,10 @@ page {
     bootstrap.external = 1
   }
 }
+
+config.pageTitleProviders {
+    profile  {
+        provider = FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider
+        before = calendarize,altPageTitle,record,seo
+    }
+}

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
@@ -1,252 +1,272 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-    xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" product-name="academic_persons">
-        <header/>
-        <body>
-            <trans-unit id="extension_configuration.types.profileTypes.label">
-                <source>Profile Types: Comma-separated list of profile types</source>
-                <target>Profiltypen: Kommagetrennte Liste von Profiltypen</target>
-            </trans-unit>
-            <trans-unit id="extension_configuration.types.physicalAddressTypes.label">
-                <source>Physical Address Types: Comma-separated list of physical address types</source>
-                <target>Physikalische Adresstypen: Kommagetrennte Liste von physischen Adresstypen</target>
-            </trans-unit>
-            <trans-unit id="extension_configuration.types.emailAddressTypes.label">
-                <source>Email Address Types: Comma-separated list of email address types</source>
-                <target>E-Mail Adresstypen: Kommagetrennte Liste von E-Mail-Adresstypen</target>
-            </trans-unit>
-            <trans-unit id="extension_configuration.types.phoneNumberTypes.label">
-                <source>Phone Number Types: Comma-separated list of phone number types</source>
-                <target>Rufnummertypen: Kommagetrennte Liste von Rufnummertypen</target>
-            </trans-unit>
-            <trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
-                <source>Group By Values: Comma-separated list of allowed group by values</source>
-                <target>Nach Werten gruppieren: Kommagetrennte Liste von zulässigen Gruppierungswerten</target>
-            </trans-unit>
-            <trans-unit id="extension_configuration.demand.allowedSortByValues.label">
-                <source>Sort By Values: Comma-separated list of allowed sort by values</source>
-                <target>Nach Werten sortieren: Kommagetrennte Liste von zulässigen Sortierwerten</target>
-            </trans-unit>
+	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" product-name="academic_persons">
+		<header/>
+		<body>
+			<trans-unit id="extension_configuration.types.profileTypes.label">
+				<source>Profile Types: Comma-separated list of profile types</source>
+				<target>Profiltypen: Kommagetrennte Liste von Profiltypen</target>
+			</trans-unit>
+			<trans-unit id="extension_configuration.types.physicalAddressTypes.label">
+				<source>Physical Address Types: Comma-separated list of physical address types</source>
+				<target>Physikalische Adresstypen: Kommagetrennte Liste von physischen Adresstypen</target>
+			</trans-unit>
+			<trans-unit id="extension_configuration.types.emailAddressTypes.label">
+				<source>Email Address Types: Comma-separated list of email address types</source>
+				<target>E-Mail Adresstypen: Kommagetrennte Liste von E-Mail-Adresstypen</target>
+			</trans-unit>
+			<trans-unit id="extension_configuration.types.phoneNumberTypes.label">
+				<source>Phone Number Types: Comma-separated list of phone number types</source>
+				<target>Rufnummertypen: Kommagetrennte Liste von Rufnummertypen</target>
+			</trans-unit>
+			<trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
+				<source>Group By Values: Comma-separated list of allowed group by values</source>
+				<target>Nach Werten gruppieren: Kommagetrennte Liste von zulässigen Gruppierungswerten</target>
+			</trans-unit>
+			<trans-unit id="extension_configuration.demand.allowedSortByValues.label">
+				<source>Sort By Values: Comma-separated list of allowed sort by values</source>
+				<target>Nach Werten sortieren: Kommagetrennte Liste von zulässigen Sortierwerten</target>
+			</trans-unit>
 
-            <trans-unit id="content.ctype.group.label">
-                <source>Academic</source>
-                <target>Academic</target>
-            </trans-unit>
-            <trans-unit id="plugin.list.label">
-                <source>Persons List</source>
-                <target>Personen Liste</target>
-            </trans-unit>
-            <trans-unit id="plugin.detail.label">
-                <source>Persons Detail</source>
-                <target>Personen Detail</target>
-            </trans-unit>
-            <trans-unit id="plugin.listAndDetail.label">
-                <source>Persons List and Detail</source>
-                <target>Personen Liste and Detail</target>
-            </trans-unit>
-            <trans-unit id="content.ctype.group.label">
-                <source>Academic</source>
-                <target>Academic</target>
-            </trans-unit>
-            <trans-unit id="plugin.selectedprofiles.label">
-                <source>Profiles: Selected Profiles</source>
-                <target>Profiles: Selected Profiles</target>
-            </trans-unit>
-            <trans-unit id="plugin.selectedprofiles.description">
-                <source>Plugin to list only selected profiles</source>
-                <target>Plugin to list only selected profiles</target>
-            </trans-unit>
-            <trans-unit id="plugin.selectedcontracts.label">
-                <source>Profiles: Selected Contracts</source>
-                <target>Profiles: Selected Contracts</target>
-            </trans-unit>
-            <trans-unit id="plugin.selectedcontracts.description">
-                <source>Plugin to list only selected contracts</source>
-                <target>Plugin to list only selected contracts</target>
-            </trans-unit>
+			<trans-unit id="content.ctype.group.label">
+				<source>Academic</source>
+				<target>Academic</target>
+			</trans-unit>
+			<trans-unit id="plugin.list.label">
+				<source>Persons List</source>
+				<target>Personen Liste</target>
+			</trans-unit>
+			<trans-unit id="plugin.detail.label">
+				<source>Persons Detail</source>
+				<target>Personen Detail</target>
+			</trans-unit>
+			<trans-unit id="plugin.listAndDetail.label">
+				<source>Persons List and Detail</source>
+				<target>Personen Liste and Detail</target>
+			</trans-unit>
+			<trans-unit id="content.ctype.group.label">
+				<source>Academic</source>
+				<target>Academic</target>
+			</trans-unit>
+			<trans-unit id="plugin.selectedprofiles.label">
+				<source>Profiles: Selected Profiles</source>
+				<target>Profiles: Selected Profiles</target>
+			</trans-unit>
+			<trans-unit id="plugin.selectedprofiles.description">
+				<source>Plugin to list only selected profiles</source>
+				<target>Plugin to list only selected profiles</target>
+			</trans-unit>
+			<trans-unit id="plugin.selectedcontracts.label">
+				<source>Profiles: Selected Contracts</source>
+				<target>Profiles: Selected Contracts</target>
+			</trans-unit>
+			<trans-unit id="plugin.selectedcontracts.description">
+				<source>Plugin to list only selected contracts</source>
+				<target>Plugin to list only selected contracts</target>
+			</trans-unit>
 
-            <trans-unit id="newContentElement.wizardItems.academic">
-                <source>Academic</source>
-                <target>Akademisch</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.list.title">
-                <source>Persons List</source>
-                <target>Personen Liste</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.list.description">
-                <source>Plugin for listing academic persons</source>
-                <target>Plugin zur Auflistung akademischer Personen</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.detail.title">
-                <source>Persons Detail</source>
-                <target>Personen Detail</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.detail.description">
-                <source>Plugin for viewing single academic persons</source>
-                <target>Plugin zur Ansicht einzelner akademischer Personen</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
-                <source>Persons List and Detail</source>
-                <target>Personen Liste und Detail</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
-                <source>Plugin for listing and viewing academic persons</source>
-                <target>Plugin zur Auflistung und Ansicht akademischer Personen</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.card.title">
-                <source>Contacts</source>
-                <target>Kontakte</target>
-            </trans-unit>
-            <trans-unit id="newContentElement.wizardItems.academic.card.description">
-                <source>Adds one or more contacts</source>
-                <target>Fügt ein oder mehrere Kontakte hinzu</target>
-            </trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic">
+				<source>Academic</source>
+				<target>Akademisch</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.list.title">
+				<source>Persons List</source>
+				<target>Personen Liste</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.list.description">
+				<source>Plugin for listing academic persons</source>
+				<target>Plugin zur Auflistung akademischer Personen</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.detail.title">
+				<source>Persons Detail</source>
+				<target>Personen Detail</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.detail.description">
+				<source>Plugin for viewing single academic persons</source>
+				<target>Plugin zur Ansicht einzelner akademischer Personen</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
+				<source>Persons List and Detail</source>
+				<target>Personen Liste und Detail</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
+				<source>Plugin for listing and viewing academic persons</source>
+				<target>Plugin zur Auflistung und Ansicht akademischer Personen</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.card.title">
+				<source>Contacts</source>
+				<target>Kontakte</target>
+			</trans-unit>
+			<trans-unit id="newContentElement.wizardItems.academic.card.description">
+				<source>Adds one or more contacts</source>
+				<target>Fügt ein oder mehrere Kontakte hinzu</target>
+			</trans-unit>
 
-            <trans-unit id="element.tab.configuration">
-                <source>Configuration</source>
-                <target>Konfiguration</target>
-            </trans-unit>
-            <trans-unit id="flexform.tab.settings">
-                <source>Settings</source>
-                <target>Einstellungen</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.detailPid.label">
-                <source>Detail Page</source>
-                <target>Detail Seite</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.listPid.label">
-                <source>List Page</source>
-                <target>Listen Seite</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.functionTypes.label">
-                <source>Function Types</source>
-                <target>Funktionstypen</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.groupBy.label">
-                <source>Group By (is given priority in sorting if activ)</source>
-                <target>Gruppieren nach (wird vorrangig bei der Sortierung berücksichtigt)</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.groupBy.items.none">
-                <source>No grouping</source>
-                <target>Keine Gruppierung</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.groupBy.items.first_name">
-                <source>First Letter of First Name</source>
-                <target>Erster Buchstabe des Vornamens</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.groupBy.items.last_name">
-                <source>First Letter of Last Name</source>
-                <target>Erster Buchstabe des Nachnamens</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.organisationalUnits.label">
-                <source>Organisational Units</source>
-                <target>Organisationseinheiten</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortBy.label">
-                <source>Sort By (sorting of activated grouping has priority)</source>
-                <target>Sortieren nach (wird nachrangig bei aktivierter Gruppierung berücksichtigt)</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.selectedContracts.label">
-                <source>Selected Contracts</source>
-                <target>Ausgewählte Verträge</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.selectedProfiles.label">
-                <source>Selected Profiles</source>
-                <target>Ausgewählte Profile</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.showFields.label">
-                <source>Show only selected Fields</source>
-                <target>Nur ausgewählte Felder anzeigen</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.showFields.groups.profile">
-                <source>Profile</source>
-                <target>Profil</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.showFields.groups.contracts">
-                <source>Contracts</source>
-                <target>Verträge</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortBy.items.none">
-                <source>No sorting</source>
-                <target>Keine Sortierung</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortBy.items.first_name">
-                <source>First Name</source>
-                <target>Vorname</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortBy.items.last_name">
-                <source>Last Name</source>
-                <target>Nachname</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortByDirection.label">
-                <source>Sort By Direction</source>
-                <target>Nach Richtung sortieren</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortByDirection.items.asc">
-                <source>Ascending</source>
-                <target>Aufsteigend</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.sortByDirection.items.desc">
-                <source>Descending</source>
-                <target>Absteigend</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.alphabetPaginationEnabled.label">
-                <source>Alphabetical Pagination</source>
-                <target>Alphabetische Paginierung</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
-                <source>Enabled</source>
-                <target>Aktiviert</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.paginationEnabled.label">
-                <source>Pagination</source>
-                <target>Paginierung</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.paginationEnabled.items.0.label">
-                <source>Enabled</source>
-                <target>Aktiviert</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.resultsPerPage.label">
-                <source>Results per Page</source>
-                <target>Ergebnisse pro Seite</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.numberOfLinks.label">
-                <source>Number of Links</source>
-                <target>Anzahl der Links</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.paginationEnabled.items.0.label">
-                <source>Enabled</source>
-                <target>Aktiviert</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.profileList.label">
-                <source>List of profiles</source>
-                <target>Liste von Profilen</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.fallbackForNonTranslated.label">
-                <source>Fallback to default language for non translated profiles</source>
-                <target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.viewMode.enabled.label">
-                <source>View Mode Toggle</source>
-                <target>Ansichtsmodus-Umschalter</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.viewMode.enabled.items.0.label">
-                <source>Enabled</source>
-                <target>Aktiviert</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.viewMode.default.label">
-                <source>View Mode Default</source>
-                <target>Standard für Ansichtsmodus</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.viewMode.default.I.list">
-                <source>List</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="flexform.el.viewMode.default.I.table">
-                <source>Table</source>
-                <target>Tabelle</target>
-            </trans-unit>
-        </body>
-    </file>
+			<trans-unit id="element.tab.configuration">
+				<source>Configuration</source>
+				<target>Konfiguration</target>
+			</trans-unit>
+			<trans-unit id="flexform.tab.settings">
+				<source>Settings</source>
+				<target>Einstellungen</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.detailPid.label">
+				<source>Detail Page</source>
+				<target>Detail Seite</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.listPid.label">
+				<source>List Page</source>
+				<target>Listen Seite</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.functionTypes.label">
+				<source>Function Types</source>
+				<target>Funktionstypen</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.groupBy.label">
+				<source>Group By (is given priority in sorting if activ)</source>
+				<target>Gruppieren nach (wird vorrangig bei der Sortierung berücksichtigt)</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.groupBy.items.none">
+				<source>No grouping</source>
+				<target>Keine Gruppierung</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.groupBy.items.first_name">
+				<source>First Letter of First Name</source>
+				<target>Erster Buchstabe des Vornamens</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.groupBy.items.last_name">
+				<source>First Letter of Last Name</source>
+				<target>Erster Buchstabe des Nachnamens</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.organisationalUnits.label">
+				<source>Organisational Units</source>
+				<target>Organisationseinheiten</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortBy.label">
+				<source>Sort By (sorting of activated grouping has priority)</source>
+				<target>Sortieren nach (wird nachrangig bei aktivierter Gruppierung berücksichtigt)</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.selectedContracts.label">
+				<source>Selected Contracts</source>
+				<target>Ausgewählte Verträge</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.selectedProfiles.label">
+				<source>Selected Profiles</source>
+				<target>Ausgewählte Profile</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.showFields.label">
+				<source>Show only selected Fields</source>
+				<target>Nur ausgewählte Felder anzeigen</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.showFields.groups.profile">
+				<source>Profile</source>
+				<target>Profil</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.showFields.groups.contracts">
+				<source>Contracts</source>
+				<target>Verträge</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortBy.items.none">
+				<source>No sorting</source>
+				<target>Keine Sortierung</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortBy.items.first_name">
+				<source>First Name</source>
+				<target>Vorname</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortBy.items.last_name">
+				<source>Last Name</source>
+				<target>Nachname</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortByDirection.label">
+				<source>Sort By Direction</source>
+				<target>Nach Richtung sortieren</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortByDirection.items.asc">
+				<source>Ascending</source>
+				<target>Aufsteigend</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.sortByDirection.items.desc">
+				<source>Descending</source>
+				<target>Absteigend</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.alphabetPaginationEnabled.label">
+				<source>Alphabetical Pagination</source>
+				<target>Alphabetische Paginierung</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
+				<source>Enabled</source>
+				<target>Aktiviert</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.paginationEnabled.label">
+				<source>Pagination</source>
+				<target>Paginierung</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.paginationEnabled.items.0.label">
+				<source>Enabled</source>
+				<target>Aktiviert</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.resultsPerPage.label">
+				<source>Results per Page</source>
+				<target>Ergebnisse pro Seite</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.numberOfLinks.label">
+				<source>Number of Links</source>
+				<target>Anzahl der Links</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.paginationEnabled.items.0.label">
+				<source>Enabled</source>
+				<target>Aktiviert</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.label">
+				<source>PageTitle display format</source>
+				<target>Seitentitel Anzeige Format</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
+				<source>for person detail page</source>
+				<target>für Person Detailansicht</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.none">
+				<source>Default page title</source>
+				<target>Standard Seitentitel</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
+				<source>Title Firstname Middlename Lastname</source>
+				<target>Titel Vorname Mittelname Nachname</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
+				<source>Lastname, Firstname Middlename</source>
+				<target>Nachname, Vorname Mittelname</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.profileList.label">
+				<source>List of profiles</source>
+				<target>Liste von Profilen</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.fallbackForNonTranslated.label">
+				<source>Fallback to default language for non translated profiles</source>
+				<target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.viewMode.enabled.label">
+				<source>View Mode Toggle</source>
+				<target>Ansichtsmodus-Umschalter</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.viewMode.enabled.items.0.label">
+				<source>Enabled</source>
+				<target>Aktiviert</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.viewMode.default.label">
+				<source>View Mode Default</source>
+				<target>Standard für Ansichtsmodus</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.viewMode.default.I.list">
+				<source>List</source>
+				<target>Liste</target>
+			</trans-unit>
+			<trans-unit id="flexform.el.viewMode.default.I.table">
+				<source>Table</source>
+				<target>Tabelle</target>
+			</trans-unit>
+		</body>
+	</file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
@@ -163,6 +163,21 @@
 			<trans-unit id="flexform.el.numberOfLinks.label">
 				<source>Number of Links</source>
 			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.label">
+				<source>PageTitle display format</source>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
+				<source>for person detail page</source>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.none">
+				<source>Default page title</source>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
+				<source>Title Firstname Middlename Lastname</source>
+			</trans-unit>
+			<trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
+				<source>Lastname, Firstname Middlename</source>
+			</trans-unit>
 			<trans-unit id="flexform.el.profileList.label">
 				<source>List of profiles</source>
 			</trans-unit>

--- a/packages/fgtclb/academic-persons/Tests/Functional/PageTitle/ProfileTitleProviderTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/PageTitle/ProfileTitleProviderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\PageTitle;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ProfileTitleProviderTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function setFromProfileKeepsUnresolvedPlaceholder(): void
+    {
+        $format = 'Some label containing a %%UNRESOLVEABLE_PLACEHOLDER%% to test against.';
+        $this->assertSame($format, $this->createSubject(new Profile(), $format)->getTitle());
+    }
+
+    public static function setFromProfileDataSets(): \Generator
+    {
+        $profile = new Profile();
+        $profile
+            ->setTitle('SomeTitle')
+            ->setFirstName('Max')
+            ->setMiddleName('Augustin')
+            ->setLastName('Müllermann');
+
+        $format = '%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%';
+        yield sprintf('#1 resolve all placeholder of pattern: "%s"', $format) => [
+            'profile' => $profile,
+            'format' => $format,
+            'expected' => 'SomeTitle Max Augustin Müllermann',
+        ];
+
+        $format = '%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%';
+        yield sprintf('#2 resolve all placeholder of pattern: "%s"', $format) => [
+            'profile' => $profile,
+            'format' => $format,
+            'expected' => 'Müllermann, Max Augustin',
+        ];
+
+        $format = ' %%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%% ';
+        yield sprintf('#3 leading and trailing format spaces are removed from resolved pattern: "%s"', $format) => [
+            'profile' => $profile,
+            'format' => $format,
+            'expected' => 'SomeTitle Max Augustin Müllermann',
+        ];
+
+        $profileLeadingTailingSpaces = new Profile();
+        $profileLeadingTailingSpaces
+            ->setTitle(' TitleWithLeadingSpace')
+            ->setFirstName('Max')
+            ->setMiddleName('Augustin')
+            ->setLastName('LastnameWithEndingSpace ');
+        $format = ' %%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%% ';
+        yield sprintf('#4 leading and trailing spaces are removed from resolved pattern: "%s"', $format) => [
+            'profile' => $profileLeadingTailingSpaces,
+            'format' => $format,
+            'expected' => 'TitleWithLeadingSpace Max Augustin LastnameWithEndingSpace',
+        ];
+
+        $profileWithSpaceSurroundedValues = new Profile();
+        $profileWithSpaceSurroundedValues
+            ->setTitle(' SomeTitle ')
+            ->setFirstName(' Max ')
+            ->setMiddleName(' Augustin ')
+            ->setLastName(' Müllermann ');
+        $format = '%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%';
+        yield sprintf('#5 multiple spaces are removed from resolved pattern: "%s"', $format) => [
+            'profile' => $profileWithSpaceSurroundedValues,
+            'format' => $format,
+            'expected' => 'SomeTitle Max Augustin Müllermann',
+        ];
+        $format = '%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%';
+        yield sprintf('#6 multiple spaces are removed from resolved pattern: "%s"', $format) => [
+            'profile' => $profileWithSpaceSurroundedValues,
+            'format' => $format,
+            'expected' => 'Müllermann, Max Augustin',
+        ];
+
+        $profile = new Profile();
+        $profile
+            ->setTitle('SomeTitle')
+            ->setFirstName('Max')
+            ->setMiddleName('Augustin')
+            ->setLastName('Müllermann');
+        $format = 'Prefix: %%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%% | Detail';
+        yield sprintf('#7 static text is kept in pattern: "%s"', $format) => [
+            'profile' => $profile,
+            'format' => $format,
+            'expected' => 'Prefix: SomeTitle Max Augustin Müllermann | Detail',
+        ];
+    }
+
+    #[DataProvider('setFromProfileDataSets')]
+    #[Test]
+    public function setFromProfileSetsExpectedTitle(
+        Profile $profile,
+        string $format,
+        string $expected,
+    ): void {
+        $this->assertSame($expected, $this->createSubject($profile, $format)->getTitle());
+    }
+
+    private function createSubject(?Profile $profile = null, string $format = ProfileTitleProvider::DETAIL_PAGE_TITLE_FORMAT): ProfileTitleProvider
+    {
+        $subject = $this->get(ProfileTitleProvider::class);
+        if ($profile !== null) {
+            $subject->setFromProfile($profile, $format);
+        }
+        return $subject;
+    }
+}

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -2,7 +2,9 @@
 
 ## X.Y.Z
 
-### BREAKING: Removed partials
+### BREAKING CHANGES
+
+#### BREAKING: Removed partials
 
 Some partials got removed as the templating structure has changed. Those partials include:
 
@@ -14,6 +16,47 @@ Some partials got removed as the templating structure has changed. Those partial
 > [!NOTE]
 > The default templating now supports basic bootstrap styling and is semantically optimized
 > to also not lack any major accessibility.
+
+### FEATURES
+
+#### `pageTitleFormat` FlexForm option for person detail view
+
+It's now possible to define the format used to generate the HTML PageTitle for
+the detail view of persons in the frontend, using the TYPO3 PageTitle API.
+
+The default format used based on `Profile` extbase model data is:
+
+```
+%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%
+```
+
+To allow easier customization in project, a new FlexForm option `pageTitleFormat`
+has been added to `listanddetail` plugin and as single new option for the `detail`
+plugin, which uses `TCA type=input` combined with a ValuePicker to allow picking
+from a list of pre-defined formats while still making it possible to define own
+custom format directly on plugin usage.
+
+The mapping from placeholder to extbase model is based on transforming the
+placeholder to camelcase using first character after separators and prefix
+it with `get`, and if the getter exists it is called to retrieve the value.
+
+For example:
+
+```
+PLACEHOLDER...: %%FIRST_NAME%%
+CAMEL_CASE....: FirstName
+PREFIXED......: getFirstName
+
+which calls `Profile->getFirstName()` to retrieve the replacement value from
+the detail view profile.
+```
+
+The whole process contains some behaviour, which needs to be kept in mind:
+
+* Leading and trailing spaces are trimmed from each value(placeholder).
+* Multiple spaces are removed from the whole format string.
+* Leading and trailing spaces are trimmed from the whole format pattern, after
+  placeholder resolving has been processed.
 
 ## 2.0.1
 


### PR DESCRIPTION
This change introduces the `ProfileTitleProvider` using TYPO3
API to setting person detail page title based on the profile
record using a format pattern.

Concrete `ProfileTitleProvider` implemetnation provides two
methods to set the title:

* Introduce flexform for `academicpersons_detail` with new
  `pageTitleFormat` setting, which could be modified for
  project using the flexform PSR-14 event(s).

* Add `pageTitleFormat` setting to `listanddetail` plugin
  flexform to allow setting page title also in that case.

* `setTitle(string $title): void` to allow setting page title
  to any string value.

* `setFromProfile(Profile $profile, string $format = ...)` to
   set the title based on profile values using the specified
   `format` with placeholders (model), defaulting to public
   `ProfileTitleProvider::DETAIL_PAGE_TITLE_FORMAT`. Format
   can be specified in plugin flexform setting.

`ProfileController::detailAction()` now uses the injected
`PageTitleProvider` to set page title using default format
and passing the concrete profile model.

Implementation is covered with functional test to directly
mitigate casual handling issues like unresolved placeholders,
static text, space/multiple-spaces handling and similar and
make it visible which behaviour is expected.

Note that a additional formengine extension (dataprovider)
may be implemented dispatching a PSR-14 event, otherwise
already existing flexform events can be used to adjust the
available options for the `pageTitleFormat` value picker.

Also notable is the fact, that TCA ValuePicker items still
uses the indexed array notation for items instead of the
new associtive variant introduced for select items in v12
(TCA only) and FlexForm (v13) and is the reason why we use
that notation for both core versions for now.

![image](https://github.com/user-attachments/assets/0d04c137-6434-4145-af66-0c80fc16a2a3)
