### PR TITLE
[TASK] Raise `'friendsofphp/php-cs-fixer':'^3.80.0'`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   },
   "require-dev": {
     "bnf/phpstan-psr-container": "^1.0.1",
-    "friendsofphp/php-cs-fixer": "^3.57.1",
+    "friendsofphp/php-cs-fixer": "^3.80.0",
     "friendsoftypo3/phpstan-typo3": "^0.9.0",
     "georgringer/numbered-pagination": "^2.1",
     "phpstan/phpdoc-parser": "^1.29.0",

--- a/packages/fgtclb/academic-programs/Classes/Collection/FileReferenceCollection.php
+++ b/packages/fgtclb/academic-programs/Classes/Collection/FileReferenceCollection.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPrograms\Collection;
 
 use Doctrine\DBAL\Driver\Exception;
-use Iterator;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -14,7 +13,7 @@ use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * @implements Iterator<int, FileReference>
+ * @implements \Iterator<int, FileReference>
  */
 final class FileReferenceCollection implements \Countable, \Iterator
 {

--- a/packages/fgtclb/typo3-category-types/Classes/Collection/FilterCollection.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Collection/FilterCollection.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace FGTCLB\CategoryTypes\Collection;
 
-use ArrayAccess;
 use FGTCLB\CategoryTypes\Domain\Model\Category;
 
 /**
- * @implements ArrayAccess<string, Category[]>
+ * @implements \ArrayAccess<string, Category[]>
  * @todo Only "offsetGet" implemented, consider to change from array access to ContainerInterface (get/has only).
  */
 class FilterCollection implements \ArrayAccess, \Stringable


### PR DESCRIPTION
Used package `friendsofphp/php-cs-fixer` changed or fixed
some detection in newer version leading to failing pipeline
checks unrelated to changes.

This change raises the package to the current version and
applies the required changes to get a green baseline again.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.1 -t 12 -s composerUpdate \
&& Build/Scripts/runTests.sh -p 8.1 -t 12 -s composer -- require \
  --dev 'friendsofphp/php-cs-fixer':'^3.80.0' \
&& Build/Scripts/runTests.sh -p 8.1 -t 12 -s cgl
```
