### PR TITLE
[!!!][TASK] Avoid constructor DI in `AbstractProfileFactory`

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Profile/AbstractProfileFactory.php
+++ b/packages/fgtclb/academic-persons/Classes/Profile/AbstractProfileFactory.php
@@ -15,6 +15,7 @@ use FGTCLB\AcademicPersons\Domain\Model\FrontendUser;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\Event\AfterProfileUpdateEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -25,7 +26,27 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 abstract class AbstractProfileFactory implements ProfileFactoryInterface
 {
-    public function __construct(protected PersistenceManagerInterface $persistenceManager, protected ExtensionConfiguration $extensionConfiguration, protected EventDispatcherInterface $eventDispatcher) {}
+    protected PersistenceManagerInterface $persistenceManager;
+    protected ExtensionConfiguration $extensionConfiguration;
+    protected EventDispatcherInterface $eventDispatcher;
+
+    #[Required]
+    public function injectEventDispatcherInterface(EventDispatcherInterface $eventDispatcher): void
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    #[Required]
+    public function injectExtensionConfiguration(ExtensionConfiguration $extensionConfiguration): void
+    {
+        $this->extensionConfiguration = $extensionConfiguration;
+    }
+
+    #[Required]
+    public function injectPersistenceManagerInterface(PersistenceManagerInterface $persistenceManager): void
+    {
+        $this->persistenceManager = $persistenceManager;
+    }
 
     public function shouldCreateProfileForUser(FrontendUserAuthentication $frontendUserAuthentication): bool
     {

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -17,6 +17,29 @@ Some partials got removed as the templating structure has changed. Those partial
 > The default templating now supports basic bootstrap styling and is semantically optimized
 > to also not lack any major accessibility.
 
+#### BREAKING: Replace constructor DI with inject-methods in `AbstractProfileFactory`
+
+Using constructor dependency injection in abstract classes defines the constructor
+as API, which should be avoided by using the inject-method approach and allows to
+implement classes using constructor DI without the requirement to deal and align
+with parent (abstract) class constructor and passing it down.
+
+`AbstractProfileFactory` used constructor DI and therefore violated the above
+described design pattern.
+
+Constructor DI arguments are now replaced with inject-methods in the abstract
+`\FGTCLB\AcademicPersons\Profile\AbstractProfileFactory`.
+
+Implementation using the abstract and defining own constructor DI arguments
+needs to remove the removed parent arguments and avoid calling the parent
+constructor.
+
+Additionally, the `\Symfony\Contracts\Service\Attribute\Required` attribute is
+used for the inject methods to tell symfony DI that these inject methods needs
+to be called and are mandatory - beside having a visually glue for developers.
+
+See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https://symfony.com/doc/current/service_container/autowiring.html#autowiring-other-methods-e-g-setters-and-public-typed-properties)
+
 ### FEATURES
 
 #### `pageTitleFormat` FlexForm option for person detail view


### PR DESCRIPTION
Using constructor dependency injection in abstract classes
defines the constructor as API, which should be avoided by
using the inject-method approach and allows to implement
classes using constructor DI without the requirement to deal
and align with parent (abstract) class constructor and passing
it down.

`AbstractProfileFactory` used constructor DI and therefore
violated the above described design pattern.

This change replaces the constructor injection with inject
methods freeing the constructor, which is a breaking change.

The next minor version already contains a couple of breaking
changes and will be communicated as such, which allows us
this change now and mitigate breaking changes related to DI
in the abstract class for the future.

Additionally, the `\Symfony\Contracts\Service\Attribute\Required`
attribute is used for the inject methods to tell symfony DI that
these inject methods needs to be called and are mandatory,
beside having a visually glue for developers. [1]

* [[1] https://symfony.com/doc/current/service_container/autowiring.html#autowiring-other-methods-e-g-setters-and-public-typed-properties](https://symfony.com/doc/current/service_container/autowiring.html#autowiring-other-methods-e-g-setters-and-public-typed-properties)
