### PR TITLE
[BUGFIX] Allow more characters for `pageTitleFormat` placeholders

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/PageTitle/ProfileTitleProvider.php
+++ b/packages/fgtclb/academic-persons/Classes/PageTitle/ProfileTitleProvider.php
@@ -39,7 +39,7 @@ final class ProfileTitleProvider extends AbstractPageTitleProvider
     {
         // replace all `%%` surrounded values with model fields
         $title = (string)preg_replace_callback(
-            pattern: '/%%([\w\d]+)%%/',
+            pattern: '/%%([[:blank:];:.\w\d\/\-\\\\]+)%%/',
             callback: function (array $matches) use ($profile): string {
                 $originalPlaceholder = $matches[1];
                 $placeholder = $matches[1];

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -81,6 +81,21 @@ The whole process contains some behaviour, which needs to be kept in mind:
 * Leading and trailing spaces are trimmed from the whole format pattern, after
   placeholder resolving has been processed.
 
+Example for allowed characters as placeholder identifier:
+
+```
+%%SOME.IDENTIFIER%%
+%%SOME:IDENTIFIER%%
+%%SOME;IDENTIFIER%%
+%%SOME-IDENTIFIER%%
+%%SOME_IDENTIFIER%%
+%%SOME/IDENTIFIER%%
+%%SOME\IDENTIFIER%%
+%%SOME IDENTIFIER%%
+```
+Note that most of them has no handling for matching person profile getters, but
+are use-full for advanced replacement using the experimental PSR-14 event.
+
 ## 2.0.1
 
 ## 2.0.0


### PR DESCRIPTION
To allow configurable person detail view page titles, a placeholder
based format option has been introduced for the added and dispatch
of a (internal) PSR14 event for each resolved placeholder, which
should help projects to implement custom placeholder replacements.

It just turned out, that the used regular expression to split the
placeholder was to restrictive and preventing to implement custom
event listener to make localization identifier like placeholders
to resolve to translated values, for example placeholders like:

```
%%LLL:EXT:myext/Resources/Private/Languages/locallang.db:identifier%%
```

That discovery made it clear, that the pattern needs to be envolved
to allow more customization and not blocking project or extension
developers, which boils down to:

* Allow space character ` ` to be part of the placeholder identifier.
* Allow double-point `:` to be part of the placeholder indentifier.
* Allow colon `;` to be part of the placeholder identifier.
* Allow dot `.` to be part of the placeholder identifer.
* Allow hyphen `-` to be part of the placeholder identifier.
* Allow slash `/` to be part of the placeholder identifier.
* Allow backslash `\` to be part of the placeholder identifier.

The dispatched event is used to verify that the above mentioned
characters are allowed and regonized for placeholder identifiers,
baked as functional tests.

* [1] https://github.com/fgtclb/academic-extensions/pull/137
