### PR TITLE
[BUGFIX] Harden TypoScript for non-web request context usage

### DIFF
--- a/packages/fgtclb/academic-jobs/Configuration/TypoScript/setup.typoscript
+++ b/packages/fgtclb/academic-jobs/Configuration/TypoScript/setup.typoscript
@@ -32,6 +32,7 @@ plugin.tx_academicjobs {
 
     saveForm {
       jobLogo {
+        # @todo How can we have a hardcoded target folder defined here ? That should be configurable.
         targetFolder = 1:/global-content/jobs/logos/
         validation {
           maxFileSize = 2M

--- a/packages/fgtclb/academic-partners/Configuration/TypoScript/Content/ContentLoad.typoscript
+++ b/packages/fgtclb/academic-partners/Configuration/TypoScript/Content/ContentLoad.typoscript
@@ -1,3 +1,6 @@
+# @todo Recheck this. Is this really safe to be enabled per default ? Or does this eventually need documentation for
+# @todo systems not using default fluid-styled-content rendering or bootstrap package or similar ?
+# @todo Also duplicated in other academic extensions ?!
 styles.content {
   getContent < styles.content.get
   getContent {

--- a/packages/fgtclb/academic-partners/Configuration/TypoScript/Page/AcademicPartners.typoscript
+++ b/packages/fgtclb/academic-partners/Configuration/TypoScript/Page/AcademicPartners.typoscript
@@ -1,4 +1,4 @@
-[traverse(page, "doktype") == 40]
+[page && traverse(page, "doktype") == 40]
   page {
     10 {
       // Template paths for PAGEVIEW based configurations

--- a/packages/fgtclb/academic-programs/Configuration/TypoScript/Content/ContentLoad.typoscript
+++ b/packages/fgtclb/academic-programs/Configuration/TypoScript/Content/ContentLoad.typoscript
@@ -1,3 +1,6 @@
+# @todo Recheck this. Is this really safe to be enabled per default ? Or does this eventually need documentation for
+# @todo systems not using default fluid-styled-content rendering or bootstrap package or similar ?
+# @todo Also duplicated in other academic extensions ?!
 styles.content {
   getContent < styles.content.get
   getContent {

--- a/packages/fgtclb/academic-programs/Configuration/TypoScript/Page/AcademicPrograms.typoscript
+++ b/packages/fgtclb/academic-programs/Configuration/TypoScript/Page/AcademicPrograms.typoscript
@@ -1,4 +1,4 @@
-[traverse(page, "doktype") == 20]
+[page && traverse(page, "doktype") == 20]
   page {
     10 {
       // Template path for PAGEVIEW based configurations

--- a/packages/fgtclb/academic-projects/Configuration/TypoScript/Content/ContentLoad.typoscript
+++ b/packages/fgtclb/academic-projects/Configuration/TypoScript/Content/ContentLoad.typoscript
@@ -1,3 +1,6 @@
+# @todo Recheck this. Is this really safe to be enabled per default ? Or does this eventually need documentation for
+# @todo systems not using default fluid-styled-content rendering or bootstrap package or similar ?
+# @todo Also duplicated in other academic extensions ?!
 styles.content {
   getContent < styles.content.get
   getContent {

--- a/packages/fgtclb/academic-projects/Configuration/TypoScript/Page/AcademicProjects.typoscript
+++ b/packages/fgtclb/academic-projects/Configuration/TypoScript/Page/AcademicProjects.typoscript
@@ -1,4 +1,4 @@
-[traverse(page, "doktype") == 30]
+[page && traverse(page, "doktype") == 30]
   page {
     10 {
       // Template paths for PAGEVIEW based configurations


### PR DESCRIPTION
TypoScript is the frontend rendering configuration tool, but some
exension tend to use extbase stuff or similar in CLI context where
no valid web request exists OR try to load TypoScript for pages,
not providing full context information in globals.

If TypoScript is not written in a safe way for context missuses,
that may crash or lead at least to spamming error log files.

For example following TypoScript condition:

```
[traverse(page, "doktype") == 30]
  # definition effective only when condition matches
[END]
```

is considered unsafe for above-mentioned, unsafe context setups.

To mitigate this, this change adds addition stuff to TypoScript
to mitigate errors (crashes), even if that means that this may
be lead to unexpected configurations, which should be safe in
the most cases.

Some todo comments added on side-findings.
