### PR TITLE
[TASK] Add `contracts.location` to showFields of related plugins

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Backend/Form/ProfileShowFieldsItemProcFunc.php
+++ b/packages/fgtclb/academic-persons/Classes/Backend/Form/ProfileShowFieldsItemProcFunc.php
@@ -13,7 +13,7 @@ class ProfileShowFieldsItemProcFunc
      */
     public function showFields(&$params): void
     {
-        // ToDo: Create a registry option to define more fields to select
+        // @todo Create a registry option to define more fields to select.
         $params['items'] = array_merge($this->defaultFieldItemShowFields(), []);
         $params['itemGroups'] = [
             'contracts' => 'Contracts',
@@ -71,6 +71,12 @@ class ProfileShowFieldsItemProcFunc
             [
                 'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'phone_numbers'),
                 'value' => 'contracts.phoneNumbers',
+                'icon' => null,
+                'group' => 'contracts',
+            ],
+            [
+                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'location'),
+                'value' => 'contracts.location',
                 'icon' => null,
                 'group' => 'contracts',
             ],

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang.xlf
@@ -19,6 +19,10 @@
 				<source>Office Hours</source>
 				<target>Bürozeiten</target>
 			</trans-unit>
+			<trans-unit id="contracts.location">
+				<source>Location</source>
+				<target>Ort</target>
+			</trans-unit>
 			<trans-unit id="contracts.emailAddresses">
 				<source>E-Mail</source>
 				<target>E-Mail</target>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
@@ -15,6 +15,9 @@
 			<trans-unit id="contracts.officeHours">
 				<source>Office Hours</source>
 			</trans-unit>
+			<trans-unit id="contracts.location">
+				<source>Location</source>
+			</trans-unit>
 			<trans-unit id="contracts.emailAdresses">
 				<source>E-Mail</source>
 			</trans-unit>

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
@@ -7,7 +7,12 @@
     <li class="list-group-item">
         <b>{f:translate(key: 'contracts.{fieldName}', extensionName: 'academic_persons')}:</b>
 
-        <f:if condition="{fieldName} == position || {fieldName} == room || {fieldName} == officeHours">
+        <f:if condition="
+            {fieldName} == position
+            || {fieldName} == room
+            || {fieldName} == officeHours
+            || {fieldName} == location
+        ">
             {contract.{fieldName}}
         </f:if>
 

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Item.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Item.html
@@ -38,11 +38,12 @@
                 <f:for
                     each="{
                         0:'position',
-                        1:'room',
-                        2:'officeHours',
-                        3:'emailAddresses',
-                        4:'phoneNumbers',
-                        5:'physicalAddresses'
+                        1:'location',
+                        2:'room',
+                        3:'officeHours',
+                        4:'emailAddresses',
+                        5:'phoneNumbers',
+                        6:'physicalAddresses'
                     }"
                     as="field"
                 >


### PR DESCRIPTION
Some plugins like the list plugin includes the `showField` option,
having a predefined list available.

This change now extends default list for `contracts` by adding
`contracts.localtion` column to it.

Furthermore the template has been adjusted to also display the
location field with its corresponding label.
