### PR TITLE
[TASK] Adjust types in `ModifyListProfilesEvent`

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -86,22 +86,7 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 
 		-
-			message: "#^Method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:getView\\(\\) has invalid return type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
 			message: "#^Method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:setProfiles\\(\\) has parameter \\$profiles with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
-			message: "#^Parameter \\$view of method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:__construct\\(\\) has invalid type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
-			message: "#^Property FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$view has unknown class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface as its type\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -101,11 +101,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Property/TypeConverter/ProfileImageUploadConverter.php
 
 		-
-			message: "#^Parameter \\#2 \\$view of class FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent constructor expects TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\|TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface, TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewInterface\\|TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface given\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:getDemand\\(\\)\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
@@ -121,22 +116,7 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 
 		-
-			message: "#^Method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:getView\\(\\) has invalid return type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
 			message: "#^Method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:setProfiles\\(\\) has parameter \\$profiles with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
-			message: "#^Parameter \\$view of method FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:__construct\\(\\) has invalid type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
-
-		-
-			message: "#^Property FGTCLB\\\\AcademicPersons\\\\Event\\\\ModifyListProfilesEvent\\:\\:\\$view has unknown class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface as its type\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
@@ -12,26 +12,26 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Event;
 
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
-use TYPO3\CMS\Extbase\Mvc\View\ViewInterface as DeprecatedExtbaseViewInterface;
+use TYPO3\CMS\Core\View\ViewInterface as CoreViewInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
-use TYPO3Fluid\Fluid\View\ViewInterface;
+use TYPO3Fluid\Fluid\View\ViewInterface as FluidViewInterface;
 
+/**
+ * Fired in {@see ProfileController::listAction()} included in `detail` and `listanddetail`
+ * extbase plugins to allow assigning additional data to the detail view or replace the
+ * profile.
+ *
+ * @todo Dispatched also in other actions, which is wrong and requires to dispatch dedicated
+ *       events and will be done in a follow-up change.
+ */
 final class ModifyListProfilesEvent
 {
     /**
      * @param QueryResultInterface<Profile> $profiles
-     * @param ViewInterface|DeprecatedExtbaseViewInterface $view
-     * @todo Add ViewInterface as type for $view when TYPO3 v11 support is dropped.
      */
     public function __construct(
         private QueryResultInterface $profiles,
-        /**
-         * The Extbase ViewInterface has been deprecated in TYPO3 v11.5 and has to be replaced with the TYPO3Fluid ViewInterface.
-         * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html
-         *
-         * @todo Add native type when v11 support is dropped.
-         */
-        private $view
+        private FluidViewInterface|CoreViewInterface $view,
     ) {}
 
     /**
@@ -50,10 +50,7 @@ final class ModifyListProfilesEvent
         $this->profiles = $profiles;
     }
 
-    /**
-     * @return DeprecatedExtbaseViewInterface|ViewInterface
-     */
-    public function getView()
+    public function getView(): FluidViewInterface|CoreViewInterface
     {
         return $this->view;
     }


### PR DESCRIPTION
The `ModifyListProfilesEvent` contains a property and
provides a getter for the view object, which has been
based on an extbase related ViewInterface and changed
through multiple TYPO3 and standalone Fluid versions.

This change uses the correct fluid and TYPO3 interfaces
now directly as native types compatible with TYPO3 v12
and v13 and removes the deprecated v11 extbase interface
as a cleanup due to dropped TYPO3 v11 support and solves
the todo comments in the aforementioned class.

That allows us to remove phpstan ignorePatters from the
baselines and further improving the code quality.

In general this follows a similar change made with [1].

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.1 -t 12 -s composerUpdate \
&& Build/Scripts/runTests.sh -p 8.1 -t 12 -s cgl \
&& Build/Scripts/runTests.sh -p 8.1 -t 12 -s phpstanGenerateBaseline \
&& Build/Scripts/runTests.sh -p 8.2 -t 13 -s composerUpdate \
&& Build/Scripts/runTests.sh -p 8.2 -t 13 -s phpstanGenerateBaseline \
&& Build/Scripts/runTests.sh -p 8.1 -t 12 -s composerUpdate
```

[1] https://github.com/fgtclb/academic-extensions/pull/141
