### PR TITLE
[BUGFIX] Use `<f:split />` to split `showFields` to gain expected result

### DIFF
--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
@@ -3,7 +3,7 @@
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 >
 
-<f:if condition="{contract.{fieldName}} && {fieldName} != 'profile.image'">
+<f:if condition="{contract.{fieldName}} && {fieldName} != 'image'">
     <li class="list-group-item">
         <b>{f:translate(key: 'contracts.{fieldName}', extensionName: 'academic_persons')}:</b>
 

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Item.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Item.html
@@ -25,10 +25,12 @@
         <f:if condition="{settings.showFields}">
             <f:then>
                 <f:for each="{settings.showFields}" as="field">
+                    <f:variable name="fieldName">{field -> f:split(separator: '.', limit: 2)}</f:variable>
+
                     <f:render
                         partial="Profile/Contract/Field"
                         arguments="{
-                            fieldName: '{field -> f:format.trim(side: \'left\', characters: \'contracts.\')}',
+                            fieldName: fieldName.1,
                             contract: contract
                         }"
                     />


### PR DESCRIPTION
As the `<f:trim />` ViewHelper did not work as expected and
did not remove the entire string. Instead each character in
it from the beginning of the target string was replaced.

To achieve the wanted behaviour the `<f:split />` ViewHelper
is the more suiting canditate for the job and is now used to
replace the `<f:trim />` ViewHelper.

`<f:trim />` usage:

```
'contracts.room' => 'm'
'contracts.orginisationalUnit' => 'rginisationalUnit'
```

`<f:split />` usage:

```
'contracts.room' => {0: 'contracts', 1: 'room'}
'contracts.orginisationalUnit' =>  {0: 'contracts', 1: 'orginisationalUnit'}
```

This way we can guarantee to have the string split at the
correct character and access the field name, to pass down
to the partial, more reliably.

`<f:split />` ViewHelper has been introduced in standaline fluid
with `2.11.0` [1] and is ensured since TYPO3 v12.4.22 [2], which
requires to have that as lowest ensured dependency boundaries.
That has been done as preparation with [3] ensure to have `2.15.0` 
as lowest expectable fluid version on board.

[1] https://github.com/TYPO3/Fluid/releases/tag/2.11.0
[2] https://packagist.org/packages/typo3/cms-fluid#v12.4.22
[3] https://github.com/fgtclb/academic-extensions/pull/148
