### PR TITLE
[FEATURE] Add new `PluginControllerActionContext` to dispatched events

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Controller;
 
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContext;
 use FGTCLB\AcademicPersons\Domain\Model\Dto\ProfileDemand;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\Domain\Repository\ContractRepository;
@@ -80,7 +81,11 @@ final class ProfileController extends ActionController
         $profiles = $this->profileRepository->findByDemand($demand);
 
         /** @var ModifyListProfilesEvent $event */
-        $event = $this->eventDispatcher->dispatch(new ModifyListProfilesEvent($profiles, $this->view));
+        $event = $this->eventDispatcher->dispatch(new ModifyListProfilesEvent(
+            $profiles,
+            $this->view,
+            new PluginControllerActionContext($this->request, $this->settings),
+        ));
         $profiles = $event->getProfiles();
 
         if ($demand->getAlphabetFilter() !== '') {
@@ -185,7 +190,11 @@ final class ProfileController extends ActionController
         $pageTitleFormat = $this->resolveDetailPageTitleFormat();
         /** @todo Add more context to ModifyDetailProfileEvent and allow PageTitleFormat to be changeable in event */
         /** @var ModifyDetailProfileEvent $event */
-        $event = $this->eventDispatcher->dispatch(new ModifyDetailProfileEvent($profile, $this->view));
+        $event = $this->eventDispatcher->dispatch(new ModifyDetailProfileEvent(
+            $profile,
+            $this->view,
+            new PluginControllerActionContext($this->request, $this->settings)
+        ));
         $profile = $event->getProfile();
 
         // Add page title based on profile name
@@ -219,7 +228,11 @@ final class ProfileController extends ActionController
         $profiles = $this->profileRepository->findByUids($profileUids);
 
         /** @var ModifyListProfilesEvent $event */
-        $event = $this->eventDispatcher->dispatch(new ModifyListProfilesEvent($profiles, $this->view));
+        $event = $this->eventDispatcher->dispatch(new ModifyListProfilesEvent(
+            $profiles,
+            $this->view,
+            new PluginControllerActionContext($this->request, $this->settings),
+        ));
         $profiles = $event->getProfiles();
 
         // Sort profiles by order in selection

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/PluginControllerActionContext.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/PluginControllerActionContext.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Controller\ProfileController;
+use FGTCLB\AcademicPersons\Event\ModifyDetailProfileEvent;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+
+/**
+ * Generic context object used to provide plugin controller action related context information, either in views
+ * or dispatched events, for example {@see ModifyDetailProfileEvent} in {@see ProfileController::detailAction()}.
+ */
+final class PluginControllerActionContext implements PluginControllerActionContextInterface
+{
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function __construct(
+        private readonly ServerRequestInterface $request,
+        private readonly array $settings,
+    ) {}
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getApplicationType(): ApplicationType
+    {
+        return ApplicationType::fromRequest($this->request);
+    }
+
+    public function getSite(): ?Site
+    {
+        return $this->request->getAttribute('site');
+    }
+
+    public function getLanguage(): ?SiteLanguage
+    {
+        return $this->request->getAttribute('language');
+    }
+
+    public function getPluginName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getPluginName();
+    }
+
+    public function getControllerName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerName();
+    }
+
+    public function getControllerObjectName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerObjectName();
+    }
+
+    public function getActionName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerActionName();
+    }
+
+    public function getControllerExtensionKey(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerExtensionKey();
+    }
+
+    public function getControllerExtensionName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerExtensionName();
+    }
+
+    public function getExtbaseRequestParameters(): ?ExtbaseRequestParameters
+    {
+        $attribute = $this->request->getAttribute('extbase');
+        return $attribute instanceof ExtbaseRequestParameters ? $attribute : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/PluginControllerActionContextInterface.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/PluginControllerActionContextInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Domain\Model\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+
+interface PluginControllerActionContextInterface
+{
+    public function getRequest(): ServerRequestInterface;
+    public function getApplicationType(): ApplicationType;
+    public function getSite(): ?Site;
+    public function getLanguage(): ?SiteLanguage;
+    public function getPluginName(): ?string;
+    public function getControllerName(): ?string;
+    public function getControllerObjectName(): ?string;
+    public function getActionName(): ?string;
+    public function getControllerExtensionKey(): ?string;
+    public function getControllerExtensionName(): ?string;
+    public function getExtbaseRequestParameters(): ?ExtbaseRequestParameters;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array;
+}

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Event;
 
 use FGTCLB\AcademicPersons\Controller\ProfileController;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContextInterface;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use TYPO3\CMS\Core\View\ViewInterface as CoreViewInterface;
 use TYPO3Fluid\Fluid\View\ViewInterface as FluidViewInterface;
@@ -26,6 +27,7 @@ final class ModifyDetailProfileEvent
     public function __construct(
         private Profile $profile,
         private FluidViewInterface|CoreViewInterface $view,
+        private PluginControllerActionContextInterface $pluginControllerActionContext,
     ) {}
 
     public function getProfile(): Profile
@@ -41,5 +43,10 @@ final class ModifyDetailProfileEvent
     public function getView(): FluidViewInterface|CoreViewInterface
     {
         return $this->view;
+    }
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
     }
 }

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Event;
 
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContextInterface;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use TYPO3\CMS\Core\View\ViewInterface as CoreViewInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -32,6 +33,7 @@ final class ModifyListProfilesEvent
     public function __construct(
         private QueryResultInterface $profiles,
         private FluidViewInterface|CoreViewInterface $view,
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
     ) {}
 
     /**
@@ -53,5 +55,10 @@ final class ModifyListProfilesEvent
     public function getView(): FluidViewInterface|CoreViewInterface
     {
         return $this->view;
+    }
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
     }
 }

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileDemandEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileDemandEvent.php
@@ -12,7 +12,11 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Event;
 
 use FGTCLB\AcademicPersons\Domain\Model\Dto\DemandInterface;
+use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
 
+/**
+ * Dispatched in {@see ProfileRepository::findByDemand().
+ */
 final class ModifyProfileDemandEvent
 {
     public function __construct(private DemandInterface $demand) {}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Model/DTO/PluginControllerActionContextTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Model/DTO/PluginControllerActionContextTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Domain\Model\DTO;
+
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContext;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
+final class PluginControllerActionContextTest extends AbstractAcademicPersonsTestCase
+{
+    public static function extbaseRequestParametersRelatedGettersReturnNullIfAttributeIsMissingDataSets(): \Generator
+    {
+        $getters = [
+            'getExtbaseRequestParameters',
+            'getPluginName',
+            'getControllerName',
+            'getControllerObjectName',
+            'getActionName',
+            'getControllerExtensionKey',
+            'getControllerExtensionName',
+        ];
+        foreach ($getters as $index => $getter) {
+            yield sprintf('#%s %s', $index, $getter) => [
+                'getterName' => $getter,
+            ];
+        }
+    }
+
+    #[DataProvider('extbaseRequestParametersRelatedGettersReturnNullIfAttributeIsMissingDataSets')]
+    #[Test]
+    public function extbaseRequestParametersRelatedGettersReturnNullIfAttributeIsMissing(string $getterName): void
+    {
+        $request = new ServerRequest();
+        $pluginControllerActionContext = new PluginControllerActionContext($request, []);
+        $this->assertTrue(method_exists($pluginControllerActionContext, $getterName));
+        $this->assertNull($pluginControllerActionContext->{$getterName}());
+    }
+
+    public function getRequestReturnsExpectedRequest(): void
+    {
+        $request = new ServerRequest();
+        $pluginControllerActionContext = new PluginControllerActionContext($request, []);
+        $this->assertSame($request, $pluginControllerActionContext->getRequest());
+    }
+
+    #[Test]
+    public function getSiteReturnsExpectedSite(): void
+    {
+        $siteStub = $this->createStub(Site::class);
+        $request = (new ServerRequest())->withAttribute('site', $siteStub);
+        $pluginControllerActionContext = new PluginControllerActionContext($request, []);
+        $this->assertSame($siteStub, $pluginControllerActionContext->getSite());
+    }
+
+    #[Test]
+    public function getLanguageReturnsExpectedSite(): void
+    {
+        $siteLanguageStub = $this->createStub(SiteLanguage::class);
+        $request = (new ServerRequest())->withAttribute('language', $siteLanguageStub);
+        $pluginControllerActionContext = new PluginControllerActionContext($request, []);
+        $this->assertSame($siteLanguageStub, $pluginControllerActionContext->getLanguage());
+    }
+
+    #[Test]
+    public function getSettingsReturnsExpectedSettings(): void
+    {
+        $settings = [
+            'key1' => 'value123',
+            'array1' => [
+                789,
+                123,
+                456,
+            ],
+        ];
+        $request = new ServerRequest();
+        $pluginControllerActionContext = new PluginControllerActionContext($request, $settings);
+        $this->assertSame($settings, $pluginControllerActionContext->getSettings());
+    }
+}

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -42,6 +42,32 @@ See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https:
 
 ### FEATURES
 
+#### Introduce `PluginControllerActionContext` suitable
+
+A new readonly DTO object `PluginControllerActionContext` is introduced and is
+attached to dispatched PSR-14 events in `ProfileController` actions.
+
+Following main getters are provided:
+
+*   `getApplicationType(): ApplicationType` to return the TYPO3 application type
+    for the current request.
+*   `getExtbaseRequestParameters(): ?ExtbaseRequestParameters` to retrieve extbase
+    attribute from request as a simple accessor.
+*   `getRequest(): ServerRequestInterface` to return the current request.
+*   `getSettings(): array` to retrieve raw plugin settings (TypoScript, FlexForm).
+*   `getSite(): ?Site` to retrieve resolved site configuration.
+*   `getLanguage(): ?SiteLanguage` to retrieve resolves site language.
+
+Following getters dispatches to `ExtbaseRequestParameters` methods and returning
+null in case the request attribute is not set in the request:
+
+* `getActionName(): ?string`
+* `getControllerName(): ?string`
+* `getControllerObjectName(): ?string`
+* `getControllerExtensionKey(): ?string`
+* `getControllerExtensionName(): ?string`
+* `getPluginName(): ?string`
+
 #### `pageTitleFormat` FlexForm option for person detail view
 
 It's now possible to define the format used to generate the HTML PageTitle for


### PR DESCRIPTION
The one or other plugin controller action dispatches PSR-14 events
to allow easier customization in project or by extending extensions,
but concreate context has been often missed, for example in cased
controller actions has been reused for custom project specific plugin
implementations.

To provide more concrete information in eventlisteners generic simple
DTO is introduced `ProfileControllerActionContext` and added to existing
dispatched events, which is considerable non-breaking.

Project or extension relying on this new context information needs to
check for existince or ensure to use version constraints ensuring they
exists.

Following main getters are provided:

* `getApplicationType(): ApplicationType` to return the TYPO3
  application type for the current request.
* `getExtbaseRequestParameters(): ?ExtbaseRequestParameters` to
  retrieve extbase attribute from request as a simple accessor.
* `getRequest(): ServerRequestInterface` to return the current
   request.
* `getSettings(): array` to retrieve raw plugin settings like
   TypoScript or FlexForm settings.
* `getSite(): ?Site` to retrieve resolved site configuration.
* `getLanguage(): ?SiteLanguage` to retrieve resolves site language.

Following getters dispatches to `ExtbaseRequestParameters` methods and returning
null in case the request attribute is not set in the request:

* `getActionName(): ?string`
* `getControllerName(): ?string`
* `getControllerObjectName(): ?string`
* `getControllerExtensionKey(): ?string`
* `getControllerExtensionName(): ?string`
* `getPluginName(): ?string`

This feature is part of a improvement chain in several areas.
