### PR TITLE
[TASK] Add PHP 8.5 to testing matrix

### DIFF
--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["12"]
     needs: ["code-quality", "linting", "unit"]
     permissions:

--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4" ]
+        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["13"]
     permissions:
       # actions: read|write|none
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4" ]
+        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["13"]
     permissions:
       # actions: read|write|none
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4" ]
+        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["13"]
     needs: ["code-quality", "linting", "unit"]
     permissions:

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -160,15 +160,16 @@ Options:
     -t <11|12>
         Only with -s composerInstall|composerInstallMin|composerInstallMax
         Specifies the TYPO3 CORE Version to be used
-            - 11: (default) use TYPO3 v11
-            - 12: use TYPO3 v12
+            - 12: (default) use TYPO3 v12
+            - 13: use TYPO3 v13
 
-    -p <8.1|8.2|8.3|8.4>
+    -p <8.1|8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
             - 8.1: use PHP 8.1 (default)
             - 8.2: use PHP 8.2
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
+            - 8.5: use PHP 8.5
 
     -u
         Update existing typo3/core-testing-*:latest container images and remove dangling local volumes.
@@ -254,7 +255,7 @@ while getopts "a:b:s:d:i:p:t:xy:o:nhu" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4|8.5)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;


### PR DESCRIPTION
First alpha version of PHP 8.5 has been released and
a core-testing image for this version build based on
upstream PHP base image.

This change allows now to use `PHP 8.5` in the known
dispatcher `Build/Scripts/runTests.sh` as option and
enables testing in automatic GitHub actions for the
new version directly.
