### PR TITLE
[TASK] Add the missing Category Types icons

### DIFF
--- a/packages/fgtclb/academic-partners/Configuration/Icons.php
+++ b/packages/fgtclb/academic-partners/Configuration/Icons.php
@@ -17,4 +17,20 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_partners/Resources/Public/Icons/Role.svg',
     ],
+    'category_types.partners.collaboration_type' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-partners/Resources/Public/Icons/CategoryTypes/CollaborationType.svg',
+    ],
+    'category_types.partners.partner_type' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-partners/Resources/Public/Icons/CategoryTypes/PartnerType.svg',
+    ],
+    'category_types.partners.region' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-partners/Resources/Public/Icons/CategoryTypes/Region.svg',
+    ],
+    'category_types.partners.sdg' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-partners/Resources/Public/Icons/CategoryTypes/Sdg.svg',
+    ],
 ];

--- a/packages/fgtclb/academic-persons/Configuration/Icons.php
+++ b/packages/fgtclb/academic-persons/Configuration/Icons.php
@@ -49,4 +49,8 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons/Resources/Public/Icons/persons_icon.svg',
     ],
+    'extension_icon' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic_persons/Resources/Public/Icons/Extension.svg',
+    ],
 ];

--- a/packages/fgtclb/academic-programs/Configuration/Icons.php
+++ b/packages/fgtclb/academic-programs/Configuration/Icons.php
@@ -9,4 +9,64 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_programs/Resources/Public/Icons/Extension.svg',
     ],
+    'category_types.programs.admission_restriction' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/AdmissionRestriction.svg',
+    ],
+    'category_types.programs.application_period' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/ApplicationPeriod.svg',
+    ],
+    'category_types.programs.begin_program' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/BeginProgram.svg',
+    ],
+    'category_types.programs.costs' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Costs.svg',
+    ],
+    'category_types.programs.degree' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Degree.svg',
+    ],
+    'category_types.programs.department' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Department.svg',
+    ],
+    'category_types.programs.job_profile' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/JobProfile.svg',
+    ],
+    'category_types.programs.location' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Location.svg',
+    ],
+    'category_types.programs.paying' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Paying.svg',
+    ],
+    'category_types.programs.performance_scope' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/PerformanceScope.svg',
+    ],
+    'category_types.programs.prerequisites' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Prerequisites.svg',
+    ],
+    'category_types.programs.program_type' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/ProgramType.svg',
+    ],
+    'category_types.programs.standard_period' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/StandardPeriod.svg',
+    ],
+    'category_types.programs.teaching_language' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/TeachingLanguage.svg',
+    ],
+    'category_types.programs.topic' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic-programs/Resources/Public/Icons/CategoryTypes/Topic.svg',
+    ],
 ];


### PR DESCRIPTION
"[TASK] To be able to use the icons separately in both backend and frontend, the missing Category Types icons are registered within the extension."