### PR TITLE
[!!!][FEATURE] Introduce new events for `SelectedProfiles` and `SelectedContracts`

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -18,6 +18,8 @@ use FGTCLB\AcademicPersons\Domain\Repository\ContractRepository;
 use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
 use FGTCLB\AcademicPersons\Event\ModifyDetailProfileEvent;
 use FGTCLB\AcademicPersons\Event\ModifyListProfilesEvent;
+use FGTCLB\AcademicPersons\Event\ModifySelectedContractsEvent;
+use FGTCLB\AcademicPersons\Event\ModifySelectedProfilesEvent;
 use FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider;
 use GeorgRinger\NumberedPagination\NumberedPagination;
 use Psr\Http\Message\ResponseInterface;
@@ -227,8 +229,8 @@ final class ProfileController extends ActionController
         $profileUids = GeneralUtility::intExplode(',', $this->settings['selectedProfiles'], true);
         $profiles = $this->profileRepository->findByUids($profileUids);
 
-        /** @var ModifyListProfilesEvent $event */
-        $event = $this->eventDispatcher->dispatch(new ModifyListProfilesEvent(
+        /** @var ModifySelectedProfilesEvent $event */
+        $event = $this->eventDispatcher->dispatch(new ModifySelectedProfilesEvent(
             $profiles,
             $this->view,
             new PluginControllerActionContext($this->request, $this->settings),
@@ -266,6 +268,14 @@ final class ProfileController extends ActionController
 
         $contractUids = GeneralUtility::intExplode(',', $this->settings['selectedContracts'], true);
         $contracts = $this->contractRepository->findByUids($contractUids);
+
+        /** @var ModifySelectedContractsEvent $event */
+        $event = $this->eventDispatcher->dispatch(new ModifySelectedContractsEvent(
+            $contracts,
+            $this->view,
+            new PluginControllerActionContext($this->request, $this->settings),
+        ));
+        $contracts = $event->getContracts();
 
         // Sort profiles by order in selection
         $sortedContracts = [];

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyDetailProfileEvent.php
@@ -26,8 +26,8 @@ final class ModifyDetailProfileEvent
 {
     public function __construct(
         private Profile $profile,
-        private FluidViewInterface|CoreViewInterface $view,
-        private PluginControllerActionContextInterface $pluginControllerActionContext,
+        private readonly FluidViewInterface|CoreViewInterface $view,
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
     ) {}
 
     public function getProfile(): Profile

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifySelectedContractsEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifySelectedContractsEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FGTCLB\AcademicPersons\Event;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContextInterface;
+use TYPO3\CMS\Core\View\ViewInterface as CoreViewInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3Fluid\Fluid\View\ViewInterface as FluidViewInterface;
+
+/**
+ * Fired in {@see ProfileController::selectedProfilesAction()} included in `academicpersons_selectedprofiles`
+ * extbase plugins to allow assigning additional data to the detail view or replace the profiles resultset.
+ */
+final class ModifySelectedContractsEvent
+{
+    /**
+     * @param QueryResultInterface<int, Contract>$contracts
+     */
+    public function __construct(
+        private QueryResultInterface $contracts,
+        private readonly FluidViewInterface|CoreViewInterface $view,
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
+    ) {}
+
+    /**
+     * @return QueryResultInterface<int, Contract>
+     */
+    public function getContracts(): QueryResultInterface
+    {
+        return $this->contracts;
+    }
+
+    /**
+     * @param QueryResultInterface<int, Contract> $profiles
+     */
+    public function setContracts(QueryResultInterface $profiles): void
+    {
+        $this->contracts = $profiles;
+    }
+
+    public function getView(): FluidViewInterface|CoreViewInterface
+    {
+        return $this->view;
+    }
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifySelectedProfilesEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifySelectedProfilesEvent.php
@@ -1,14 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
-/*
- * This file is part of the "academic_persons" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
- */
-
 namespace FGTCLB\AcademicPersons\Event;
 
 use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContextInterface;
@@ -18,14 +9,13 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3Fluid\Fluid\View\ViewInterface as FluidViewInterface;
 
 /**
- * Fired in {@see ProfileController::listAction()} included in `academicpersons_detail` and
- * `academicpersons_listanddetail`  extbase plugins to allow assigning additional data to
- * the detail view or replace the profile.
+ * Fired in {@see ProfileController::selectedProfilesAction()} included in `academicpersons_selectedprofiles`
+ * extbase plugins to allow assigning additional data to the detail view or replace the profiles resultset.
  */
-final class ModifyListProfilesEvent
+final class ModifySelectedProfilesEvent
 {
     /**
-     * @param QueryResultInterface<Profile> $profiles
+     * @param QueryResultInterface<int, Profile> $profiles
      */
     public function __construct(
         private QueryResultInterface $profiles,
@@ -34,7 +24,7 @@ final class ModifyListProfilesEvent
     ) {}
 
     /**
-     * @return QueryResultInterface<Profile>
+     * @return QueryResultInterface<int, Profile>
      */
     public function getProfiles(): QueryResultInterface
     {
@@ -42,7 +32,7 @@ final class ModifyListProfilesEvent
     }
 
     /**
-     * @param QueryResultInterface<Profile> $profiles
+     * @param QueryResultInterface<int, Profile> $profiles
      */
     public function setProfiles(QueryResultInterface $profiles): void
     {

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -4,6 +4,14 @@
 
 ### BREAKING CHANGES
 
+#### BREAKING: `ProfilesController::selectedProfilesAction()` no longer dispatches `ModifyListProfilesEvent`
+
+`ProfilesController::selectedProfilesAction()` dispatched the `ModifyListProfilesEvent`
+PSR14 event accidentally due to copy&paste when introducing the new plugin and action
+for `2.0.x`. This event is no longer dispatched for this action, instead the new and
+correct event [ModifySelectedProfilesEvent](#feature-modifyselectedprofilesevent-profilescontrollerselectedprofilesaction)
+is now dispatched.
+
 #### BREAKING: Removed partials
 
 Some partials got removed as the templating structure has changed. Those partials include:
@@ -42,7 +50,44 @@ See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https:
 
 ### FEATURES
 
-#### Introduce `PluginControllerActionContext` suitable
+#### FEATURE: Introduce new PSR-14 events `ModifySelectedProfilesEvent` and `ModifySelectedContractsEvent`
+
+New PSR-14 events are introduced which are dispatched in `ProfileController`
+actions.
+
+##### FEATURE: `ModifySelectedProfilesEvent` (ProfilesController::selectedProfilesAction())
+
+`ProfileController::selectedProfilesAction()` dispatches now the new PSR-14
+`ModifySelectedProfilesEvent` instead of erroneous copied listAction event
+`ModifyListProfilesEvent`, which is no longer dispatched. That should not
+be that of an issue for most implementations.
+
+The event provides following methods:
+
+* `getProfiles(): QueryResultInterface` return current result set.
+* `setProfiles(QueryResultInterface $profiles): void` to allow setting a custom
+  resultset.
+* `getView(): FluidViewInterface|CoreViewInterface` return the current view to
+  allow assigning custom values to the view.
+* `getPluginControllerActionContext(): PluginControllerActionContextInterface`
+  to provide more context information, see [FEATURE `PluginControllerActionContext`](#feature-introduce-plugincontrolleractioncontext-suitable).
+
+##### FEATURE: `ModifySelectedContractsEvent` (ProfilesController::selectedContractsAction())
+
+`ProfileController::selectedContractsAction()` dispatches now the new PSR-14
+`ModifySelectedContractsEvent`.
+
+The event provides following methods:
+
+* `getContracts(): QueryResultInterface` return current result set.
+* `setContracts(QueryResultInterface $contracts): void` to allow setting a custom
+  resultset.
+* `getView(): FluidViewInterface|CoreViewInterface` return the current view to
+  allow assigning custom values to the view.
+* `getPluginControllerActionContext(): PluginControllerActionContextInterface`
+  to provide more context information, see [FEATURE `PluginControllerActionContext`](#feature-introduce-plugincontrolleractioncontext-suitable).
+
+#### FEATURE: Introduce `PluginControllerActionContext` suitable
 
 A new readonly DTO object `PluginControllerActionContext` is introduced and is
 attached to dispatched PSR-14 events in `ProfileController` actions.


### PR DESCRIPTION
Starting with `2.x` and moving to `TYPO3 v12 & v13` compatibility, two new
plugins has been introduced:

* academicpersons_selectedprofiles
* academicpersons_selectedcontracts

where the `academicpersons_selectedprofiles` was meant as a standalone controllable
plugin in projects as replacedment for the subfeature to select profiles and the
`academicpersons_list` and `academicpersons_listanddetail`, and some code has been
copy & pasted during the implementation of the new actions for the new plugins.

Sadly, dispatching the same `ModifyListProfilesEvent` has also copied over making
it hard in projects or addon extension to distingush for which plugin the event
has been dispatched.

With recently introduced `PluginControllerActionContextInterface` added to the
dispatched event eventlistiner have already easier access to context information,
still making the name of the dispatched event wrong.

This change introduces now dedicated events for the above-mentioned actions, and
removes dispatching the `ModifyListProfilesEvent` for the `selectedProfilesAction`,
which is the `breaking` part of the change.

For the upcoming next minor version an exemption to contain breaking changes have
been already decided making the decision easier. Additionally, we could consider
this with minor impact as most usages will not implementing these events special
for the new one and the risk is considerable low but existing.
