### PR TITLE
[BUGFIX] Use `SvgIconProvider` for svg category icons

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/ServiceProvider.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AbstractServiceProvider
             $categoryTypes = $categoryTypeRegistry->getCategoryTypes();
 
             foreach ($categoryTypes as $categoryType) {
-                $iconProviderClassName = $iconRegistry->detectIconProvider($categoryType->getIconIdentifier());
+                $iconProviderClassName = $iconRegistry->detectIconProvider($categoryType->getIcon());
 
                 $iconRegistry->registerIcon(
                     $categoryType->getIconIdentifier(),


### PR DESCRIPTION
`EXT:cagtegory_types` provides a yaml based configuration file to
register category types along with icons in one place and ensures
to register categorys at all related places, for example the TCA
configuration for `sys_category` (type feature) along with icon
classes. It uses registered icon identifiers, which are registered
by the extension `ServiceProvider` during DI build time.

For registration of icons the `IconRegistry::detectIconProvider()`
method has been used to decide which iconProvider to use looking
for `.svg` in provided icon file.

However, the implementation hands over the icon identifier and
not the icon file and the detection returns always the default
`BitmapIconProvider` even for  `SVG` files.

This change passes now the icon to the detect method to get the
correct `SvgIconProvider` for svg icon files, which allows to
render svg in the frontend directly and not using an `image` tag.
