### PR TITLE
[FEATURE] Introduce `ModifyProfileTitlePlaceholderReplacementEvent` in `ProfileTitleProvider`

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -189,11 +189,12 @@ final class ProfileController extends ActionController
             );
         }
 
+        $pluginControllerActionContext = new PluginControllerActionContext($this->request, $this->settings);
         /** @var ModifyDetailProfileEvent $event */
         $event = $this->eventDispatcher->dispatch(new ModifyDetailProfileEvent(
             $profile,
             $this->view,
-            new PluginControllerActionContext($this->request, $this->settings),
+            $pluginControllerActionContext,
             ProfileTitleProvider::DETAIL_PAGE_TITLE_FORMAT,
             $this->resolveDetailPageTitleFormat(),
         ));
@@ -201,6 +202,7 @@ final class ProfileController extends ActionController
 
         // Add page title based on profile name
         $this->profileTitleProvider->setFromProfile(
+            $pluginControllerActionContext,
             $profile,
             $event->getPageTitleFormatToUse(),
         );

--- a/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileTitlePlaceholderReplacementEvent.php
+++ b/packages/fgtclb/academic-persons/Classes/Event/ModifyProfileTitlePlaceholderReplacementEvent.php
@@ -4,23 +4,31 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Event;
 
+use FGTCLB\AcademicPersons\Domain\Model\Dto\PluginControllerActionContextInterface;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider;
 
 /**
- * Fired in {@see ProfileTitleProvider::dispatchReplacementEvent()} for each found pageTitleFormat
- * placeholder value (`%%SOME_IDENTIFIER%%` => `SOME_IDENTIFER`) to allow changing the replacement
- * value.
+ * Fired in {@see ProfileTitleProvider::dispatchModifyProfileTitlePlaceholderReplacementEvent()} for each
+ * found pageTitleFormat placeholder value (`%%SOME_IDENTIFIER%%` => `SOME_IDENTIFER`) to allow changing
+ * the replacement value.
  *
- * @internal event implementation is considered experimental for now and not part of Public API.
+ * Note that the event is executed after all internal replacement methods has been processed and that
+ * this event is dispatched for each single placeholder on its own.
  */
-final class ProfileTitlePlaceholderReplacementEvent
+final class ModifyProfileTitlePlaceholderReplacementEvent
 {
     public function __construct(
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
         private readonly Profile $profile,
         private readonly string $placeholder,
         private string $replacement,
     ) {}
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
+    }
 
     /**
      * Person profile extbase model for the current detail view page.

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -50,7 +50,41 @@ See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https:
 
 ### FEATURES
 
-#### FEATURE: Allow modifing default and settings pageTitleFormat for detail view
+#### FEATURE: Introduce `ModifyProfileTitlePlaceholderReplacementEvent` in `ProfileTitleProvider`
+
+With recent changes a series of features has been implemented to
+make the HTML title tag for person profile pages more flexible,
+with a placeholder based FlexForm options and also allowing to
+influence the default and the setting pageTitleFormat.
+
+The used `ProfileTitleProvider` already looks into the format
+string and provides the ability to replace placeholders, which
+matches getters in the profile.
+
+To provide even more flexibility, this change introduces a new
+PSR-14 Event `ModifyProfileTitlePlaceholderReplacementEvent`,
+which is dispatched for each placeholder enriched with quite a
+handfull of use-full context information.
+
+Following methods are available on the event:
+
+* `getPluginControllerActionContext(): PluginControllerActionContextInterface`
+  containing the request along with easy access methods to site,
+  siteLanguage and extbase plugin information and the plugin
+  settings.
+* `getProfile(): Profile` the current person profile to display.
+* `getPlaceholder()` the original/raw placeholder identifier.
+* `getReplacement()` the value to replace the placeholder with,
+  which may differ already if a earlier event listener changed
+  the value using `setReplacement()`.
+* `setReplacement(string $replacement): void` to set the value
+  used to replace the placeholder.
+
+This event allows project to implement custom placeholders and
+the replacement without using old-school xclassing technique.
+
+
+#### FEATURE: Allow modifying default and settings pageTitleFormat for detail view
 
 It's possible to set a pageTitleFormat in the plugin settings for
 plugins using the `ProfileController::detailAction()`, which is


### PR DESCRIPTION
With recent changes a series of features has been implemented to
make the HTML title tag for person profile pages more flexible,
with a placeholder based FlexForm options and also allowing to
influence the default and the setting pageTitleFormat.

The used `ProfileTitleProvider` already looks into the format
string and provides the ability to replace placeholders, which
matches getters in the profile.

To provide even more flexibility, this change introduces a new
PSR-14 Event `ModifyProfileTitlePlaceholderReplacementEvent`,
which is dispatched for each placeholder enriched with quite a
handfull of use-full context information.

Following methods are available on the event:

* `getPluginControllerActionContext(): PluginControllerActionContextInterface`
  containing the request along with easy access methods to site,
  siteLanguage and extbase plugin information and the plugin
  settings.
* `getProfile(): Profile` the current person profile to display.
* `getPlaceholder()` the original/raw placeholder identifier.
* `getReplacement()` the value to replace the placeholder with,
  which may differ already if a earlier event listener changed
  the value using `setReplacement()`.
* `setReplacement(string $replacement): void` to set the value
  used to replace the placeholder.

This event allows project to implement custom placeholders and
the replacement without using old-school xclassing technique.
