### PR TITLE
[FEATURE] Introduce localized pageTitleFormat placeholder (`LLL:EXT:`)

### DIFF
--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<xliff version="1.2"
+	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
 	<file source-language="en" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="academic_persons">
 		<header/>
 		<body>

--- a/packages/fgtclb/academic-persons/Tests/Functional/AbstractAcademicPersonsTestCase.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/AbstractAcademicPersonsTestCase.php
@@ -16,4 +16,22 @@ abstract class AbstractAcademicPersonsTestCase extends FunctionalTestCase
     protected array $testExtensionsToLoad = [
         'fgtclb/academic-persons',
     ];
+
+    protected function addCoreExtension(string ...$extensions): void
+    {
+        foreach ($extensions as $extension) {
+            if ($extension !== '' && !in_array($extension, $this->coreExtensionsToLoad)) {
+                $this->coreExtensionsToLoad[] = $extension;
+            }
+        }
+    }
+
+    protected function addTestExtension(string ...$extensions): void
+    {
+        foreach ($extensions as $extension) {
+            if ($extension !== '' && !in_array($extension, $this->testExtensionsToLoad)) {
+                $this->testExtensionsToLoad[] = $extension;
+            }
+        }
+    }
 }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/de.locallang.xlf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.2"
+	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
+		<header/>
+		<body>
+
+			<!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
+
+			<trans-unit id="placeholder.with.dots">
+				<source>Placeholder with dots</source>
+				<target>Platzhalter mit Punkten</target>
+			</trans-unit>
+			<trans-unit id="placeholder-with-dashes">
+				<source>Placeholder with dashes</source>
+				<target>Platzhalter mit Bindestrichen</target>
+			</trans-unit>
+			<trans-unit id="placeholder_with_underscores">
+				<source>Placeholder with underscores</source>
+				<target>Platzhalter mit Unterstrichen</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/locallang.xlf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.2"
+	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
+		<header/>
+		<body>
+
+			<!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
+
+			<trans-unit id="placeholder.with.dots">
+				<source>Placeholder with dots</source>
+			</trans-unit>
+			<trans-unit id="placeholder-with-dashes">
+				<source>Placeholder with dashes</source>
+			</trans-unit>
+			<trans-unit id="placeholder_with_underscores">
+				<source>Placeholder with underscores</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/composer.json
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "tests/language-files",
+    "description": "Extension providing language files for tests",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech",
+            "role": "Maintainer"
+        }
+    ],
+    "require": {
+        "typo3/cms-core": "^12.4.22 || ^13.4",
+        "fgtclb/academic-persons": "2.0.*@dev"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_language_files"
+        }
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/ext_emconf.php
@@ -1,0 +1,23 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'TESTS: Academic Persons Language Files',
+    'description' => 'Extension providing language files for tests',
+    'category' => 'fe,be',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => 'web-vision GmbH',
+    'state' => 'beta',
+    'version' => '2.0.2',
+    'clearCacheOnLoad' => true,
+    'constraints' => [
+        'depends' => [
+            'typo3' => '12.4.22-13.4.99',
+            'academic_persons' => '2.0.2',
+        ],
+        'conflicts' => [
+        ],
+        'suggests' => [
+        ],
+    ],
+];

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -50,6 +50,29 @@ See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https:
 
 ### FEATURES
 
+#### FEATURE: Introduce localized pageTitleFormat placeholder (`LLL:EXT:`)
+
+It's a valid use-case to use a pageTitleFormat for the person
+profile detail page view as HTML page title including localized
+text as placeholders and could be implemented using the PSR-14
+event `ModifyProfileTitlePlaceholderReplacementEvent` dispatched
+in the `ProfileTitleProvider`.
+
+Localization is a generic feature and it's most likely that it's
+use-full for a broader audience this change adds now support for
+localization placeholder in the format:
+
+```
+%%LLL:EXT:<extension-key>/Resources/.../locallang.xlf:identifier%%
+```
+
+Note that no context fallback detection is made like within fluid
+templates or extbase context areas and a valid relative path for
+the default language file within a extension needs to be provided.
+
+Functional tests are added to cover the new feature basically and
+provide some examples, using a dedicated test fixture extension.
+
 #### FEATURE: Introduce `ModifyProfileTitlePlaceholderReplacementEvent` in `ProfileTitleProvider`
 
 With recent changes a series of features has been implemented to


### PR DESCRIPTION
It's a valid use-case to use a pageTitleFormat for the person
profile detail page view as HTML page title including localized
text as placeholders and could be implemented using the PSR-14
event `ModifyProfileTitlePlaceholderReplacementEvent` dispatched
in the `ProfileTitleProvider`.

Localization is a generic feature and it's most likely that it's
use-full for a broader audience this change adds now support for
localization placeholder in the format:

```
%%LLL:EXT:<extension-key>/Resources/.../locallang.xlf:identifier%%
```

Note that no context fallback detection is made like within fluid
templates or extbase context areas and a valid relative path for
the default language file within a extension needs to be provided.

Functional tests are added to cover the new feature basically and
provide some examples, using a dedicated test fixture extension.
