### PR TITLE
[TASK] Pass content element data to view in controller actions

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\ErrorController;
 
 /**
@@ -146,5 +147,10 @@ abstract class AbstractActionController extends ActionController
             ContextualFeedbackSeverity::ERROR,
             true
         );
+    }
+
+    protected function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
+    {
+        return $this->request->getAttribute('currentContentObject');
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -43,6 +43,7 @@ final class ContractController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
         ]);
         return $this->htmlResponse();
@@ -53,6 +54,7 @@ final class ContractController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
         ]);
@@ -66,6 +68,7 @@ final class ContractController extends AbstractActionController
     public function newAction(Profile $profile, ?ContractFormData $contractFormData = null): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
             'contractFormData' => $contractFormData ?? new ContractFormData(),
             'functionTypes' => $this->functionTypeRepository->findAll(),
@@ -103,6 +106,7 @@ final class ContractController extends AbstractActionController
     public function editAction(Contract $contract): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'contractFormData' => ContractFormData::createFromContract($contract),
@@ -186,6 +190,7 @@ final class ContractController extends AbstractActionController
     public function confirmDeleteAction(Contract $contract): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'contract' => $contract,
         ]);
         return $this->htmlResponse();

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -41,6 +41,7 @@ final class EmailAddressController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'emailAddresses' => $contract->getEmailAddresses(),
@@ -53,6 +54,7 @@ final class EmailAddressController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $emailAddress->getContract()->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
@@ -67,6 +69,7 @@ final class EmailAddressController extends AbstractActionController
     public function newAction(Contract $contract, ?EmailFormData $emailAddressFormData = null): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'emailAddressFormData' => $emailAddressFormData ?? new EmailFormData(),
@@ -103,6 +106,7 @@ final class EmailAddressController extends AbstractActionController
     public function editAction(Email $emailAddress): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $emailAddress->getContract()->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
@@ -191,6 +195,7 @@ final class EmailAddressController extends AbstractActionController
     public function confirmDeleteAction(Email $emailAddress): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $emailAddress->getContract()->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -39,6 +39,7 @@ final class PhoneNumberController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'phoneNumbers' => $contract->getPhoneNumbers(),
@@ -52,6 +53,7 @@ final class PhoneNumberController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $phoneNumber->getContract()->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
@@ -67,6 +69,7 @@ final class PhoneNumberController extends AbstractActionController
     public function newAction(Contract $contract, ?PhoneNumberFormData $phoneNumberFormData = null): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'phoneNumberFormData' => $phoneNumberFormData ?? new PhoneNumberFormData(),
@@ -104,6 +107,7 @@ final class PhoneNumberController extends AbstractActionController
     public function editAction(PhoneNumber $phoneNumber): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $phoneNumber->getContract()->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
@@ -189,6 +193,7 @@ final class PhoneNumberController extends AbstractActionController
     public function confirmDeleteAction(PhoneNumber $phoneNumber): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $phoneNumber->getContract()->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -41,6 +41,7 @@ final class PhysicalAddressController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'physicalAddresses' => $contract->getPhysicalAddresses(),
@@ -54,6 +55,7 @@ final class PhysicalAddressController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $physicalAddress->getContract()->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
@@ -69,6 +71,7 @@ final class PhysicalAddressController extends AbstractActionController
     public function newAction(Contract $contract, ?AddressFormData $addressFormData = null): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'addressFormData' => $addressFormData ?? new AddressFormData(),
@@ -106,6 +109,7 @@ final class PhysicalAddressController extends AbstractActionController
     public function editAction(Address $physicalAddress): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $physicalAddress->getContract()->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
@@ -195,6 +199,7 @@ final class PhysicalAddressController extends AbstractActionController
     public function confirmDeleteAction(Address $physicalAddress): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $physicalAddress->getContract()->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -44,6 +44,7 @@ final class ProfileController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profiles' => $profiles,
         ]);
 
@@ -55,6 +56,7 @@ final class ProfileController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
         ]);
 
@@ -68,6 +70,7 @@ final class ProfileController extends AbstractActionController
     public function editAction(Profile $profile): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
             'profileFormData' => ProfileFormData::createFromProfile($profile),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
@@ -116,6 +119,7 @@ final class ProfileController extends AbstractActionController
     public function editImageAction(Profile $profile): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -42,9 +42,24 @@ final class ProfileInformationController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
 
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
             'type' => $type,
             'profileInformations' => $profile->_getProperty($type),
+        ]);
+
+        return $this->htmlResponse();
+    }
+
+    public function showAction(ProfileInformation $profileInformation): ResponseInterface
+    {
+        $this->userSessionService->saveRefererToSession($this->request);
+
+        $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'profile' => $profileInformation->getProfile(),
+            'type' => $profileInformation->getType(),
+            'profileInformation' => $profileInformation,
         ]);
 
         return $this->htmlResponse();
@@ -57,6 +72,7 @@ final class ProfileInformationController extends AbstractActionController
     public function newAction(Profile $profile, string $type, ?ProfileInformationFormData $profileInformationFormData = null): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
             'type' => $type,
             'profileInformationFormData' => $profileInformationFormData ?? ProfileInformationFormData::createEmptyForType($this->settingsRegistry->getProfileInformationTypeMapping($type)),
@@ -96,6 +112,7 @@ final class ProfileInformationController extends AbstractActionController
     public function editAction(ProfileInformation $profileInformation): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profileInformation->getProfile(),
             'profileInformation' => $profileInformation,
             'profileInformationFormData' => ProfileInformationFormData::createFromProfileInformation($profileInformation),
@@ -185,6 +202,7 @@ final class ProfileInformationController extends AbstractActionController
     public function confirmDeleteAction(ProfileInformation $profileInformation): ResponseInterface
     {
         $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profileInformation->getProfile(),
             'profileInformation' => $profileInformation,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),


### PR DESCRIPTION
As the content element data is necessary for handling semantic e.g. heading levels correctly and is useful to have available in the frontend in general, the current content object is passed to the view as data object through all controller actions.