### PR TITLE
[TASK] Allow TypoScript settings to override empty FlexForm settings

### DIFF
--- a/packages/fgtclb/academic-persons/Configuration/TypoScript/Default/setup.typoscript
+++ b/packages/fgtclb/academic-persons/Configuration/TypoScript/Default/setup.typoscript
@@ -34,3 +34,12 @@ config.pageTitleProviders {
         before = calendarize,altPageTitle,record,seo
     }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------
+//  Add following FlexForm settings (settings.<identifier>) to be allowed overridden in TypoScript if empty in FlexForm,
+//  still taking set values in FlexForm as the higher candidates but have a sane fallback to system wide defaults.
+//
+//  https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-99976-IntroduceignoreFlexFormSettingsIfEmptyExtbaseConfiguration.html
+// ----------------------------------------------------------------------------------------------------------------------
+@import 'EXT:academic_persons/Configuration/TypoScript/Shared/allow_typoscript_override_empty_flexform_settings.typoscript'
+// ----------------------------------------------------------------------------------------------------------------------

--- a/packages/fgtclb/academic-persons/Configuration/TypoScript/Shared/allow_typoscript_override_empty_flexform_settings.typoscript
+++ b/packages/fgtclb/academic-persons/Configuration/TypoScript/Shared/allow_typoscript_override_empty_flexform_settings.typoscript
@@ -1,20 +1,4 @@
-@import 'EXT:academic_persons/Configuration/TypoScript/Default/setup.typoscript'
 
-page = PAGE
-page {
-  typeNum = 0
-
-  10 < styles.content.get
-
-  includeCSS {
-    bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css
-    bootstrap.external = 1
-  }
-  includeJSFooter {
-    bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js
-    bootstrap.external = 1
-  }
-}
 
 // ----------------------------------------------------------------------------------------------------------------------
 //  Add following FlexForm settings (settings.<identifier>) to be allowed overridden in TypoScript if empty in FlexForm,
@@ -22,12 +6,7 @@ page {
 //
 //  https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-99976-IntroduceignoreFlexFormSettingsIfEmptyExtbaseConfiguration.html
 // ----------------------------------------------------------------------------------------------------------------------
-@import 'EXT:academic_persons/Configuration/TypoScript/Shared/allow_typoscript_override_empty_flexform_settings.typoscript'
+plugin.tx_academicpersons.ignoreFlexFormSettingsIfEmpty := addToList(detailPid)
+plugin.tx_academicpersons.ignoreFlexFormSettingsIfEmpty := addToList(pageTitleFormat)
+plugin.tx_academicpersons.ignoreFlexFormSettingsIfEmpty := addToList(showFields)
 // ----------------------------------------------------------------------------------------------------------------------
-
-config.pageTitleProviders {
-    profile  {
-        provider = FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider
-        before = calendarize,altPageTitle,record,seo
-    }
-}


### PR DESCRIPTION
TYPO3 provides the ability to define settings for plugin in TypoScript and
also as FlexForm (`pi_flexform`) settings. Extbase `ConfigurationManager`
merged settings from both sources having FlexForm options with the higher
priority, which means that empty FlexForm settings overrides TypoScript
settings.

In many cases it is more suitable that TypoScript settings should override
FlexForm settings when not set (empty) to allow instance wide configuration
and placing plugins in `tt_content` without setting the values on each of
these places. In the past, Extension authors needed to define these cases
and implement that manually for each plugin/action again and again, which
was a pain in the ass.

Since TYPO3 v12.3 the new option `ignoreFlexFormSettingsIfEmpty` [1] gives
the option to tell TYPO3 to use TypoScript settings over the empty FlexForm
counterpart in instances even if the orignal extension does not implemented
it that way or missed to deal with it, like we missed it. The sideeffect is,
that we can ship this configuration directly for options where it is really
obious that TypoScript needs to overrule empty FlexForm settings.

For example the `Detail PageID` (`detailPid`) setting for all plugins related
to display profile short information is a good candidate to have it set once
in TypoScript as a system wide setting and can leave the setting in flexform
empty and still link to the correct detail page.

Following that, we now use `ignoreFlexFormSettingsIfEmpty` for the following
FlexForm options of `EXT:academic_persons` to make them overrideable within
TypoScript over empty FlexForm values:

* settings.detailPid
* settings.pageTitleFormat
* settings.showFields

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-99976-IntroduceignoreFlexFormSettingsIfEmptyExtbaseConfiguration.html
