### PR TITLE
[BUGFIX] Harden `SyncChangesToTranslations` event listener

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
@@ -11,9 +11,18 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * @todo This event reacts on an PSR-14 event dispatched in FE, BE and CLI(BE) context AND relies on a global
+ *       request object ($GLOBALS['TYPO3_REQUEST']) providing attribute `site` and the expectation limits it
+ *       to a frontend request. Overall this is a bad design and fails, because the PSR-14 event will also
+ *       dispatched in CLI context (cli command) AND eventualy in BE context when project using DataHandler
+ *       hooks dispatching that event again. That means, the whole working chain with the event, this listener
+ *       needs to be made context unaware and hard gobal expectations on request must fall.
+ */
 final class SyncChangesToTranslations
 {
     private ?int $defaultLanguage = null;
@@ -334,6 +343,7 @@ final class SyncChangesToTranslations
 
     private function getSite(): ?Site
     {
-        return ($GLOBALS['TYPO3_REQUEST'] ?? null)?->getAttribute('site');
+        $site = ($GLOBALS['TYPO3_REQUEST'] ?? null)?->getAttribute('site');
+        return $site instanceof NullSite ? null : $site;
     }
 }


### PR DESCRIPTION
The `SyncChangesToTranslations` PSR-14 event listener reacts on
the a event dispatched in FE, BE and CLI(BE) context and still
relies having a valid global frontend request available in the
global variable `$GLOBALS['TYPO3_REQUEST']` to pull resolved
site from it, which is the basic information to handle the sync
of profile transations.

It has been revealed, that projects tends to integrate DataHandler
hooks dispatching the very same event without having a correct FE
context set globaly and in that case a `NullSite` will be returned
from the BE request object as `site` attribute incompatible to the
`?Site` return type declaration of `getSite()` method.

The solution needs to be refactoring the whole calling chain and
transport requirete site/siteLanguage information directly with
the corresponding PSR-14 event, which is a bigger rework with a
lot of signature changes across multiple academic extensions.

To mitigate the heavy and nasty PHP TypeError

```
FGTCLB\AcademicPersonsEdit\EventListener\SyncChangesToTranslations::getSite():\
Return value must be of type ?TYPO3\CMS\Core\Site\Entity\Site, \
TYPO3\CMS\Core\Site\Entity\NullSite returned
```

in case the above mentioned missuse hits, this change checks for
NullSite and handes it in the way that no site has been provided.

Overall handling in the EventListener is worked to be more type
and error reluctant as a first and quick bugfix.
