### PR TITLE
[BUGFIX] Streamline extbase model properties and getters

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -138,6 +138,13 @@ final class ContractController extends AbstractActionController
     public function sortAction(Contract $contractFromForm, string $sortDirection): ResponseInterface
     {
         $profile = $contractFromForm->getProfile();
+        if ($profile === null) {
+            // @todo Needs to be handled properly.
+            throw new \RuntimeException(
+                'Contract does not have a profile.',
+                1752936133,
+            );
+        }
 
         if (!in_array($sortDirection, ['up', 'down'])
             || $profile->getContracts()->count() <= 1

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -55,7 +55,7 @@ final class EmailAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $emailAddress->getContract()->getProfile(),
+            'profile' => $emailAddress->getContract()?->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
         ]);
@@ -107,7 +107,7 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $emailAddress->getContract()->getProfile(),
+            'profile' => $emailAddress->getContract()?->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
             'emailAddressFormData' => EmailFormData::createFromEmail($emailAddress),
@@ -143,6 +143,13 @@ final class EmailAddressController extends AbstractActionController
     public function sortAction(Email $emailAddressFromForm, string $sortDirection): ResponseInterface
     {
         $contract = $emailAddressFromForm->getContract();
+        if ($contract === null) {
+            // @todo Needs to be handled properly.
+            throw new \RuntimeException(
+                'Could not get contract.',
+                1752939173,
+            );
+        }
 
         if (!in_array($sortDirection, ['up', 'down'])
             || $contract->getEmailAddresses()->count() <= 1
@@ -196,7 +203,7 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $emailAddress->getContract()->getProfile(),
+            'profile' => $emailAddress->getContract()?->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -54,7 +54,7 @@ final class PhoneNumberController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $phoneNumber->getContract()->getProfile(),
+            'profile' => $phoneNumber->getContract()?->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
         ]);
@@ -108,7 +108,7 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $phoneNumber->getContract()->getProfile(),
+            'profile' => $phoneNumber->getContract()?->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
             'phoneNumberFormData' => PhoneNumberFormData::createFromPhoneNumber($phoneNumber),
@@ -141,6 +141,13 @@ final class PhoneNumberController extends AbstractActionController
     public function sortAction(PhoneNumber $phoneNumberFromForm, string $sortDirection): ResponseInterface
     {
         $contract = $phoneNumberFromForm->getContract();
+        if ($contract === null) {
+            // @todo Needs to be handled properly.
+            throw new \RuntimeException(
+                'Could not get contract.',
+                1752939240,
+            );
+        }
 
         if (!in_array($sortDirection, ['up', 'down'])
             || $contract->getPhoneNumbers()->count() <= 1
@@ -194,7 +201,7 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $phoneNumber->getContract()->getProfile(),
+            'profile' => $phoneNumber->getContract()?->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -56,7 +56,7 @@ final class PhysicalAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $physicalAddress->getContract()->getProfile(),
+            'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
         ]);
@@ -110,7 +110,7 @@ final class PhysicalAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $physicalAddress->getContract()->getProfile(),
+            'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
             'addressFormData' => AddressFormData::createFromAddress($physicalAddress),
@@ -147,6 +147,13 @@ final class PhysicalAddressController extends AbstractActionController
     public function sortAction(Address $physicalAddressFromForm, string $sortDirection): ResponseInterface
     {
         $contract = $physicalAddressFromForm->getContract();
+        if ($contract === null) {
+            // @todo Needs to be handled properly.
+            throw new \RuntimeException(
+                'Could not get contract.',
+                1752938846,
+            );
+        }
 
         if (!in_array($sortDirection, ['up', 'down'])
             || $contract->getPhysicalAddresses()->count() <= 1
@@ -200,7 +207,7 @@ final class PhysicalAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profile' => $physicalAddress->getContract()->getProfile(),
+            'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -146,6 +146,13 @@ final class ProfileInformationController extends AbstractActionController
     {
         $sortingItemFromForm = $profileInformation;
         $profile = $sortingItemFromForm->getProfile();
+        if ($profile === null) {
+            // @todo Needs to be handled properly.
+            throw new \RuntimeException(
+                'Could not get contract.',
+                1752938963,
+            );
+        }
         $sortingItems = $this->profileInformationRepository->findByProfileAndType(
             $profile,
             $sortingItemFromForm->getType()

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Address.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Address.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class Address extends AbstractEntity
 {
-    protected Contract $contract;
+    protected ?Contract $contract = null;
     protected string $street = '';
     protected string $streetNumber = '';
     protected string $additional = '';
@@ -42,7 +42,7 @@ class Address extends AbstractEntity
         return $this;
     }
 
-    public function getContract(): Contract
+    public function getContract(): ?Contract
     {
         return $this->contract;
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class Contract extends AbstractEntity
 {
-    protected Profile $profile;
+    protected ?Profile $profile = null;
     protected ?OrganisationalUnit $organisationalUnit = null;
     protected ?FunctionType $functionType = null;
     protected ?\DateTime $validFrom = null;
@@ -74,7 +74,7 @@ class Contract extends AbstractEntity
         return $this;
     }
 
-    public function getProfile(): Profile
+    public function getProfile(): ?Profile
     {
         return $this->profile;
     }
@@ -189,6 +189,11 @@ class Contract extends AbstractEntity
         return $this->publish;
     }
 
+    public function getPublish(): bool
+    {
+        return $this->publish;
+    }
+
     public function setSorting(int $sorting): self
     {
         $this->sorting = $sorting;
@@ -289,26 +294,12 @@ class Contract extends AbstractEntity
 
     public function getLabel(): string
     {
-        $firstName = '-';
-        $lastName = '-';
-        if ($this->profile !== null) {
-            $firstName = $this->profile->getLastName() ?: '-';
-            $lastName = $this->profile->getFirstName() ?: '-';
-        }
-
-        $functionType = '-';
-        if ($this->functionType !== null) {
-            $functionType = $this->functionType->getFunctionName() ?: '-';
-        }
-
-        $organisationalUnit = '-';
-        if ($this->organisationalUnit !== null) {
-            $organisationalUnit = $this->organisationalUnit->getUnitName() ?: '-';
-        }
-
-        $validFrom = $this->validFrom ? $this->validFrom->format('Y-m-d') : '-';
-        $validTo = $this->validTo ? $this->validTo->format('Y-m-d') : '-';
-
+        $firstName = ($this->getProfile()?->getLastName() ?? '') ?: '-';
+        $lastName = ($this->getProfile()?->getFirstName() ?? '') ?: '-';
+        $functionType = ($this->getFunctionType()?->getFunctionName() ?? '') ?: '-';
+        $organisationalUnit = ($this->getOrganisationalUnit()?->getUnitName() ?? '') ?: '-';
+        $validFrom = ($this->getValidFrom()?->format('Y-m-d') ?? '') ?: '-';
+        $validTo = ($this->getValidTo()?->format('Y-m-d') ?? '') ?: '-';
         return sprintf(
             '%s, %s / %s / %s / %s-%s',
             $firstName,
@@ -319,4 +310,5 @@ class Contract extends AbstractEntity
             $validTo
         );
     }
+
 }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Email.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Email.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class Email extends AbstractEntity
 {
-    protected Contract $contract;
+    protected ?Contract $contract = null;
     protected string $email = '';
     protected string $type = '';
     protected int $sorting = 0;
@@ -36,7 +36,7 @@ class Email extends AbstractEntity
         return $this;
     }
 
-    public function getContract(): Contract
+    public function getContract(): ?Contract
     {
         return $this->contract;
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/PhoneNumber.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/PhoneNumber.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class PhoneNumber extends AbstractEntity
 {
-    protected Contract $contract;
+    protected ?Contract $contract = null;
     protected string $phoneNumber = '';
     protected string $type = '';
     protected int $sorting = 0;
@@ -36,7 +36,7 @@ class PhoneNumber extends AbstractEntity
         return $this;
     }
 
-    public function getContract(): Contract
+    public function getContract(): ?Contract
     {
         return $this->contract;
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/ProfileInformation.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/ProfileInformation.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class ProfileInformation extends AbstractEntity
 {
-    protected Profile $profile;
+    protected ?Profile $profile = null;
     protected string $type = '';
     protected string $title = '';
     protected string $bodytext = '';
@@ -41,7 +41,7 @@ class ProfileInformation extends AbstractEntity
         return $this;
     }
 
-    public function getProfile(): Profile
+    public function getProfile(): ?Profile
     {
         return $this->profile;
     }

--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ContractTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ContractTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ContractTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeCreated(): void
+    {
+        new Contract();
+    }
+
+    #[Test]
+    public function getProfileReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getProfile());
+    }
+
+    #[Test]
+    public function getOrganizationaUnitReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getOrganisationalUnit());
+    }
+
+    #[Test]
+    public function getFunctionTypeReturnsNulForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getFunctionType());
+    }
+
+    #[Test]
+    public function getEmployeeTypeReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getEmployeeType());
+    }
+
+    #[Test]
+    public function getLocationReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getLocation());
+    }
+
+    #[Test]
+    public function getValidFromReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getValidFrom());
+    }
+
+    #[Test]
+    public function getValidToReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contract())->getValidTo());
+    }
+
+    #[Test]
+    public function getPositionReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new Contract())->getPosition());
+    }
+
+    #[Test]
+    public function getRoomReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new Contract())->getRoom());
+    }
+
+    #[Test]
+    public function getOfficeHoursReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new Contract())->getOfficeHours());
+    }
+
+    #[Test]
+    public function getPublishReturnsFalseForNewModel(): void
+    {
+        $this->assertFalse((new Contract())->getPublish());
+    }
+
+    #[Test]
+    public function isPublishReturnsFalseForNewModel(): void
+    {
+        $this->assertFalse((new Contract())->isPublish());
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class EmailTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeCreated(): void
+    {
+        new Email();
+    }
+
+    #[Test]
+    public function getContractReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Email())->getContract());
+    }
+
+    #[Test]
+    public function getEmailReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new Email())->getEmail());
+    }
+
+    #[Test]
+    public function getTypeReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new Email())->getType());
+    }
+
+    #[Test]
+    public function getSortingReturnsIntegerZeroForNewModel(): void
+    {
+        $this->assertSame(0, (new Email())->getSorting());
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/PhoneNumberTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/PhoneNumberTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class PhoneNumberTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeCreated(): void
+    {
+        new PhoneNumber();
+    }
+
+    #[Test]
+    public function getContractReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new PhoneNumber())->getContract());
+    }
+
+    #[Test]
+    public function getPhoneNumberReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new PhoneNumber())->getPhoneNumber());
+    }
+
+    #[Test]
+    public function getTypeReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new PhoneNumber())->getType());
+    }
+
+    #[Test]
+    public function getSortingReturnsIntegerZeroForNewModel(): void
+    {
+        $this->assertSame(0, (new PhoneNumber())->getSorting());
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPersons\Domain\Model\ProfileInformation;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ProfileInformationTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeCreated(): void
+    {
+        new ProfileInformation();
+    }
+
+    #[Test]
+    public function getProfileReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new ProfileInformation())->getProfile());
+    }
+
+    #[Test]
+    public function getTypeReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new ProfileInformation())->getType());
+    }
+
+    #[Test]
+    public function getTitleReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new ProfileInformation())->getTitle());
+    }
+
+    #[Test]
+    public function getBodytextReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new ProfileInformation())->getBodytext());
+    }
+
+    #[Test]
+    public function getLinkReturnsEmptyStringForNewModel(): void
+    {
+        $this->assertSame('', (new ProfileInformation())->getLink());
+    }
+
+    #[Test]
+    public function getYearReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new ProfileInformation())->getYear());
+    }
+
+    #[Test]
+    public function getYearStartReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new ProfileInformation())->getYearStart());
+    }
+
+    #[Test]
+    public function getYearEndReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new ProfileInformation())->getYearEnd());
+    }
+
+    #[Test]
+    public function getSortingReturnsIntegerZeroForNewModel(): void
+    {
+        $this->assertSame(0, (new ProfileInformation())->getSorting());
+    }
+}


### PR DESCRIPTION
Extbase has quite some requirements related to model properties
and setter/getter methods, special with newer PHP versions and
native types.

That also boils down to the two ways models may be created:

* using new (in manual code) and thus this constructor
* hydrating from the database not calling the constructor

Extbase in general maps data directly to the properies for all
data retrieved from the database, which means for relations
that it will be left out and requires that relations are declared
as nullabe and getter/setter can deal with it.

All of these things has not been respected and are now streamlined
to avoid issues in different flavours and places.
