### PR TITLE
[FEATURE] Add link to remove alphabet filter

### DIFF
--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/List/AlphabetPagination.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/List/AlphabetPagination.html
@@ -10,6 +10,15 @@
 
 <nav class="alphabetical-pagination mb-4">
     <ul class="pagination justify-content-center">
+        <li class="page-item">
+            <f:link.action
+                arguments="{demand: '{alphabetFilter: \'\'}'}"
+                class="page-link"
+                rel="nofollow"
+            >
+                <span>A-Z</span>
+            </f:link.action>
+        </li>
         <f:for each="{alphabets}" as="alphabet">
             <li class="page-item">
                 <f:if condition="{demand.alphabetFilter} == {alphabet}">


### PR DESCRIPTION
At the moment, once an alphabet letter has been selected
to filter profiles, there is a lack of a global option
that allows to remove that alphabet filter. This aims
to cover that usercase.
