### PR TITLE
[BUGFIX] Change tab addition on pages table

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/pages.php
@@ -1,6 +1,8 @@
 <?php
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 if (!defined('TYPO3')) {
     die('Not authorized');
@@ -50,13 +52,14 @@ if (!defined('TYPO3')) {
             ],
         ]
     );
-    ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
+
+    $GLOBALS['TCA'] = GeneralUtility::makeInstance(TcaManipulator::class)->addToPageTypesGeneralTab(
+        $GLOBALS['TCA'],
         implode(',', [
             '--div--;LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:pages.tx_academiccontacts4pages_contacts',
             'tx_academiccontacts4pages_contacts',
         ]),
-        '',
-        'after:title'
+        [],
+        [254, 255]
     );
 })();

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicPartners\Backend\FormEngine\CountryItems;
 use FGTCLB\AcademicPartners\Enumeration\PageTypes;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 defined('TYPO3') or die;
 
@@ -274,26 +276,23 @@ defined('TYPO3') or die;
         $additionalTCAcolumns
     );
 
-    // Add the partnerships tab and column to all page types
-    ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
+    $GLOBALS['TCA'] = GeneralUtility::makeInstance(TcaManipulator::class)->addToPageTypesGeneralTab(
+        $GLOBALS['TCA'],
         implode(',', [
             '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:tx_academicpartners_domain_model_partnership',
             'tx_academicpartners_partnerships',
         ]),
-        '',
-        'after:title'
+        [],
+        [254, 255]
     );
 
-    // Add all other columns only to academic partners page type
-    ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
+    $GLOBALS['TCA'] = GeneralUtility::makeInstance(TcaManipulator::class)->addToPageTypesGeneralTab(
+        $GLOBALS['TCA'],
         implode(',', [
             '--div--;LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:pages.div.partner_information',
             '--palette--;;address',
             '--palette--;;geocode',
         ]),
-        (string)PageTypes::ACADEMIC_PARTNERS,
-        'after:title'
+        [PageTypes::ACADEMIC_PARTNERS]
     );
 })();

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicPrograms\Enumeration\PageTypes;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 defined('TYPO3') or die;
 
@@ -85,18 +87,15 @@ defined('TYPO3') or die;
         $additionalTCAcolumns
     );
 
-    ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
-        '--div--;'
-            . 'LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:pages.div.program'
-            . ','
-            . implode(',', [
-                'credit_points',
-                'job_profile',
-                'performance_scope',
-                'prerequisites',
-            ]),
-        (string)PageTypes::TYPE_ACADEMIC_PROGRAM,
-        'after:title'
+    $GLOBALS['TCA'] = GeneralUtility::makeInstance(TcaManipulator::class)->addToPageTypesGeneralTab(
+        $GLOBALS['TCA'],
+        implode(',', [
+            '--div--;LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:pages.div.program',
+            'credit_points',
+            'job_profile',
+            'performance_scope',
+            'prerequisites',
+        ]),
+        [PageTypes::TYPE_ACADEMIC_PROGRAM]
     );
 })();

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
@@ -1,9 +1,11 @@
 <?php
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicProjects\Enumeration\PageTypes;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 if (!defined('TYPO3')) {
     die('Not authorized');
@@ -161,21 +163,20 @@ if (!defined('TYPO3')) {
         ])
     );
 
-    ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
-        implode(',', [
-            '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project',
-            '--palette--;;project_info',
-            '--palette--;;project_date',
-        ]),
-        (string)PageTypes::TYPE_ACEDEMIC_PROJECT,
-        'after:title'
-    );
-
     if (!isset($GLOBALS['TCA']['pages']['types'][PageTypes::TYPE_ACEDEMIC_PROJECT]['columnsOverrides'])) {
         $GLOBALS['TCA']['pages']['types'][PageTypes::TYPE_ACEDEMIC_PROJECT]['columnsOverrides'] = [];
     }
 
     $GLOBALS['TCA']['pages']['types'][PageTypes::TYPE_ACEDEMIC_PROJECT]['columnsOverrides']['title']['config']['max'] = 60;
     //$GLOBALS['TCA']['pages']['types'][PageTypes::TYPE_ACEDEMIC_PROJECT]['columnsOverrides']['categories']['l10n_mode'] = 'exclude';
+
+    $GLOBALS['TCA'] = GeneralUtility::makeInstance(TcaManipulator::class)->addToPageTypesGeneralTab(
+        $GLOBALS['TCA'],
+        implode(',', [
+            '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project',
+            '--palette--;;project_info',
+            '--palette--;;project_date',
+        ]),
+        [PageTypes::TYPE_ACEDEMIC_PROJECT]
+    );
 })();


### PR DESCRIPTION
Due to the general tab of pages sometimes having more
than just the title palette, fields or palettes added after the
title palette will always show up in the wrong tab.

This was caused by adding a complete tab after the title
palette, which then causes this split-up.

To adress this issue we now use the `TcaManipulator` class of the
`EXT:academic_base`, which safely adds TCA behind the general tab
instead of relying on the `addToAllTCATypes` function provided by
the `ExtensionManagementUtility`. This had to be done since
this function does not support adding after tabs (yet).