### PR TITLE
[BUGFIX] Use correct key for select item icon value

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Backend/Form/ProfileShowFieldsItemProcFunc.php
+++ b/packages/fgtclb/academic-persons/Classes/Backend/Form/ProfileShowFieldsItemProcFunc.php
@@ -29,7 +29,7 @@ class ProfileShowFieldsItemProcFunc
         $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
         $selectLabelKey = ($typo3MajorVersion >= 12) ? 'label' : 0;
         $selectValueKey = ($typo3MajorVersion >= 12) ? 'value' : 1;
-        $selectIconKey = ($typo3MajorVersion >= 12) ? 'icon' : 1;
+        $selectIconKey = ($typo3MajorVersion >= 12) ? 'icon' : 2;
         $selectGroupKey = ($typo3MajorVersion >= 12) ? 'group' : 3;
 
         return [


### PR DESCRIPTION
Value item array for TCA select fields used integer keys for a long
time with specific meaning for each position [1], for example:

```php
[
  [
    0 => 'item label',
    1 => 'item value',
    2 => 'item icon identifier',
    3 => 'group identifier',
  ],
],
```

This behaviour has changed in TYPO3 v12 in favour of associative keys,
making it easier to read and understand for developers with the side
effect that it is not that fragile when ordering puzzles arround [2],
for example:

```php
[
  [
    'label' => 'item label',
    'value' => 'item value',
    'icon' => 'item icon identifier',
    'group' => 'group identifier',
  ],
],
```

To provide dual TYPO3 core version support and avoid automatic
TCA migration and hitting `E_USER_DEPRECATED` messages due to
the deprecation, a key-to-use switch had been added with commit
6f3682b3164af50d17eda4feb26d457b8b459ac8 [3] to either use the
interger or associative key when building the select items within
a itemUserProcFunc.

It has been missed during the review, that `1` has been used for
the `value` (correct) and for the `icon`(incorrect) again, putting
TYPO3 in the fallback mode to use the translated label as value,
which is not intended and leading to subsequential errors in TYPO3
instances using this version.

This change now uses the correct value (`2`) for the icon in TYPO3
v11 instances fully mitigating revealed issues in instances.

[1] https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/ColumnsConfig/Type/Select/Properties/Items.html#columns-select-properties-items
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html
[3] https://github.com/fgtclb/academic-extensions/commit/6f3682b3164af50d17eda4feb26d457b8b459ac8