### PR TITLE
[BUGFIX] Remove `declare(strict_types=1);` in `ext_emconf.php`

### DIFF
--- a/packages/fgtclb/academic-contact4pages/ext_emconf.php
+++ b/packages/fgtclb/academic-contact4pages/ext_emconf.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Contacts for Pages',
     'description' => 'Role based relations between profiles and pages',


### PR DESCRIPTION
The TYPO3 Extension Repository fails when a extension `ext_emconf.php`
contains the PHP `declare(strict_types=1);` and cannot properly decode
the extension details to handle the upload.

This change removes that statement to make `ext_emconf.php` valid for
an automatic upload to TER using the `typo3/tailor` tool.
