### PR TITLE
[TASK] Improve TYPO3 v13 for `EXT:academic-bite-jobs` 

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core13/AcademicBiteJobsList.xml
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core13/AcademicBiteJobsList.xml
@@ -18,7 +18,7 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <label><numIndex index="0"></numIndex></label>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.all</label>
                             <value>all</value>
                         </numIndex>
                         <numIndex index="1" type="array">

--- a/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/config.yaml
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/config.yaml
@@ -1,0 +1,2 @@
+name: fgtclb/academic-bite-jobs
+label: Academic Bite Jobs

--- a/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/constants.typoscript
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/constants.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:academic_bite_jobs/Configuration/TypoScript/constants.typoscript'

--- a/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/page.tsconfig
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:academic_bite_jobs/Configuration/TsConfig/Wizards/*.tsconfig'

--- a/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/setup.typoscript
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/Sets/AcademicBiteJobs/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:academic_bite_jobs/Configuration/TypoScript/setup.typoscript'

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -30,10 +30,18 @@ defined('TYPO3') or die;
         'academic_bite_jobs'
     );
     ExtensionManagementUtility::addPiFlexFormValue(
-        'academicbitejobs_list',
-        sprintf('FILE:EXT:academic_bite_jobs/Configuration/FlexForms/Core%s/AcademicBiteJobsList.xml', $typo3MajorVersion)
+        '*',
+        sprintf('FILE:EXT:academic_bite_jobs/Configuration/FlexForms/Core%s/AcademicBiteJobsList.xml', $typo3MajorVersion),
+        'academicbitejobs_list'
     );
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicbitejobs_list'] = 'recursive,select_key';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicbitejobs_list'] = 'pi_flexform';
-
+    ExtensionManagementUtility::addToAllTCAtypes(
+        'tt_content',
+        implode(',', [
+            '--div--;LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:plugin.bite.list.configuration',
+            'pi_flexform',
+            'pages',
+        ]),
+        'academicbitejobs_list',
+        'after:subheader',
+    );
 })();

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -21,7 +21,7 @@ defined('TYPO3') or die;
 
     ExtensionManagementUtility::addPlugin(
         [
-            'label' => 'LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:plugin.list.label',
+            'label' => 'LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:plugin.bite.list.label',
             'value' => 'academicbitejobs_list',
             'icon' => 'bitejobs_list',
             'group' => 'academic',

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
@@ -1,0 +1,15 @@
+mod.wizards.newContentElement.wizardItems.academic {
+  header = LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:content.ctype.group.label
+  after = special
+  elements {
+    academicbitejobs_list {
+      iconIdentifier = bitejobs_list
+      title = LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:plugin.bite.list.label
+      tt_content_defValues {
+        CType = academicbitejobs_list
+      }
+    }
+  }
+
+  show := addToList(academicbitejobs_list)
+}

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang_be.xlf
@@ -17,6 +17,11 @@
                 <target>Bite: Jobliste</target>
             </trans-unit>
 
+			<trans-unit id="plugin.bite.list.configuration">
+				<source>Configuration</source>
+				<target>Konfiguration</target>
+			</trans-unit>
+
             <trans-unit id="flexform.tab.settings">
                 <source>Settings</source>
                 <target>Einstellungen</target>

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang_be.xlf
@@ -14,6 +14,10 @@
                 <source>Bite: List of Jobs</source>
             </trans-unit>
 
+			<trans-unit id="plugin.bite.list.configuration">
+				<source>Configuration</source>
+			</trans-unit>
+
             <trans-unit id="flexform.tab.settings">
                 <source>Settings</source>
             </trans-unit>


### PR DESCRIPTION
* **[TASK] Introduce site set based configuration**

  According to site sets in v13 introduced lately the files and folder
  structure is changed for working in both v12 and v13 systems. This
  contains mainly the creation of files which load the former available
  TypoScript files.

  Additionally the tsConfig for the New Content Element Wizard has been
  added.
  
  [1] https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/SiteHandling/SiteSets.html

  
* **[TASK] Overhaul of loading of plugin flex form**

  The flexform based configuration tab for the plugin was missing in v13.
  This was fixed according to the standard way working throughout all of
  the `academic_*` extensions so far.

  This contains:

  * Fixed registration error of the flexform file for the plugin content 
    element. 
  * Fixed formengine tab by passing the correct options within the TCA
    Override file for `ExtensionManagementUtility::addToAllTCAtypes()`.
      
* **[TASK] Add missing translations**

  Some of the used translation identifiers for the defined
  flexform tab are not provided by the xliff files and are
  now added. Additionally, a wrong translation key in the
  plugin registration is fixed now.
