### PR TITLE
[TASK] Disable PHP8.5 testing for now

### DIFF
--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
+        php-version: [ "8.1", "8.2", "8.3", "8.4"]
         typo3: ["12"]
     needs: ["code-quality", "linting", "unit"]
     permissions:

--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
+        php-version: [ "8.2", "8.3", "8.4"]
         typo3: ["13"]
     needs: ["code-quality", "linting", "unit"]
     permissions:


### PR DESCRIPTION
PHP8.5.0beta1 introduced new deprecation, which hits TYPO3,
phpunit and other dependencies for several reasons and the
TYPO3 Core related mitigation have been already been merged
or are in the making.

However, new TYPO3 releases are required to fully have all
dependencies ensured to work with PHP8.5.0beta1.

That is not doable quickly, so disable PHP8.5 testing for
now until a reasonable mitigation can be found to unblock
current work in multiple areas.
