### PR TITLE
[TASK] Remove obsolete newContentElement wizard header group

### DIFF
--- a/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
+++ b/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
@@ -1,7 +1,5 @@
 mod.wizards {
     newContentElement.wizardItems.academic {
-        header = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:wizard_items.academic
-        after = special
         elements {
             academicprojects_projectlist {
                 iconIdentifier = actions-code-merge

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang_be.xlf
@@ -118,10 +118,6 @@
 
 			<!-- Wizard -->
 
-			<trans-unit id="wizard_items.academic">
-				<source>Academic</source>
-				<target>Akademisch</target>
-			</trans-unit>
 			<trans-unit id="plugin.project_list.name">
 				<source>Projects</source>
 				<target>Projekte</target>

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/locallang_be.xlf
@@ -92,9 +92,6 @@
 
 			<!-- Wizard -->
 
-			<trans-unit id="wizard_items.academic">
-				<source>Academic</source>
-			</trans-unit>
 			<trans-unit id="plugin.project_list.name">
 				<source>Projects</source>
 			</trans-unit>


### PR DESCRIPTION
TCA `tt_content` CTypes group `academic` and the group for
the `newContentElement wizard` has been moved to the new
`EXT:academic_base` and removed from dedicated extensions,
but missed for `EXT:academic_projects`.               

This is now removed with this change along with the matching
translation.