### PR TITLE
[TASK] Fix typo in Site Set TSconfig import path

### DIFF
--- a/packages/fgtclb/academic-base/Configuration/Sets/AcademicBaseCTypeGroup/page.tsconfig
+++ b/packages/fgtclb/academic-base/Configuration/Sets/AcademicBaseCTypeGroup/page.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:academic_/Configuration/TsConfig/Wizards/*.tsconfig'
+@import 'EXT:academic_base/Configuration/TsConfig/Wizards/*.tsconfig'


### PR DESCRIPTION
This commit resolves a typo in the `page.tsconfig` file for the Site Set configuration for TYPO3 v13. The import path for the `academic_base` extension was incorrectly spelled as `academic_`.

This correction ensures that the TSconfig files are properly loaded from the correct extension directory.