### PR TITLE
[TASK] Set missing branch alias for `EXT:academic_base`

### DIFF
--- a/packages/fgtclb/academic-base/composer.json
+++ b/packages/fgtclb/academic-base/composer.json
@@ -24,6 +24,9 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "academic_base"
+        },
+        "branch-alias": {
+            "dev-main": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
This change sets the missing branch alias for the
`EXT:academic_base` to mitigate issues using the
development version in projects.

Used command(s):

```shell
BIN_COMPOSER="$( which composer2-81 )" \
&& ${BIN_COMPOSER} config \
  -d packages/fgtclb/academic-base \
  "extra"."branch-alias"."dev-main" "2.0.x-dev"
```
