### PR TITLE
[TASK] Introduce centralized `FileUploadConverter` implementation

### DIFF
--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,6 +1,21 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$priority\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+
+		-
+			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$sourceTypes\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+
+		-
+			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$targetType\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+
+		-
 			message: "#^Method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php

--- a/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+++ b/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Extbase\Property\TypeConverter;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Http\UploadedFile;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Resource\DuplicationBehavior;
+use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference as CoreFileReference;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\Security\FileNameValidator;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference as ExtbaseFileReference;
+use TYPO3\CMS\Extbase\Error\Error;
+use TYPO3\CMS\Extbase\Property\Exception\TypeConverterException;
+use TYPO3\CMS\Extbase\Property\PropertyMappingConfigurationInterface;
+use TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter;
+
+/**
+ * Provides an extbase type converter to map uploaded files to file reference properties.
+ *
+ * @internal to be used within `EXT:academic_*` extensions only and not part of public API. That means it is
+ *           not covered by breaking policy and semver and can change at any time.
+ *
+ * @todo The implementation is based `EXT:form/Classes/Mvc/Property/TypeConverter/UploadedFileReferenceConverter.php`,
+ *       but the exact version is not known. The implementation differs and misses quite some stuff existing in the
+ *       TYPO3 v12 and v13 implementation, which requires a revisit with deeper investigation along with dedicated
+ *       adoption of these changes.
+ */
+final class FileUploadConverter extends AbstractTypeConverter
+{
+    public const CONFIGURATION_UPLOAD_FOLDER = 'uploadFolder';
+    public const CONFIGURATION_VALIDATION_FILESIZE_MAXIMUM = 'validationFileSizeMaximum';
+    public const CONFIGURATION_VALIDATION_MIME_TYPE_ALLOWED_MIME_TYPES = 'validationMimeTypeAllowedMimeTypes';
+
+    public function __construct(
+        private readonly ResourceFactory $resourceFactory,
+        private readonly LanguageServiceFactory $languageServiceFactory,
+        private readonly LoggerInterface $logger,
+    ) {
+        // @todo Remove method call and method when TYPO3 v12 support is dropped.
+        //       https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-94117-RegisterExtbaseTypeConvertersAsServices.html
+        $this->configureProperties();
+    }
+
+    /**
+     * Actually convert from $source to $targetType, taking into account the fully
+     * built $convertedChildProperties and $configuration.
+     *
+     * @param UploadedFile $source
+     * @param array<string, mixed> $convertedChildProperties
+     */
+    public function convertFrom(
+        $source,
+        string $targetType,
+        array $convertedChildProperties = [],
+        ?PropertyMappingConfigurationInterface $configuration = null
+    ): Error|ExtbaseFileReference|null {
+        if (! $source instanceof UploadedFile) {
+            throw new \RuntimeException(
+                sprintf(
+                    '$source must be instance of "%s"',
+                    UploadedFile::class,
+                ),
+                1756381290,
+            );
+        }
+        $uploadedFileInformation = $source;
+        $targetFolderIdentifier = '1:user_upload/';
+        $maxFileSize = PHP_INT_MAX . 'B';
+        $allowedMimeTypes = '';
+        if ($configuration !== null) {
+            $targetFolderIdentifier = $configuration->getConfigurationValue(
+                self::class,
+                self::CONFIGURATION_UPLOAD_FOLDER,
+            );
+            $maxFileSize = $configuration->getConfigurationValue(
+                self::class,
+                self::CONFIGURATION_VALIDATION_FILESIZE_MAXIMUM,
+            );
+            $allowedMimeTypes = $configuration->getConfigurationValue(
+                self::class,
+                self::CONFIGURATION_VALIDATION_MIME_TYPE_ALLOWED_MIME_TYPES,
+            );
+        }
+
+        if ($uploadedFileInformation->getError() !== \UPLOAD_ERR_OK) {
+            return GeneralUtility::makeInstance(
+                Error::class,
+                $this->getUploadErrorMessage($uploadedFileInformation->getError()),
+                1756373245,
+            );
+        }
+
+        if ($uploadedFileInformation->getClientFilename() === null) {
+            return null;
+        }
+
+        try {
+            $this->validateUploadedFile($uploadedFileInformation, $maxFileSize, $allowedMimeTypes);
+            return $this->importUploadedResource($uploadedFileInformation, $targetFolderIdentifier, $uploadedFileInformation->getClientFilename());
+        } catch (TypeConverterException $e) {
+            return GeneralUtility::makeInstance(
+                Error::class,
+                $e->getMessage(),
+                $e->getCode()
+            );
+        }
+    }
+
+    /**
+     * @throws TypeConverterException
+     */
+    private function importUploadedResource(
+        UploadedFile $uploadedFileInformation,
+        string $targetFolderIdentifier,
+        ?string $targetFileName
+    ): ExtbaseFileReference {
+        if (!GeneralUtility::makeInstance(FileNameValidator::class)->isValid((string)$uploadedFileInformation->getClientFilename())) {
+            throw new TypeConverterException('Uploading files with PHP file extensions is not allowed!', 1753712929);
+        }
+
+        $targetFolder = $this->getOrCreateTargetFolder($targetFolderIdentifier);
+        /** @var File $uploadedFile */
+        $uploadedFile = $targetFolder->getStorage()->addUploadedFile(
+            $uploadedFileInformation,
+            $targetFolder,
+            $targetFileName,
+            DuplicationBehavior::REPLACE
+        );
+
+        return $this->createFileReferenceFromFalFileObject($uploadedFile);
+    }
+
+    /**
+     * @throws TypeConverterException
+     */
+    private function validateUploadedFile(UploadedFile $uploadedFileInformation, string $maxFileSize, string $allowedMimeTypes): void
+    {
+        $languageService = $this->getLanguageService();
+        $maxFileSizeInBytes = GeneralUtility::getBytesFromSizeMeasurement($maxFileSize);
+        $allowedMimeTypesArray = GeneralUtility::trimExplode(',', $allowedMimeTypes);
+
+        if ($uploadedFileInformation->getSize() > $maxFileSizeInBytes) {
+            throw new TypeConverterException(
+                $languageService->sL(
+                    'LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530345'
+                ),
+                1756373506,
+            );
+        }
+
+        if (!in_array($uploadedFileInformation->getClientMediaType(), $allowedMimeTypesArray, true)) {
+            throw new TypeConverterException(
+                sprintf(
+                    $languageService->sL(
+                        'LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:validation.error.1471708998'
+                    ),
+                    $uploadedFileInformation->getClientMediaType()
+                ),
+                1756373500,
+            );
+        }
+    }
+
+    /**
+     * @throws TypeConverterException
+     */
+    private function getOrCreateTargetFolder(string $targetFolderIdentifier): Folder
+    {
+        if (empty($targetFolderIdentifier)) {
+            throw new TypeConverterException(
+                'Missing target upload folder "uploadFolder"  in TypeConverter configuration',
+                1756373407,
+            );
+        }
+
+        try {
+            $uploadFolder = $this->resourceFactory->retrieveFileOrFolderObject($targetFolderIdentifier);
+        } catch (ResourceDoesNotExistException) {
+            $parts = GeneralUtility::trimExplode(':', $targetFolderIdentifier);
+            if (count($parts) === 2) {
+                $storageUid = (int)$parts[0];
+                $folderIdentifier = $parts[1];
+                $uploadFolder = $this->resourceFactory->getStorageObject($storageUid)->createFolder($folderIdentifier);
+            } else {
+                throw new TypeConverterException(
+                    sprintf(
+                        'Target upload folder "%s" does not exist and creation of forbidden by TypeConverter configuration',
+                        $targetFolderIdentifier
+                    ),
+                    1756373399,
+                );
+            }
+        }
+
+        if (!$uploadFolder instanceof Folder) {
+            throw new TypeConverterException(
+                sprintf('Target upload folder "%s" is not accessible', $targetFolderIdentifier),
+                1756373390,
+            );
+        }
+
+        return $uploadFolder;
+    }
+
+    private function createFileReferenceFromFalFileReferenceObject(CoreFileReference $falFileReference): ExtbaseFileReference
+    {
+        $fileReference = GeneralUtility::makeInstance(ExtbaseFileReference::class);
+        $fileReference->setOriginalResource($falFileReference);
+        return $fileReference;
+    }
+
+    private function createFileReferenceFromFalFileObject(File $file): ExtbaseFileReference
+    {
+        $fileReference = $this->resourceFactory->createFileReferenceObject(
+            [
+                'uid_local' => $file->getUid(),
+                'uid_foreign' => StringUtility::getUniqueId('NEW_'),
+                'uid' => StringUtility::getUniqueId('NEW_'),
+                'crop' => null,
+            ]
+        );
+
+        return $this->createFileReferenceFromFalFileReferenceObject($fileReference);
+    }
+
+    /**
+     * Returns a human-readable message for the given PHP file upload error
+     * constant.
+     */
+    protected function getUploadErrorMessage(int $errorCode): string
+    {
+        $languageService = $this->getLanguageService();
+        switch ($errorCode) {
+            case \UPLOAD_ERR_INI_SIZE:
+                $this->logger->error('The uploaded file exceeds the upload_max_filesize directive in php.ini.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530345');
+            case \UPLOAD_ERR_FORM_SIZE:
+                $this->logger->error('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530345');
+            case \UPLOAD_ERR_PARTIAL:
+                $this->logger->error('The uploaded file was only partially uploaded.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530346');
+            case \UPLOAD_ERR_NO_FILE:
+                $this->logger->error('No file was uploaded.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530347');
+            case \UPLOAD_ERR_NO_TMP_DIR:
+                $this->logger->error('Missing a temporary folder.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530348');
+            case \UPLOAD_ERR_CANT_WRITE:
+                $this->logger->error('Failed to write file to disk.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530348');
+            case \UPLOAD_ERR_EXTENSION:
+                $this->logger->error('File upload stopped by extension.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530348');
+            default:
+                $this->logger->error('Unknown upload error.');
+                return $languageService->sL('LLL:EXT:academic_base/Resources/Private/Language/locallang.xlf:upload.error.150530348');
+        }
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        $request = ($GLOBALS['TYPO3_REQUEST'] ?? null);
+        if ($request instanceof ServerRequestInterface && $request->getAttribute('language') instanceof SiteLanguage) {
+            return $this->languageServiceFactory->createFromSiteLanguage($request->getAttribute('language'));
+        }
+        if ($request instanceof ServerRequestInterface && $request->getAttribute('site') instanceof Site) {
+            return $this->languageServiceFactory->createFromSiteLanguage($request->getAttribute('site')->getDefaultLanguage());
+        }
+        return $this->languageServiceFactory->create('default');
+    }
+
+    /**
+     * Set deprecated properties for TYPO3 v12 in cases some code will request deprecated methods to retrieve the
+     * information. Properties are now configured within `EXT:academic_base/Configuration/Services.yaml`.
+     *
+     * @todo Remove method together with call in {@see self::__construct()} when TYPO3 v12 support is dropped.
+     *       https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-94117-RegisterExtbaseTypeConvertersAsServices.html
+     */
+    private function configureProperties(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 13) {
+            $this->sourceTypes = ['array'];
+            $this->targetType = ExtbaseFileReference::class;
+            $this->priority = 10;
+        }
+    }
+}

--- a/packages/fgtclb/academic-base/Configuration/Services.yaml
+++ b/packages/fgtclb/academic-base/Configuration/Services.yaml
@@ -4,7 +4,16 @@ services:
     autoconfigure: true
     public: false
 
-#  FGTCLB\AcademicBase\:
-#    resource: '../Classes/*'
-#    exclude:
-#      - '../Classes/Domain/Model/*'
+  FGTCLB\AcademicBase\:
+    resource: '../Classes/*'
+    exclude:
+      - '../Classes/Domain/Model/*'
+
+  # @internal not part of public API
+  FGTCLB\AcademicBase\Extbase\Property\TypeConverter\FileUploadConverter:
+    tags:
+      - name: extbase.type_converter
+        priority: 10
+        target: TYPO3\CMS\Extbase\Domain\Model\FileReference
+        sources: TYPO3\CMS\Core\Http\UploadedFile
+

--- a/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang.xlf
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file
+		source-language="en"
+		target-language="de"
+		datatype="plaintext"
+		original="EXT:academic_base/Resources/Private/Language/locallang.xlf"
+		date="2023-09-02T12:17:09Z"
+		product-name="academic_base"
+	>
+		<header/>
+		<body>
+			<trans-unit id="upload.error.150530345" xml:space="preserve">
+				<source>Maximum file size exceeded.</source>
+				<target>Maximale Dateigröße erreicht.</target>
+			</trans-unit>
+			<trans-unit id="upload.error.150530346" xml:space="preserve">
+				<source>Upload failed. The file was only partially uploaded, please try again.</source>
+				<target>Hochladen fehlgeschlagen. Die Datei wurde nur teilweise hochgeladen, bitte erneut versuchen.</target>
+			</trans-unit>
+			<trans-unit id="upload.error.150530347" xml:space="preserve">
+				<source>No file was uploaded.</source>
+				<target>Es wurde keine Datei hochgeladen.</target>
+			</trans-unit>
+			<trans-unit id="upload.error.150530348" xml:space="preserve">
+				<source>Upload failed.</source>
+				<target>Hochladen fehlgeschlagen.</target>
+			</trans-unit>
+
+			<trans-unit id="validation.error.1471708998" xml:space="preserve">
+				<source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
+				<target>Ungültiger Medientyp angegeben, "%s" ist nicht erlaubt für diese Datei. Siehe Beschreibung für dieses Feld.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fgtclb/academic-base/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/locallang.xlf
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file
+		source-language="en"
+		datatype="plaintext"
+		original="EXT:academic_base/Resources/Private/Language/locallang.xlf"
+		date="2023-09-02T12:17:09Z"
+		product-name="academic_base"
+	>
+		<header/>
+		<body>
+			<trans-unit id="upload.error.150530345" xml:space="preserve">
+				<source>Maximum file size exceeded.</source>
+			</trans-unit>
+			<trans-unit id="upload.error.150530346" xml:space="preserve">
+				<source>Upload failed. The file was only partially uploaded, please try again.</source>
+			</trans-unit>
+			<trans-unit id="upload.error.150530347" xml:space="preserve">
+				<source>No file was uploaded.</source>
+			</trans-unit>
+			<trans-unit id="upload.error.150530348" xml:space="preserve">
+				<source>Upload failed.</source>
+			</trans-unit>
+
+			<trans-unit id="validation.error.1471708998" xml:space="preserve">
+				<source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/packages/fgtclb/academic-base/Tests/Functional/AbstractAcademicBaseTestCase.php
+++ b/packages/fgtclb/academic-base/Tests/Functional/AbstractAcademicBaseTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Functional;
+
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+
+abstract class AbstractAcademicBaseTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/academic-base',
+    ];
+}

--- a/packages/fgtclb/academic-base/Tests/Functional/Extbase/Property/TypeConverter/FileUploadConverterTest.php
+++ b/packages/fgtclb/academic-base/Tests/Functional/Extbase/Property/TypeConverter/FileUploadConverterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Functional\Extbase\Property\TypeConverter;
+
+use FGTCLB\AcademicBase\Extbase\Property\TypeConverter\FileUploadConverter;
+use FGTCLB\AcademicBase\Tests\Functional\AbstractAcademicBaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\UploadedFile;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\Property\TypeConverterRegistry;
+
+final class FileUploadConverterTest extends AbstractAcademicBaseTestCase
+{
+    #[Test]
+    public function canBeInstanciatedWithGeneralUtilityMakeinstance(): void
+    {
+        $this->assertInstanceOf(
+            FileUploadConverter::class,
+            GeneralUtility::makeInstance(FileUploadConverter::class),
+        );
+    }
+
+    #[Test]
+    public function typeConverterRegistryReturnsFileUploadConverterForUploadedFileSourceAndFileReferenceTarget(): void
+    {
+        $this->assertInstanceOf(
+            FileUploadConverter::class,
+            $this->typeConverterRegistry()->findTypeConverter(UploadedFile::class, FileReference::class)
+        );
+    }
+
+    private function typeConverterRegistry(): TypeConverterRegistry
+    {
+        return $this->get(TypeConverterRegistry::class);
+    }
+}

--- a/packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
+++ b/packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+final class ExtensionLoadedTest extends AbstractAcademicBaseTestCase
+{
+    #[Test]
+    public function testCaseLoadsExtension(): void
+    {
+        $this->assertContains('fgtclb/academic-base', $this->testExtensionsToLoad);
+    }
+
+    #[Test]
+    public function extensionIsLoaded(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('academic_base'));
+    }
+}


### PR DESCRIPTION
Since ages projects and extensions needs to implement a custom
extbase TypeConvert to support file upload in extbase related
forms to be attached as file references to extbase models or
DTO's, enforcing to make adoptions for TYPO3 core changes over
and over again.

With TYPO3 v13 [1] a new system has been introduced to provide
that feature directly, which we cannot use due to the support
of TYPO3 v12 and a backport within a extension is not reasonable
based on the required patches, xclasses and similiar deep within
extbase internal API and class constructs.

The academic extensions implemeted already such a custom type
converter and needs it in more places and is the reason why it
is now implemented in `EXT:academic_base` to have a shared and
reusable implementation across all academic extensions requiring
it until TYPO3 v12 support is dropped and the new TYPO3 v13 way
can be used.

`EXT:academic_person_edit` implementation has been used as the
starting point for this implementation and is modernized and
streamlined in the same way to respect the changed TypeConverter
registration with TYPO3 v12 [2] by making the configuration in
`EXT:academic_base/Configuration/Services.yaml`. Until TYPO3 v12
support can be dropped the implementation calls a internal method
to configure the "same" configuration hardcoded  in case 3rd party
code may call the deprecated methods, not doing so for TYPO3 v13
to avoid phpstan issues regarding property type registrations. [3][4]

Implementing this in `EXT:academic_base` now mitigates code
duplication and reduces maintenance or missing to fix the
same thing in multiple places.

Orignally the implementation has been borrowed from `EXT:forms`
and the code base diverged quite a lot meanwhile. Due to time
constraints the improved development of TYPO3 v12/v13 is not
part of this change and will be investigated in follow ups and
is therefore commented as a todo in the class php-docblock.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Feature-103511-IntroduceExtbaseFileUploadHandling.html
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-94117-ImproveExtbaseTypeConverterRegistration.html
[3] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-94117-RegisterExtbaseTypeConvertersAsServices.html
[4] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-94117-RegisterExtbaseTypeConvertersAsServices.html

Co-authored-by: Stefan Bürk <stefan@buerk.tech>
