### PR TITLE
[TASK] Reduce pipeline usage

### DIFF
--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
+        php-version: [ "8.1", "8.5" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4"]
+        php-version: [ "8.1", "8.4"]
         typo3: ["12"]
     needs: ["code-quality", "linting", "unit"]
     permissions:

--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
+        php-version: [ "8.2", "8.5" ]
         typo3: ["13"]
     permissions:
       # actions: read|write|none
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4"]
+        php-version: [ "8.2", "8.4"]
         typo3: ["13"]
     needs: ["code-quality", "linting", "unit"]
     permissions:


### PR DESCRIPTION
It is more than enough to test with lowest and highest
php-version per TYPO3 version and leaving versions in
between out. The hightst php-version reports and fails
on all issues for not tested version in the range in
general.

That reduces the executed pipeline runs which saves some
resources (green it) and maginally speeds up pull-request
pipeline execution times.
