### PR TITLE
[BUGFIX] Mitigate flexform issues for EXT:academic_persons_edit

### DIFF
--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
@@ -45,7 +45,7 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="=0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.groupBy.items.none</numIndex>
+                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.groupBy.items.none</numIndex>
                             <numIndex index="1"></numIndex>
                         </numIndex>
                     </items>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
@@ -170,7 +170,7 @@
                             <numIndex index="1">table</numIndex>
                         </numIndex>
                     </items>
-                    <default>asc</default>
+                    <default>list</default>
                 </config>
             </settings.viewMode.default>
             <settings.fallbackForNonTranslated>


### PR DESCRIPTION
- **[BUGFIX] Use valid `<numIndex index=""/>` value in flexform**
  The list plugin flexform for TYPO3 v12 includes the invalid
  `<numIndex index="=0"/>" value for `settings.demand.groupBy`
  leading to an exception in the backend with message
  
  ```
  TYPO3\CMS\Core\Schema\Struct\SelectItem::__construct():
  Argument #2 ($label) must be of type string, null given,
  called in vendor/typo3/cms-core/Classes/Schema/Struct/SelectItem.php
  on line 58
  ```
  
  This change replaces invalid `=0` index with `0` index to
  mitigate the issue and to use the value it should be and
  defining a valid flexform structure.
  

- **[BUGFIX] Use suitable default for flexform select field**
  TYPO3 v12 flexform definition declared invalid default
  value for the `settings.viewMode.default`, which does
  not exists in the available items.
  
  This change modifies the flexform definition to declare
  `list` instead of invalid `asc` default value for the
  `settings.viewMode.default` of the TYPO3 v12 flexform
  and matching the TYPO3 v13 flexform definition.
  