### PR TITLE
[TASK] Enrich template variables with content element data

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
+++ b/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
@@ -7,6 +7,7 @@ namespace FGTCLB\AcademicBiteJobs\Controller;
 use FGTCLB\AcademicBiteJobs\Services\BiteJobsService;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class BiteJobsController extends ActionController
 {
@@ -16,11 +17,19 @@ class BiteJobsController extends ActionController
 
     public function listAction(): ResponseInterface
     {
+        $contentElementData = $this->getCurrentContentObjectRenderer()?->data ?? [];
+
         $this->view->assignMultiple([
+            'data' => $contentElementData,
             'jobs' => $this->biteJobsService->fetchBiteJobs($this->request),
             'jobRelations' => $this->biteJobsService->findCustomjobRelations(),
         ]);
 
         return $this->htmlResponse();
+    }
+
+    private function getCurrentContentObjectRenderer(): ?ContentObjectRenderer
+    {
+        return $this->request->getAttribute('currentContentObject');
     }
 }


### PR DESCRIPTION
Sometimes there is the need for rendering informations contained in the content element which delivers the list plugin. This could be headers or layout informations just to name two of them. For ease of use we inject those information into the view variables.

This gives an easy way for rendering those stuff, e.g:
```
<f:render partial="Header/All" arguments="{data}" />
```