### PR TITLE
[TASK] Add missing controller action to plugin registration

### DIFF
--- a/packages/fgtclb/academic-persons-edit/ext_localconf.php
+++ b/packages/fgtclb/academic-persons-edit/ext_localconf.php
@@ -33,6 +33,7 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
             ]),
             ProfileInformationController::class => implode(',', [
                 'list',
+                'show',
                 'new',
                 'create',
                 'edit',


### PR DESCRIPTION
The `show` action for plugine `AcademicPersonsEdit->ProfileEditing`
is missing in the corresponding plugin configuraiton for extension
`EXT:academic_persons_edit`. This is added now.
