### PR TITLE
[BUGFIX] Use working configuration for `sorting` fields

### DIFF
--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
@@ -47,6 +47,7 @@ $tcaConfiguration = [
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_address',
         ],
+        'sortby' => 'sorting',
     ],
     'columns' => [
         'hidden' => [
@@ -93,8 +94,9 @@ $tcaConfiguration = [
             ],
         ],
         'sorting' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.sorting.label',
             'config' => [
-                'type' => 'none',
+                'type' => 'passthrough',
             ],
         ],
         'contract' => [

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -33,6 +33,7 @@ $tcaConfiguration = [
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_contract',
         ],
+        'sortby' => 'sorting',
     ],
     'columns' => [
         'hidden' => [
@@ -83,7 +84,7 @@ $tcaConfiguration = [
         'sorting' => [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.sorting.label',
             'config' => [
-                'type' => 'none',
+                'type' => 'passthrough',
             ],
         ],
         'profile' => [

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
@@ -33,6 +33,7 @@ $tcaConfiguration = [
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_email',
         ],
+        'sortby' => 'sorting',
     ],
     'columns' => [
         'hidden' => [
@@ -79,8 +80,9 @@ $tcaConfiguration = [
             ],
         ],
         'sorting' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.sorting.label',
             'config' => [
-                'type' => 'none',
+                'type' => 'passthrough',
             ],
         ],
         'contract' => [

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
@@ -35,6 +35,7 @@ $tcaConfiguration = [
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_phone_number',
         ],
+        'sortby' => 'sorting',
     ],
     'columns' => [
         'hidden' => [
@@ -81,8 +82,9 @@ $tcaConfiguration = [
             ],
         ],
         'sorting' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.sorting.label',
             'config' => [
-                'type' => 'none',
+                'type' => 'passthrough',
             ],
         ],
         'contract' => [

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
@@ -35,6 +35,7 @@ $tcaConfiguration = [
         'typeicon_classes' => [
             'default' => 'tx_academicpersons_domain_model_profile_information',
         ],
+        'sortby' => 'sorting',
     ],
     'columns' => [
         'hidden' => [
@@ -149,6 +150,12 @@ $tcaConfiguration = [
                 'type' => 'number',
                 'min' => 0,
                 'max' => 9999,
+            ],
+        ],
+        'sorting' => [
+            'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.sorting.label',
+            'config' => [
+                'type' => 'passthrough',
             ],
         ],
     ],


### PR DESCRIPTION
TYPO3 provides the ability for a dedicated sorting field,
which can be configured using `TCA->ctrl->sortBy` config.
Tables configured with that fields get's automatically a
sorting fields, either directly and also for the relation
and handles this automatically when DataHandler is used.

Even if the field is configured in `ext_tables.sql` and
the extbase domain model has a property `sorting` along
with the getter/setter, reading and persisting the data
does not work out of the box. For a working state it's
mandantory that a column is configured in TCA and due
to the nature it should be `TCAtype=passthrough`.

No table of `EXT:academic_persons` configured `sortBy`
TCA control configuration and most of them even not
the column. Some had a column, but of TCAtype=`none`
which is even worser as that means that there will be
no automatic persistance handling at all.

To mitigate issues due to the missing configuration,
this change:

* Adds `TCA->ctrl->sortBy` configuration for all tables.
* Adds `TCA->columns` column for the sorting field with
  `TCAtype=passthrough`, which includes adopting it for
  existing `TCAtype=none` fields.

No rule without excamption, which means that following
tables are not adjusted because sorting fields does
not make much sense for them:

* `tx_academicpersons_domain_model_function_type`
* `tx_academicpersons_domain_model_location`
* `tx_academicpersons_domain_model_organisational_unit`
* `tx_academicpersons_domain_model_profile`

> [!NOTE]
> The configuration made with this change is elementary
> to have the ability to resort entries using extbase
> domain models, which would not be possible otherwise.
