### PR TITLE
[BUGFIX] Add missing delete confirmation template

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Contract/ConfirmDelete.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Contract/ConfirmDelete.html
@@ -1,0 +1,21 @@
+<html
+    lang="en"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+    <f:layout name="Default" />
+    <f:section name="Main">
+        <h1>Delete contract</h1>
+        <p>
+            Do you really want to delete the contract<br />
+            "{contract.position} / {contract.validFrom -> f:format.date(format: 'd.m.Y')} / {contract.validTo -> f:format.date(format: 'd.m.Y')} / {contract.organisationalUnit.unitName} / {contract.functionType.functionName} "?
+        </p>
+        <f:render
+            partial="Buttons/DeleteCancel"
+            arguments="{
+                deleteUrl: '{f:uri.action(action: \'delete\', arguments: \'{contract: contract}\')}',
+                cancelUrl: cancelUrl
+            }"
+        />
+    </f:section>
+</html>


### PR DESCRIPTION
The fluid template for the contract deletion confirmation
does not exists and is now added in a raw form, not using
translation for now.

Usually translation **must** be done directly and still
we make a examption here due to the fact that reworking
the complete `EXT:academic_persons_edit` templates is
already scheduled and in the making including finishing
the translation.

This change is done in that way to have a working state
for development/testing purpose.
