### PR TITLE
[BUGFIX] Set `enctype="multipart/form-data"` for image upload form

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/EditImage.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/EditImage.html
@@ -28,6 +28,7 @@
                     action="addImage"
                     name="profile"
                     object="{profile}"
+                    enctype="multipart/form-data"
                 >
                     <f:form.validationResults for="profile.image">
                         <f:if condition="{validationResults.flattenedErrors}">


### PR DESCRIPTION
It's important to use the correct form enctype for HTML, otherwise
files are not properly uploaded and handled by PHP and TYPO3. This
has been missed for `EXT:academic_persons_edit` upload form and is
now set to ensure working file upload.
