### PR TITLE
[BUGFIX] ACE-33: Add missing `Repository->findAll()` to repositories

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/AddressRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/AddressRepository.php
@@ -12,9 +12,23 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Domain\Repository;
 
 use FGTCLB\AcademicPersons\Domain\Model\Address;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<Address>
  */
-class AddressRepository extends Repository {}
+class AddressRepository extends Repository
+{
+    /**
+     * @return QueryResultInterface<int, Address>
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ContractRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ContractRepository.php
@@ -22,6 +22,18 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 class ContractRepository extends Repository
 {
     /**
+     * @return QueryResultInterface<int, Contract>
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+
+    /**
      * @param int[] $uids
      * @return QueryResultInterface<int, Contract>
      */

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/EmailRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/EmailRepository.php
@@ -12,9 +12,23 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Domain\Repository;
 
 use FGTCLB\AcademicPersons\Domain\Model\Email;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<Email>
  */
-class EmailRepository extends Repository {}
+class EmailRepository extends Repository
+{
+    /**
+     * @return QueryResultInterface<int, Email>
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/FunctionTypeRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/FunctionTypeRepository.php
@@ -26,6 +26,8 @@ class FunctionTypeRepository extends Repository
     public function findAll(): QueryResultInterface
     {
         $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
         $query->getQuerySettings()->setRespectStoragePage(false);
         return $query->execute();
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/LocationRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/LocationRepository.php
@@ -12,9 +12,23 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Domain\Repository;
 
 use FGTCLB\AcademicPersons\Domain\Model\Location;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<Location>
  */
-class LocationRepository extends Repository {}
+class LocationRepository extends Repository
+{
+    /**
+     * @return QueryResultInterface<int, Location>
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/OrganisationalUnitRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/OrganisationalUnitRepository.php
@@ -26,6 +26,8 @@ class OrganisationalUnitRepository extends Repository
     public function findAll(): QueryResultInterface
     {
         $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
         $query->getQuerySettings()->setRespectStoragePage(false);
         return $query->execute();
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/PhoneNumberRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/PhoneNumberRepository.php
@@ -12,9 +12,23 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Domain\Repository;
 
 use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<PhoneNumber>
  */
-class PhoneNumberRepository extends Repository {}
+class PhoneNumberRepository extends Repository
+{
+    /**
+     * @return QueryResultInterface<int, PhoneNumber>
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileInformationRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileInformationRepository.php
@@ -24,6 +24,18 @@ class ProfileInformationRepository extends Repository
     /**
      * @return QueryResultInterface<int, ProfileInformation>
      */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+
+    /**
+     * @return QueryResultInterface<int, ProfileInformation>
+     */
     public function findByProfileAndType(Profile $profile, string $type): QueryResultInterface
     {
         $query = $this->createQuery();

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
@@ -39,6 +39,18 @@ class ProfileRepository extends Repository
     /**
      * @return QueryResultInterface<int, Profile>
      */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        // @todo Completely ignoring storage pages is a bad design, special for multi site instances.
+        //       Needs a better way to deal with this hear and in other places.
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+
+    /**
+     * @return QueryResultInterface<int, Profile>
+     */
     public function findByDemand(DemandInterface $demand): QueryResultInterface
     {
         $query = $this->createQuery();


### PR DESCRIPTION
Some repositories already implemented `findAll()` on
their own to ignore storage pages by using following
query setting:

```php
// extbase query
$query = $this->createQuery();
$query->getQuerySettings()->setRespectStoragePage(false);
```

That helps in the plugins to get selectable data, for
example with the frontend edit forms provided by the
`EXT:academic_persons_edit`.

In general, that is not a good solution and we need to
come up with a general working and better approach for
it, but to mitigate some issues within the form handling
of `EXT:academic_persons_edit` we apply the same code
fragment by either adding the `findAll()` method or
adjusting it to the remaining repository implementations.
