### PR TITLE
[BUGFIX] ACE-33: Assign available locations in `ContractController->editAction()`

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -123,6 +123,7 @@ final class ContractController extends AbstractActionController
             'contractFormData' => ContractFormData::createFromContract($contract),
             'functionTypes' => $this->functionTypeRepository->findAll(),
             'organisationalUnits' => $this->organisationalUnitRepository->findAll(),
+            'locations' => $this->locationRepository->findAll(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('contract')->validations,
         ]);

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Contract/Edit.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Contract/Edit.html
@@ -26,6 +26,7 @@
                     contract: contractFormData,
                     functionTypes: functionTypes,
                     organisationalUnits: organisationalUnits,
+                    locations: locations,
                     validations: validations
                 }"
             />


### PR DESCRIPTION
Locations are relations to contracts, albeit only one can be selected,
which requires that the `EXT:academic_persons_edit` edit form needs
to display them and requires that the lookup items exists in the
fluid template scope.

Passing available locations in `ContractController` has been added
recently, but two things has been missed:

* Assigning available locations are not done in `editAction()`,
  only in `newAction()`. This is now corrected.
* Assigned location variable has not passed down to the responsible
  partial template rendering the location select, which is corrected
  now.
