### PR TITLE
[BUGFIX] ACE-33: Display available genders as select field

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/Profile.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/Profile.html
@@ -3,14 +3,18 @@
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
     data-namespace-typo3-fluid="true"
 >
-
     <f:render
-        partial="Forms/Textfield"
+        partial="Forms/Select"
         arguments="{
             element: {
                 form: 'profile',
                 identifier: 'gender',
-                validations: validations
+                options: genderOptions,
+                optionValueField: 'value',
+                optionLabelField: 'label',
+                prependOptionValue: '',
+                prependOptionLabel: '---',
+                validations: validations,
             }
         }"
     />

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/Edit.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/Edit.html
@@ -45,7 +45,11 @@
             />
             <f:render
                 partial="Properties/Profile"
-                arguments="{profile: profileFormData, validations: validations}"
+                arguments="{
+                    profile: profileFormData,
+                    genderOptions: genderOptions,
+                    validations: validations,
+                }"
             />
             <f:render
                 partial="Buttons/SaveExitCancel"


### PR DESCRIPTION
The `Profile->gender` field is defined as `TCAtype=select`
with a defined set of available options already used for
TYPO3 Backend data management, but the implementation for
`EXT:academic_persons_edit` frontend form handling used
a simple text input field diverting FE and BE handling.

This change alignes FE and BE handling with:

* Available genders are read from the TCA definition of
  the `Profile->gender` field, only respecting simply
  items and not evaluating itemProcFunc or mirroring
  custom `FormEngine` node handling and proccessing.

* Pass the available genders down and render `gender`
  field as select box now.

Note that server side validation of selected gender
against available genders are not processed yet and
will be considerd and/or implemented in a dedicated
change.
