### PR TITLE
[TASK] ACE-33: Add `post-redirect-get(PRG)` for form persisting actions

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -21,7 +21,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Factory\ContractFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -104,10 +103,9 @@ final class ContractController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['contract' => $contract]);
+        return $this->createFormPersistencePrgRedirect('edit', ['contract' => $contract]);
     }
 
     // =================================================================================================================
@@ -146,8 +144,7 @@ final class ContractController extends AbstractActionController
         ) {
             return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['contract' => $contract]);
+        return $this->createFormPersistencePrgRedirect('edit', ['contract' => $contract]);
     }
 
     public function sortAction(Contract $contract, string $sortDirection): ResponseInterface
@@ -165,7 +162,7 @@ final class ContractController extends AbstractActionController
             || $profile->getContracts()->count() <= 1
         ) {
             $this->addTranslatedErrorMessage('contracts.sort.error.notPossible');
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
 
         // Convert contracts to array
@@ -201,8 +198,7 @@ final class ContractController extends AbstractActionController
                 break;
             }
         }
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     // =================================================================================================================
@@ -222,6 +218,6 @@ final class ContractController extends AbstractActionController
     {
         $this->contractRepository->remove($contract);
         $this->addTranslatedSuccessMessage('contracts.success.delete.done');
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -20,7 +20,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\EmailFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Extbase\Annotation\Validate;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -101,10 +100,9 @@ final class EmailAddressController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['emailAddress' => $emailAddress]);
+        return $this->createFormPersistencePrgRedirect('edit', ['emailAddress' => $emailAddress]);
     }
 
     // =================================================================================================================
@@ -146,10 +144,9 @@ final class EmailAddressController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['emailAddress' => $emailAddress]);
+        return $this->createFormPersistencePrgRedirect('edit', ['emailAddress' => $emailAddress]);
     }
 
     public function sortAction(Email $emailAddress, string $sortDirection): ResponseInterface
@@ -167,7 +164,7 @@ final class EmailAddressController extends AbstractActionController
             || $contract->getEmailAddresses()->count() <= 1
         ) {
             $this->addTranslatedErrorMessage('emailAddress.sort.error.notPossible');
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
 
         // Convert contracts to array
@@ -204,7 +201,7 @@ final class EmailAddressController extends AbstractActionController
             }
         }
 
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     // =================================================================================================================
@@ -227,6 +224,6 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->emailAddressRepository->remove($emailAddress);
         $this->addTranslatedSuccessMessage('emailAddress.success.delete.done');
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -18,7 +18,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Factory\PhoneNumberFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -44,7 +43,6 @@ final class PhoneNumberController extends AbstractActionController
             'contract' => $contract,
             'phoneNumbers' => $contract->getPhoneNumbers(),
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -58,7 +56,6 @@ final class PhoneNumberController extends AbstractActionController
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -76,7 +73,6 @@ final class PhoneNumberController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('phoneNumber')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -102,10 +98,9 @@ final class PhoneNumberController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['phoneNumber' => $phoneNumber]);
+        return $this->createFormPersistencePrgRedirect('edit', ['phoneNumber' => $phoneNumber]);
     }
 
     // =================================================================================================================
@@ -123,7 +118,6 @@ final class PhoneNumberController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('phoneNumber')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -144,10 +138,9 @@ final class PhoneNumberController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['phoneNumber' => $phoneNumber]);
+        return $this->createFormPersistencePrgRedirect('edit', ['phoneNumber' => $phoneNumber]);
     }
 
     public function sortAction(PhoneNumber $phoneNumber, string $sortDirection): ResponseInterface
@@ -165,7 +158,7 @@ final class PhoneNumberController extends AbstractActionController
             || $contract->getPhoneNumbers()->count() <= 1
         ) {
             $this->addTranslatedErrorMessage('phoneNumber.sort.error.notPossible');
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
 
         // Convert contracts to array
@@ -201,8 +194,7 @@ final class PhoneNumberController extends AbstractActionController
                 break;
             }
         }
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     // =================================================================================================================
@@ -218,7 +210,6 @@ final class PhoneNumberController extends AbstractActionController
             'phoneNumber' => $phoneNumber,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -226,6 +217,6 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->phoneNumberRepository->remove($phoneNumber);
         $this->addTranslatedSuccessMessage('phoneNumber.success.delete.done');
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -20,7 +20,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\AddressFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Extbase\Annotation\Validate;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -46,7 +45,6 @@ final class PhysicalAddressController extends AbstractActionController
             'contract' => $contract,
             'physicalAddresses' => $contract->getPhysicalAddresses(),
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -60,7 +58,6 @@ final class PhysicalAddressController extends AbstractActionController
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -78,7 +75,6 @@ final class PhysicalAddressController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('physicalAddress')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -104,10 +100,9 @@ final class PhysicalAddressController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['physicalAddress' => $physicalAddress]);
+        return $this->createFormPersistencePrgRedirect('edit', ['physicalAddress' => $physicalAddress]);
     }
 
     // =================================================================================================================
@@ -125,7 +120,6 @@ final class PhysicalAddressController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('physicalAddress')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -150,10 +144,9 @@ final class PhysicalAddressController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['physicalAddress' => $physicalAddress]);
+        return $this->createFormPersistencePrgRedirect('edit', ['physicalAddress' => $physicalAddress]);
     }
 
     public function sortAction(Address $physicalAddress, string $sortDirection): ResponseInterface
@@ -171,7 +164,7 @@ final class PhysicalAddressController extends AbstractActionController
             || $contract->getPhysicalAddresses()->count() <= 1
         ) {
             $this->addTranslatedErrorMessage('contracts.sort.error.notPossible');
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
 
         // Convert contracts to array
@@ -207,8 +200,7 @@ final class PhysicalAddressController extends AbstractActionController
                 break;
             }
         }
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     // =================================================================================================================
@@ -224,16 +216,13 @@ final class PhysicalAddressController extends AbstractActionController
             'physicalAddress' => $physicalAddress,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);
-
         return $this->htmlResponse();
     }
 
     public function deleteAction(Address $physicalAddress): ResponseInterface
     {
         $this->addressRepository->remove($physicalAddress);
-
         $this->addTranslatedSuccessMessage('physicalAddress.success.delete.done');
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -19,7 +19,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -76,7 +75,6 @@ final class ProfileController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('profile')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -97,10 +95,9 @@ final class ProfileController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['profile' => $profile]);
+        return $this->createFormPersistencePrgRedirect('edit', ['profile' => $profile]);
     }
 
     // =================================================================================================================
@@ -127,7 +124,6 @@ final class ProfileController extends AbstractActionController
             'profile' => $profile,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -156,8 +152,7 @@ final class ProfileController extends AbstractActionController
     {
         $this->profileRepository->update($profile);
         $this->persistenceManager->persistAll();
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     public function removeImageAction(Profile $profile): ResponseInterface
@@ -167,8 +162,7 @@ final class ProfileController extends AbstractActionController
             $imageFile = $image->getOriginalResource()->getOriginalFile();
             $imageFile->getStorage()->deleteFile($imageFile);
         }
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     private function buildProfileImageNameWithoutExtension(int $profileUid): string

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -18,7 +18,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileInformationFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -47,7 +46,6 @@ final class ProfileInformationController extends AbstractActionController
             'type' => $type,
             'profileInformations' => $profile->_getProperty($type),
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -61,7 +59,6 @@ final class ProfileInformationController extends AbstractActionController
             'type' => $profileInformation->getType(),
             'profileInformation' => $profileInformation,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -113,10 +110,9 @@ final class ProfileInformationController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['profileInformation' => $profileInformation]);
+        return $this->createFormPersistencePrgRedirect('edit', ['profileInformation' => $profileInformation]);
     }
 
     // =================================================================================================================
@@ -133,7 +129,6 @@ final class ProfileInformationController extends AbstractActionController
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('profileInformation')->validations,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -154,10 +149,9 @@ final class ProfileInformationController extends AbstractActionController
         if ($this->request->hasArgument('submit')
             && $this->request->getArgument('submit') === 'save-and-close'
         ) {
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
-
-        return (new ForwardResponse('edit'))->withArguments(['profileInformation' => $profileInformation]);
+        return $this->createFormPersistencePrgRedirect('edit', ['profileInformation' => $profileInformation]);
     }
 
     /**
@@ -182,7 +176,7 @@ final class ProfileInformationController extends AbstractActionController
             || $sortingItems->count() <= 1
         ) {
             $this->addTranslatedErrorMessage('profileInformations.sort.error.notPossible');
-            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+            return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
         }
 
         // Convert profile informations to array
@@ -218,8 +212,7 @@ final class ProfileInformationController extends AbstractActionController
                 break;
             }
         }
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 
     // =================================================================================================================
@@ -234,16 +227,13 @@ final class ProfileInformationController extends AbstractActionController
             'profileInformation' => $profileInformation,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);
-
         return $this->htmlResponse();
     }
 
     public function deleteAction(ProfileInformation $profileInformation): ResponseInterface
     {
         $this->profileInformationRepository->remove($profileInformation);
-
         $this->addTranslatedSuccessMessage('profileInformation.success.delete.done');
-
-        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request));
+        return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }
 }


### PR DESCRIPTION
It is good practice to use `POST`, `PUT`, `PATCH` and `DELETE`
http verbs (methods) for sending data to be persisted removing
them from server logs and mitigate simple get argument attacks
and link phishing.

That leads to a nifty side-effect that reloading the submitted
page will resend the data and perists it again or trying to
delete it, which seems to be reason to use `ForwardResponses()`
. This kind of response is a special implementation of TYPO3
Extbase MVC and only reroutes the request internally hidden
from clients, for example browsers.

The general technique to mitigate these kind of issues is called
`post-redirect-get` or in short `PRG`, which describes basically
that a POST request returns a redirect response to the same uri
using GET and discarding submitted data along with the original
request [1].

This change implements PRG now for `EXT:academic_persons_edit`
actions dealing with data persistance or manipulation to send
a redirect response instead of forwarding internally.

We Use `303 - see other` status code which is considerable the
semantically correct status code to tell the browser / client
to redirect to another uri and discard the POST data and not
sending it along with the redirect), which is what we want for
a `post-redirect-get (PRG)` implementation.

The same status code is also used for other redirect responses
within these controllers instead of `302` to follow semantic
correcet status code usage.

[1] https://en.ryte.com/wiki/Post-Redirect-Get/
