### PR TITLE
[BUGFIX] ACE-33: Render `type` select options for address, email and phonenumber

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -18,6 +18,7 @@ use FGTCLB\AcademicPersonsEdit\Domain\Factory\PhoneNumberFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -68,6 +69,7 @@ final class PhoneNumberController extends AbstractActionController
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
+            'availableTypes' => $this->getAvailableTypes(),
             'contract' => $contract,
             'phoneNumberFormData' => $phoneNumberFormData ?? new PhoneNumberFormData(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
@@ -112,6 +114,7 @@ final class PhoneNumberController extends AbstractActionController
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $phoneNumber->getContract()?->getProfile(),
+            'availableTypes' => $this->getAvailableTypes(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
             'phoneNumberFormData' => PhoneNumberFormData::createFromPhoneNumber($phoneNumber),
@@ -218,5 +221,53 @@ final class PhoneNumberController extends AbstractActionController
         $this->phoneNumberRepository->remove($phoneNumber);
         $this->addTranslatedSuccessMessage('phoneNumber.success.delete.done');
         return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
+    }
+
+    /**
+     * @return array<int<0, max>, array{
+     *      label: string,
+     *      value: string,
+     *  }>
+     * @todo Evaluating TCA in frontend for available options is a hard task to do correctly requiring to execute
+     *       TCA item proc functions and so on. It also does not account for eventually FormEngine nodes processing
+     *       additional stuff. Current implementation calls the itemProcFunc with a minimal set as context data, but
+     *       cannot simulate all the stuff provided by FormEngine.
+     * @todo Use TcaSchema for TYPO3 v13, either as dual version OR when dropping TYPO3 v12 support.
+     */
+    private function getAvailableTypes(): array
+    {
+        $tableName = 'tx_academicpersons_domain_model_phone_number';
+        $fieldName = 'type';
+        $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+        $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemProcFunc !== '') {
+            $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+            $processorParameters = [
+                'items' => &$items,
+                'config' => $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config'],
+                'table' => $tableName,
+                'field' => $fieldName,
+            ];
+            GeneralUtility::callUserFunction($itemProcFunc, $processorParameters, $this);
+            $items = $processorParameters['items'];
+        }
+        $returnItems = [];
+        foreach ($items as $item) {
+            $itemValue = (string)($item['value'] ?? '');
+            if ($itemValue === '') {
+                // Skip empty string values, handled with `<f:form.select prependOptionLabel="---" />`
+                // in the fluid template.
+                continue;
+            }
+            $labelIdentifier = (string)($item['label'] ?? '');
+            $returnItems[] = [
+                'label' => ($this->localizationUtility->translate(
+                    $labelIdentifier,
+                    'persons_edit',
+                ) ?? $labelIdentifier) ?: $labelIdentifier,
+                'value' => $itemValue,
+            ];
+        }
+        return $returnItems;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -19,6 +19,7 @@ use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AddressFormData;
 use FGTCLB\AcademicPersonsEdit\Domain\Validator\AddressFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
@@ -72,6 +73,7 @@ final class PhysicalAddressController extends AbstractActionController
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'addressFormData' => $addressFormData ?? new AddressFormData(),
+            'availableTypes' => $this->getAvailableTypes(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('physicalAddress')->validations,
         ]);
@@ -116,6 +118,7 @@ final class PhysicalAddressController extends AbstractActionController
             'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
+            'availableTypes' => $this->getAvailableTypes(),
             'addressFormData' => AddressFormData::createFromAddress($physicalAddress),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('physicalAddress')->validations,
@@ -224,5 +227,53 @@ final class PhysicalAddressController extends AbstractActionController
         $this->addressRepository->remove($physicalAddress);
         $this->addTranslatedSuccessMessage('physicalAddress.success.delete.done');
         return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
+    }
+
+    /**
+     * @return array<int<0, max>, array{
+     *      label: string,
+     *      value: string,
+     *  }>
+     * @todo Evaluating TCA in frontend for available options is a hard task to do correctly requiring to execute
+     *       TCA item proc functions and so on. It also does not account for eventually FormEngine nodes processing
+     *       additional stuff. Current implementation calls the itemProcFunc with a minimal set as context data, but
+     *       cannot simulate all the stuff provided by FormEngine.
+     * @todo Use TcaSchema for TYPO3 v13, either as dual version OR when dropping TYPO3 v12 support.
+     */
+    private function getAvailableTypes(): array
+    {
+        $tableName = 'tx_academicpersons_domain_model_address';
+        $fieldName = 'type';
+        $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+        $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemProcFunc !== '') {
+            $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+            $processorParameters = [
+                'items' => &$items,
+                'config' => $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config'],
+                'table' => $tableName,
+                'field' => $fieldName,
+            ];
+            GeneralUtility::callUserFunction($itemProcFunc, $processorParameters, $this);
+            $items = $processorParameters['items'];
+        }
+        $returnItems = [];
+        foreach ($items as $item) {
+            $itemValue = (string)($item['value'] ?? '');
+            if ($itemValue === '') {
+                // Skip empty string values, handled with `<f:form.select prependOptionLabel="---" />`
+                // in the fluid template.
+                continue;
+            }
+            $labelIdentifier = (string)($item['label'] ?? '');
+            $returnItems[] = [
+                'label' => ($this->localizationUtility->translate(
+                    $labelIdentifier,
+                    'persons_edit',
+                ) ?? $labelIdentifier) ?: $labelIdentifier,
+                'value' => $itemValue,
+            ];
+        }
+        return $returnItems;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Lists/EmailAddresses.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Lists/EmailAddresses.html
@@ -4,7 +4,7 @@
     data-namespace-typo3-fluid="true"
 >
     <f:link.action
-        controller="PhoneNumber"
+        controller="EmailAddress"
         action="new"
         arguments="{contract: contract}"
         class="btn btn-primary"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/EmailAddress.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/EmailAddress.html
@@ -14,11 +14,16 @@
         }"
     />
     <f:render
-        partial="Forms/Textfield"
+        partial="Forms/Select"
         arguments="{
             element: {
                 form: 'emailAddress',
                 identifier: 'type',
+                options: availableTypes,
+                optionValueField: 'value',
+                optionLabelField: 'label',
+                prependOptionValue: '',
+                prependOptionLabel: '---',
                 validations: validations
             }
         }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/PhoneNumber.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/PhoneNumber.html
@@ -14,11 +14,16 @@
         }"
     />
     <f:render
-        partial="Forms/Textfield"
+        partial="Forms/Select"
         arguments="{
             element: {
                 form: 'phoneNumber',
                 identifier: 'type',
+                options: availableTypes,
+                optionValueField: 'value',
+                optionLabelField: 'label',
+                prependOptionValue: '',
+                prependOptionLabel: '---',
                 validations: validations
             }
         }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/PhysicalAddress.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Properties/PhysicalAddress.html
@@ -74,11 +74,16 @@
         }"
     />
     <f:render
-        partial="Forms/Textfield"
+        partial="Forms/Select"
         arguments="{
             element: {
                 form: 'physicalAddress',
                 identifier: 'type',
+                options: availableTypes,
+                optionValueField: 'value',
+                optionLabelField: 'label',
+                prependOptionValue: '',
+                prependOptionLabel: '---',
                 validations: validations
             }
         }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/EmailAddress/Edit.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/EmailAddress/Edit.html
@@ -23,6 +23,7 @@
             <f:render
                 partial="Properties/EmailAddress"
                 arguments="{
+                    availableTypes: availableTypes,
                     emailAddress: emailAddressFormData,
                     validations: validations
                 }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/EmailAddress/New.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/EmailAddress/New.html
@@ -12,16 +12,18 @@
         />
         <f:form
             action="create"
-            name="emailAddress"
-            object="{emailAddress}"
+            name="emailAddressFormData"
+            object="{emailAddressFormData}"
+            arguments="{contract: contract}"
         >
             <f:render
                 partial="Buttons/SaveExitCancel"
                 arguments="{cancelUrl: cancelUrl}"
             />
             <f:render
-                partial="Properties/PhoneNumber"
+                partial="Properties/EmailAddress"
                 arguments="{
+                    availableTypes: availableTypes,
                     emailAddress: emailAddress,
                 }"
             />

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhoneNumber/Edit.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhoneNumber/Edit.html
@@ -23,6 +23,7 @@
             <f:render
                 partial="Properties/PhoneNumber"
                 arguments="{
+                    availableTypes: availableTypes,
                     phoneNumber: phoneNumberFormData,
                     validations: validations
                 }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhoneNumber/New.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhoneNumber/New.html
@@ -23,6 +23,7 @@
             <f:render
                 partial="Properties/PhoneNumber"
                 arguments="{
+                    availableTypes: availableTypes,
                     phoneNumber: phoneNumberFormData,
                     validations: validations
                 }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhysicalAddress/Edit.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhysicalAddress/Edit.html
@@ -23,6 +23,7 @@
             <f:render
                 partial="Properties/PhysicalAddress"
                 arguments="{
+                    availableTypes: availableTypes,
                     physicalAddress: addressFormData,
                     validations: validations
                 }"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhysicalAddress/New.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/PhysicalAddress/New.html
@@ -23,6 +23,7 @@
             <f:render
                 partial="Properties/PhysicalAddress"
                 arguments="{
+                    availableTypes: availableTypes,
                     physicalAddress: addressFormData,
                     validations: validations
                 }"


### PR DESCRIPTION
`EXT:academic_persons` entity `Contracts` contains following
the relation data fields:

* email_addresses
* phone_numbers
* physical_address

`EXT:academic_persons_edit` is responsible to provide edit
capabilities to the fronted and displays CRUD handling for
these sub entities related to `contracts` rendering the
`type` field as `text input field`. That diverges from the
TCA configuration used for backend FormEngine rendering and
make not much sense in this form.

To streamline the edit behaviour for these fields, this change:

* Enrichres related controllers to resolve the type select items
  reading the TCA items **and** dispatching the **itemsProcFunc**
  with simplified context. That may need further improvements in
  the future.

* Resolves type select items are assigned to new/edit actions of
  the corresponding controller implementation to pass lookup data
  to the view.

* Fluid templates are adjusted to pass the lookup data for `type`
  down to the required partials.

* Fluid templates are adjusted to render a select field instead
  of a text input field for the `type` field now.

* Link generation for the `new email` button now uses the correct
  controller and therefor generation the correct link.
