### PR TITLE
[BUGFIX] ACE-33: Ensure that validation are used for persisting actions

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -19,8 +19,10 @@ use FGTCLB\AcademicPersons\Domain\Repository\LocationRepository;
 use FGTCLB\AcademicPersons\Domain\Repository\OrganisationalUnitRepository;
 use FGTCLB\AcademicPersonsEdit\Domain\Factory\ContractFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ContractFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -81,6 +83,10 @@ final class ContractController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'contractFormData',
+        'validator' => ContractFormDataValidator::class,
+    ])]
     public function createAction(Profile $profile, ContractFormData $contractFormData): ResponseInterface
     {
         $contract = $this->contractFactory->createFromFormData(
@@ -128,6 +134,10 @@ final class ContractController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'contractFormData',
+        'validator' => ContractFormDataValidator::class,
+    ])]
     public function updateAction(Contract $contract, ContractFormData $contractFormData): ResponseInterface
     {
         $this->contractRepository->update(

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -80,6 +80,10 @@ final class EmailAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'emailAddressFormData',
+        'validator' => EmailFormDataValidator::class,
+    ])]
     public function createAction(Contract $contract, EmailFormData $emailAddressFormData): ResponseInterface
     {
         $emailAddress = $this->emailAddressFactory->createFromFormData(

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -16,9 +16,11 @@ use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
 use FGTCLB\AcademicPersons\Domain\Repository\PhoneNumberRepository;
 use FGTCLB\AcademicPersonsEdit\Domain\Factory\PhoneNumberFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\PhoneNumberFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -78,6 +80,10 @@ final class PhoneNumberController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'phoneNumberFormData',
+        'validator' => PhoneNumberFormDataValidator::class,
+    ])]
     public function createAction(Contract $contract, PhoneNumberFormData $phoneNumberFormData): ResponseInterface
     {
         $phoneNumber = $this->phoneNumberFactory->createFromFormData(
@@ -124,6 +130,10 @@ final class PhoneNumberController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'phoneNumberFormData',
+        'validator' => PhoneNumberFormDataValidator::class,
+    ])]
     public function updateAction(
         PhoneNumber $phoneNumber,
         PhoneNumberFormData $phoneNumberFormData

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -80,6 +80,10 @@ final class PhysicalAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'addressFormData',
+        'validator' => AddressFormDataValidator::class,
+    ])]
     public function createAction(Contract $contract, AddressFormData $addressFormData): ResponseInterface
     {
         $physicalAddress = $this->addressFactory->createFromFormData(

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -16,9 +16,11 @@ use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
 use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -79,10 +81,12 @@ final class ProfileController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    public function updateAction(
-        Profile $profile,
-        ProfileFormData $profileFormData
-    ): ResponseInterface {
+    #[Validate([
+        'param' => 'profileFormData',
+        'validator' => ProfileFormDataValidator::class,
+    ])]
+    public function updateAction(Profile $profile, ProfileFormData $profileFormData): ResponseInterface
+    {
         $this->profileRepository->update(
             $this->profileFactory->updateFromFormData(
                 $this->academicPersonsSettings->getValidationSetWithFallback('profile'),

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -16,8 +16,10 @@ use FGTCLB\AcademicPersons\Domain\Model\ProfileInformation;
 use FGTCLB\AcademicPersons\Domain\Repository\ProfileInformationRepository;
 use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileInformationFactory;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileInformationFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -82,6 +84,10 @@ final class ProfileInformationController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'profileInformationFormData',
+        'validator' => ProfileInformationFormDataValidator::class,
+    ])]
     public function createAction(Profile $profile, ProfileInformationFormData $profileInformationFormData): ResponseInterface
     {
         $profileInformation = $this->profileInformationFactory->createFromFormData(
@@ -132,6 +138,10 @@ final class ProfileInformationController extends AbstractActionController
         return $this->htmlResponse();
     }
 
+    #[Validate([
+        'param' => 'profileInformationFormData',
+        'validator' => ProfileInformationFormDataValidator::class,
+    ])]
     public function updateAction(
         ProfileInformation $profileInformation,
         ProfileInformationFormData $profileInformationFormData,


### PR DESCRIPTION
All of the `EXT:academic_persons_edit` controller follows a
generic design pattern to provide `CRUD` functionalities to
the frontend plugin for `EXT:academic_persons` domain models.

The generic logic are:

* `newAction()` display initial create form.
* `createAction()` is the POST data handling for the
  `newAction()` handling the persistance of submitted
  data along with server side validation for the data
  transfered (DTO form object) and is the counterpart
  of `newAction()`.
* `editAction()` displays the edit form for the model.
* `updateAction()` handles the persistance of submitted
  data along with server side validation for the data
  transferered (DTO form object) and is the counterpart
  of `editAction()`.

Together with the form data objects (DTO) dedicated
validation implementation has been introduced and
declared for controller actions using the extbase
`Validate` php attribute. Sadly, this has not been
done for all `updateAction()` and completly missed
for the `createAction()`.

This change modifies all `EXT:academic_persons_edit`
controllers to add the correct validator config for
`createAction()` and `updateAction()` and literally
adding the **must have** server side validation to
complete the edit cycle if frontend validation has
been circumvented.
