### PR TITLE
[!!!][TASK] ACE-33: Remove obsolete form DTO from controller `newAction()`

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -66,12 +66,12 @@ final class ContractController extends AbstractActionController
     //  Handle creation of new entity
     // =================================================================================================================
 
-    public function newAction(Profile $profile, ?ContractFormData $contractFormData = null): ResponseInterface
+    public function newAction(Profile $profile): ResponseInterface
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
-            'contractFormData' => $contractFormData ?? new ContractFormData(),
+            'contractFormData' => new ContractFormData(),
             'functionTypes' => $this->functionTypeRepository->findAll(),
             'organisationalUnits' => $this->organisationalUnitRepository->findAll(),
             'locations' => $this->locationRepository->findAll(),

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -66,14 +66,14 @@ final class EmailAddressController extends AbstractActionController
     //  Handle creation of new entity
     // =================================================================================================================
 
-    public function newAction(Contract $contract, ?EmailFormData $emailAddressFormData = null): ResponseInterface
+    public function newAction(Contract $contract): ResponseInterface
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $contract,
-            'emailAddressFormData' => $emailAddressFormData ?? new EmailFormData(),
+            'emailAddressFormData' => new EmailFormData(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('emailAddress')->validations,
         ]);

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -64,14 +64,14 @@ final class PhoneNumberController extends AbstractActionController
     //  Handle creation of new entity
     // =================================================================================================================
 
-    public function newAction(Contract $contract, ?PhoneNumberFormData $phoneNumberFormData = null): ResponseInterface
+    public function newAction(Contract $contract): ResponseInterface
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $contract,
-            'phoneNumberFormData' => $phoneNumberFormData ?? new PhoneNumberFormData(),
+            'phoneNumberFormData' => new PhoneNumberFormData(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('phoneNumber')->validations,
         ]);

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -66,13 +66,13 @@ final class PhysicalAddressController extends AbstractActionController
     //  Handle creation of new entity
     // =================================================================================================================
 
-    public function newAction(Contract $contract, ?AddressFormData $addressFormData = null): ResponseInterface
+    public function newAction(Contract $contract): ResponseInterface
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $contract->getProfile(),
             'contract' => $contract,
-            'addressFormData' => $addressFormData ?? new AddressFormData(),
+            'addressFormData' => new AddressFormData(),
             'availableTypes' => $this->getAvailableTypes(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('physicalAddress')->validations,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -66,10 +66,10 @@ final class ProfileInformationController extends AbstractActionController
     //  Handle creation of new entity
     // =================================================================================================================
 
-    public function newAction(Profile $profile, string $type, ?ProfileInformationFormData $profileInformationFormData = null): ResponseInterface
+    public function newAction(Profile $profile, string $type): ResponseInterface
     {
         $mappedType = $this->academicPersonsSettings->getProfileInformationType($type)?->type ?? '';
-        $profileInformationFormData ??= ProfileInformationFormData::createEmptyForType($mappedType);
+        $profileInformationFormData = ProfileInformationFormData::createEmptyForType($mappedType);
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,

--- a/packages/fgtclb/academic-persons-edit/UPGRADE.md
+++ b/packages/fgtclb/academic-persons-edit/UPGRADE.md
@@ -2,6 +2,66 @@
 
 ## X.Y.Z
 
+### BREAKING: Removed nullable form dto argument from all controller `newActions()`
+
+The `newAction()` of the `EXT:academic_persons_edit` controllers only
+displays the initial form for create a new entity submitting data
+submission to the `createAction()` [POST] and never handles the form
+again. Following that, there is no need to have form data as optional
+argument for the `newAction()` and beside that this would allow to
+prefill data used for the form using link manipulations as the action
+is a GET action, which we do not want to work.
+
+Not verified if having the form object as nullable for action in place
+has been required in earlier extbase days, but today that is absolutely
+not the case and **could** only be uses to prefill form data calling
+that action with corresponding get arguments, which can be considered
+dangerous and needs to be omitted in the first place.
+
+In case the validation for the `createAction()` is invalid extbase
+calls the `errorAction()` of the controller forwarding the request
+internally to the `newAction()` along with the validationResult,
+already omitting to send the form data argument and being null in
+any-case. Using the `<f:form.* />` fluid ViewHelpers to render the
+form elements takes care of this and keep the entered values as
+values even if the form dto object is initialized with empty values,
+which means that we do not have to take care of that ourself.
+
+The optional (nullable) form arguments are removed from following actions:
+
+* `ContractController->newAction()`
+* `EmailAdressController->newAction()`
+* `PhoneNumberController->newAction()`
+* `PhysicalAddressController->newAction()`
+* `ProfileInformationController->newAction()`
+
+Making this visiable, for example this
+
+```php
+public function newAction(
+    Profile $profile,
+    ?ContractFormData $contractFormData = null,
+): ResponseInterface { /* ... */ }
+```
+
+to
+
+```php
+public function newAction(
+    Profile $profile,
+): ResponseInterface { /* ... */ }
+```
+
+> [!IMPORTANT]
+> There may be use-cases in project's to provide kind of prefilled
+> actions albeit this should be only a edge-case. In these cases,
+> the project should implement a custom controller and action to
+> create the entity with the prefilled data and display (redirect)
+> to the `editAction()`. If that case raises up in projects we may
+> revisit this here and eventually come up with another solution,
+> considering security aspects more seriously in these cases.
+
+
 ### BREAKING: Migrated extbase plugins from `list_type` to `CType`
 
 TYPO3 v13 deprecated the `tt_content` sub-type feature, only used for `CType=list` sub-typing also known


### PR DESCRIPTION
The `newAction()` of the `EXT:academic_persons_edit` controllers only
displays the initial form for create a new entity submitting data
submission to the `createAction()` [POST] and never handles the form
again. Following that, there is no need to have form data as optional
argument for the `newAction()` and beside that this would allow to
prefill data used for the form using link manipulations as the action
is a GET action, which we do not want to work.

Not verified if having the form object as nullable for action in place
has been required in earlier extbase days, but today that is absolutely
not the case and **could** only be uses to prefill form data calling
that action with corresponding get arguments, which can be considered
dangerous and needs to be omitted in the first place.

In case the validation for the `createAction()` is invalid extbase
calls the `errorAction()` of the controller forwarding the request
internally to the `newAction()` along with the validationResult,
already omitting to send the form data argument and being null in
any-case. Using the `<f:form.* />` fluid ViewHelpers to render the
form elements takes care of this and keep the entered values as
values even if the form dto object is initialized with empty values,
which means that we do not have to take care of that ourself.

This change removes the optional (nullable) argument for the form DTO
from the `newAction()` method of all controllers closing this hole in
the implementation.

The optional (nullable) form arguments are removed from following actions:

* `ContractController->newAction()`
* `EmailAdressController->newAction()`
* `PhoneNumberController->newAction()`
* `PhysicalAddressController->newAction()`
* `ProfileInformationController->newAction()`

Making this visiable, for example this

```php
public function newAction(
	Profile $profile,
	?ContractFormData $contractFormData = null,
): ResponseInterface {/* ... */}
```

to

```php
public function newAction(
	Profile $profile,
): ResponseInterface { /* ... */ }
```

> [!IMPORTANT]
> There may be use-cases in project's to provide kind of prefilled
> actions albeit this should be only a edge-case. In these cases,
> the project should implement a custom controller and action to
> create the entity with the prefilled data and display (redirect)
> to the `editAction()`. If that case raises up in projects we may
> revisit this here and eventually come up with another solution,
> considering security aspects more seriously in these cases.
