### PR TITLE
[TASK] ACE-33: Add `typo3/cms-lowlevel` `to monorepo-shared`

### DIFF
--- a/packages-dev/monorepo-shared/composer.json
+++ b/packages-dev/monorepo-shared/composer.json
@@ -34,6 +34,7 @@
         "typo3/cms-frontend": "^12.4.22 || ^13.4",
         "typo3/cms-info": "^12.4.22 || ^13.4",
         "typo3/cms-install": "^12.4.22 || ^13.4",
+        "typo3/cms-lowlevel": "12.4.22 || ^13.4",
         "typo3/cms-recycler": "^12.4.22 || ^13.4",
         "typo3/cms-redirects": "^12.4.22 || ^13.4",
         "typo3/cms-reports": "^12.4.22 || ^13.4",
@@ -56,6 +57,27 @@
     "extra": {
         "branch-alias": {
             "dev-main": "2.0.x-dev"
+        }
+    },
+    "repositories": {
+        "packages": {
+            "type": "path",
+            "url": "../../packages/*/*",
+            "options": {
+                "versions": {
+                    "fgtclb/academic-bite-jobs": "2.0.2-dev",
+                    "fgtclb/academic-contacts4pages": "2.0.2-dev",
+                    "fgtclb/academic-jobs": "2.0.2-dev",
+                    "fgtclb/academic-partners": "2.0.2-dev",
+                    "fgtclb/academic-persons": "2.0.2-dev",
+                    "fgtclb/academic-persons-edit": "2.0.2-dev",
+                    "fgtclb/academic-persons-sync": "2.0.2-dev",
+                    "fgtclb/academic-programs": "2.0.2-dev",
+                    "fgtclb/academic-projects": "2.0.2-dev",
+                    "fgtclb/category-types": "2.0.2-dev",
+                    "fgtclb/academic-base": "2.0.2-dev"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This change adds `typo3/cms-lowlevel` as required
dependency to `fgtclb/academics-monorepo-shared`,
ensuring that the backend configuration moduel is
available for the ddev instances.

Used command(s):

```shell
BIN_COMPOSER="$( which composer )" \
&& ${BIN_COMPOSER} config \
    -d packages-dev/monorepo-shared \
    "repositories"."packages" \
    --json '{"type": "path", "url": "../../packages/*/*", "options": {"versions": {"fgtclb/academic-bite-jobs": "2.0.2-dev","fgtclb/academic-contacts4pages": "2.0.2-dev","fgtclb/academic-jobs": "2.0.2-dev","fgtclb/academic-partners": "2.0.2-dev","fgtclb/academic-persons": "2.0.2-dev","fgtclb/academic-persons-edit": "2.0.2-dev","fgtclb/academic-persons-sync": "2.0.2-dev","fgtclb/academic-programs": "2.0.2-dev","fgtclb/academic-projects": "2.0.2-dev","fgtclb/category-types": "2.0.2-dev","fgtclb/academic-base": "2.0.2-dev"}}}' \
&& ${BIN_COMPOSER} require \
    -d packages-dev/monorepo-shared \
    --no-update \
    'typo3/cms-lowlevel':'12.4.22 || ^13.4'
```
