### PR TITLE
[TASK] ACE-33: Enhance form data transformation and validation

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
@@ -13,6 +13,8 @@ namespace FGTCLB\AcademicPersonsEdit\Controller;
 
 use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
 use FGTCLB\AcademicPersonsEdit\Attributes\ListSortingMode;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData;
+use FGTCLB\AcademicPersonsEdit\Property\TypeConverter\AbstractFormDataConverter;
 use FGTCLB\AcademicPersonsEdit\Service\DataTransferObject\ListSortingProcess;
 use FGTCLB\AcademicPersonsEdit\Service\ListSortingService;
 use FGTCLB\AcademicPersonsEdit\Service\UserSessionService;
@@ -25,6 +27,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -120,6 +123,11 @@ abstract class AbstractActionController extends ActionController
             );
         }
 
+        /** @var Argument $argument */
+        foreach ($this->arguments as $argument) {
+            $this->setCurrentRequestForAbstractFormDataBasedArguments($argument);
+        }
+
         // Map date and time arguments
         foreach (self::DATETIME_ARGUMENTS as $argument => $datetimeProperties) {
             if ($this->arguments->hasArgument($argument)) {
@@ -135,6 +143,29 @@ abstract class AbstractActionController extends ActionController
                 }
             }
         }
+    }
+
+    /**
+     * @param Argument $argument
+     */
+    private function setCurrentRequestForAbstractFormDataBasedArguments(Argument $argument): void
+    {
+        $dataType = $argument->getDataType();
+        if (!class_exists($dataType)
+            || !in_array(AbstractFormData::class, class_parents($dataType), true)
+        ) {
+            // Argument is not mapped to an object and is not based on AbstractFormData. Skip.
+            return;
+        }
+        $argument
+            ->getPropertyMappingConfiguration()
+            ->setTypeConverterOptions(
+                AbstractFormDataConverter::class,
+                [
+                    'request' => $this->request,
+                    'argumentName' => $argument->getName(),
+                ]
+            );
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/AddressFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/AddressFactory.php
@@ -50,6 +50,23 @@ class AddressFactory
         return $address;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, AddressFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setContract(ValidationSet $validationSet, AddressModel $model, Contract $contract): AddressModel
     {
         // ValidationSet not evaluated as contract is required to be set for new models
@@ -59,129 +76,73 @@ class AddressFactory
 
     private function setStreet(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('street');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setStreet($form->getStreet());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'street')) {
+            $override = $form->getPropertyOverride('street');
+            $model->setStreet(is_string($override) ? $override : $form->getStreet());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setStreet($form->getStreet());
         return $model;
     }
 
     private function setStreetNumber(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('streetNumber');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setStreetNumber($form->getStreetNumber());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'streetNumber')) {
+            $override = $form->getPropertyOverride('streetNumber');
+            $model->setStreetNumber(is_string($override) ? $override : $form->getStreetNumber());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setStreetNumber($form->getStreetNumber());
         return $model;
     }
 
     private function setAdditional(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('additional');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setAdditional($form->getAdditional());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'additional')) {
+            $override = $form->getPropertyOverride('additional');
+            $model->setAdditional(is_string($override) ? $override : $form->getAdditional());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setAdditional($form->getAdditional());
         return $model;
     }
 
     private function setZip(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('zip');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setZip($form->getZip());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'zip')) {
+            $override = $form->getPropertyOverride('zip');
+            $model->setZip(is_string($override) ? $override : $form->getZip());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setZip($form->getZip());
         return $model;
     }
 
     private function setCity(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('city');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setCity($form->getCity());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'city')) {
+            $override = $form->getPropertyOverride('city');
+            $model->setCity(is_string($override) ? $override : $form->getCity());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setCity($form->getCity());
         return $model;
     }
 
     private function setState(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('state');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setState($form->getState());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'state')) {
+            $override = $form->getPropertyOverride('state');
+            $model->setState(is_string($override) ? $override : $form->getState());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setState($form->getState());
         return $model;
     }
 
     private function setCountry(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('country');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setCountry($form->getCountry());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'country')) {
+            $override = $form->getPropertyOverride('country');
+            $model->setCountry(is_string($override) ? $override : $form->getCountry());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setCountry($form->getCountry());
         return $model;
     }
 
     private function setType(ValidationSet $validationSet, AddressModel $model, AddressFormData $form): AddressModel
     {
-        $validation = $validationSet->get('type');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setType($form->getType());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'type')) {
+            $override = $form->getPropertyOverride('type');
+            $model->setType(is_string($override) ? $override : $form->getType());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setType($form->getType());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ContractFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ContractFactory.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersonsEdit\Domain\Factory;
 
 use FGTCLB\AcademicPersons\Domain\Model\Contract as ContractModel;
+use FGTCLB\AcademicPersons\Domain\Model\FunctionType;
+use FGTCLB\AcademicPersons\Domain\Model\Location;
+use FGTCLB\AcademicPersons\Domain\Model\OrganisationalUnit;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\Settings\ValidationSet;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
@@ -45,6 +48,23 @@ class ContractFactory
         return $contract;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, ContractFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setProfile(ValidationSet $validationSet, ContractModel $model, Profile $profile): ContractModel
     {
         // ValidationSet not evaluated as profile is required to be set for new models
@@ -54,145 +74,82 @@ class ContractFactory
 
     private function setOrganisationalUnit(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('organisationalUnit');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setOrganisationalUnit($form->getOrganisationalUnit());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'organisationalUnit')) {
+            $override = $form->getPropertyOverride('organisationalUnit');
+            $model->setOrganisationalUnit($override instanceof OrganisationalUnit ? $override : $form->getOrganisationalUnit());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setOrganisationalUnit($form->getOrganisationalUnit());
         return $model;
     }
 
     private function setFunctionType(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('functionType');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setFunctionType($form->getFunctionType());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'functionType')) {
+            $override = $form->getPropertyOverride('functionType');
+            $model->setFunctionType($override instanceof FunctionType ? $override : $form->getFunctionType());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setFunctionType($form->getFunctionType());
         return $model;
     }
 
     private function setValidFrom(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('validFrom');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setValidFrom($form->getValidFrom());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'validFrom')) {
+            $override = $form->getPropertyOverride('validFrom');
+            $model->setValidFrom($override instanceof \DateTime ? $override : $form->getValidFrom());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setValidFrom($form->getValidFrom());
         return $model;
     }
 
     private function setValidTo(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('validFrom');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setValidTo($form->getValidTo());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'validTo')) {
+            $override = $form->getPropertyOverride('validTo');
+            $model->setValidTo($override instanceof \DateTime ? $override : $form->getValidTo());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setValidTo($form->getValidTo());
         return $model;
     }
 
     private function setPosition(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('position');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setPosition($form->getPosition());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'position')) {
+            $override = $form->getPropertyOverride('position');
+            $model->setPosition(is_string($override) ? $override : $form->getPosition());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setPosition($form->getPosition());
         return $model;
     }
 
     private function setLocation(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('location');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setLocation($form->getLocation());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'location')) {
+            $override = $form->getPropertyOverride('location');
+            $model->setLocation($override instanceof Location ? $override : $form->getLocation());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setLocation($form->getLocation());
         return $model;
     }
 
     private function setRoom(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('room');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setRoom($form->getRoom());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'room')) {
+            $override = $form->getPropertyOverride('room');
+            $model->setRoom(is_string($override) ? $override : $form->getRoom());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setRoom($form->getRoom());
         return $model;
     }
 
     private function setOfficeHours(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('officeHours');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setOfficeHours($form->getOfficeHours());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'officeHours')) {
+            $override = $form->getPropertyOverride('officeHours');
+            $model->setOfficeHours(is_string($override) ? $override : $form->getOfficeHours());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setOfficeHours($form->getOfficeHours());
         return $model;
     }
 
     private function setPublish(ValidationSet $validationSet, ContractModel $model, ContractFormData $form): ContractModel
     {
-        $validation = $validationSet->get('publish');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setPublish($form->isPublish());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'publish')) {
+            $override = $form->getPropertyOverride('publish');
+            $model->setPublish(is_bool($override) ? $override : $form->isPublish());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setPublish($form->isPublish());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/EmailFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/EmailFactory.php
@@ -31,6 +31,23 @@ class EmailFactory
         return $email;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, EmailFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setContract(ValidationSet $validationSet, EmailModel $model, Contract $contract): EmailModel
     {
         // ValidationSet not evaluated as contract is required to be set for new models
@@ -40,33 +57,19 @@ class EmailFactory
 
     private function setEmail(ValidationSet $validationSet, EmailModel $model, EmailFormData $form): EmailModel
     {
-        $validation = $validationSet->get('email');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setEmail($form->getEmail());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'email')) {
+            $override = $form->getPropertyOverride('email');
+            $model->setEmail(is_string($override) ? $override : $form->getEmail());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setEmail($form->getEmail());
         return $model;
     }
 
     private function setType(ValidationSet $validationSet, EmailModel $model, EmailFormData $form): EmailModel
     {
-        $validation = $validationSet->get('type');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setType($form->getType());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'type')) {
+            $override = $form->getPropertyOverride('type');
+            $model->setType(is_string($override) ? $override : $form->getType());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setType($form->getType());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/PhoneNumberFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/PhoneNumberFactory.php
@@ -31,6 +31,23 @@ class PhoneNumberFactory
         return $phoneNumber;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, PhoneNumberFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setContract(ValidationSet $validationSet, PhoneNumberModel $model, Contract $contract): PhoneNumberModel
     {
         // ValidationSet not evaluated as contract is required to be set for new models
@@ -40,33 +57,19 @@ class PhoneNumberFactory
 
     private function setPhoneNumber(ValidationSet $validationSet, PhoneNumberModel $model, PhoneNumberFormData $form): PhoneNumberModel
     {
-        $validation = $validationSet->get('phoneNumber');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setPhoneNumber($form->getPhoneNumber());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'phoneNumber')) {
+            $override = $form->getPropertyOverride('phoneNumber');
+            $model->setPhoneNumber(is_string($override) ? $override : $form->getPhoneNumber());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setPhoneNumber($form->getPhoneNumber());
         return $model;
     }
 
     private function setType(ValidationSet $validationSet, PhoneNumberModel $model, PhoneNumberFormData $form): PhoneNumberModel
     {
-        $validation = $validationSet->get('type');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setType($form->getType());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'type')) {
+            $override = $form->getPropertyOverride('type');
+            $model->setType(is_string($override) ? $override : $form->getType());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setType($form->getType());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFactory.php
@@ -55,243 +55,155 @@ class ProfileFactory
         return $profile;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, ProfileFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setGender(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('gender');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setGender($form->getGender());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'gender')) {
+            $override = $form->getPropertyOverride('gender');
+            $model->setGender(is_string($override) ? $override : $form->getGender());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setGender($form->getGender());
         return $model;
     }
 
     private function setTitle(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('title');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setTitle($form->getTitle());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'title')) {
+            $override = $form->getPropertyOverride('title');
+            $model->setTitle(is_string($override) ? $override : $form->getTitle());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setTitle($form->getTitle());
         return $model;
     }
 
     private function setFirstName(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('firstName');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setFirstName($form->getFirstName());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'firstName')) {
+            $override = $form->getPropertyOverride('firstName');
+            $model->setFirstName(is_string($override) ? $override : $form->getFirstName());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setFirstName($form->getFirstName());
         return $model;
     }
 
     private function setMiddleName(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('middleName');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setMiddleName($form->getMiddleName());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'middleName')) {
+            $override = $form->getPropertyOverride('middleName');
+            $model->setMiddleName(is_string($override) ? $override : $form->getMiddleName());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setMiddleName($form->getMiddleName());
         return $model;
     }
 
     private function setLastName(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('lastName');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setLastName($form->getLastName());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'lastName')) {
+            $override = $form->getPropertyOverride('lastName');
+            $model->setLastName(is_string($override) ? $override : $form->getLastName());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setLastName($form->getLastName());
         return $model;
     }
 
     private function setWebsite(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('website');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setWebsite($form->getWebsite());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'website')) {
+            $override = $form->getPropertyOverride('website');
+            $model->setWebsite(is_string($override) ? $override : $form->getWebsite());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setWebsite($form->getWebsite());
         return $model;
     }
 
     private function setWebsiteTitle(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('websiteTitle');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setWebsiteTitle($form->getWebsiteTitle());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'websiteTitle')) {
+            $override = $form->getPropertyOverride('websiteTitle');
+            $model->setWebsiteTitle(is_string($override) ? $override : $form->getWebsiteTitle());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setWebsiteTitle($form->getWebsiteTitle());
         return $model;
     }
 
     private function setPublicationsLink(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('publicationsLink');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setPublicationsLink($form->getPublicationsLink());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'publicationsLink')) {
+            $override = $form->getPropertyOverride('publicationsLink');
+            $model->setPublicationsLink(is_string($override) ? $override : $form->getPublicationsLink());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setPublicationsLink($form->getPublicationsLink());
         return $model;
     }
 
     private function setPublicationsLinkTitle(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('publicationsLinkTitle');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setPublicationsLinkTitle($form->getPublicationsLinkTitle());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'publicationsLinkTitle')) {
+            $override = $form->getPropertyOverride('publicationsLinkTitle');
+            $model->setPublicationsLinkTitle(is_string($override) ? $override : $form->getPublicationsLinkTitle());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setPublicationsLinkTitle($form->getPublicationsLinkTitle());
         return $model;
     }
 
     private function setTeachingArea(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('teachingArea');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setTeachingArea($form->getTeachingArea());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'teachingArea')) {
+            $override = $form->getPropertyOverride('teachingArea');
+            $model->setTeachingArea(is_string($override) ? $override : $form->getTeachingArea());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setTeachingArea($form->getTeachingArea());
         return $model;
     }
 
     private function setCoreCompetences(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('coreCompetences');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setCoreCompetences($form->getCoreCompetences());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'coreCompetences')) {
+            $override = $form->getPropertyOverride('coreCompetences');
+            $model->setCoreCompetences(is_string($override) ? $override : $form->getCoreCompetences());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setCoreCompetences($form->getCoreCompetences());
         return $model;
     }
 
     private function setSupervisedThesis(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('supervisedThesis');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setSupervisedThesis($form->getSupervisedThesis());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'supervisedThesis')) {
+            $override = $form->getPropertyOverride('supervisedThesis');
+            $model->setSupervisedThesis(is_string($override) ? $override : $form->getSupervisedThesis());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setSupervisedThesis($form->getSupervisedThesis());
         return $model;
     }
 
     private function setSupervisedDoctoralThesis(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('supervisedDoctoralThesis');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setSupervisedDoctoralThesis($form->getSupervisedDoctoralThesis());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'supervisedDoctoralThesis')) {
+            $override = $form->getPropertyOverride('supervisedDoctoralThesis');
+            $model->setSupervisedDoctoralThesis(is_string($override) ? $override : $form->getSupervisedDoctoralThesis());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setSupervisedDoctoralThesis($form->getSupervisedDoctoralThesis());
         return $model;
     }
 
     private function setMiscellaneous(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('miscellaneous');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setMiscellaneous($form->getMiscellaneous());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'miscellaneous')) {
+            $override = $form->getPropertyOverride('miscellaneous');
+            $model->setMiscellaneous(is_string($override) ? $override : $form->getMiscellaneous());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setMiscellaneous($form->getMiscellaneous());
         return $model;
     }
 
     private function setSkipSync(ValidationSet $validationSet, ProfileModel $model, ProfileFormData $form): ProfileModel
     {
-        $validation = $validationSet->get('skipSync');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setSkipSync($form->getSkipSync());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'skipSync')) {
+            $override = $form->getPropertyOverride('skipSync');
+            $model->setSkipSync(is_bool($override) ? $override : $form->getSkipSync());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setSkipSync($form->getSkipSync());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileInformationFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileInformationFactory.php
@@ -41,6 +41,23 @@ class ProfileInformationFactory
         return $profileInformation;
     }
 
+    /**
+     * A value is applied to the domain model only when the property may be written
+     * (not readOnly / disabled by validation configuration) and has been sent within
+     * the current request or registered as override on the form data object.
+     */
+    private function mayApplyProperty(ValidationSet $validationSet, ProfileInformationFormData $form, string $propertyName): bool
+    {
+        $validation = $validationSet->get($propertyName);
+        if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+            // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+            return false;
+        }
+        // Only apply values sent within the current request or registered as override
+        // (e.g. filled up by a PSR-14 event from another source before transformation).
+        return $form->shouldApplyProperty($propertyName);
+    }
+
     private function setProfile(ValidationSet $validationSet, ProfileInformationModel $model, Profile $profile): ProfileInformationModel
     {
         // ValidationSet not evaluated as profile is required to be set for new models
@@ -50,113 +67,64 @@ class ProfileInformationFactory
 
     private function setType(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('type');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setType($form->getType());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'type')) {
+            $override = $form->getPropertyOverride('type');
+            $model->setType(is_string($override) ? $override : $form->getType());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setType($form->getType());
         return $model;
     }
 
     private function setTitle(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('title');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setTitle($form->getTitle());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'title')) {
+            $override = $form->getPropertyOverride('title');
+            $model->setTitle(is_string($override) ? $override : $form->getTitle());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setTitle($form->getTitle());
         return $model;
     }
 
     private function setBodytext(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('bodytext');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setBodytext($form->getBodytext());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'bodytext')) {
+            $override = $form->getPropertyOverride('bodytext');
+            $model->setBodytext(is_string($override) ? $override : $form->getBodytext());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setBodytext($form->getBodytext());
         return $model;
     }
 
     private function setLink(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('link');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setLink($form->getLink());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'link')) {
+            $override = $form->getPropertyOverride('link');
+            $model->setLink(is_string($override) ? $override : $form->getLink());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setLink($form->getLink());
         return $model;
     }
 
     private function setYear(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('year');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setYear($form->getYear());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'year')) {
+            $override = $form->getPropertyOverride('year');
+            $model->setYear(is_int($override) ? $override : $form->getYear());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setYear($form->getYear());
         return $model;
     }
 
     private function setYearStart(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('yearStart');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setYearStart($form->getYearStart());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'yearStart')) {
+            $override = $form->getPropertyOverride('yearStart');
+            $model->setYearStart(is_int($override) ? $override : $form->getYearStart());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setYearStart($form->getYearStart());
         return $model;
     }
 
     private function setYearEnd(ValidationSet $validationSet, ProfileInformationModel $model, ProfileInformationFormData $form): ProfileInformationModel
     {
-        $validation = $validationSet->get('yearEnd');
-        if ($validation === null) {
-            // No validation configured, assume that value is valid and needs to be set.
-            $model->setYearEnd($form->getYearEnd());
-            return $model;
+        if ($this->mayApplyProperty($validationSet, $form, 'yearEnd')) {
+            $override = $form->getPropertyOverride('yearEnd');
+            $model->setYearEnd(is_int($override) ? $override : $form->getYearEnd());
         }
-        if ($validation->readOnly || $validation->disabled) {
-            // ReadOnly or disabled, ignore value to prevent empty existing persisted data
-            return $model;
-        }
-        $model->setYearEnd($form->getYearEnd());
         return $model;
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Dto/AbstractFormData.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Dto/AbstractFormData.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Domain\Model\Dto;
 
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API. May change at any time.
  */
-class AbstractFormData
+abstract class AbstractFormData
 {
+    private ?ServerRequestInterface $request = null;
+    private ?string $argumentName = null;
+
+    /**
+     * Override values applied during the DTO to domain model transformation even
+     * when the corresponding property was not sent within the current request.
+     *
+     * @var array<string, mixed>
+     */
+    private array $propertyOverrides = [];
+
     // =================================================================================================================
     // Magic methods
     // =================================================================================================================
@@ -23,5 +37,90 @@ class AbstractFormData
     public function _hasProperty(string $propertyName): bool
     {
         return property_exists($this, $propertyName);
+    }
+
+    final public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->request = $request;
+    }
+
+    final protected function getRequest(): ?ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    final public function setArgumentName(string $argumentName): void
+    {
+        $this->argumentName = $argumentName;
+    }
+
+    final public function getArgumentName(): ?string
+    {
+        return $this->argumentName;
+    }
+
+    protected function getExtbaseRequestParameters(): ?ExtbaseRequestParameters
+    {
+        return $this->request?->getAttribute('extbase') ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function getActionRequestArguments(): ?array
+    {
+        return $this->getExtbaseRequestParameters()?->getArguments() ?? null;
+    }
+
+    /**
+     * Determine whether the given property has been sent within the current request
+     * for the argument this form data object has been mapped from. Only properties
+     * really transferred with the request are considered, allowing the transformation
+     * to skip values which have not been part of the submitted form.
+     */
+    public function wasPropertySentInRequest(string $propertyName): bool
+    {
+        $arguments = $this->getActionRequestArguments();
+        $argumentName = $this->getArgumentName();
+        if ($arguments === null || $argumentName === null || $argumentName === '') {
+            return false;
+        }
+        $namespacedArguments = $arguments[$argumentName] ?? null;
+        if (!is_array($namespacedArguments)) {
+            return false;
+        }
+        return array_key_exists($propertyName, $namespacedArguments);
+    }
+
+    /**
+     * Register an override value for a property. Registered overrides are applied
+     * during the DTO to domain model transformation even if the property has not
+     * been sent within the current request. This is the intended extension point
+     * for PSR-14 event listeners filling up data from other sources before the
+     * transformation runs.
+     */
+    final public function setPropertyOverride(string $propertyName, mixed $value): void
+    {
+        $this->propertyOverrides[$propertyName] = $value;
+    }
+
+    final public function hasPropertyOverride(string $propertyName): bool
+    {
+        return array_key_exists($propertyName, $this->propertyOverrides);
+    }
+
+    final public function getPropertyOverride(string $propertyName): mixed
+    {
+        return $this->propertyOverrides[$propertyName] ?? null;
+    }
+
+    /**
+     * A property value must be applied to the domain model when it has either been
+     * sent within the current request, or has been registered as override value.
+     */
+    final public function shouldApplyProperty(string $propertyName): bool
+    {
+        return $this->wasPropertySentInRequest($propertyName)
+            || $this->hasPropertyOverride($propertyName);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Classes/Property/TypeConverter/AbstractFormDataConverter.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Property/TypeConverter/AbstractFormDataConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Property\TypeConverter;
+
+use FGTCLB\AcademicPersonsEdit\Controller\AbstractActionController;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Extbase\Property\PropertyMappingConfigurationInterface;
+use TYPO3\CMS\Extbase\Property\TypeConverter\ObjectConverter;
+
+/**
+ * Provides type converter for argument types based on {@see AbstractFormData} to set
+ * the request to the object instance using {@see AbstractFormData::setRequest()} as
+ * long as provided within the configuration.
+ *
+ * {@see AbstractActionController::setCurrentRequestForAbstractFormDataBasedArguments()}
+ * set the request as TypeConverter options for all {@see AbstractFormData} arguments,
+ * called from {@see AbstractActionController::initializeAction()} and therefore for
+ * all controller actions extending {@see AbstractActionController}. Sadly, there is
+ * no better way currently.
+ *
+ * Note that fallback to `$GLOBALS['TYPO3_REQUEST']` is added for now, but may be
+ * removed and is considered experimental for now.
+ */
+final class AbstractFormDataConverter extends ObjectConverter
+{
+    /**
+     * @param mixed $source
+     * @param array<string, mixed> $convertedChildProperties
+     */
+    public function convertFrom(
+        $source,
+        string $targetType,
+        array $convertedChildProperties = [],
+        ?PropertyMappingConfigurationInterface $configuration = null
+    ): ?object {
+        /** @var mixed $request */
+        $request = $configuration?->getConfigurationValue(self::class, 'request') ?? $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $argumentName = $configuration?->getConfigurationValue(self::class, 'argumentName') ?? null;
+        $object = parent::convertFrom($source, $targetType, $convertedChildProperties, $configuration);
+        if (!($object instanceof AbstractFormData)) {
+            return $object;
+        }
+        if ($request instanceof ServerRequestInterface) {
+            $object->setRequest($request);
+        }
+        if (is_string($argumentName) && $argumentName !== '') {
+            $object->setArgumentName($argumentName);
+        }
+        return $object;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Configuration/Services.yaml
+++ b/packages/fgtclb/academic-persons-edit/Configuration/Services.yaml
@@ -18,3 +18,11 @@ services:
       - name: 'event.listener'
         identifier: syncChangesToTranslations
         event: 'FGTCLB\AcademicPersons\Event\AfterProfileUpdateEvent'
+
+  # @internal not part of public API
+  FGTCLB\AcademicPersonsEdit\Property\TypeConverter\AbstractFormDataConverter:
+    tags:
+      - name: extbase.type_converter
+        priority: 50
+        target: FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData
+        sources: array

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-FormDataTransformationOnlyMapsSubmittedFields.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-FormDataTransformationOnlyMapsSubmittedFields.rst
@@ -1,0 +1,78 @@
+.. _important-ace-33-academic-persons-edit:
+
+==============================================================================
+Important: Form data transformation only maps submitted fields
+==============================================================================
+
+Description
+===========
+
+The frontend editing of `EXT:academic_persons_edit` maps submitted form
+data transfer objects (:php:`\FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData`
+descendants) onto the domain models through the per-property factory
+classes in :php:`\FGTCLB\AcademicPersonsEdit\Domain\Factory\*`.
+
+Until now these factories wrote **every** property on each request, so a
+field that was not part of the submitted form was silently overwritten
+with the empty default of the form data object, wiping already persisted
+data. This is corrected: a property is now only applied when it was
+actually sent within the current request.
+
+To make this possible the following additions were made (all of them on
+:php:`@internal` classes that are not part of the public API):
+
+* :php:`\FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData`
+  carries the current request and the mapped argument name and exposes
+  :php:`wasPropertySentInRequest(string $propertyName): bool` to detect
+  which properties were part of the submission. The request and argument
+  name are provided by the new
+  :php:`\FGTCLB\AcademicPersonsEdit\Property\TypeConverter\AbstractFormDataConverter`,
+  which is registered for all :php:`AbstractFormData` based arguments in
+  :php:`\FGTCLB\AcademicPersonsEdit\Controller\AbstractActionController::initializeAction()`.
+* All factory classes (`Profile`, `ProfileInformation`, `Contract`,
+  `Address`, `Email`, `PhoneNumber`) skip properties that were neither
+  sent within the request nor registered as override. The existing
+  ``readOnly`` / ``disabled`` validation configuration keeps precedence
+  and continues to protect persisted data.
+* For the case where a property is not part of the request but still has
+  to be written - for example when a PSR-14 event fills up data from
+  another source before the transformation runs -
+  :php:`AbstractFormData` gained a per-property override store via
+  :php:`setPropertyOverride(string $propertyName, mixed $value)`,
+  :php:`hasPropertyOverride(string $propertyName)` and
+  :php:`getPropertyOverride(string $propertyName)`. Registered overrides
+  are applied even when the property was not submitted.
+
+Additionally
+:php:`\FGTCLB\AcademicPersonsEdit\Domain\Factory\ContractFactory::setValidTo()`
+was fixed to evaluate the validation configuration of ``validTo`` instead
+of ``validFrom``.
+
+Impact
+======
+
+The runtime behaviour of the frontend edit forms changes: submitting a
+form no longer resets fields that are not contained in that form. Fields
+are only written when they were part of the request or were explicitly
+registered as override on the form data object. No public method
+signature changed in an incompatible way.
+
+Affected Installations
+======================
+
+Only installations that extend or replace the internal form data factory
+classes or :php:`AbstractFormData`, or that relied on the previous
+"always overwrite" behaviour of the transformation, need to take the
+changed behaviour into account. All other installations benefit from the
+fix without any action required.
+
+Migration
+=========
+
+No explicit migration is required. Custom code that populates a form data
+object outside of the request (e.g. within a PSR-14 event) and expects
+the value to be persisted must register it via
+:php:`AbstractFormData::setPropertyOverride()` so the transformation
+applies it despite the property not being part of the request.
+
+.. index:: PHP, ext:academic_persons_edit

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Factory/ProfileFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Factory/ProfileFactoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\Settings\Validation;
+use FGTCLB\AcademicPersons\Settings\ValidationSet;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ProfileFactoryTest extends UnitTestCase
+{
+    /**
+     * @param array<string, mixed> $sentProperties
+     */
+    private function bindRequest(ProfileFormData $form, array $sentProperties): void
+    {
+        $parameters = new ExtbaseRequestParameters();
+        $parameters->setArguments(['profileFormData' => $sentProperties]);
+        $form->setRequest((new ServerRequest())->withAttribute('extbase', $parameters));
+        $form->setArgumentName('profileFormData');
+    }
+
+    private function createExistingProfile(): Profile
+    {
+        $profile = new Profile();
+        $profile->setFirstName('OldFirst');
+        $profile->setLastName('OldLast');
+        $profile->setGender('OldGender');
+        $profile->setTitle('OldTitle');
+        $profile->setWebsite('OldWebsite');
+        $profile->setSkipSync(false);
+        return $profile;
+    }
+
+    #[Test]
+    public function updateAppliesPropertySentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', []);
+        $form = new ProfileFormData(firstName: 'NewFirst');
+        $this->bindRequest($form, ['firstName' => 'NewFirst']);
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertSame('NewFirst', $profile->getFirstName());
+    }
+
+    #[Test]
+    public function updatePreservesPropertyNotSentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', []);
+        // Only firstName is sent, lastName defaults to '' on the form data object.
+        $form = new ProfileFormData(firstName: 'NewFirst');
+        $this->bindRequest($form, ['firstName' => 'NewFirst']);
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        // lastName was not part of the request and must not be overwritten with the empty default.
+        $this->assertSame('OldLast', $profile->getLastName());
+    }
+
+    #[Test]
+    public function updateAppliesRegisteredOverrideEvenIfNotSentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', []);
+        $form = new ProfileFormData(firstName: 'NewFirst');
+        $this->bindRequest($form, ['firstName' => 'NewFirst']);
+        // Website was not sent, but an event registered an override value.
+        $form->setPropertyOverride('website', 'OverrideWebsite');
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertSame('OverrideWebsite', $profile->getWebsite());
+    }
+
+    #[Test]
+    public function updateAppliesBooleanOverrideEvenIfNotSentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', []);
+        $form = new ProfileFormData(firstName: 'NewFirst');
+        $this->bindRequest($form, ['firstName' => 'NewFirst']);
+        $form->setPropertyOverride('skipSync', true);
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertTrue($profile->getSkipSync());
+    }
+
+    #[Test]
+    public function updateSkipsReadOnlyPropertyEvenIfSentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', [
+            'gender' => new Validation('gender', 'gender', false, false, true, [], []),
+        ]);
+        $form = new ProfileFormData(gender: 'NewGender');
+        $this->bindRequest($form, ['gender' => 'NewGender']);
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertSame('OldGender', $profile->getGender());
+    }
+
+    #[Test]
+    public function updateSkipsDisabledPropertyEvenIfSentInRequest(): void
+    {
+        $validationSet = new ValidationSet('profile', [
+            'title' => new Validation('title', 'title', false, true, false, [], []),
+        ]);
+        $form = new ProfileFormData(title: 'NewTitle');
+        $this->bindRequest($form, ['title' => 'NewTitle']);
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertSame('OldTitle', $profile->getTitle());
+    }
+
+    #[Test]
+    public function updateWithoutRequestKeepsAllPersistedValues(): void
+    {
+        // No request bound and no overrides: nothing may be applied, persisted data stays untouched.
+        $validationSet = new ValidationSet('profile', []);
+        $form = new ProfileFormData(firstName: 'NewFirst', lastName: 'NewLast');
+
+        $profile = (new ProfileFactory())->updateFromFormData($validationSet, $this->createExistingProfile(), $form);
+
+        $this->assertSame('OldFirst', $profile->getFirstName());
+        $this->assertSame('OldLast', $profile->getLastName());
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AbstractFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AbstractFormDataTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class AbstractFormDataTest extends UnitTestCase
+{
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function createRequestWithArguments(array $arguments): ServerRequestInterface
+    {
+        $parameters = new ExtbaseRequestParameters();
+        $parameters->setArguments($arguments);
+        return (new ServerRequest())->withAttribute('extbase', $parameters);
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsFalseWithoutRequest(): void
+    {
+        $form = new ProfileFormData();
+        $form->setArgumentName('profileFormData');
+
+        $this->assertFalse($form->wasPropertySentInRequest('firstName'));
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsFalseWithoutArgumentName(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+
+        $this->assertFalse($form->wasPropertySentInRequest('firstName'));
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsTrueForSentProperty(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        $this->assertTrue($form->wasPropertySentInRequest('firstName'));
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsTrueForSentEmptyProperty(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => ''],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        // A property submitted with an empty value counts as sent.
+        $this->assertTrue($form->wasPropertySentInRequest('firstName'));
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsFalseForNotSentProperty(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        $this->assertFalse($form->wasPropertySentInRequest('lastName'));
+    }
+
+    #[Test]
+    public function wasPropertySentInRequestReturnsFalseForForeignArgumentNamespace(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'otherFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        $this->assertFalse($form->wasPropertySentInRequest('firstName'));
+    }
+
+    #[Test]
+    public function propertyOverrideCanBeRegisteredAndRead(): void
+    {
+        $form = new ProfileFormData();
+
+        $this->assertFalse($form->hasPropertyOverride('firstName'));
+        $this->assertNull($form->getPropertyOverride('firstName'));
+
+        $form->setPropertyOverride('firstName', 'override');
+
+        $this->assertTrue($form->hasPropertyOverride('firstName'));
+        $this->assertSame('override', $form->getPropertyOverride('firstName'));
+    }
+
+    #[Test]
+    public function propertyOverrideAcceptsNullAsExplicitValue(): void
+    {
+        $form = new ProfileFormData();
+        $form->setPropertyOverride('firstName', null);
+
+        $this->assertTrue($form->hasPropertyOverride('firstName'));
+        $this->assertNull($form->getPropertyOverride('firstName'));
+    }
+
+    #[Test]
+    public function shouldApplyPropertyReturnsTrueWhenSentInRequest(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        $this->assertTrue($form->shouldApplyProperty('firstName'));
+    }
+
+    #[Test]
+    public function shouldApplyPropertyReturnsTrueForOverriddenButNotSentProperty(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+        $form->setPropertyOverride('lastName', 'override');
+
+        $this->assertTrue($form->shouldApplyProperty('lastName'));
+    }
+
+    #[Test]
+    public function shouldApplyPropertyReturnsFalseWhenNeitherSentNorOverridden(): void
+    {
+        $form = new ProfileFormData();
+        $form->setRequest($this->createRequestWithArguments([
+            'profileFormData' => ['firstName' => 'foo'],
+        ]));
+        $form->setArgumentName('profileFormData');
+
+        $this->assertFalse($form->shouldApplyProperty('lastName'));
+    }
+}


### PR DESCRIPTION
`EXT:academic_persons_edit` comes with a customized form and validation
handling, based on the yaml-based configuration system used to define
validations for BE (FormEngine) and in the frontend using extbase form
handling provided through form data transfer objects (`AbstractFormData`)
combined with a transformation service (`Factory` - bad naming).

The combined concept lacked proper checking during the data transformation
whether a property had actually been sent within the persisting request or
not. Because of that, fields not part of a submission were silently
overwritten with the empty default of the form data object, wiping already
persisted data. This change implements that missing piece, and additionally
considers the case that a property **may** not be sent in the request but
still needs to be set - for example when a PSR-14 event fills up missing
data based on other sources before the transformation runs.

## What changed

* `AbstractFormData` carries the current request and the mapped argument
  name and exposes `wasPropertySentInRequest()` to detect which properties
  were part of the submission.

* Added `AbstractFormDataConverter`, which sets the request and argument
  name on the mapped `AbstractFormData` instance during property mapping,
  based on the corresponding `TypeConverterOptions`.

* `AbstractActionController::initializeAction()` registers the converter
  options for all `AbstractFormData` based arguments (request + argument
  name). Sadly, there is no event or a more configurable way to do that in
  TYPO3.

* All factory classes (`Profile`, `ProfileInformation`, `Contract`,
  `Address`, `Email`, `PhoneNumber`) now skip properties that were neither
  sent within the request nor registered as override, while `readOnly` /
  `disabled` validation configuration keeps precedence to protect persisted
  data.

* To cover the "fill up data from another source" use case,
  `AbstractFormData` gained a per-property override store
  (`setPropertyOverride()`, `hasPropertyOverride()`,
  `getPropertyOverride()`). Registered overrides are applied even when the
  property was not submitted.

* Fixed `ContractFactory::setValidTo()`, which evaluated the validation
  configuration of `validFrom` instead of `validTo`.

## Notes

* All touched classes are `@internal` / not part of the public API, so this
  is not a breaking change. The most notable change is behavioural (the
  transformation no longer overwrites fields absent from a submission),
  documented in an `Important` changelog note for `2.4`.

* Added unit tests covering request detection, override handling and the
  factory apply/skip/override/readOnly behaviour.

## Review feedback

* Adopted the `wasPropertySendInRequest` -> `wasPropertySentInRequest`
  rename suggested in review.

Refs: ACE-33
