### PR TITLE
[BUGFIX] ACE-33: Use correct variable names in `EmailFactory->updateFromFormData()`

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/EmailFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/EmailFactory.php
@@ -26,9 +26,9 @@ class EmailFactory
 
     public function updateFromFormData(ValidationSet $validationSet, EmailModel $email, EmailFormData $form): EmailModel
     {
-        $emailAddress = $this->setEmail($validationSet, $email, $form);
-        $emailAddress = $this->setType($validationSet, $email, $form);
-        return $emailAddress;
+        $email = $this->setEmail($validationSet, $email, $form);
+        $email = $this->setType($validationSet, $email, $form);
+        return $email;
     }
 
     private function setContract(ValidationSet $validationSet, EmailModel $model, Contract $contract): EmailModel


### PR DESCRIPTION
`EmailFactory->updateFromFormData()` has a mismatch in variable
name usage between sub method return values and method argument
passing and thus breaking correct model update based on the form
data transfer object.

This change uses the correct variable names now to repair the
update of the domain model object and set form data correctly.
