### PR TITLE
wip: [BUGFIX] Respect hidden profiles/contract when showing page related contacts

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
@@ -25,8 +25,15 @@ final class ContactsController extends ActionController
         $contacts = $this->contactRepository->findByPid((int)($contentElementData['pid'] ?? 0));
 
         $roles = [];
+        $availableContacts = [];
         foreach ($contacts as $contact) {
+            if ($contact->getContract() === null || $contact->getContract()->getProfile() === null) {
+                continue;
+            }
+
+            $availableContacts[] = $contact;
             $role = $contact->getRole();
+
             if ($role !== null) {
                 $roles[$role->getUid()] = $role;
             }
@@ -34,7 +41,7 @@ final class ContactsController extends ActionController
 
         $this->view->assignMultiple([
             'data' => $contentElementData,
-            'contacts' => $contacts,
+            'contacts' => $availableContacts,
             'roles' => $roles,
         ]);
 

--- a/packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php
@@ -35,12 +35,21 @@ class ContactsProcessor implements DataProcessorInterface
         $processedData['contacts'] = $contacts;
 
         $roles = [];
+        $availableContacts = [];
         foreach ($contacts as $contact) {
+            if ($contact->getContract() === null || $contact->getContract()->getProfile() === null) {
+                continue;
+            }
+
+            $availableContacts[] = $contact;
             $role = $contact->getRole();
+
             if ($role !== null) {
                 $roles[$role->getUid()] = $role;
             }
         }
+
+        $processedData['contacts'] = $availableContacts;
         $processedData['roles'] = $roles;
 
         return $processedData;


### PR DESCRIPTION
As the contacts4pages had been able to show the contract related information of a hidden profile, they now are checked if either the contract or the profile are not available to prevent this issue.

Another approach would've been adjusting the findByPid function of the ContactsRepository to not return relations of hidden contracts or profiles in the first place.