### PR TITLE
[FEATURE] Add `academic:createprofiles` options `--include-pids` and `--exclude-pids` 

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Command/CreateProfilesCommand.php
+++ b/packages/fgtclb/academic-persons/Classes/Command/CreateProfilesCommand.php
@@ -17,6 +17,7 @@ use FGTCLB\AcademicPersons\Provider\FrontendUserProvider;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -31,13 +32,31 @@ final class CreateProfilesCommand extends Command
 
     protected function configure(): void
     {
-        $this->setHelp('This command create profiles for all frontend users that do not have a profile yet but should have one.');
+        $this
+            ->setHelp('This command create profiles for all frontend users that do not have a profile yet but should have one.')
+            ->addOption(
+                'exclude-pids',
+                'e',
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list of PIDs to exclude',
+                null
+            )
+            ->addOption(
+                'include-pids',
+                'i',
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list of PIDs to include',
+                null
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $frontendUsers = $this->frontendUserProvider->getUsersWithoutProfile();
-
+        // @todo getUsersWithoutProfile() should return the doctrine result and not the full retrieved record array
+        $frontendUsers = $this->frontendUserProvider->getUsersWithoutProfile(
+            $this->getCommaSeparatedIntegerValueListOptionAsArrayOfIntegerValues($input, 'include-pids'),
+            $this->getCommaSeparatedIntegerValueListOptionAsArrayOfIntegerValues($input, 'exclude-pids'),
+        );
         foreach ($frontendUsers as $frontendUser) {
             $frontendUserAuthentication = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
             $frontendUserAuthentication->user = $frontendUser;
@@ -56,5 +75,30 @@ final class CreateProfilesCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param string $option
+     * @return int[]
+     */
+    private function getCommaSeparatedIntegerValueListOptionAsArrayOfIntegerValues(InputInterface $input, string $option): array
+    {
+        if ($option === '') {
+            return [];
+        }
+        $valuesStringList = $this->getOptionWithEmptyStringFallback($input, $option);
+        $values = GeneralUtility::intExplode(',', $valuesStringList, true);
+        $values = array_unique($values);
+        $values = array_values($values);
+        return $values;
+    }
+
+    private function getOptionWithEmptyStringFallback(InputInterface $input, string $option): mixed
+    {
+        if ($option === '' || !$input->hasOption($option)) {
+            return '';
+        }
+        return (string)($input->getOption($option)) ?: '';
     }
 }

--- a/packages/fgtclb/academic-persons/Classes/Provider/FrontendUserProvider.php
+++ b/packages/fgtclb/academic-persons/Classes/Provider/FrontendUserProvider.php
@@ -19,12 +19,15 @@ final class FrontendUserProvider
     public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     /**
+     * @param int[] $includePids
+     * @param int[] $excludePids
      * @return array<int, array<string, mixed>>
+     * @todo getUsersWithoutProfile() should return the doctrine result and not the full retrieved record array
      */
-    public function getUsersWithoutProfile(): array
+    public function getUsersWithoutProfile(array $includePids = [], array $excludePids = []): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('fe_users');
-        return $queryBuilder
+        $queryBuilder
             ->select('fe_users.*')
             ->from('fe_users')
             ->leftJoin(
@@ -42,7 +45,38 @@ final class FrontendUserProvider
                     'fe_users.tx_extbase_type',
                     $queryBuilder->createNamedParameter('Tx_Academicpersonsedit_Domain_Model_FrontendUser', Connection::PARAM_STR)
                 )
-            )
+            );
+
+        // Ensure to have index in rising order without wholes (integer index keys)
+        $includePids = array_values($includePids);
+        $excludePids = array_values($excludePids);
+        // Remove excluded pids from include pids as this make no sense to have the same pid as IN() and NOT IN()
+        if ($includePids !== [] && $excludePids !== []) {
+            $includePids = array_values(
+                array_filter(
+                    $includePids,
+                    static fn($value) => !in_array($value, $excludePids, true),
+                )
+            );
+        }
+        if ($excludePids !== []) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->notIn(
+                    'fe_users.pid',
+                    $queryBuilder->quoteArrayBasedValueListToIntegerList($excludePids)
+                )
+            );
+        }
+        if ($includePids !== []) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->in(
+                    'fe_users.pid',
+                    $queryBuilder->quoteArrayBasedValueListToIntegerList($includePids)
+                )
+            );
+        }
+
+        return $queryBuilder
             ->groupBy('fe_users.uid')
             ->executeQuery()
             ->fetchAllAssociative();

--- a/packages/fgtclb/academic-persons/UPGRADE.md
+++ b/packages/fgtclb/academic-persons/UPGRADE.md
@@ -50,6 +50,33 @@ See [Autowiring other Methods (e.g. Setters and Public Typed Properties)](https:
 
 ### FEATURES
 
+#### FEATURE: Add `academic:createprofiles` options `--include-pids` and `--exclude-pids`
+
+`EXT:academic_persons` provides a command to create profiles for
+frontend users, extendable by dispatching events to allow devs
+customizing the profile creation in projects, for example to
+base it on special needs like retrieving updated user data from
+LDAP oder other services.
+
+Until now, all frontend users without profiles on any pid has
+been fetched, which does not respect use-cases where frontend
+users for dedicated logins are required and profile creation
+is not wanted, needed or suitable.
+
+This change adds following new options to the provided command
+`vendor/bin/typo3 academic:createprofiles`:
+
+* `--include-pids`: comma-separated list of storage pid's from
+  which frontend users should be fetched (only).
+
+* `--exclude-pids`: comma-separated list of storage pid's from
+  which frontend users should be ignored (skipped).
+
+> [!IMPORTANT]
+> While both options can be used together it is important to
+> know that `--exclude-pids` takes higher priorities and are
+> ignored even if pid is also included in `include-pids`.
+
 #### FEATURE: Introduce localized pageTitleFormat placeholder (`LLL:EXT:`)
 
 It's a valid use-case to use a pageTitleFormat for the person


### PR DESCRIPTION
`EXT:academic_persons` provides a command to create profiles for
frontend users, extendable by dispatching events to allow devs
customizing the profile creation in projects, for example to
base it on special needs like retrieving updated user data from
LDAP oder other services.

Until now, all frontend users without profiles on any pid has
been fetched, which does not respect use-cases where frontend
users for dedicated logins are required and profile creation
is not wanted, needed or suitable.

This change adds following new options to the provided command
`vendor/bin/typo3 academic:createprofiles`:

* `--include-pids`: comma-separated list of storage pid's from
  which frontend users should be fetched (only).

* `--exclude-pids`: comma-separated list of storage pid's from
  which frontend users should be ignored (skipped).

> [!IMPORTANT]
> While both options can be used together it is important to
> know that `--exclude-pids` takes higher priorities and are
> ignored even if pid is also included in `include-pids`.
