### PR TITLE
[TASK] Ensure that select items are resolved correctly in JobController

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Controller/GetSelectItemsForTcaManagedTableFieldMethodTrait.php
+++ b/packages/fgtclb/academic-base/Classes/Controller/GetSelectItemsForTcaManagedTableFieldMethodTrait.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Controller;
+
+use FGTCLB\AcademicJobs\Controller\JobController;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Provides method {@see self::getSelectItemsForTcaManagedTableField()} to be used in extbase action controllers,
+ * for example {@see JobController::newAction()} or events to get tca select field items respecting itemUserProc
+ * function **and** translating item labels directly.
+ *
+ * @api considered API and to be used in projects or extension extending academic extensions.
+ */
+trait GetSelectItemsForTcaManagedTableFieldMethodTrait
+{
+    /**
+     * Determine select items for tca managed table field respecting configured itemUserProc function,
+     * translating item labels directly to remove the need to translate them in fluid view when passed
+     * into one.
+     *
+     * See for example {@see JobController::newAction()}.
+     *
+     * @param string[] $removeItemByValue
+     * @return array<int<0, max>, array{
+     *      label: string,
+     *      value: string,
+     *  }>
+     * @todo Evaluating TCA in frontend for available options is a hard task to do correctly requiring to execute
+     *       TCA item proc functions and so on. It also does not account for eventually FormEngine nodes processing
+     *       additional stuff. Current implementation calls the itemProcFunc with a minimal set as context data, but
+     *       cannot simulate all the stuff provided by FormEngine.
+     * @todo Use TcaSchema for TYPO3 v13, either as dual version OR when dropping TYPO3 v12 support.
+     */
+    protected function getSelectItemsForTcaManagedTableField(
+        LocalizationUtility $localizationUtility,
+        string $extensionKey,
+        string $tableName,
+        string $fieldName,
+        array $removeItemByValue = [''],
+    ): array {
+        $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+        $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemProcFunc !== '') {
+            $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+            $processorParameters = [
+                'items' => &$items,
+                'config' => $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config'],
+                'table' => $tableName,
+                'field' => $fieldName,
+            ];
+            GeneralUtility::callUserFunction($itemProcFunc, $processorParameters, $this);
+            $items = $processorParameters['items'];
+        }
+        $returnItems = [];
+        foreach ($items as $item) {
+            $itemValue = (string)($item['value'] ?? '');
+            if (in_array($itemValue, $removeItemByValue, true)) {
+                // Skip empty string values, handled with `<f:form.select prependOptionLabel="---" />`
+                // in the fluid template.
+                continue;
+            }
+            $labelIdentifier = (string)($item['label'] ?? '');
+            $returnItems[] = [
+                'label' => ($localizationUtility->translate(
+                    $labelIdentifier,
+                    $extensionKey,
+                ) ?? $labelIdentifier) ?: $labelIdentifier,
+                'value' => $itemValue,
+            ];
+        }
+        return $returnItems;
+    }
+}

--- a/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/EmploymentTypeItems.php
+++ b/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/EmploymentTypeItems.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Backend\FormEngine;
 
 use TYPO3\CMS\Core\Utility\ArrayUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 final class EmploymentTypeItems
 {
@@ -18,20 +17,22 @@ final class EmploymentTypeItems
             $parameters['items'],
             $this->getEmploymentTypes()
         );
+        // @todo Add PSR-14 event to allow dynamic modification of items in project to avoid the need replace
+        //       this itemsProcFunc class.
     }
 
     /**
      * @return array<int, array{label: string|null, value: int}>
      */
-    public function getEmploymentTypes(): array
+    private function getEmploymentTypes(): array
     {
         return [
             [
-                'label' => LocalizationUtility::translate('LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.employment_type.fulltime'),
+                'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.employment_type.fulltime',
                 'value' => 1,
             ],
             [
-                'label' => LocalizationUtility::translate('LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.employment_type.parttime'),
+                'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.employment_type.parttime',
                 'value' => 2,
             ],
         ];

--- a/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/TypeItems.php
+++ b/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/TypeItems.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Backend\FormEngine;
 
 use TYPO3\CMS\Core\Utility\ArrayUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 final class TypeItems
 {
@@ -18,24 +17,26 @@ final class TypeItems
             $parameters['items'],
             $this->getTypes()
         );
+        // @todo Add PSR-14 event to allow dynamic modification of items in project to avoid the need replace
+        //       this itemsProcFunc class.
     }
 
     /**
      * @return array<int, array{label: string|null, value: int}>
      */
-    public function getTypes(): array
+    private function getTypes(): array
     {
         return [
             [
-                'label' => LocalizationUtility::translate('LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.job'),
+                'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.job',
                 'value' => 1,
             ],
             [
-                'label' => LocalizationUtility::translate('LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.sidejob'),
+                'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.sidejob',
                 'value' => 2,
             ],
             [
-                'label' => LocalizationUtility::translate('LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.thesis'),
+                'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.thesis',
                 'value' => 3,
             ],
         ];


### PR DESCRIPTION
`EXT:academic_jobs` provides two itemProcFuncs used to declare the
select items for `type` and `employe_type` available for backend
(FormEngine) also providing additional public methods for the items
directly. The latter method is used within the extbase controller
for the frontend plugin and the reason why the itemProcFunc classes
directly translated the item labels required for the frontend but
not for backend.

The controller used the items method directly and therefore has
the issue that this does not respect manually configured items
using TCA/TCAOverride or repecting replaced itemProcFunc config,
for example done in project to extend/modify the items.

This change streamlines the implementation now:

* `EmploymentTypeItems` and `TypeItems` are modified making the
   default items methods private and removing direct translating
   item labels.

* Introduce `GetSelectItemsForTcaManagedTableFieldMethodTrait`
  in `EXT:academic_base` to provide a reusable method to be
  used in controllers return the tca select items. This trait
  could later also be used in extension to retrieve select
  items the same field, for example if additional select fields
  has been added.

* `JobController` removes the type classes (DI), adding localization
  utility to be injected and replace the field item retrieven for
  the view using the `EXT:academic_base` method trait.
