### PR TITLE
[FEATURE] Introduce `ModifyJobControllerNewActionViewEvent` in `JobController`

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Domain/Model/DTO/PluginControllerActionContext.php
+++ b/packages/fgtclb/academic-base/Classes/Domain/Model/DTO/PluginControllerActionContext.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Domain\Model\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Generic context object used to provide plugin controller action related context information, either in views
+ * or dispatched events.
+ *
+ * Default implementation for {@see PluginControllerActionContextInterface} to be used within the academic extension
+ * to dispatch events in extbase controller actions and transport generic context data in a shared manner for all of
+ * them.
+ */
+final class PluginControllerActionContext implements PluginControllerActionContextInterface
+{
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function __construct(
+        private readonly ServerRequestInterface $request,
+        private readonly array $settings,
+    ) {}
+
+    public function getContentObjectRenderer(): ?ContentObjectRenderer
+    {
+        return $this->request->getAttribute('currentContentObject');
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getApplicationType(): ApplicationType
+    {
+        return ApplicationType::fromRequest($this->request);
+    }
+
+    public function getSite(): ?Site
+    {
+        return $this->request->getAttribute('site');
+    }
+
+    public function getLanguage(): ?SiteLanguage
+    {
+        return $this->request->getAttribute('language');
+    }
+
+    public function getPluginName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getPluginName();
+    }
+
+    public function getControllerName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerName();
+    }
+
+    public function getControllerObjectName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerObjectName();
+    }
+
+    public function getActionName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerActionName();
+    }
+
+    public function getControllerExtensionKey(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerExtensionKey();
+    }
+
+    public function getControllerExtensionName(): ?string
+    {
+        return $this->getExtbaseRequestParameters()?->getControllerExtensionName();
+    }
+
+    public function getExtbaseRequestParameters(): ?ExtbaseRequestParameters
+    {
+        $attribute = $this->request->getAttribute('extbase');
+        return $attribute instanceof ExtbaseRequestParameters ? $attribute : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+}

--- a/packages/fgtclb/academic-base/Classes/Domain/Model/DTO/PluginControllerActionContextInterface.php
+++ b/packages/fgtclb/academic-base/Classes/Domain/Model/DTO/PluginControllerActionContextInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Domain\Model\Dto;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Interface describing an extbase plugin controller action context container for the bare minimum,
+ * using the interface in controller action events instead of a concrete implementation open it up
+ * for customization in the future.
+ */
+interface PluginControllerActionContextInterface
+{
+    public function getContentObjectRenderer(): ?ContentObjectRenderer;
+    public function getRequest(): ServerRequestInterface;
+    public function getApplicationType(): ApplicationType;
+    public function getSite(): ?Site;
+    public function getLanguage(): ?SiteLanguage;
+    public function getPluginName(): ?string;
+    public function getControllerName(): ?string;
+    public function getControllerObjectName(): ?string;
+    public function getActionName(): ?string;
+    public function getControllerExtensionKey(): ?string;
+    public function getControllerExtensionName(): ?string;
+    public function getExtbaseRequestParameters(): ?ExtbaseRequestParameters;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSettings(): array;
+}

--- a/packages/fgtclb/academic-base/UPGRADE.md
+++ b/packages/fgtclb/academic-base/UPGRADE.md
@@ -1,0 +1,75 @@
+# Upgrade 2.0
+
+## X.Y.Z
+
+### FEATURE: Introduce `PluginControllerActionContextInterface` and `PluginControllerActionContext`
+
+Interface `\FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContextInterface`
+is introduced to describe a shared DTO container for generic data structures required in
+extbase controller action based events. The interface **should** be used for native type
+declaration in the event, and either a custom implementation based on the event or default
+implementation `\FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext` can
+be used to create container when dispatching the events. In most cases provided default
+implementation should be enough, and additional data provided directly as event property
+and getter/setter.
+
+**Custom event**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExt\Event;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContextInterface;
+
+final class MyCustomControllerActionEvent
+{
+    public function __construct(
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
+        // ... additional properties
+    ) {}
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
+    }
+}
+```
+
+**Dispatch custom event in a controller providing the context information**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExt\Controller;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use MyVendor\MyExt\Event\MyCustomControllerActionEvent;
+
+final class MyController extends ActionController
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {}
+
+    public function customAction(): ResponseInterface
+    {
+        // Dispatch custom PSR-14 event having at least the plugin controller
+        // action context data attached, allowing to determine the action and
+        // plugin data within an event listener avoiding that this has to be
+        // loaded manually again.
+        $event = $this->eventDispatcher->dispatch(new MyCustomControllerActionEvent(
+            pluginControllerActionContext: new PluginControllerActionContext(
+                request: $this->request,
+                settings: $this->settings,
+            ),
+        ));
+    }
+}
+```

--- a/packages/fgtclb/academic-jobs/Classes/Event/ModifyJobControllerNewActionViewEvent.php
+++ b/packages/fgtclb/academic-jobs/Classes/Event/ModifyJobControllerNewActionViewEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Event;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContextInterface;
+use FGTCLB\AcademicJobs\Controller\JobController;
+use TYPO3\CMS\Core\View\ViewInterface as CoreViewInterface;
+use TYPO3Fluid\Fluid\View\ViewInterface as FluidViewInterface;
+
+/**
+ * Fired in {@see JobController::newAction()} to allow assigning additional values to the view.
+ */
+final class ModifyJobControllerNewActionViewEvent
+{
+    public function __construct(
+        private readonly PluginControllerActionContextInterface $pluginControllerActionContext,
+        private readonly FluidViewInterface|CoreViewInterface $view,
+    ) {}
+
+    public function getPluginControllerActionContext(): PluginControllerActionContextInterface
+    {
+        return $this->pluginControllerActionContext;
+    }
+
+    public function getView(): FluidViewInterface|CoreViewInterface
+    {
+        return $this->view;
+    }
+}

--- a/packages/fgtclb/academic-jobs/UPGRADE.md
+++ b/packages/fgtclb/academic-jobs/UPGRADE.md
@@ -2,6 +2,56 @@
 
 ## X.Y.Z
 
+### FEATURE: Introduce `ModifyJobControllerNewActionViewEvent` in `JobController::newAction()`
+
+`JobController::newAction()` dispatches now the newly introduced PSR-14 event
+`\FGTCLB\AcademicJobs\Event\ModifyJobControllerNewActionViewEvent` providing
+following methods:
+
+* `getPluginControllerActionContext(): PluginControllerActionAcontext` to
+  extbase controller action plugin context data, which can be used to make
+  decisions using the event.
+* `getView(): FluidViewInterface|CoreViewInterface` to retrieve the view
+  instance, which can be used to assign additional data, but disallowing
+  to replace the instance.
+
+Implementing a event listener for this event allows attaching additional
+variables to the view for the `JobController::newAction()`, for example
+to provide additional select field options in case fields are changed,
+from text to a select field for example and avoid the need to implement
+a custom ViewHelper to retrieve the "select options" within the modifed
+views.
+
+**Example event listener**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExt\EventListener;
+
+use FGTCLB\AcademicJobs\Event\ModifyJobControllerNewActionViewEvent;
+
+final class ModifyJobControllerNewActionViewEventListener
+{
+    public function __invoke(
+        ModifyJobControllerNewActionViewEvent $event,
+    ): void {
+        $settings = $event
+            ->getPluginControllerActionContext()
+            ->getSettings();
+
+        // Assign additional variables to the new action view.
+        $event->getView()->assignMultiple(
+            [
+                'additionalViewVariable' => 1234,
+            ],
+        );
+    }
+}
+```
+
 ### FEATURE: Dispatch `ModifyTcaSelectFieldItemsEvent` in `TypeItems` and `EmploymentTypeItems`
 
 Following provided `itemsProcFunc` handlers now dispatches the new


### PR DESCRIPTION
`JobController::newAction()` dispatches now the newly introduced PSR-14
event `\FGTCLB\AcademicJobs\Event\ModifyJobControllerNewActionViewEvent`
providing following methods:

* `getPluginControllerActionContext(): PluginControllerActionAcontext`
  to extbase controller action plugin context data, which can be used
  to make decisions using the event.
* `getView(): FluidViewInterface|CoreViewInterface` to retrieve the
  view instance, which can be used to assign additional data, but
  disallowing to replace the instance.

Implementing a event listener for this event allows attaching additional
variables to the view for the `JobController::newAction()`, for example
to provide additional select field options in case fields are changed,
from text to a select field for example and avoid the need to implement
a custom ViewHelper to retrieve the "select options" within the modifed
views.

Example
-------

```php
<?php

declare(strict_types=1);

namespace MyVendor\MyExt\EventListener;

use FGTCLB\AcademicJobs\Event\ModifyJobControllerNewActionViewEvent;

final class ModifyJobControllerNewActionViewEventListener
{
    public function __invoke(
        ModifyJobControllerNewActionViewEvent $event,
    ): void {
        $settings = $event
            ->getPluginControllerActionContext()
            ->getSettings();

        // Assign additional variables to the new action view.
        $event->getView()->assignMultiple(
            [
                'additionalViewVariable' => 1234,
            ],
        );
    }
}
