### PR TITLE
[FEATURE] Dispatch PSR-14 `ModifyTcaSelectFieldItemsEvent` in `itemsProcFunc`

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Event/ModifyTcaSelectFieldItemsEvent.php
+++ b/packages/fgtclb/academic-base/Classes/Event/ModifyTcaSelectFieldItemsEvent.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Event;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+/**
+ * Shared event to be dispatched in itemsProcFunc for select fields, TCA and/or flexform,
+ * provided by academic extensions, for example:
+ *
+ * - {@see \FGTCLB\AcademicJobs\Backend\FormEngine\EmploymentTypeItems::itemsProcFunc()}
+ * - {@see \FGTCLB\AcademicJobs\Backend\FormEngine\TypeItems::itemsProcFunc()}
+ */
+final class ModifyTcaSelectFieldItemsEvent
+{
+    /**
+     * @param array{
+     *     items: array<int, array{
+     *      label?: string|null,
+     *      value?: mixed,
+     *      icon?: string|null,
+     *      group?: string|null,
+     *     }>,
+     *     config: array<string, mixed>,
+     *     TSconfig: array<string, mixed>,
+     *     table: string,
+     *     row: array<string, mixed>,
+     *     field: string,
+     *     effectivePid: int,
+     *     site: Site|null,
+     *     flexParentDatabaseRow?: array<string, mixed>|null,
+     *     inlineParentUid?: int,
+     *     inlineParentTableName?: string,
+     *     inlineParentFieldName?: string,
+     *     inlineParentConfig?: array<string, mixed>,
+     *     inlineTopMostParentUid?: int,
+     *     inlineTopMostParentTableName?: string,
+     *     inlineTopMostParentFieldName?: string,
+     * } $parameters
+     */
+    public function __construct(
+        private array $parameters,
+    ) {}
+
+    /**
+     * @link https://docs.typo3.org/m/typo3/reference-tca/main/en-us/ColumnsConfig/CommonProperties/ItemsProcFunc.html#passed-parameters
+     * @return array{
+     *      items: array<int, array{
+     *       label?: string|null,
+     *       value?: mixed,
+     *       icon?: string|null,
+     *       group?: string|null,
+     *      }>,
+     *      config: array<string, mixed>,
+     *      TSconfig: array<string, mixed>,
+     *      table: string,
+     *      row: array<string, mixed>,
+     *      field: string,
+     *      effectivePid: int,
+     *      site: Site|null,
+     *      flexParentDatabaseRow?: array<string, mixed>|null,
+     *      inlineParentUid?: int,
+     *      inlineParentTableName?: string,
+     *      inlineParentFieldName?: string,
+     *      inlineParentConfig?: array<string, mixed>,
+     *      inlineTopMostParentUid?: int,
+     *      inlineTopMostParentTableName?: string,
+     *      inlineTopMostParentFieldName?: string,
+     *  }
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array{
+     *      items: array<int, array{
+     *       label?: string|null,
+     *       value?: mixed,
+     *       icon?: string|null,
+     *       group?: string|null,
+     *      }>,
+     *      config: array<string, mixed>,
+     *      TSconfig: array<string, mixed>,
+     *      table: string,
+     *      row: array<string, mixed>,
+     *      field: string,
+     *      effectivePid: int,
+     *      site: Site|null,
+     *      flexParentDatabaseRow?: array<string, mixed>|null,
+     *      inlineParentUid?: int,
+     *      inlineParentTableName?: string,
+     *      inlineParentFieldName?: string,
+     *      inlineParentConfig?: array<string, mixed>,
+     *      inlineTopMostParentUid?: int,
+     *      inlineTopMostParentTableName?: string,
+     *      inlineTopMostParentFieldName?: string,
+     *  } $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/EmploymentTypeItems.php
+++ b/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/EmploymentTypeItems.php
@@ -4,27 +4,65 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Backend\FormEngine;
 
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * `itemsProcFunc` handler dispatching {@see ModifyTcaSelectFieldItemsEvent} PSR-14 event
+ * with {@see self::getDefaultEmploymentTypes()} to allow projects or other extension to
+ * modify the available select items.
+ *
+ * This is executed in the backend in FormEngine for TCA fields using this itemsProcFunc
+ * handler and also in controllers to retrieve the select options of the field.
+ */
 final class EmploymentTypeItems
 {
     /**
-     * @param array<string, mixed> $parameters
+     * @param array{
+     *      items: array<int, array{
+     *       label?: string|null,
+     *       value?: mixed,
+     *       icon?: string|null,
+     *       group?: string|null,
+     *      }>,
+     *      config: array<string, mixed>,
+     *      TSconfig: array<string, mixed>,
+     *      table: string,
+     *      row: array<string, mixed>,
+     *      field: string,
+     *      effectivePid: int,
+     *      site: Site|null,
+     *      flexParentDatabaseRow?: array<string, mixed>|null,
+     *      inlineParentUid?: int,
+     *      inlineParentTableName?: string,
+     *      inlineParentFieldName?: string,
+     *      inlineParentConfig?: array<string, mixed>,
+     *      inlineTopMostParentUid?: int,
+     *      inlineTopMostParentTableName?: string,
+     *      inlineTopMostParentFieldName?: string,
+     *  } $parameters
      */
     public function itemsProcFunc(array &$parameters): void
     {
         ArrayUtility::mergeRecursiveWithOverrule(
             $parameters['items'],
-            $this->getEmploymentTypes()
+            $this->getDefaultEmploymentTypes()
         );
-        // @todo Add PSR-14 event to allow dynamic modification of items in project to avoid the need replace
-        //       this itemsProcFunc class.
+        /** @var ModifyTcaSelectFieldItemsEvent $event */
+        $event = GeneralUtility::makeInstance(EventDispatcherInterface::class)->dispatch(new ModifyTcaSelectFieldItemsEvent(parameters: $parameters));
+        $parameters = $event->getParameters();
     }
 
     /**
-     * @return array<int, array{label: string|null, value: int}>
+     * @return array<int, array{
+     *     label: string|null,
+     *     value: int,
+     * }>
      */
-    private function getEmploymentTypes(): array
+    private function getDefaultEmploymentTypes(): array
     {
         return [
             [

--- a/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/TypeItems.php
+++ b/packages/fgtclb/academic-jobs/Classes/Backend/FormEngine/TypeItems.php
@@ -4,27 +4,65 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Backend\FormEngine;
 
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * `itemsProcFunc` handler dispatching {@see ModifyTcaSelectFieldItemsEvent} PSR-14 event
+ * with {@see self::getDefaultEmploymentTypes()} to allow projects or other extension to
+ * modify the available select items.
+ *
+ * This is executed in the backend in FormEngine for TCA fields using this itemsProcFunc
+ * handler and also in controllers to retrieve the select options of the field.
+ */
 final class TypeItems
 {
     /**
-     * @param array<string, mixed> $parameters
+     * @param array{
+     *      items: array<int, array{
+     *       label?: string|null,
+     *       value?: mixed,
+     *       icon?: string|null,
+     *       group?: string|null,
+     *      }>,
+     *      config: array<string, mixed>,
+     *      TSconfig: array<string, mixed>,
+     *      table: string,
+     *      row: array<string, mixed>,
+     *      field: string,
+     *      effectivePid: int,
+     *      site: Site|null,
+     *      flexParentDatabaseRow?: array<string, mixed>|null,
+     *      inlineParentUid?: int,
+     *      inlineParentTableName?: string,
+     *      inlineParentFieldName?: string,
+     *      inlineParentConfig?: array<string, mixed>,
+     *      inlineTopMostParentUid?: int,
+     *      inlineTopMostParentTableName?: string,
+     *      inlineTopMostParentFieldName?: string,
+     *  } $parameters
      */
     public function itemsProcFunc(array &$parameters): void
     {
         ArrayUtility::mergeRecursiveWithOverrule(
             $parameters['items'],
-            $this->getTypes()
+            $this->getDefaultTypes()
         );
-        // @todo Add PSR-14 event to allow dynamic modification of items in project to avoid the need replace
-        //       this itemsProcFunc class.
+        /** @var ModifyTcaSelectFieldItemsEvent $event */
+        $event = GeneralUtility::makeInstance(EventDispatcherInterface::class)->dispatch(new ModifyTcaSelectFieldItemsEvent(parameters: $parameters));
+        $parameters = $event->getParameters();
     }
 
     /**
-     * @return array<int, array{label: string|null, value: int}>
+     * @return array<int, array{
+     *     label: string|null,
+     *     value: int,
+     * }>
      */
-    private function getTypes(): array
+    private function getDefaultTypes(): array
     {
         return [
             [

--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -110,6 +110,7 @@ final class JobController extends ActionController
         $this->view->assignMultiple([
             'validations' => $this->settingsRegistry->getValidationsForFrontend('job'),
             'employmentTypeOptions' => $this->getSelectItemsForTcaManagedTableField(
+                $this->request,
                 $this->localizationUtility,
                 'academic_jobs',
                 'tx_academicjobs_domain_model_job',
@@ -117,6 +118,7 @@ final class JobController extends ActionController
                 [''],
             ),
             'typeOptions' => $this->getSelectItemsForTcaManagedTableField(
+                $this->request,
                 $this->localizationUtility,
                 'academic_jobs',
                 'tx_academicjobs_domain_model_job',

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Backend/FormEngine/EmploymentTypeItemsTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Backend/FormEngine/EmploymentTypeItemsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Backend\FormEngine;
+
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use FGTCLB\AcademicJobs\Backend\FormEngine\EmploymentTypeItems;
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class EmploymentTypeItemsTest extends AbstractAcademicJobsTestCase
+{
+    /** @var array<string, mixed>|null */
+    protected ?array $backupTCA = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $backupTCA = $GLOBALS['TCA'];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->backupTCA !== null) {
+            $GLOBALS['TCA'] = $this->backupTCA;
+            if (class_exists(TcaSchemaFactory::class)) {
+                /** @var TcaSchemaFactory $tcaSchemaFactory */
+                $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
+                $tcaSchemaFactory->load($GLOBALS['TCA'], true);
+            }
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function itemsProcFuncReturnsExpectedDefaultItems(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $subject = new EmploymentTypeItems();
+        $invokeGetDefaultEmploymentTypes = new \ReflectionMethod($subject, 'getDefaultEmploymentTypes');
+        $expectedDefaultItems = $invokeGetDefaultEmploymentTypes->invoke($subject);
+        $this->assertSame($expectedDefaultItems, $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field'));
+    }
+
+    #[Test]
+    public function itemsProcFuncDispatchesEventWithDefaultItems(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $subject = new EmploymentTypeItems();
+        $invokeGetDefaultEmploymentTypes = new \ReflectionMethod($subject, 'getDefaultEmploymentTypes');
+
+        $countDispatched = 0;
+        $countDispatchedForExpectedField = 0;
+        $dispatchedItems = [];
+
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'event-dispatch-checker',
+            static function (ModifyTcaSelectFieldItemsEvent $event) use (
+                &$countDispatched,
+                &$countDispatchedForExpectedField,
+                &$dispatchedItems,
+            ): void {
+                $countDispatched++;
+                $tableName = $event->getParameters()['table'];
+                $fieldName = $event->getParameters()['field'];
+                if ($tableName === 'fake_table' && $fieldName === 'fake_field') {
+                    $countDispatchedForExpectedField++;
+                    $dispatchedItems = $event->getParameters()['items'];
+                }
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyTcaSelectFieldItemsEvent::class, 'event-dispatch-checker');
+
+        $expectedDefaultItems = $invokeGetDefaultEmploymentTypes->invoke($subject);
+        $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field');
+        $this->assertSame(1, $countDispatched);
+        $this->assertSame(1, $countDispatchedForExpectedField);
+        $this->assertSame($expectedDefaultItems, $dispatchedItems);
+    }
+
+    #[Test]
+    public function addedItemWithEventListenerGetsReturned(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $itemsToSet = [
+            0 => [
+                'label' => 'some label',
+                'value' => 123,
+            ],
+        ];
+
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'event-dispatch-modification-checker',
+            static function (ModifyTcaSelectFieldItemsEvent $event) use ($itemsToSet): void {
+
+                $tableName = $event->getParameters()['table'];
+                $fieldName = $event->getParameters()['field'];
+                if ($tableName === 'fake_table' && $fieldName === 'fake_field') {
+                    $parameters = $event->getParameters();
+                    $parameters['items'] = $itemsToSet;
+                    $event->setParameters($parameters);
+                }
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyTcaSelectFieldItemsEvent::class, 'event-dispatch-modification-checker');
+
+        $this->assertSame($itemsToSet, $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field'));
+    }
+
+    /**
+     * @return array<int, array{
+     *     label?: string|null,
+     *     value?: mixed,
+     *     icon?: string|null,
+     *     group?: string|null,
+     * }>
+     */
+    private function callItemsProcFunc(
+        int $pageId,
+        Site $site,
+        string $tableName,
+        string $fieldName,
+    ): array {
+        $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemProcFunc === '') {
+            throw new \RuntimeException(
+                sprintf(
+                    'No itemProcFunc configured for "%s.%s".',
+                    $tableName,
+                    $fieldName,
+                ),
+                1759136962,
+            );
+        }
+        $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+        $processorParameters = [
+            'items' => &$items,
+            'config' => $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config'],
+            'TSconfig' => BackendUtility::getPagesTSconfig($pageId),
+            'table' => $tableName,
+            'field' => $fieldName,
+            'effectivePid' => $pageId,
+            'site' => $site,
+        ];
+        GeneralUtility::callUserFunction($itemProcFunc, $processorParameters, $this);
+        $items = $processorParameters['items'];
+        return $items;
+    }
+
+    private function applyFakeTableTca(): void
+    {
+        $GLOBALS['TCA']['fake_table'] = [
+            'ctrl' => [
+                'title' => 'fake-table',
+            ],
+            'columns' => [
+                'fake_field' => [
+                    'exclude' => true,
+                    'label' => 'fake-field',
+                    'config' => [
+                        'type' => 'select',
+                        'renderType' => 'selectSingle',
+                        'itemsProcFunc' => EmploymentTypeItems::class . '->itemsProcFunc',
+                        'size' => 1,
+                        'maxitems' => 1,
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ];
+        if (class_exists(TcaSchemaFactory::class)) {
+            /** @var TcaSchemaFactory $tcaSchemaFactory */
+            $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
+            $tcaSchemaFactory->load($GLOBALS['TCA'], true);
+        }
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Backend/FormEngine/TypeItemsTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Backend/FormEngine/TypeItemsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Backend\FormEngine;
+
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use FGTCLB\AcademicJobs\Backend\FormEngine\TypeItems;
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class TypeItemsTest extends AbstractAcademicJobsTestCase
+{
+    /** @var array<string, mixed>|null */
+    protected ?array $backupTCA = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $backupTCA = $GLOBALS['TCA'];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->backupTCA !== null) {
+            $GLOBALS['TCA'] = $this->backupTCA;
+            if (class_exists(TcaSchemaFactory::class)) {
+                /** @var TcaSchemaFactory $tcaSchemaFactory */
+                $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
+                $tcaSchemaFactory->load($GLOBALS['TCA'], true);
+            }
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function itemsProcFuncReturnsExpectedDefaultItems(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $subject = new TypeItems();
+        $invokeGetDefaultTypes = new \ReflectionMethod($subject, 'getDefaultTypes');
+        $expectedDefaultItems = $invokeGetDefaultTypes->invoke($subject);
+        $this->assertSame($expectedDefaultItems, $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field'));
+    }
+
+    #[Test]
+    public function itemsProcFuncDispatchesEventWithDefaultItems(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $subject = new TypeItems();
+        $invokeGetDefaultTypes = new \ReflectionMethod($subject, 'getDefaultTypes');
+
+        $countDispatched = 0;
+        $countDispatchedForExpectedField = 0;
+        $dispatchedItems = [];
+
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'event-dispatch-checker',
+            static function (ModifyTcaSelectFieldItemsEvent $event) use (
+                &$countDispatched,
+                &$countDispatchedForExpectedField,
+                &$dispatchedItems,
+            ): void {
+                $countDispatched++;
+                $tableName = $event->getParameters()['table'];
+                $fieldName = $event->getParameters()['field'];
+                if ($tableName === 'fake_table' && $fieldName === 'fake_field') {
+                    $countDispatchedForExpectedField++;
+                    $dispatchedItems = $event->getParameters()['items'];
+                }
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyTcaSelectFieldItemsEvent::class, 'event-dispatch-checker');
+
+        $expectedDefaultItems = $invokeGetDefaultTypes->invoke($subject);
+        $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field');
+        $this->assertSame(1, $countDispatched);
+        $this->assertSame(1, $countDispatchedForExpectedField);
+        $this->assertSame($expectedDefaultItems, $dispatchedItems);
+    }
+
+    #[Test]
+    public function addedItemWithEventListenerGetsReturned(): void
+    {
+        $this->applyFakeTableTca();
+        $site = new Site('acme', 1, []);
+        $itemsToSet = [
+            0 => [
+                'label' => 'some label',
+                'value' => 123,
+            ],
+        ];
+
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'event-dispatch-modification-checker',
+            static function (ModifyTcaSelectFieldItemsEvent $event) use ($itemsToSet): void {
+
+                $tableName = $event->getParameters()['table'];
+                $fieldName = $event->getParameters()['field'];
+                if ($tableName === 'fake_table' && $fieldName === 'fake_field') {
+                    $parameters = $event->getParameters();
+                    $parameters['items'] = $itemsToSet;
+                    $event->setParameters($parameters);
+                }
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyTcaSelectFieldItemsEvent::class, 'event-dispatch-modification-checker');
+
+        $this->assertSame($itemsToSet, $this->callItemsProcFunc(1, $site, 'fake_table', 'fake_field'));
+    }
+
+    /**
+     * @return array<int, array{
+     *     label?: string|null,
+     *     value?: mixed,
+     *     icon?: string|null,
+     *     group?: string|null,
+     * }>
+     */
+    private function callItemsProcFunc(
+        int $pageId,
+        Site $site,
+        string $tableName,
+        string $fieldName,
+    ): array {
+        $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemProcFunc === '') {
+            throw new \RuntimeException(
+                sprintf(
+                    'No itemProcFunc configured for "%s.%s".',
+                    $tableName,
+                    $fieldName,
+                ),
+                1759136962,
+            );
+        }
+        $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
+        $processorParameters = [
+            'items' => &$items,
+            'config' => $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config'],
+            'TSconfig' => BackendUtility::getPagesTSconfig($pageId),
+            'table' => $tableName,
+            'field' => $fieldName,
+            'effectivePid' => $pageId,
+            'site' => $site,
+        ];
+        GeneralUtility::callUserFunction($itemProcFunc, $processorParameters, $this);
+        $items = $processorParameters['items'];
+        return $items;
+    }
+
+    private function applyFakeTableTca(): void
+    {
+        $GLOBALS['TCA']['fake_table'] = [
+            'ctrl' => [
+                'title' => 'fake-table',
+            ],
+            'columns' => [
+                'fake_field' => [
+                    'exclude' => true,
+                    'label' => 'fake-field',
+                    'config' => [
+                        'type' => 'select',
+                        'renderType' => 'selectSingle',
+                        'itemsProcFunc' => TypeItems::class . '->itemsProcFunc',
+                        'size' => 1,
+                        'maxitems' => 1,
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ];
+        if (class_exists(TcaSchemaFactory::class)) {
+            /** @var TcaSchemaFactory $tcaSchemaFactory */
+            $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
+            $tcaSchemaFactory->load($GLOBALS['TCA'], true);
+        }
+    }
+}

--- a/packages/fgtclb/academic-jobs/UPGRADE.md
+++ b/packages/fgtclb/academic-jobs/UPGRADE.md
@@ -2,6 +2,71 @@
 
 ## X.Y.Z
 
+### FEATURE: Dispatch `ModifyTcaSelectFieldItemsEvent` in `TypeItems` and `EmploymentTypeItems`
+
+Following provided `itemsProcFunc` handlers now dispatches the new
+PSR-14 `\FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent`:
+
+* `\FGTCLB\AcademicJobs\Backend\FormEngine\EmploymentTypeItems`
+* `\FGTCLB\AcademicJobs\Backend\FormEngine\TypeItems`
+
+This allows projects to modify the available select items for the
+backend (FormEngine) and also for the frontend using a PSR-14 event
+listener:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExt\EventListener;
+
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+#[AsEventListener(identifier: 'project/modify-academic-jobs-tca-select-items')]
+final public ModifyTcaSelectFieldItemsEventListener
+{
+    public function __invoke(ModifyTcaSelectFieldItemsEvent $event): void
+    {
+        $tableName = $event->getParameters()['table'];
+        $fieldName = $event->getParameters()['field'];
+        if ($tableName !== 'tx_academicjobs_domain_model_job') {
+            // Not the table we want to handle. Skip
+            return;
+        }
+        if ($fieldName === 'type') {
+            $this->modifyJobsTypeSelectItems($event);
+        }
+        if ($fieldName === 'employment_type') {
+            $this->modifyJobsEmploymentTypeSelectItems($event);
+        }
+    }
+
+    private function modifyJobsTypeSelectItems(
+        ModifyTcaSelectFieldItemsEvent $event,
+    ): void {
+        $parameters = $event->getParameters();
+        $parameters['items'][] = [
+            'label' => 'LLL:EXT:my_ext/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.custom_type',
+            'value' => 10
+        ];
+        $event->setParameters($parameters);
+    }
+
+    private function modifyJobsEmploymentTypeSelectItems(
+        ModifyTcaSelectFieldItemsEvent $event,
+    ): void {
+        $parameters = $event->getParameters();
+        $parameters['items'][] = [
+            'label' => 'LLL:EXT:my_ext/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.employment_type.custom_type',
+            'value' => 10
+        ];
+        $event->setParameters($parameters);
+    }
+}
+```
+
 ### BREAKING: Removed `ImageUploadConverter`
 
 Custom `ImageUploadConverter` implementation is removed in favour of the shared


### PR DESCRIPTION
`EXT:academic_jobs` provides following `itemsProcFunc` handler:

* `EmploymentTypeItems`
* `TypeItems`

which defines default items for fields (TCA or flexfom) using
these `itemsProcFunc` handlers. These are used in the backend
within the `FormEngine` and additionally dispatched manually
in the `JobController` to retrieve the available select items.

Previously, it was required to add them either directly not
having an influence to the ordering OR to implement a custom
`itemsProcFunc` replacing the shipped version and both ways
are not really nice or testable.

To provide an easier way for projects to modify the available
select items, the handler now dispatches the newly introduced
shared event `ModifyTcaSelectFieldItemsEvent` added to the    
`EXT:academic_base` extension to reuse the same event in the   
other extension later and having an easy way to modify these
thins within one event listener and a central event avoiding
the need to deal with douzen of dedicatly named events for
the same purpose.

Further, the event and handler defines proper phpstan array
shapes helping directly to get the structure of the passed
argument.

Dispatching the event and that the event can be used to
manipulate the items are covered with functional tests.