### PR TITLE
[TASK] Pass type options to fluid templates rendering the form fields

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/EmailAddress.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/EmailAddress.html
@@ -26,7 +26,10 @@
                 element: {
                     form: 'emailAddress',
                     identifier: 'type',
-                    validations: validations
+                    validations: validations,
+                    options: availableTypes,
+                    optionValueField: 'value',
+                    optionLabelField: 'label',
                 }
             }"
         />

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/PhoneNumber.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/PhoneNumber.html
@@ -26,7 +26,10 @@
                 element: {
                     form: 'phoneNumber',
                     identifier: 'type',
-                    validations: validations
+                    validations: validations,
+                    options: availableTypes,
+                    optionValueField: 'value',
+                    optionLabelField: 'label',
                 }
             }"
         />

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/PhysicalAddress.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/PhysicalAddress.html
@@ -109,7 +109,10 @@
                 element: {
                     form: 'physicalAddress',
                     identifier: 'type',
-                    validations: validations
+                    validations: validations,
+                    options: availableTypes,
+                    optionValueField: 'value',
+                    optionLabelField: 'label',
                 }
             }"
         />


### PR DESCRIPTION
Because the passed variables were missing the select options
those were always empty. Passing them down to the select
partial now renders the options.