### PR TITLE
[TASK] Extract record translation into dedicated `RecordSyncronizationService`

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
@@ -4,19 +4,15 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\EventListener;
 
-use Doctrine\DBAL\Result;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
 use FGTCLB\AcademicPersons\Event\AfterProfileUpdateEvent;
+use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
 use FGTCLB\AcademicPersonsEdit\Profile\ProfileTranslator;
-use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * @todo This event reacts on an PSR-14 event dispatched in FE, BE and CLI(BE) context AND relies on a global
@@ -29,9 +25,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 final class SyncChangesToTranslations
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
         private readonly ProfileTranslator $profileTranslator,
         private readonly SiteFinder $siteFinder,
+        private readonly RecordSyncronizerInterface $recordSyncronizer,
     ) {}
 
     public function __invoke(AfterProfileUpdateEvent $event): void
@@ -55,296 +51,15 @@ final class SyncChangesToTranslations
             // No site found, nothing to do.
             return;
         }
-        $this->synchronizeTranslations(
-            $site,
-            $site->getDefaultLanguage()->getLanguageId(),
-            $this->profileTranslator->getAllowedLanguageIds(),
-            'tx_academicpersons_domain_model_profile',
-            $profile->getUid(),
-            [],
+
+        $context = SyncronizerContext::create(
+            recordSyncronizer: $this->recordSyncronizer,
+            site: $site,
+            allowedLanguageIds: $this->profileTranslator->getAllowedLanguageIds(),
+            tableName: 'tx_academicpersons_domain_model_profile',
+            uid: $profile->getUid(),
         );
-    }
-
-    /**
-     * @param int[] $allowedLanguageIds
-     * @param array<string, mixed> $values
-     */
-    private function synchronizeTranslations(
-        Site $site,
-        int $defaultLanguageId,
-        array $allowedLanguageIds,
-        string $table,
-        int $uid,
-        array $values,
-    ): void {
-        $defaultRecord = $this->getDefaultRecord($table, $uid, $defaultLanguageId);
-        if (empty($defaultRecord)) {
-            return;
-        }
-
-        $tcaColumns = $GLOBALS['TCA'][$table]['columns'];
-        foreach ($allowedLanguageIds as $languageUid) {
-            $translatedRecord = $this->getTranslatedRecord($table, $uid, $languageUid);
-
-            // Create translation if it does not exist
-            if (empty($translatedRecord)) {
-                $translatedRecord = $this->createTranslation(
-                    $table,
-                    $defaultRecord,
-                    $languageUid,
-                    $values
-                );
-                // @todo Add error handling
-                if (empty($translatedRecord)) {
-                    continue;
-                }
-            } else {
-                // Else synchronize values from the default record into its translation
-                $this->updateTranslation($table, $defaultRecord, $translatedRecord);
-            }
-
-            // Synchronize inline child records
-            foreach ($tcaColumns as $columnName => $columnDefinition) {
-                // @todo Check if this condition fits for all cases
-                if ($columnDefinition['config']['type'] === 'inline'
-                    && $columnName !== 'sys_file_reference'
-                ) {
-                    $inlineTable = $columnDefinition['config']['foreign_table'];
-                    $inlineField = $columnDefinition['config']['foreign_field'];
-
-                    $inlineChilds = $this->getInlineChilds(
-                        $inlineTable,
-                        $inlineField,
-                        $defaultRecord['uid'],
-                        $defaultLanguageId,
-                    );
-                    if ($inlineChilds === null) {
-                        // No inline children. Skip to next loop iteration.
-                        continue;
-                    }
-                    while ($inlineChild = $inlineChilds->fetchAssociative()) {
-                        $this->synchronizeTranslations(
-                            $site,
-                            $defaultLanguageId,
-                            $allowedLanguageIds,
-                            $inlineTable,
-                            $inlineChild['uid'],
-                            [
-                                (string)$inlineField => $translatedRecord['uid'],
-                            ],
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * @param string $table
-     * @param array<string, mixed> $defaultRecord
-     * @param int $languageUid
-     * @param array<string, mixed> $values
-     * @return array<string, mixed>
-     */
-    private function createTranslation(
-        string $table,
-        array $defaultRecord,
-        int $languageUid,
-        array $values = []
-    ): array {
-        $defaultRecoredUid = $defaultRecord['uid'];
-        $tcaColumns = $GLOBALS['TCA'][$table]['columns'];
-        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
-
-        // Exclude inline columns from the default record
-        $excludeColumns = array_merge(
-            ['uid', 'l10n_diffsource', 't3ver_oid', 't3ver_wsid', 't3ver_state', 't3ver_stage'],
-            array_keys($values)
-        );
-        foreach ($tcaColumns as $columnName => $columnDefinition) {
-            if ($columnDefinition['config']['type'] === 'inline') {
-                $excludeColumns[] = $columnName;
-            }
-        }
-
-        // Merge default record values with the given values
-        foreach ($defaultRecord as $columnName => $value) {
-            if (!in_array($columnName, $excludeColumns)) {
-                $values[$columnName] = $value;
-            }
-        }
-
-        // Override language specific values
-        $values['sys_language_uid'] = $languageUid;
-        if (isset($tcaCtrl['transOrigPointerField'])) {
-            $values[$tcaCtrl['transOrigPointerField']] = $defaultRecoredUid;
-        }
-        if (isset($tcaCtrl['translationSource'])) {
-            $values[$tcaCtrl['translationSource']] = $defaultRecoredUid;
-        }
-        $values['crdate'] = $GLOBALS['EXEC_TIME'];
-        $values['tstamp'] = $GLOBALS['EXEC_TIME'];
-
-        $queryBuilder = $this->getQueryBuilder($table);
-        $queryBuilder->insert($table);
-        $queryBuilder->values($values);
-
-        $queryBuilder->executeStatement();
-
-        return $this->getTranslatedRecord($table, $defaultRecoredUid, $languageUid);
-    }
-
-    /**
-     * @param string $table
-     * @param array<string, mixed> $defaultRecord
-     * @param array<string, mixed> $translatedRecord
-     */
-    private function updateTranslation(
-        string $table,
-        array $defaultRecord,
-        array $translatedRecord
-    ): void {
-        $tcaColumns = $GLOBALS['TCA'][$table]['columns'];
-        $updateColumns = [];
-        foreach ($tcaColumns as $columnName => $columnDefinition) {
-            if (isset($columnDefinition['config']['type'])
-                && is_string($columnDefinition['config']['type'])
-                && $columnDefinition['config']['type'] !== 'inline'
-                && isset($columnDefinition['l10n_mode'])
-                && $columnDefinition['l10n_mode'] === 'exclude'
-            ) {
-                $updateColumns[] = $columnName;
-            }
-        }
-
-        // Skip if there are no columns to update
-        if (empty($updateColumns)) {
-            return;
-        }
-
-        $queryBuilder = $this->getQueryBuilder($table);
-        $queryBuilder->update($table)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid',
-                    $queryBuilder->createNamedParameter($translatedRecord['uid'], Connection::PARAM_INT)
-                )
-            );
-
-        foreach ($updateColumns as $columnName) {
-            $queryBuilder->set($columnName, $defaultRecord[$columnName]);
-        }
-
-        $queryBuilder->executeStatement();
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function getDefaultRecord(
-        string $table,
-        int $uid,
-        int $defaultLanguageId,
-    ): array {
-        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
-
-        $queryBuilder = $this->getQueryBuilder($table);
-        $queryBuilder->select('*')
-            ->from($table)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid',
-                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
-                ),
-                $queryBuilder->expr()->eq(
-                    $tcaCtrl['languageField'],
-                    $queryBuilder->createNamedParameter($defaultLanguageId, Connection::PARAM_INT)
-                )
-            )
-            ->setMaxResults(1);
-
-        $resultArray = $queryBuilder->executeQuery()->fetchAssociative();
-
-        return $resultArray ?: [];
-    }
-
-    /**
-     * @param string $table
-     * @param int $uid
-     * @param int $languageUid
-     * @return array<string, mixed>
-     */
-    private function getTranslatedRecord(
-        string $table,
-        int $uid,
-        int $languageUid
-    ): array {
-        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
-
-        $queryBuilder = $this->getQueryBuilder($table);
-        $queryBuilder->select('*')
-            ->from($table)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    $tcaCtrl['translationSource'] ?? $tcaCtrl['transOrigPointerField'],
-                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
-                ),
-                $queryBuilder->expr()->eq(
-                    $tcaCtrl['languageField'],
-                    $queryBuilder->createNamedParameter((int)$languageUid, Connection::PARAM_INT)
-                )
-            )
-            ->setMaxResults(1);
-
-        $resultArray = $queryBuilder->executeQuery()->fetchAssociative();
-
-        return $resultArray ?: [];
-    }
-
-    /**
-     * @return Result|null
-     */
-    private function getInlineChilds(
-        string $table,
-        string $field,
-        int $uid,
-        int $defaultLanguageId,
-    ): ?Result {
-        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
-
-        if (!isset($tcaCtrl['languageField'])) {
-            return null;
-        }
-        $queryBuilder = $this->getQueryBuilder($table);
-        $queryBuilder->select('*')
-            ->from($table)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    $field,
-                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
-                ),
-                $queryBuilder->expr()->eq(
-                    $tcaCtrl['languageField'],
-                    $queryBuilder->createNamedParameter($defaultLanguageId, Connection::PARAM_INT)
-                )
-            );
-
-        return $queryBuilder->executeQuery();
-    }
-
-    /**
-     * Get a query builder for a table.
-     *
-     * @param string $table Table name present in $GLOBALS['TCA']
-     * @return QueryBuilder
-     */
-    private function getQueryBuilder(string $table): QueryBuilder
-    {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        return $queryBuilder;
+        $this->recordSyncronizer->syncronize($context);
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/EventListener/SyncChangesToTranslationsTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/EventListener/SyncChangesToTranslationsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\EventListener;
+
+use FGTCLB\AcademicPersons\Service\RecordSyncronizer;
+use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersonsEdit\EventListener\SyncChangesToTranslations;
+use FGTCLB\AcademicPersonsEdit\Profile\ProfileTranslator;
+use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+final class SyncChangesToTranslationsTest extends AbstractAcademicPersonsEditTestCase
+{
+    #[Test]
+    public function eventListenerCanBeRetrievedFromContainer(): void
+    {
+        $eventListener = $this->get(SyncChangesToTranslations::class);
+        $this->assertInstanceOf(SyncChangesToTranslations::class, $eventListener);
+
+        $eventListenerReflection = new \ReflectionClass($eventListener);
+        $this->assertInstanceOf(RecordSyncronizerInterface::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
+        $this->assertInstanceOf(RecordSyncronizer::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
+        $this->assertInstanceOf(ProfileTranslator::class, $eventListenerReflection->getProperty('profileTranslator')->getValue($eventListener));
+        $this->assertInstanceOf(SiteFinder::class, $eventListenerReflection->getProperty('siteFinder')->getValue($eventListener));
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/Syncronizer/SyncronizerContext.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/Syncronizer/SyncronizerContext.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer;
+
+use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
+final class SyncronizerContext
+{
+    /**
+     * @param array<int, SiteLanguage> $allowedSiteLanguages
+     */
+    public function __construct(
+        public readonly RecordSyncronizerInterface $recordSyncronizer,
+        public readonly Site $site,
+        public readonly SiteLanguage $defaultLanguage,
+        public readonly array $allowedSiteLanguages,
+        public readonly string $tableName,
+        public readonly int $uid,
+    ) {}
+
+    /**
+     * @param RecordSyncronizerInterface $recordSyncronizer
+     * @param Site $site
+     * @param array<int, string|int> $allowedLanguageIds
+     * @param string $tableName
+     * @param int $uid
+     * @return self
+     */
+    public static function create(
+        RecordSyncronizerInterface $recordSyncronizer,
+        Site $site,
+        array $allowedLanguageIds,
+        string $tableName,
+        int $uid,
+    ): self {
+        $allowedSiteLanguages = [];
+        foreach ($allowedLanguageIds as $allowedLanguageId) {
+            $allowedLanguageId = (int)$allowedLanguageId;
+            if ($allowedLanguageId <= 0) {
+                continue;
+            }
+            try {
+                $siteLanguage = $site->getLanguageById($allowedLanguageId);
+                $allowedSiteLanguages[$siteLanguage->getLanguageId()] = $siteLanguage;
+            } catch (\InvalidArgumentException $e) {
+                if ($e->getCode() !== 1522960188) {
+                    // Some unexpected exception occorued, rethrow. We only want to handle the
+                    // specific TYPO3 exception code indicating that passed language id does
+                    // not exist for the passed site configuration.
+                    throw $e;
+                }
+            }
+        }
+        return new self(
+            recordSyncronizer: $recordSyncronizer,
+            site: $site,
+            defaultLanguage: $site->getDefaultLanguage(),
+            allowedSiteLanguages: $allowedSiteLanguages,
+            tableName: $tableName,
+            uid: $uid,
+        );
+    }
+
+    public function withRecord(string $tableName, int $uid): self
+    {
+        return new self(
+            recordSyncronizer: $this->recordSyncronizer,
+            site: $this->site,
+            defaultLanguage: $this->defaultLanguage,
+            allowedSiteLanguages: $this->allowedSiteLanguages,
+            tableName: $tableName,
+            uid: $uid,
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getAllowedLanguageIds(): array
+    {
+        return array_keys($this->allowedSiteLanguages);
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Service/RecordSyncronizer.php
+++ b/packages/fgtclb/academic-persons/Classes/Service/RecordSyncronizer.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Service;
+
+use Doctrine\DBAL\Result;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @internal being experimental for now until implementation has been streamlined, tested and covered with tests.
+ * @final not marked as final for functional testing reasons (for now). Class should not be extended otherwise.
+ */
+#[AsAlias(id: RecordSyncronizerInterface::class, public: true)]
+#[Autoconfigure(public: true)]
+class RecordSyncronizer implements RecordSyncronizerInterface
+{
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    public function syncronize(SyncronizerContext $context): void
+    {
+        $this->syncronizeRecord($context, []);
+    }
+
+    /**
+     * @param array<string, int|float|string|bool|null> $values
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function syncronizeRecord(SyncronizerContext $context, array $values): void
+    {
+        $defaultRecord = $this->getDefaultRecord(
+            $context->tableName,
+            $context->uid,
+            $context->defaultLanguage->getLanguageId(),
+        );
+        if ($defaultRecord === null) {
+            return;
+        }
+        $tcaColumns = $GLOBALS['TCA'][$context->tableName]['columns'];
+        foreach ($context->allowedSiteLanguages as $allowedSiteLanguage) {
+            $translatedRecord = $this->getTranslatedRecord(
+                $context->tableName,
+                $context->uid,
+                $allowedSiteLanguage->getLanguageId(),
+            );
+            if ($translatedRecord !== null) {
+                $this->updateTranslation(
+                    $context,
+                    $defaultRecord,
+                    $translatedRecord,
+                );
+                continue;
+            }
+            $translatedRecord = $this->createTranslation(
+                $context->tableName,
+                $defaultRecord,
+                $allowedSiteLanguage->getLanguageId(),
+                $values,
+            );
+            if ($translatedRecord === null) {
+                // Failed to create translation record, skip relation synchronization.
+                continue;
+            }
+            foreach ($tcaColumns as $columnName => $columnDefinition) {
+                $columnType = $columnDefinition['type'] ?? 'unknown';
+                if (!($columnType === 'inline' && $columnName !== 'sys_file_reference')) {
+                    // Non inline fields or column `sys_file_reference` should be skipped.
+                    // @todo Column name `sys_file_reference` exclude does not make sense and should be most likely
+                    //       `foreign_table` and will investigated at a later point, kept for now during moving code
+                    //       around to prepare for better testability and avoiding a side task for now.
+                    continue;
+                }
+                $inlineTable = $columnDefinition['config']['foreign_table'];
+                $inlineField = $columnDefinition['config']['foreign_field'];
+                $inlineChilds = $this->getInlineChilds(
+                    $inlineTable,
+                    $inlineField,
+                    $defaultRecord['uid'],
+                    $context->defaultLanguage->getLanguageId(),
+                );
+                if ($inlineChilds === null) {
+                    // No inline children. Skip to next loop iteration.
+                    continue;
+                }
+                while ($inlineChild = $inlineChilds->fetchAssociative()) {
+                    $this->syncronizeRecord(
+                        $context->withRecord($inlineTable, $inlineChild['uid']),
+                        [
+                            (string)$inlineField => $translatedRecord['uid'],
+                        ],
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDefaultRecord(
+        string $table,
+        int $uid,
+        int $defaultLanguageId,
+    ): ?array {
+        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
+
+        $queryBuilder = $this->getQueryBuilder($table);
+        $queryBuilder->select('*')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    $tcaCtrl['languageField'],
+                    $queryBuilder->createNamedParameter($defaultLanguageId, Connection::PARAM_INT)
+                )
+            )
+            ->setMaxResults(1);
+
+        $resultArray = $queryBuilder->executeQuery()->fetchAssociative();
+
+        return $resultArray ?: null;
+    }
+
+    /**
+     * @param string $table
+     * @param int $uid
+     * @param int $languageUid
+     * @return array<string, mixed>
+     */
+    private function getTranslatedRecord(
+        string $table,
+        int $uid,
+        int $languageUid
+    ): ?array {
+        $tcaCtrl = $GLOBALS['TCA'][$table]['ctrl'];
+
+        $queryBuilder = $this->getQueryBuilder($table);
+        $queryBuilder->select('*')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    $tcaCtrl['translationSource'] ?? $tcaCtrl['transOrigPointerField'],
+                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    $tcaCtrl['languageField'],
+                    $queryBuilder->createNamedParameter((int)$languageUid, Connection::PARAM_INT)
+                )
+            )
+            ->setMaxResults(1);
+
+        $resultArray = $queryBuilder->executeQuery()->fetchAssociative();
+
+        return $resultArray ?: null;
+    }
+
+    /**
+     * @param string $tableName
+     * @param array<string, mixed> $defaultRecord
+     * @param int $languageUid
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>|null
+     */
+    private function createTranslation(
+        string $tableName,
+        array $defaultRecord,
+        int $languageUid,
+        array $values = []
+    ): ?array {
+        $defaultRecoredUid = $defaultRecord['uid'];
+        $tcaColumns = $GLOBALS['TCA'][$tableName]['columns'];
+        $tcaCtrl = $GLOBALS['TCA'][$tableName]['ctrl'];
+
+        // Exclude inline columns from the default record
+        $excludeColumns = array_merge(
+            ['uid', 'l10n_diffsource', 't3ver_oid', 't3ver_wsid', 't3ver_state', 't3ver_stage'],
+            array_keys($values)
+        );
+        foreach ($tcaColumns as $columnName => $columnDefinition) {
+            if ($columnDefinition['config']['type'] === 'inline') {
+                $excludeColumns[] = $columnName;
+            }
+        }
+
+        // Merge default record values with the given values
+        foreach ($defaultRecord as $columnName => $value) {
+            if (!in_array($columnName, $excludeColumns)) {
+                $values[$columnName] = $value;
+            }
+        }
+
+        // Override language specific values
+        $values['sys_language_uid'] = $languageUid;
+        if (isset($tcaCtrl['transOrigPointerField'])) {
+            $values[$tcaCtrl['transOrigPointerField']] = $defaultRecoredUid;
+        }
+        if (isset($tcaCtrl['translationSource'])) {
+            $values[$tcaCtrl['translationSource']] = $defaultRecoredUid;
+        }
+        $values['crdate'] = $GLOBALS['EXEC_TIME'];
+        $values['tstamp'] = $GLOBALS['EXEC_TIME'];
+
+        $queryBuilder = $this->getQueryBuilder($tableName);
+        $queryBuilder->insert($tableName);
+        $queryBuilder->values($values);
+
+        $queryBuilder->executeStatement();
+
+        return $this->getTranslatedRecord($tableName, $defaultRecoredUid, $languageUid);
+    }
+
+    /**
+     * @param array<string, mixed> $defaultRecord
+     * @param array<string, mixed> $translatedRecord
+     */
+    private function updateTranslation(
+        SyncronizerContext $context,
+        array $defaultRecord,
+        array $translatedRecord
+    ): void {
+        $tcaColumns = $GLOBALS['TCA'][$context->tableName]['columns'];
+        $updateColumns = [];
+        foreach ($tcaColumns as $columnName => $columnDefinition) {
+            if (isset($columnDefinition['config']['type'])
+                && is_string($columnDefinition['config']['type'])
+                && $columnDefinition['config']['type'] !== 'inline'
+                && isset($columnDefinition['l10n_mode'])
+                && $columnDefinition['l10n_mode'] === 'exclude'
+            ) {
+                $updateColumns[] = $columnName;
+            }
+        }
+
+        // Skip if there are no columns to update
+        if (empty($updateColumns)) {
+            return;
+        }
+
+        $queryBuilder = $this->getQueryBuilder($context->tableName);
+        $queryBuilder->update($context->tableName)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($translatedRecord['uid'], Connection::PARAM_INT)
+                ),
+            );
+
+        foreach ($updateColumns as $columnName) {
+            $queryBuilder->set($columnName, $defaultRecord[$columnName]);
+        }
+
+        $queryBuilder->executeStatement();
+    }
+
+    /**
+     * @return Result|null
+     */
+    private function getInlineChilds(
+        string $tableName,
+        string $field,
+        int $uid,
+        int $defaultLanguageId,
+    ): ?Result {
+        $tcaCtrl = $GLOBALS['TCA'][$tableName]['ctrl'];
+        if (!isset($tcaCtrl['languageField'])) {
+            return null;
+        }
+        $queryBuilder = $this->getQueryBuilder($tableName);
+        $queryBuilder->select('*')
+            ->from($tableName)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    $field,
+                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    $tcaCtrl['languageField'],
+                    $queryBuilder->createNamedParameter($defaultLanguageId, Connection::PARAM_INT)
+                )
+            );
+
+        return $queryBuilder->executeQuery();
+    }
+
+    /**
+     * Get a query builder for a table.
+     *
+     * @param string $table Table name present in $GLOBALS['TCA']
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(string $table): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        return $queryBuilder;
+    }
+}

--- a/packages/fgtclb/academic-persons/Classes/Service/RecordSyncronizerInterface.php
+++ b/packages/fgtclb/academic-persons/Classes/Service/RecordSyncronizerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Service;
+
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
+
+/**
+ * @internal being experimental for now until implementation has been streamlined, tested and covered with tests.
+ */
+interface RecordSyncronizerInterface
+{
+    public function syncronize(
+        SyncronizerContext $context,
+    ): void;
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Service/RecordSyncronizerTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Service/RecordSyncronizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Service;
+
+use FGTCLB\AcademicPersons\Service\RecordSyncronizer;
+use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class RecordSyncronizerTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function serviceCanBeFetchedFromContainerByInterface(): void
+    {
+        $service = $this->get(RecordSyncronizerInterface::class);
+        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+    }
+
+    #[Test]
+    public function serviceCanBeFetchedFromContainerByClassName(): void
+    {
+        $service = $this->get(RecordSyncronizer::class);
+        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+    }
+
+    #[Test]
+    public function serviceCanBeFetchedFromGeneralUtilityByInterface(): void
+    {
+        $service = GeneralUtility::makeInstance(RecordSyncronizerInterface::class);
+        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+    }
+
+    #[Test]
+    public function serviceCanBeFetchedFromGeneralUtilityByClassName(): void
+    {
+        $service = GeneralUtility::makeInstance(RecordSyncronizer::class);
+        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+    }
+}


### PR DESCRIPTION
`EXT:academic_persons_edit` implements a PSR-14 event for the
`AfterProfileUpdateEvent` event dispatched in the controller,
with the goal to syncronize profile and relations for languages
configured in the extension configuration.

The internal code within the event listener to handle the sync
for profile and relation records has a couple of issues, which
needs to be investigated, fixed and tested.

Following best practice, event listeners should be glue code
like for example controllers and using services to accomplish
complexer tasks, which is not done here.

This change extracts the handling code from the event listener
of `EXT:academic_persons_edit` into a new services provided by
`EXT:academic_persons` now with a streamlined outer surface,
moving the internal code simply to the new service as private
methods.

Note that the implementation is not touched or changed yet by
intention, which will be done in a dedicated followup along
with added functional test coverage.

The change prepare working on fixing issues and is not itself
a bugfix.
