### PR TITLE
[TASK] ACE-104: Fix typo in synchronizer classes

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/EventListener/SyncChangesToTranslations.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\EventListener;
 
-use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SynchronizerContext;
 use FGTCLB\AcademicPersons\Event\AfterProfileUpdateEvent;
-use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizerInterface;
 use FGTCLB\AcademicPersonsEdit\Profile\ProfileTranslator;
 use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
@@ -27,7 +27,7 @@ final class SyncChangesToTranslations
     public function __construct(
         private readonly ProfileTranslator $profileTranslator,
         private readonly SiteFinder $siteFinder,
-        private readonly RecordSyncronizerInterface $recordSyncronizer,
+        private readonly RecordSynchronizerInterface $recordSyncronizer,
     ) {}
 
     public function __invoke(AfterProfileUpdateEvent $event): void
@@ -52,14 +52,14 @@ final class SyncChangesToTranslations
             return;
         }
 
-        $context = SyncronizerContext::create(
+        $context = SynchronizerContext::create(
             recordSyncronizer: $this->recordSyncronizer,
             site: $site,
             allowedLanguageIds: $this->profileTranslator->getAllowedLanguageIds(),
             tableName: 'tx_academicpersons_domain_model_profile',
             uid: $profile->getUid(),
         );
-        $this->recordSyncronizer->syncronize($context);
+        $this->recordSyncronizer->synchronize($context);
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/EventListener/SyncChangesToTranslationsTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/EventListener/SyncChangesToTranslationsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\EventListener;
 
-use FGTCLB\AcademicPersons\Service\RecordSyncronizer;
-use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizer;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizerInterface;
 use FGTCLB\AcademicPersonsEdit\EventListener\SyncChangesToTranslations;
 use FGTCLB\AcademicPersonsEdit\Profile\ProfileTranslator;
 use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
@@ -21,8 +21,8 @@ final class SyncChangesToTranslationsTest extends AbstractAcademicPersonsEditTes
         $this->assertInstanceOf(SyncChangesToTranslations::class, $eventListener);
 
         $eventListenerReflection = new \ReflectionClass($eventListener);
-        $this->assertInstanceOf(RecordSyncronizerInterface::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
-        $this->assertInstanceOf(RecordSyncronizer::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
+        $this->assertInstanceOf(RecordSynchronizerInterface::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
+        $this->assertInstanceOf(RecordSynchronizer::class, $eventListenerReflection->getProperty('recordSyncronizer')->getValue($eventListener));
         $this->assertInstanceOf(ProfileTranslator::class, $eventListenerReflection->getProperty('profileTranslator')->getValue($eventListener));
         $this->assertInstanceOf(SiteFinder::class, $eventListenerReflection->getProperty('siteFinder')->getValue($eventListener));
     }

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/Syncronizer/SynchronizerContext.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Dto/Syncronizer/SynchronizerContext.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer;
 
-use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizerInterface;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 
-final class SyncronizerContext
+final class SynchronizerContext
 {
     /**
      * @param array<int, SiteLanguage> $allowedSiteLanguages
      */
     public function __construct(
-        public readonly RecordSyncronizerInterface $recordSyncronizer,
+        public readonly RecordSynchronizerInterface $recordSyncronizer,
         public readonly Site $site,
         public readonly SiteLanguage $defaultLanguage,
         public readonly array $allowedSiteLanguages,
@@ -23,7 +23,7 @@ final class SyncronizerContext
     ) {}
 
     /**
-     * @param RecordSyncronizerInterface $recordSyncronizer
+     * @param RecordSynchronizerInterface $recordSyncronizer
      * @param Site $site
      * @param array<int, string|int> $allowedLanguageIds
      * @param string $tableName
@@ -31,7 +31,7 @@ final class SyncronizerContext
      * @return self
      */
     public static function create(
-        RecordSyncronizerInterface $recordSyncronizer,
+        RecordSynchronizerInterface $recordSyncronizer,
         Site $site,
         array $allowedLanguageIds,
         string $tableName,

--- a/packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizer.php
+++ b/packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Service;
 
 use Doctrine\DBAL\Result;
-use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SynchronizerContext;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Database\Connection;
@@ -18,24 +18,24 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @internal being experimental for now until implementation has been streamlined, tested and covered with tests.
  * @final not marked as final for functional testing reasons (for now). Class should not be extended otherwise.
  */
-#[AsAlias(id: RecordSyncronizerInterface::class, public: true)]
+#[AsAlias(id: RecordSynchronizerInterface::class, public: true)]
 #[Autoconfigure(public: true)]
-class RecordSyncronizer implements RecordSyncronizerInterface
+class RecordSynchronizer implements RecordSynchronizerInterface
 {
     public function __construct(
         private readonly ConnectionPool $connectionPool,
     ) {}
 
-    public function syncronize(SyncronizerContext $context): void
+    public function synchronize(SynchronizerContext $context): void
     {
-        $this->syncronizeRecord($context, []);
+        $this->synchronizeRecord($context, []);
     }
 
     /**
      * @param array<string, int|float|string|bool|null> $values
      * @throws \Doctrine\DBAL\Exception
      */
-    private function syncronizeRecord(SyncronizerContext $context, array $values): void
+    private function synchronizeRecord(SynchronizerContext $context, array $values): void
     {
         $defaultRecord = $this->getDefaultRecord(
             $context->tableName,
@@ -92,7 +92,7 @@ class RecordSyncronizer implements RecordSyncronizerInterface
                     continue;
                 }
                 while ($inlineChild = $inlineChilds->fetchAssociative()) {
-                    $this->syncronizeRecord(
+                    $this->synchronizeRecord(
                         $context->withRecord($inlineTable, $inlineChild['uid']),
                         [
                             (string)$inlineField => $translatedRecord['uid'],
@@ -226,7 +226,7 @@ class RecordSyncronizer implements RecordSyncronizerInterface
      * @param array<string, mixed> $translatedRecord
      */
     private function updateTranslation(
-        SyncronizerContext $context,
+        SynchronizerContext $context,
         array $defaultRecord,
         array $translatedRecord
     ): void {

--- a/packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizerInterface.php
+++ b/packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizerInterface.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Service;
 
-use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SyncronizerContext;
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SynchronizerContext;
 
 /**
  * @internal being experimental for now until implementation has been streamlined, tested and covered with tests.
  */
-interface RecordSyncronizerInterface
+interface RecordSynchronizerInterface
 {
-    public function syncronize(
-        SyncronizerContext $context,
+    public function synchronize(
+        SynchronizerContext $context,
     ): void;
 }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Service/RecordSyncronizerTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Service/RecordSyncronizerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersons\Tests\Functional\Service;
 
-use FGTCLB\AcademicPersons\Service\RecordSyncronizer;
-use FGTCLB\AcademicPersons\Service\RecordSyncronizerInterface;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizer;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizerInterface;
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -15,32 +15,32 @@ final class RecordSyncronizerTest extends AbstractAcademicPersonsTestCase
     #[Test]
     public function serviceCanBeFetchedFromContainerByInterface(): void
     {
-        $service = $this->get(RecordSyncronizerInterface::class);
-        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
-        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+        $service = $this->get(RecordSynchronizerInterface::class);
+        $this->assertInstanceOf(RecordSynchronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSynchronizer::class, $service);
     }
 
     #[Test]
     public function serviceCanBeFetchedFromContainerByClassName(): void
     {
-        $service = $this->get(RecordSyncronizer::class);
-        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
-        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+        $service = $this->get(RecordSynchronizer::class);
+        $this->assertInstanceOf(RecordSynchronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSynchronizer::class, $service);
     }
 
     #[Test]
     public function serviceCanBeFetchedFromGeneralUtilityByInterface(): void
     {
-        $service = GeneralUtility::makeInstance(RecordSyncronizerInterface::class);
-        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
-        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+        $service = GeneralUtility::makeInstance(RecordSynchronizerInterface::class);
+        $this->assertInstanceOf(RecordSynchronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSynchronizer::class, $service);
     }
 
     #[Test]
     public function serviceCanBeFetchedFromGeneralUtilityByClassName(): void
     {
-        $service = GeneralUtility::makeInstance(RecordSyncronizer::class);
-        $this->assertInstanceOf(RecordSyncronizerInterface::class, $service);
-        $this->assertInstanceOf(RecordSyncronizer::class, $service);
+        $service = GeneralUtility::makeInstance(RecordSynchronizer::class);
+        $this->assertInstanceOf(RecordSynchronizerInterface::class, $service);
+        $this->assertInstanceOf(RecordSynchronizer::class, $service);
     }
 }


### PR DESCRIPTION
Translation synchronization related code has been extracted
into dedicated services recently, sadly the type naming the
classes and method(s) has been overseen.

This change renames classes and methods to have the correct
spelling `synchronization` instead of `syncronization` and
similar. Mind the missing `h`.
