### PR TITLE
[BUGFIX] Use correct object property name for `EmailAddressFormData`

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/EmailAddress.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Properties/EmailAddress.html
@@ -11,7 +11,7 @@
             arguments="{
                 element: {
                     form: 'emailAddress',
-                    identifier: 'emailAddress',
+                    identifier: 'email',
                     validations: validations,
                     autocomplete: 'email'
                 }


### PR DESCRIPTION
Extbase comes with a lot of convention and magic in the
bagpack, which requires honest build up of things.

Automatic controller arguments mapping to DTO objects,
which are not extended from persisted extbase models,
has the requirement that the form identifier used in
fluid templates with `f:form.*` ViewHelpers needs to
match the `constructor argument name`.

This has been provided correctly fixing CRUD functions
of `EXT:academic_persons_edit`, but later the shipped
fluid templates has been reworked and not adopted in
the correct way.

This change uses the correct identifier for the email
adress DTO `email` argument in the property template,
which allows persistance of email addresses again.
