### PR TITLE
[TASK] Avoid inline syntax for validationEnsure ViewHelper usage

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Checkbox.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Checkbox.html
@@ -12,8 +12,10 @@
 
 <f:variable
     name="validation"
-    value="{p:validationEnsure(identifier: element.identifier, validations: element.validations)}"
-/>
+><p:validationEnsure
+    validations="{element.validations}"
+    identifier="{element.identifier}"
+/></f:variable>
 
 <f:render
     partial="Profile/Forms/FieldWrapper"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/DateTime.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/DateTime.html
@@ -12,8 +12,10 @@
 
 <f:variable
     name="validation"
-    value="{p:validationEnsure(identifier: element.identifier, validations: element.validations)}"
-/>
+><p:validationEnsure
+    validations="{element.validations}"
+    identifier="{element.identifier}"
+/></f:variable>
 
 <f:render
     partial="Profile/Forms/FieldWrapper"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Select.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Select.html
@@ -12,8 +12,10 @@
 
 <f:variable
     name="validation"
-    value="{p:validationEnsure(identifier: element.identifier, validations: element.validations)}"
-/>
+><p:validationEnsure
+    validations="{element.validations}"
+    identifier="{element.identifier}"
+/></f:variable>
 
 <f:render
     partial="Profile/Forms/FieldWrapper"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Textarea.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Textarea.html
@@ -12,8 +12,10 @@
 
 <f:variable
     name="validation"
-    value="{p:validationEnsure(identifier: element.identifier, validations: element.validations)}"
-/>
+><p:validationEnsure
+    validations="{element.validations}"
+    identifier="{element.identifier}"
+/></f:variable>
 
 <f:render
     partial="Profile/Forms/FieldWrapper"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Textfield.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Forms/Textfield.html
@@ -12,8 +12,10 @@
 
 <f:variable
     name="validation"
-    value="{p:validationEnsure(identifier: element.identifier, validations: element.validations)}"
-/>
+><p:validationEnsure
+    validations="{element.validations}"
+    identifier="{element.identifier}"
+/></f:variable>
 
 <f:render
     partial="Profile/Forms/FieldWrapper"


### PR DESCRIPTION
Using inline ViewHelper notation breaks IDE support to display
ViewHelper arguments help with available (generated) XSD files
and prevents autocompletion.

This change reverts switching to inline notation for ensuring
validations information is set correctly and keep IDE support
available.

Using inline notation for ViewHelpers **should** only be used
if there is now way around, for example within a attribute of
a HTML tag and is considered best-practice by TYPO3 Core and
Fluid Team maintainers. Even in case of attributes assigning
the ViewHelper result into a variable before usage and using
the variable instead makes templates more readable and keeps
IDE features working.

Litterally, `f:translate` is used with inline notation in all
places, which makes it harde to find typo's in wrong usages,
and **should** also be replaced in a dedicated change.

Needs a battle between maintainer and integrator first to
sort this out.
