### PR TITLE
[BUGFIX] Fix misreferenced label of appearance tab for TYPO3 v12.4.22

### DIFF
--- a/packages/fgtclb/academic-study-plan/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-study-plan/Configuration/TCA/Overrides/tt_content.php
@@ -81,7 +81,7 @@ defined('TYPO3') or die();
                 --palette--;;headers,
                 tx_academicstudyplan_semesters,
                 tx_academicstudyplan_footer_note,
-            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:appearance,
+            --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
                 --palette--;;frames,
                 --palette--;;appearanceLinks,
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,

--- a/packages/fgtclb/academic-study-plan/composer.json
+++ b/packages/fgtclb/academic-study-plan/composer.json
@@ -21,6 +21,7 @@
         "typo3/cms-backend": "^12.4.22 || ^13.4",
         "typo3/cms-core": "^12.4.22 || ^13.4",
         "typo3/cms-fluid": "^12.4.22 || ^13.4",
+        "typo3/cms-frontend": "^12.4.22 || ^13.4",
         "typo3/cms-install": "^12.4.22 || ^13.4"
     },
     "autoload": {


### PR DESCRIPTION
In TYPO3 v12.4.22, the label for the appearance tab is not (yet) included in `typo3/cms-core`:

https://github.com/TYPO3-CMS/core/blob/v12.4.22/Resources/Private/Language/Form/locallang_tabs.xlf

When referencing this missing label for a tab, the corresponding tab naturally remains unlabelled.

Instead, the label is defined in `typo3/cms-frontend`:

https://github.com/TYPO3-CMS/frontend/blob/v12.4.22/Resources/Private/Language/locallang_ttc.xlf#L780-L782

This label remains defined even in TYPO3 v14.2.0:

https://github.com/TYPO3-CMS/frontend/blob/v14.2.0/Resources/Private/Language/locallang_ttc.xlf#L447-L449

Referencing this label instead of the definition in `typo3/cms-core` appears to remain for backwards compatibility.
Since this project declares support for TYPO3 v12.4.22, it should use the label reference that has existed since then.