### PR TITLE
[BUGFIX] ACE-226: Ensure extbase overlay mode for selected projects

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
@@ -32,6 +32,11 @@ class ProjectRepository extends Repository
         if (!empty($demand->getPages())) {
             if ($demand->getShowSelected() === true) {
                 $constraints[] = $query->in('uid', $demand->getPages());
+                // Selecting record ids in the backend (FormEngine) are always persisted using the default language
+                // uid of the records unrelated to the language and leads to missing translated contend depending on
+                // the site configuration and frontend context. In these cases we need to disable respecting the
+                // system langauge to tell Extbase ORM to do proper overlay handling in this case.
+                $query->getQuerySettings()->setRespectSysLanguage(false);
             } else {
                 $constraints[] = $query->in('pid', $demand->getPages());
                 $query->getQuerySettings()->setRespectStoragePage(true);


### PR DESCRIPTION
Using selected record id's persisted through backend FormEngine
as filter within extbase is sensible to the used query context
mode.

This change enforces to ignore the system language in case of
selected profiles and show selected option to put extbase in
the correct query context mode retrieving the correct translated
record or in case of language strict mode the translated records
at all.
