### PR TITLE
[TASK] DPL-81: Use PHP8.5 for core-13 unit/functional tests

### DIFF
--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -14,37 +14,10 @@ jobs:
       matrix:
         php-version: [ "8.1" ]
         typo3: ["12"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
@@ -67,37 +40,10 @@ jobs:
       matrix:
         php-version: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         typo3: ["12"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
@@ -112,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.5" ]
+        php-version: [ "8.1", "8.4" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -145,7 +91,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
@@ -159,41 +105,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.4"]
+        php-version: [ "8.1", "8.4" ]
         typo3: ["12"]
-    needs: ["code-quality", "linting", "unit"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
-
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"

--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -14,37 +14,10 @@ jobs:
       matrix:
         php-version: [ "8.2" ]
         typo3: ["13"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
@@ -65,35 +38,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.3", "8.4", "8.5" ]
+        php-version: [ "8.2", "8.5" ]
         typo3: ["13"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
     steps:
 
       - name: "Checkout"
@@ -114,38 +60,10 @@ jobs:
       matrix:
         php-version: [ "8.2", "8.5" ]
         typo3: ["13"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
-
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
@@ -154,49 +72,19 @@ jobs:
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
 
 
-# @todo - Mitigate automatic TCA migrations within all extensions properly and avoid deprecation messages,
-#         which breaks functional test executions
   functional:
     name: "functional"
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.2", "8.4"]
+        php-version: [ "8.2", "8.5" ]
         typo3: ["13"]
     needs: ["code-quality", "linting", "unit"]
-    permissions:
-      # actions: read|write|none
-      actions: none
-      # checks: read|write|none
-      checks: none
-      # contents: read|write|none
-      contents: read
-      # deployments: read|write|none
-      deployments: none
-      # id-token: read|write|none
-      id-token: none
-      # issues: read|write|none
-      issues: none
-      # discussions: read|write|none
-      discussions: none
-      # packages: read|write|none
-      packages: read
-      # pages: read|write|none
-      pages: none
-      # pull-requests: read|write|none
-      pull-requests: none
-      # repository-projects: read|write|none
-      repository-projects: read
-      # security-events: read|write|none
-      security-events: none
-      # statuses: read|write|none
-      statuses: none
-
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Service/ListSortingServiceTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Service/ListSortingServiceTest.php
@@ -71,7 +71,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
         $listSortingService = new ListSortingService();
         $listSortingService->injectPersistenceManager($persistenceManagerMock);
         $invoker = (new \ReflectionMethod($listSortingService, 'createListSortingProcess'));
-        $invoker->setAccessible(true);
 
         $this->expectException(InvalidItemProvidedException::class);
         $this->expectExceptionCode(1774370991);
@@ -88,7 +87,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
         $listSortingService = new ListSortingService();
         $listSortingService->injectPersistenceManager($persistenceManagerMock);
         $invoker = (new \ReflectionMethod($listSortingService, 'createListSortingProcess'));
-        $invoker->setAccessible(true);
 
         $this->expectException(InvalidItemProvidedException::class);
         $this->expectExceptionCode(1774371062);
@@ -105,7 +103,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
         $listSortingService = new ListSortingService();
         $listSortingService->injectPersistenceManager($persistenceManagerMock);
         $invoker = (new \ReflectionMethod($listSortingService, 'createListSortingProcess'));
-        $invoker->setAccessible(true);
         $process = $invoker->invoke($listSortingService, [], 0);
         $this->assertInstanceOf(ListSortingProcess::class, $process);
         $this->assertSame(0, $process->targetItemUid);
@@ -129,7 +126,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
         $model2 = self::createTestModel(1);
         $items = [0 => $model1, 1 => $model2];
         $invoker = (new \ReflectionMethod($listSortingService, 'createListSortingProcess'));
-        $invoker->setAccessible(true);
         $process = $invoker->invoke($listSortingService, $items, 1);
         $this->assertInstanceOf(ListSortingProcess::class, $process);
         $this->assertSame(1, $process->targetItemUid);
@@ -153,7 +149,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
         $model2 = self::createTestModel(1);
         $items = [0 => $model1, 1 => $model2];
         $invoker = (new \ReflectionMethod($listSortingService, 'createListSortingProcess'));
-        $invoker->setAccessible(true);
         $process = $invoker->invoke($listSortingService, $items, 3);
         $this->assertInstanceOf(ListSortingProcess::class, $process);
         $this->assertSame(3, $process->targetItemUid);
@@ -177,7 +172,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
             items: [],
         );
         $invoker = (new \ReflectionMethod($listSortingService, 'applyArrayItemsIndexAsSortingValue'));
-        $invoker->setAccessible(true);
         $returnedProcess = $invoker->invoke($listSortingService, $process);
         $this->assertInstanceOf(ListSortingProcess::class, $returnedProcess);
         $this->assertFalse($returnedProcess->changed);
@@ -199,7 +193,6 @@ final class ListSortingServiceTest extends AbstractAcademicPersonsEditTestCase
             items: $items,
         );
         $invoker = (new \ReflectionMethod($listSortingService, 'applyArrayItemsIndexAsSortingValue'));
-        $invoker->setAccessible(true);
         $returnedProcess = $invoker->invoke($listSortingService, $process);
         $this->assertInstanceOf(ListSortingProcess::class, $returnedProcess);
         $this->assertTrue($returnedProcess->changed);


### PR DESCRIPTION
This tests ensures that suiting lowest/highest PHP
version used for unit and functional tests aligns
with the PHP version range supported by used TYPO3
version.
