### PR TITLE
[BUGFIX] ACE-227: Use correct `TCA` path for delete field name

### DIFF
--- a/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
+++ b/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
@@ -153,6 +153,7 @@ final class StudyPlanService
 
     private function getTableLanguageFieldName(string $tableName): ?string
     {
+        // See: https://docs.typo3.org/permalink/t3tca:confval-ctrl-languagefield
         if (isset($GLOBALS['TCA'][$tableName])
             && is_array($GLOBALS['TCA'][$tableName])
             && isset($GLOBALS['TCA'][$tableName]['ctrl'])
@@ -168,6 +169,7 @@ final class StudyPlanService
 
     private function getTableHiddenFieldName(string $tableName): ?string
     {
+        // See: https://docs.typo3.org/permalink/t3tca:confval-ctrl-enablecolumns -> `disabled`
         if (isset($GLOBALS['TCA'][$tableName])
             && is_array($GLOBALS['TCA'][$tableName])
             && isset($GLOBALS['TCA'][$tableName]['ctrl'])
@@ -184,17 +186,16 @@ final class StudyPlanService
     }
     private function getTableDeletedFieldName(string $tableName): ?string
     {
+        // See: https://docs.typo3.org/permalink/t3tca:confval-ctrl-delete
         if (isset($GLOBALS['TCA'][$tableName])
             && is_array($GLOBALS['TCA'][$tableName])
             && isset($GLOBALS['TCA'][$tableName]['ctrl'])
             && is_array($GLOBALS['TCA'][$tableName]['ctrl'])
-            && isset($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns'])
-            && is_array($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns'])
-            && isset($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']['deleted'])
-            && is_string($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']['deleted'])
-            && trim((string)$GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']['deleted']) !== ''
+            && isset($GLOBALS['TCA'][$tableName]['ctrl']['delete'])
+            && is_string($GLOBALS['TCA'][$tableName]['ctrl']['delete'])
+            && trim((string)$GLOBALS['TCA'][$tableName]['ctrl']['delete']) !== ''
         ) {
-            return trim((string)($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']['deleted'])) ?: null;
+            return trim((string)($GLOBALS['TCA'][$tableName]['ctrl']['delete'])) ?: null;
         }
         return null;
     }

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/Service/StudyPlanServiceTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/Service/StudyPlanServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicStudyPlan\Tests\Functional\Service;
+
+use FGTCLB\AcademicStudyPlan\Service\StudyPlanService;
+use FGTCLB\AcademicStudyPlan\Tests\Functional\AbstractAcademicStudyPlanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class StudyPlanServiceTest extends AbstractAcademicStudyPlanTestCase
+{
+    public static function getTableHiddenFieldNameDataSets(): \Generator
+    {
+        $sets = [
+            // Extension
+            'tx_academicstudyplan_domain_model_category' => 'hidden',
+            'tx_academicstudyplan_domain_model_module' => 'hidden',
+            'tx_academicstudyplan_domain_model_semester' => 'hidden',
+            // TYPO3 Core Cross checks
+            'pages' => 'hidden',
+            'tt_content' => 'hidden',
+            'sys_log' => null,
+        ];
+        $c = 0;
+        foreach ($sets as $tableName => $expected) {
+            $c++;
+            $label = sprintf(
+                '#%s "%s": %s',
+                $c,
+                $tableName,
+                ($expected !== null ? '"' . $tableName . '"' : 'NULL'),
+            );
+            yield $label => [
+                'tableName' => $tableName,
+                'expected' => $expected,
+            ];
+        }
+    }
+
+    #[DataProvider('getTableHiddenFieldNameDataSets')]
+    #[Test]
+    public function getTableHiddenFieldNameReturnsExpectedColumnName(string $tableName, ?string $expected): void
+    {
+        $subject = $this->get(StudyPlanService::class);
+        $invoker = new \ReflectionMethod($subject, 'getTableHiddenFieldName');
+        $this->assertSame($expected, $invoker->invoke($subject, $tableName));
+    }
+
+    public static function getTableDeletedFieldNameDataSets(): \Generator
+    {
+        $sets = [
+            // Extension
+            'tx_academicstudyplan_domain_model_category' => 'deleted',
+            'tx_academicstudyplan_domain_model_module' => 'deleted',
+            'tx_academicstudyplan_domain_model_semester' => 'deleted',
+            // TYPO3 Core Cross checks
+            'pages' => 'deleted',
+            'tt_content' => 'deleted',
+            'sys_log' => null,
+        ];
+        $c = 0;
+        foreach ($sets as $tableName => $expected) {
+            $c++;
+            $label = sprintf(
+                '#%s "%s": %s',
+                $c,
+                $tableName,
+                ($expected !== null ? '"' . $tableName . '"' : 'NULL'),
+            );
+            yield $label => [
+                'tableName' => $tableName,
+                'expected' => $expected,
+            ];
+        }
+    }
+
+    #[DataProvider('getTableDeletedFieldNameDataSets')]
+    #[Test]
+    public function getTableDeletedFieldNameReturnsExpectedColumnName(string $tableName, ?string $expected): void
+    {
+        $subject = $this->get(StudyPlanService::class);
+        $invoker = new \ReflectionMethod($subject, 'getTableDeletedFieldName');
+        $this->assertSame($expected, $invoker->invoke($subject, $tableName));
+    }
+
+    public static function getTableLanguageFieldNameDataSets(): \Generator
+    {
+        $sets = [
+            // Extension
+            'tx_academicstudyplan_domain_model_category' => 'sys_language_uid',
+            'tx_academicstudyplan_domain_model_module' => 'sys_language_uid',
+            'tx_academicstudyplan_domain_model_semester' => 'sys_language_uid',
+            // TYPO3 Core Cross checks
+            'pages' => 'sys_language_uid',
+            'tt_content' => 'sys_language_uid',
+            'sys_log' => null,
+        ];
+        $c = 0;
+        foreach ($sets as $tableName => $expected) {
+            $c++;
+            $label = sprintf(
+                '#%s "%s": %s',
+                $c,
+                $tableName,
+                ($expected !== null ? '"' . $tableName . '"' : 'NULL'),
+            );
+            yield $label => [
+                'tableName' => $tableName,
+                'expected' => $expected,
+            ];
+        }
+    }
+
+    #[DataProvider('getTableLanguageFieldNameDataSets')]
+    #[Test]
+    public function getTableLanguageFieldNameReturnsExpectedColumnName(string $tableName, ?string $expected): void
+    {
+        $subject = $this->get(StudyPlanService::class);
+        $invoker = new \ReflectionMethod($subject, 'getTableLanguageFieldName');
+        $this->assertSame($expected, $invoker->invoke($subject, $tableName));
+    }
+}


### PR DESCRIPTION
`\FGTCLB\AcademicStudyPlan\Service\StudyPlanService` provides
a couple of configuration read methods, for example to get
configured column names for common fields like:

* `hidden` field for not published reords
* `deleted` field for soft delete field
* `sys_language_uid` language field for language
  aware tables

The above mentioned values are configured in `TCA->ctrl` for
tables in different places, and for `deleted` field the wrong
path traversle has been implemented in

  `StudyPlanService::getTableDeletedFieldName()`

failing to get configured soft delete records.

This methid is used in

  `StudyPlanService::getDeletedRestrictionForTable()`

to build SQL query conditions based on the current frontend
context options. Not retrieving a `deleted` field name skips
this step and even soft-deleted records are retrieved in FE
context.

Following action have been taken by this change:

* `StudyPlanService::getTableDeletedFieldName()` is modified
  to read the deleted field name using the correct TCA path.

* `StudyPlanServiceTest` functional test is added testing
  low level field name methods for now. Extensive tests
  for higher restriction **should** be covered with more
  extensive tests scheduled as part of a bigger epic to
  cover all services and plugins with extensive constellation
  tests.

With these actions the service does not return deleted
records in the frontend unless `EXT:adminpanel` is used
and display hidden records is explicitly allowed.
