### PR TITLE
[BUGFIX] ACE-222: Avoid TypeError in FrontendEnvironmentBuilder

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Core12/Environment/FrontendEnvironmentBuilder.php
+++ b/packages/fgtclb/academic-base/Classes/Core12/Environment/FrontendEnvironmentBuilder.php
@@ -82,7 +82,7 @@ final class FrontendEnvironmentBuilder implements EnvironmentBuilderInterface
         $serverParams = [
             'HTTP_HOST' => $uri->getHost(),
             'SERVER_NAME' => $uri->getHost(),
-            'HTTPS' => $uri->getScheme() === 'https',
+            'HTTPS' => ($uri->getScheme() === 'https' ? 'on' : 'off'),
             'SCRIPT_FILENAME' => __FILE__,
             'SCRIPT_NAME' => rtrim($uri->getPath(), '/') . '/',
             'REMOTE_ADDR' => '127.0.1',

--- a/packages/fgtclb/academic-base/Classes/Core13/Environment/FrontendEnvironmentBuilder.php
+++ b/packages/fgtclb/academic-base/Classes/Core13/Environment/FrontendEnvironmentBuilder.php
@@ -99,7 +99,7 @@ final class FrontendEnvironmentBuilder implements EnvironmentBuilderInterface
         $serverParams = [
             'HTTP_HOST' => $uri->getHost(),
             'SERVER_NAME' => $uri->getHost(),
-            'HTTPS' => $uri->getScheme() === 'https',
+            'HTTPS' => ($uri->getScheme() === 'https' ? 'on' : 'off'),
             'SCRIPT_FILENAME' => __FILE__,
             'SCRIPT_NAME' => rtrim($uri->getPath(), '/') . '/',
             'REMOTE_ADDR' => '127.0.0.1',


### PR DESCRIPTION
The `FrontendEnvironmentBuilder`  for TYPO3 v12 and  v13 has
been enhanced to also populate the `$_SERVER['HTTPS']` value
based on the `SiteConfiguration` or `SiteLanguage`.

However, the value is set as bool which is invalid because in
casual WebRequests this is a string of values `OFF` or `ON` .
This leads to TypeError due to a missing (string) cast before
passing it to `strtolower()` special for newer PHP version due
to version b/c changes and needs to be fixed.

This change sets now `(string)on` or  `(string)off` for the
`$_SERVER['HTTPS']` globally and also within the request to
mitigate the TypeError.

Related: ACE-214
