### PR TITLE
[TASK] ACE-228: Introduce ProfileFormDataFactory for controller context

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Controller;
 
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
 use FGTCLB\AcademicBase\Extbase\Property\TypeConverter\FileUploadConverter;
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
 use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
 use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFormDataFactoryInterface;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
 use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
@@ -30,6 +32,7 @@ final class ProfileController extends AbstractActionController
     public function __construct(
         private readonly ProfileFactory $profileFactory,
         private readonly ProfileRepository $profileRepository,
+        private readonly ProfileFormDataFactoryInterface $profileFormDataFactory,
     ) {}
 
     // =================================================================================================================
@@ -54,19 +57,17 @@ final class ProfileController extends AbstractActionController
 
     public function showAction(Profile $profile): ResponseInterface
     {
+        $pluginControllerActionContext = new PluginControllerActionContext($this->request, $this->settings);
         $cancelUrl = $this->uriBuilder->reset()->uriFor(
             'list',
         );
-
         $this->userSessionService->saveRefererToSession($this->request);
-
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
-            'profileFormData' => ProfileFormData::createFromProfile($profile),
+            'profileFormData' => $this->profileFormDataFactory->createFromProfile($pluginControllerActionContext, $profile),
             'cancelUrl' => $cancelUrl,
         ]);
-
         return $this->htmlResponse();
     }
 
@@ -76,10 +77,11 @@ final class ProfileController extends AbstractActionController
 
     public function editAction(Profile $profile): ResponseInterface
     {
+        $pluginControllerActionContext = new PluginControllerActionContext($this->request, $this->settings);
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
             'profile' => $profile,
-            'profileFormData' => ProfileFormData::createFromProfile($profile),
+            'profileFormData' => $this->profileFormDataFactory->createFromProfile($pluginControllerActionContext, $profile),
             'genderOptions' => $this->getAvailableGenderSelectItems(),
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
             'validations' => $this->academicPersonsSettings->getValidationSetWithFallback('profile')->validations,

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFormDataFactory.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFormDataFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Domain\Factory;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+/**
+ * Provides default implementation of {@see ProfileFormDataFactoryInterface} handling default
+ * `EXT:academic_persons_edit` data mapping from {@see Profile} to {@see ProfileFormData}.
+ *
+ * Projects can use service decoration to provide custom mappings; {@see PluginControllerActionContext} is
+ * provided to gave context for decision if custom handling is reasonable or requires additional work.
+ *
+ * @internal not part of public API.
+ */
+#[AsAlias(id: ProfileFormDataFactoryInterface::class, public: true)]
+final class ProfileFormDataFactory implements ProfileFormDataFactoryInterface
+{
+    public function createFromProfile(
+        PluginControllerActionContext $pluginControllerContext,
+        Profile $profile,
+    ): ProfileFormData {
+        return new ProfileFormData(
+            title: $profile->getTitle(),
+            firstName: $profile->getFirstName(),
+            middleName: $profile->getMiddleName(),
+            lastName: $profile->getLastName(),
+            gender: $profile->getGender(),
+            publicationsLink: $profile->getPublicationsLink(),
+            publicationsLinkTitle: $profile->getPublicationsLinkTitle(),
+            website: $profile->getWebsite(),
+            websiteTitle: $profile->getWebsiteTitle(),
+            coreCompetences: $profile->getCoreCompetences(),
+            miscellaneous: $profile->getMiscellaneous(),
+            supervisedDoctoralThesis: $profile->getSupervisedDoctoralThesis(),
+            supervisedThesis: $profile->getSupervisedThesis(),
+            teachingArea: $profile->getTeachingArea(),
+            skipSync: $profile->getSkipSync(),
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFormDataFactoryInterface.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/ProfileFormDataFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Domain\Factory;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
+use FGTCLB\AcademicPersons\Controller\ProfileController;
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+
+/**
+ * Defines the surface for creating ProfileFormData instances in {@see ProfileController} actions.
+ * @internal not part of public API.
+ */
+interface ProfileFormDataFactoryInterface
+{
+    public function createFromProfile(
+        PluginControllerActionContext $pluginControllerContext,
+        Profile $profile,
+    ): ProfileFormData;
+}

--- a/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Dto/ProfileFormData.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Dto/ProfileFormData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersonsEdit\Domain\Model\Dto;
 
 use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFormDataFactoryInterface;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API. May change at any time.
@@ -61,25 +62,33 @@ class ProfileFormData extends AbstractFormData
         $this->skipSync = $skipSync;
     }
 
+    /**
+     * @deprecated since 2.3 and will be removed in 3.0. Use {@see ProfileFormDataFactoryInterface::createFromProfile()} instead.
+     */
     public static function createFromProfile(Profile $profile): self
     {
-        $instance = new self();
-        $instance->title = $profile->getTitle();
-        $instance->firstName = $profile->getFirstName();
-        $instance->middleName = $profile->getMiddleName();
-        $instance->lastName = $profile->getLastName();
-        $instance->gender = $profile->getGender();
-        $instance->publicationsLink = $profile->getPublicationsLink();
-        $instance->publicationsLinkTitle = $profile->getPublicationsLinkTitle();
-        $instance->website = $profile->getWebsite();
-        $instance->websiteTitle = $profile->getWebsiteTitle();
-        $instance->coreCompetences = $profile->getCoreCompetences();
-        $instance->miscellaneous = $profile->getMiscellaneous();
-        $instance->supervisedDoctoralThesis = $profile->getSupervisedDoctoralThesis();
-        $instance->supervisedThesis = $profile->getSupervisedThesis();
-        $instance->teachingArea = $profile->getTeachingArea();
-        $instance->skipSync = $profile->getSkipSync();
-        return $instance;
+        trigger_error(
+            'ProfileFormData::createFromProfile() is deprecated since 2.3 and will be removed in 3.0. Use '
+            . 'ProfileFormDataFactoryInterface->createFromProfile() instead.',
+            E_USER_DEPRECATED,
+        );
+        return new ProfileFormData(
+            title: $profile->getTitle(),
+            firstName: $profile->getFirstName(),
+            middleName: $profile->getMiddleName(),
+            lastName: $profile->getLastName(),
+            gender: $profile->getGender(),
+            publicationsLink: $profile->getPublicationsLink(),
+            publicationsLinkTitle: $profile->getPublicationsLinkTitle(),
+            website: $profile->getWebsite(),
+            websiteTitle: $profile->getWebsiteTitle(),
+            coreCompetences: $profile->getCoreCompetences(),
+            miscellaneous: $profile->getMiscellaneous(),
+            supervisedDoctoralThesis: $profile->getSupervisedDoctoralThesis(),
+            supervisedThesis: $profile->getSupervisedThesis(),
+            teachingArea: $profile->getTeachingArea(),
+            skipSync: $profile->getSkipSync(),
+        );
     }
 
     public function getTitle(): string


### PR DESCRIPTION
`ProfileFormData::createFromProfile()` is a static method to create a
instance pre-filled from the passed `Profile` instance, which works
fine for default implementations. This is called in `ProfileController`
in methods `showAction()` and `editAction()`.

Classes with static methods are hard to overide and prevents project
related customization.

To open up at this place the factory pattern is now introduced, which
includes:

* `ProfileFormDataFactoryInterface` describing required methods to
  be implemented. (Contract).

* `ProfileFormDataFactory` as default implementation for the interface,
  which returns the default `ProfileFormData` class prefilled with the
  data.

Currently only one method is required and implemented with following
signature:

```php
public function createFromProfile(
  PluginControllerActionContext $pluginControllerContext,
  Profile $profile,
): ProfileFormData;
```

The factory is now injected into `ProfileController` and replaces the

        `ProfileFormData::createFromProfile()`

calls with

        `$this->profileFormDataFactory->createFromProfile()`

The factory call gets the current plugin controller context passed,
which includes also the current request and allows acces to context
data.

It's highly recommended that projects requiring to handle custom
data using the DI `service decorator pattern` and providing a
custom factory.
