### PR TITLE
[TASK] ACE-228: Normalize `ext_emconf.php`

### DIFF
--- a/packages/fgtclb/academic-base/Tests/Functional/Fixtures/Extensions/test_base_dependency_injection/ext_emconf.php
+++ b/packages/fgtclb/academic-base/Tests/Functional/Fixtures/Extensions/test_base_dependency_injection/ext_emconf.php
@@ -3,21 +3,16 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TESTS: Academic Base Dependency Injection Tests',
     'description' => 'Provide classes to test dependency injection',
-    'category' => 'plugin',
-    'author' => 'Stefan Bürk',
-    'author_email' => 'stefan@buerk.tech',
-    'author_company' => 'web-vision GmbH',
-    'state' => 'beta',
     'version' => '2.3.2',
-    'clearCacheOnLoad' => true,
+    'category' => 'plugin',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_base' => '2.3.2',
-        ],
-        'conflicts' => [
-        ],
-        'suggests' => [
         ],
     ],
 ];

--- a/packages/fgtclb/academic-base/ext_emconf.php
+++ b/packages/fgtclb/academic-base/ext_emconf.php
@@ -1,18 +1,18 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
+    'title' => 'FGTCLB: Academic Base',
+    'description' => 'Base functionality accross academic extensions.',
+    'version' => '2.3.2',
+    'category' => 'misc',
+    'state' => 'beta',
     'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
     'author_email' => 'hello@fgtclb.com',
-    'category' => 'fe,be',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'backend' => '12.4.22-13.4.99',
         ],
     ],
-    'description' => 'Base functionality accross academic extensions.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Base',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-bite-jobs/ext_emconf.php
+++ b/packages/fgtclb/academic-bite-jobs/ext_emconf.php
@@ -1,18 +1,18 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
+    'title' => 'FGTCLB: Academic Bite Jobs',
+    'description' => 'The Academic Bite Jobs extension shows jobs from the B-Ite Job Board.',
+    'version' => '2.3.2',
+    'category' => 'misc',
+    'state' => 'beta',
     'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
     'author_email' => 'hello@fgtclb.com',
-    'category' => 'fe,be',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_base' => '2.3.2',
         ],
     ],
-    'description' => 'The Academic Bite Jobs extension shows jobs from the B-Ite Job Board.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Bite Jobs',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-contact4pages/ext_emconf.php
+++ b/packages/fgtclb/academic-contact4pages/ext_emconf.php
@@ -1,21 +1,19 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Academic Contags for Pages',
+    'description' => 'Role based relations between profiles and pages',
+    'version' => '2.3.2',
     'category' => 'fe',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_base' => '2.3.2',
             'academic_persons' => '2.3.2',
         ],
-        'conflicts' => [],
-        'suggests' => [],
     ],
-    'description' => 'Role based relations between profiles and pages',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Contags for Pages',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Fixtures/Extensions/test_jobcontact_schema/ext_emconf.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Fixtures/Extensions/test_jobcontact_schema/ext_emconf.php
@@ -3,21 +3,16 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TESTS: Academic Jobs TCA',
     'description' => 'Extension providing TCA for tests',
-    'category' => 'fe,be',
-    'author' => 'Stefan Bürk',
-    'author_email' => 'stefan@buerk.tech',
-    'author_company' => 'web-vision GmbH',
+    'version' => '2.3.2',
+    'category' => 'misc',
     'state' => 'beta',
-    'version' => '2.3.1',
-    'clearCacheOnLoad' => true,
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_jobs' => '2.3.2',
-        ],
-        'conflicts' => [
-        ],
-        'suggests' => [
         ],
     ],
 ];

--- a/packages/fgtclb/academic-jobs/ext_emconf.php
+++ b/packages/fgtclb/academic-jobs/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
+    'title' => 'FGTCLB: Academic Jobs',
+    'description' => 'The Academic Jobs extension allows users to create and manage job postings.',
+    'version' => '2.3.2',
+    'category' => 'misc',
+    'state' => 'beta',
     'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
     'author_email' => 'hello@fgtclb.com',
-    'category' => 'fe,be',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -14,8 +18,4 @@ $EM_CONF[$_EXTKEY] = [
             'academic_base' => '2.3.2',
         ],
     ],
-    'description' => 'The Academic Jobs extension allows users to create and manage job postings.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Jobs',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-partners/ext_emconf.php
+++ b/packages/fgtclb/academic-partners/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
+    'title' => 'FGTCLB: Academic Partners',
+    'description' => 'Extension for showing academic partners in list and map view',
+    'version' => '2.3.2',
+    'category' => 'misc',
+    'state' => 'beta',
     'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
     'author_email' => 'hello@fgtclb.com',
-    'category' => 'fe,be',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -14,12 +18,8 @@ $EM_CONF[$_EXTKEY] = [
             'academic_base' => '2.3.2',
             'category_types' => '2.3.2',
         ],
-        'suggest' => [
+        'suggests' => [
             'page_backend_layout' => '2.0.0-2.9.99',
         ],
     ],
-    'description' => 'Extension for showing academic partners in list and map view',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Partners',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-persons-edit/ext_emconf.php
+++ b/packages/fgtclb/academic-persons-edit/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Academic Persons Edit',
+    'description' => 'Provides the option to assign frontend users to academic persons and allow editing the profiles in frontend.',
+    'version' => '2.3.2',
     'category' => 'plugin',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -12,13 +16,5 @@ $EM_CONF[$_EXTKEY] = [
             'academic_base' => '2.3.2',
             'academic_persons' => '2.3.2',
         ],
-        'conflicts' => [
-        ],
-        'suggests' => [
-        ],
     ],
-    'description' => 'Provides the option to assign frontend users to academic persons and allow editing the profiles in frontend.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Persons Edit',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-persons-sync/ext_emconf.php
+++ b/packages/fgtclb/academic-persons-sync/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Academic Persons Sync',
+    'description' => 'Adds some configuration for external users providers like Active Directory.',
+    'version' => '2.3.2',
     'category' => 'plugin',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -13,13 +17,5 @@ $EM_CONF[$_EXTKEY] = [
             'academic_persons' => '2.3.2',
             'academic_persons_edit' => '2.3.2',
         ],
-        'conflicts' => [
-        ],
-        'suggests' => [
-        ],
     ],
-    'description' => 'Adds some configuration for external users providers like Active Directory.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Persons Sync',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/ext_emconf.php
@@ -3,21 +3,16 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TESTS: Academic Persons Language Files',
     'description' => 'Extension providing language files for tests',
-    'category' => 'fe,be',
-    'author' => 'Stefan Bürk',
-    'author_email' => 'stefan@buerk.tech',
-    'author_company' => 'web-vision GmbH',
-    'state' => 'beta',
     'version' => '2.3.2',
-    'clearCacheOnLoad' => true,
+    'category' => 'misc',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_persons' => '2.3.2',
-        ],
-        'conflicts' => [
-        ],
-        'suggests' => [
         ],
     ],
 ];

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_messy_profile_factory/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_messy_profile_factory/ext_emconf.php
@@ -3,21 +3,16 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TESTS: Academic Persons Language Files',
     'description' => 'Extension providing language files for tests',
-    'category' => 'fe,be',
-    'author' => 'Stefan Bürk',
-    'author_email' => 'stefan@buerk.tech',
-    'author_company' => 'web-vision GmbH',
-    'state' => 'beta',
     'version' => '2.3.2',
-    'clearCacheOnLoad' => true,
+    'category' => 'misc',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_persons' => '2.3.2',
-        ],
-        'conflicts' => [
-        ],
-        'suggests' => [
         ],
     ],
 ];

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_plugin_templates/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_plugin_templates/ext_emconf.php
@@ -3,21 +3,16 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TESTS: Academic Persons Plugin Templates',
     'description' => 'Provide plugin template overrides for academic-persons for functional tests',
-    'category' => 'plugin',
-    'author' => 'Stefan Bürk',
-    'author_email' => 'stefan@buerk.tech',
-    'author_company' => 'web-vision GmbH',
-    'state' => 'beta',
     'version' => '2.3.2',
-    'clearCacheOnLoad' => true,
+    'category' => 'plugin',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_persons' => '2.3.2',
-        ],
-        'conflicts' => [
-        ],
-        'suggests' => [
         ],
     ],
 ];

--- a/packages/fgtclb/academic-persons/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Academic Persons',
+    'description' => 'Adds a person database to TYPO3 with plugins to show them in the frontend.',
+    'version' => '2.3.2',
     'category' => 'plugin',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -15,14 +19,8 @@ $EM_CONF[$_EXTKEY] = [
             'rte_ckeditor' => '12.4.22-13.4.99',
             'academic_base' => '2.3.2',
         ],
-        'conflicts' => [
-        ],
         'suggests' => [
             'numbered_pagination' => '2.1.0-2.99.99',
         ],
     ],
-    'description' => 'Adds a person database to TYPO3 with plugins to show them in the frontend.',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Persons',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-programs/ext_emconf.php
+++ b/packages/fgtclb/academic-programs/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: University Educational Program',
+    'description' => 'Educational Program page for TYPO3 with structured data based on sys_category',
+    'version' => '2.3.2',
     'category' => 'fe',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -15,13 +19,8 @@ $EM_CONF[$_EXTKEY] = [
             'academic_base' => '2.3.2',
             'category_types' => '2.3.2',
         ],
-        'conflicts' => [],
         'suggests' => [
             'page_backend_layout' => '2.0.0-2.99.99',
         ],
     ],
-    'description' => 'Educational Program page for TYPO3 with structured data based on sys_category',
-    'state' => 'beta',
-    'title' => 'FGTCLB: University Educational Program',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-projects/ext_emconf.php
+++ b/packages/fgtclb/academic-projects/ext_emconf.php
@@ -1,10 +1,14 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Academic Projects',
+    'description' => 'Academic project pages for TYPO3 with specific structured data and typed sys_categories',
+    'version' => '2.3.2',
     'category' => 'fe',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
@@ -15,11 +19,5 @@ $EM_CONF[$_EXTKEY] = [
             'academic_base' => '2.3.2',
             'category_types' => '2.3.2',
         ],
-        'conflicts' => [],
-        'suggests' => [],
     ],
-    'description' => 'Academic project pages for TYPO3 with specific structured data and typed sys_categories',
-    'state' => 'beta',
-    'title' => 'FGTCLB: Academic Projects',
-    'version' => '2.3.2',
 ];

--- a/packages/fgtclb/academic-study-plan/ext_emconf.php
+++ b/packages/fgtclb/academic-study-plan/ext_emconf.php
@@ -3,19 +3,17 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Academic Study Plan',
     'description' => 'TYPO3 extension for building and displaying academic study plans with semesters, modules, and categorization features.',
-    'category' => 'fe',
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
-    'state' => 'beta',
     'version' => '2.3.2',
+    'category' => 'fe',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.0.0-13.4.99',
             'backend' => '12.0.0-13.4.99',
             'academic_base' => '2.3.2',
         ],
-        'conflicts' => [],
-        'suggests' => [],
     ],
 ];

--- a/packages/fgtclb/typo3-category-types/ext_emconf.php
+++ b/packages/fgtclb/typo3-category-types/ext_emconf.php
@@ -1,20 +1,18 @@
 <?php
 
 $EM_CONF[$_EXTKEY] = [
-    'author' => 'FGTCLB',
-    'author_company' => 'FGTCLB GmbH',
-    'author_email' => 'hello@fgtclb.com',
+    'title' => 'FGTCLB: Basic Typed categories',
     'description' => 'Basic extension for typed categories',
+    'version' => '2.3.2',
     'category' => 'misc',
+    'state' => 'beta',
+    'author' => 'FGTCLB',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
             'academic_base' => '2.3.2',
         ],
-        'conflicts' => [],
-        'suggests' => [],
     ],
-    'state' => 'beta',
-    'title' => 'FGTCLB: Basic Typed categories',
-    'version' => '2.3.2',
 ];


### PR DESCRIPTION
This changes uses the `ext_emconf.php` normalization of the
upcoming tool `packwright` to all of the split- and test
extension files in a good shape.

Used command(s):

```bash
pkw-dev extemconf:normalize -t 12 -- packages/**/ext_emconf.php && \
pkw-dev extemconf:set \
  --ext-version=2.3.2 \
  --author-company='FGTCLB GmbH' \
  --author-email='hello@fgtclb.com' \
  -- packages/**/ext_emconf.php
```

> [!NOTE]
> `pkw (packwraight)` not realease in public yet. It's the upcoming
> TYPO3 extension release took with a couple of helpers. Currently
> only `ext_emconf.php` validation, normalization, value setting and
> constraints handling is availalbe and the reason that the development
> version has been used.

This is done as preparation for the next release.
