### PR TITLE
[BUGFIX] Process concatenated showFields string to array for card action

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -137,6 +137,11 @@ final class ProfileController extends ActionController
         return $this->htmlResponse();
     }
 
+    public function initializeCardAction(): void
+    {
+        $this->settings['showFields'] = !empty($this->settings['showFields']) ? GeneralUtility::trimExplode(',', $this->settings['showFields']) : null;
+    }
+
     /**
      * @todo This action is literally broken in multi language sites. Needs to be adopted and covered
      *       with functional tests.


### PR DESCRIPTION
Due to the templates accessing the showFields field as array in e.g. the
ForViewHelper as "each" argument, this fields' value must be an array. In the
list, selectedProfiles and selectedContracts actions this field was preprocessed
by the controller and exploded from string into the expected array. Because the
card action was missing this preprocessing in its initializeAction, the templates
would constantly crash. This change now adds the initializeCardAction to
handle this preprocessing correctly.