### PR TITLE
[TASK] ACE-251: Bump actions/checkout to v6 in workflows

### DIFF
--- a/.github/workflows/core-13.yml
+++ b/.github/workflows/core-13.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |


### PR DESCRIPTION
## What

Standardises the `actions/checkout` action version across the CI
workflows. Seven of the nine usages already pinned `@v6`; the two
remaining stragglers on `@v4` are bumped to `@v6`:

- `.github/workflows/core-13.yml`
- `.github/workflows/publish.yml`

## Why

`actions/checkout@v4` targets Node 20, which GitHub Actions runners now
force onto Node 24 and flag with a deprecation warning (seen on the
`linting (8.2, 13)` job). Bumping to `@v6` removes the warning and makes
all checkout steps consistent.

`@v7` is the current highest major, but is intentionally not adopted here
to keep the pin consistent with the other seven usages; a move to `@v7`
would be a separate, repo-wide change.

Resolves ACE-251.