### PR TITLE
[TASK] ACE-252: Bump split package checkout to v6

### DIFF
--- a/packages/fgtclb/academic-base/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-base/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-bite-jobs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-bite-jobs/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-contact4pages/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-contact4pages/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-jobs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-jobs/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-partners/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-partners/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-persons-edit/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons-edit/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-persons-sync/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons-sync/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-persons/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-programs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-programs/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-projects/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-projects/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/academic-study-plan/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-study-plan/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |

--- a/packages/fgtclb/typo3-category-types/.github/workflows/publish.yml
+++ b/packages/fgtclb/typo3-category-types/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag
         run: |


### PR DESCRIPTION
## What

Bumps `actions/checkout` from `@v4` to `@v6` in the per-extension
`publish.yml` workflows shipped inside every split package
(`packages/fgtclb/*/.github/workflows/publish.yml`, 12 files). These are
mirrored out to the standalone read-only GitHub repos.

## Why

Follow-up to ACE-251, which only standardised the mono-repo **root**
workflows. The split-package `publish.yml` copies were still on
`actions/checkout@v4`, which targets Node 20 and triggers the GitHub
Actions deprecation warning on current runners.

`shivammathur/setup-php@v2` and `softprops/action-gh-release@v2` are the
current highest majors and are intentionally left unchanged. Consistent
with ACE-251, `@v6` (not `@v7`) is used to match the root workflows.

## Scope

Workflow-only change; one line per file (`uses: actions/checkout@v4` →
`@v6`). No PHP/test code touched.

Resolves ACE-252.