### PR TITLE
[TASK] Add release automation scripts

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+#
+# release — orchestrate the two-phase GitHub release of the academic-extensions
+# mono repository.
+#
+# Given a single release version (e.g. 2.4.0) this drives the full workflow:
+#
+#   PHASE 1 (release)
+#     - branch release-X.Y.Z off the source branch
+#     - bin/set-version X.Y.Z release
+#     - commit "[RELEASE] X.Y.Z", push, open PR, wait for checks, admin-merge
+#     - refresh source branch, tag X.Y.Z, push the tag
+#
+#   PHASE 2 (post-release, next patch W = Z+1)
+#     - branch set-version-X.Y.W off the merged source branch
+#     - bin/set-version X.Y.W post-release
+#     - commit "[TASK] Set version X.Y.W", push, open PR, checks, admin-merge
+#
+# The version-applying work is delegated to bin/set-version; this script owns only
+# git and GitHub (gh) operations.
+#
+# Safety model (two independent gates):
+#   --dry-run   Print EVERYTHING, touch nothing (local and remote alike).
+#   --execute   Actually perform the remote/irreversible operations (git push,
+#               gh pr create/checks/merge, git tag + tag push). WITHOUT --execute
+#               the local branch/commit/set-version steps run for real but every
+#               remote/irreversible operation is only PRINTED. So a bare run can
+#               never mutate the remote or create tags.
+#
+# Usage:
+#   bin/release <release-version> [options]
+#
+#   <release-version>        MAJOR.MINOR.PATCH, e.g. 2.4.0
+#
+# Options:
+#   --source-branch=<name>   base/source branch (default: main)
+#   --dry-run                print the whole plan, change nothing
+#   --execute                enable remote/irreversible operations
+#   -h, --help               show this help
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT_DIR}"
+
+SET_VERSION_BIN="${SCRIPT_DIR}/set-version"
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+DRY_RUN=0
+EXECUTE=0
+
+info()  { printf '\n>> %s\n' "$*"; }
+note()  { printf '   %s\n' "$*"; }
+warn()  { printf 'WARNING: %s\n' "$*" >&2; }
+die()   { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '3,52p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+}
+
+# Local, reversible operations: executed unless --dry-run.
+run() {
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        printf '   [dry-run]  %s\n' "$*"
+        return 0
+    fi
+    printf '   [run]      %s\n' "$*"
+    "$@"
+}
+
+# Remote / irreversible operations: executed ONLY with --execute (and not
+# --dry-run). Otherwise merely printed. This is the hard guardrail.
+run_remote() {
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        printf '   [dry-run]  %s\n' "$*"
+        return 0
+    fi
+    if [ "${EXECUTE}" -eq 0 ]; then
+        printf '   [skipped]  (needs --execute) %s\n' "$*"
+        return 0
+    fi
+    printf '   [remote]   %s\n' "$*"
+    "$@"
+}
+
+# Invoke bin/set-version, forwarding --dry-run when appropriate.
+run_set_version() {
+    local version="$1" type="$2"
+    local -a cmd=("${SET_VERSION_BIN}" "${version}" "${type}" "--source-branch=${SOURCE_BRANCH}")
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        cmd+=("--dry-run")
+        printf '   [dry-run]  %s\n' "${cmd[*]}"
+        "${cmd[@]}"
+        return 0
+    fi
+    printf '   [run]      %s\n' "${cmd[*]}"
+    "${cmd[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+PASSED_VERSION=""
+SOURCE_BRANCH="main"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)          DRY_RUN=1 ;;
+        --execute)          EXECUTE=1 ;;
+        --source-branch=*)  SOURCE_BRANCH="${1#*=}" ;;
+        --source-branch)    shift; SOURCE_BRANCH="${1:-}" ;;
+        -h|--help)          usage; exit 0 ;;
+        -*)                 die "Unknown option: $1 (see --help)" ;;
+        *)
+            [ -z "${PASSED_VERSION}" ] || die "Unexpected extra argument: $1 (see --help)"
+            PASSED_VERSION="$1"
+            ;;
+    esac
+    shift
+done
+
+[ -n "${PASSED_VERSION}" ] || die "Missing <release-version> argument (see --help)"
+
+if [ "${DRY_RUN}" -eq 1 ] && [ "${EXECUTE}" -eq 1 ]; then
+    die "--dry-run and --execute are mutually exclusive."
+fi
+
+# ---------------------------------------------------------------------------
+# Validate version and derive the next dev (post-release) version (patch + 1).
+# ---------------------------------------------------------------------------
+if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+fi
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+NEXT_DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+RELEASE_BRANCH="release-${RELEASE_VERSION}"
+POST_BRANCH="set-version-${NEXT_DEV_VERSION}"
+RELEASE_COMMIT="[RELEASE] ${RELEASE_VERSION}"
+POST_COMMIT="[TASK] Set version ${NEXT_DEV_VERSION}"
+
+# ---------------------------------------------------------------------------
+# Resolve + verify tooling.
+# ---------------------------------------------------------------------------
+resolve_bin() {
+    local var="$1" name="$2" path
+    path="$(command -v "${name}" 2>/dev/null || true)"
+    [ -n "${path}" ] || die "Required tool '${name}' not found on PATH."
+    printf -v "${var}" '%s' "${path}"
+}
+resolve_bin GIT git
+resolve_bin GH  gh
+[ -x "${SET_VERSION_BIN}" ] || die "bin/set-version not found or not executable at ${SET_VERSION_BIN}"
+
+# ---------------------------------------------------------------------------
+# Mode banner
+# ---------------------------------------------------------------------------
+MODE="default (local runs, remote SKIPPED — needs --execute)"
+[ "${DRY_RUN}" -eq 1 ] && MODE="dry-run (nothing is changed)"
+[ "${EXECUTE}" -eq 1 ] && MODE="EXECUTE (remote operations WILL run)"
+
+info "release ${RELEASE_VERSION}"
+note "source branch      : ${SOURCE_BRANCH}"
+note "release branch     : ${RELEASE_BRANCH}     commit \"${RELEASE_COMMIT}\""
+note "post-release branch: ${POST_BRANCH}   commit \"${POST_COMMIT}\""
+note "next dev version   : ${NEXT_DEV_VERSION}"
+note "mode               : ${MODE}"
+
+# ---------------------------------------------------------------------------
+# Pre-flight guards.
+#  - work tree / repo sanity: always required.
+#  - clean working tree + no existing tag: required. A dirty tree or an existing
+#    tag is fatal in --execute; only a warning otherwise so the flow can still be
+#    dry-run/rehearsed.
+# ---------------------------------------------------------------------------
+info "Pre-flight checks"
+"${GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git work tree."
+
+if "${GIT}" rev-parse -q --verify "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+    die "Tag '${RELEASE_VERSION}' already exists — refusing to re-release."
+fi
+note "no local tag '${RELEASE_VERSION}' — ok"
+
+if [ -n "$("${GIT}" status --porcelain)" ]; then
+    if [ "${EXECUTE}" -eq 1 ]; then
+        die "Working tree is not clean — commit or stash before an --execute release."
+    fi
+    warn "Working tree is not clean (tolerated because this is not an --execute run)."
+else
+    note "working tree clean — ok"
+fi
+
+# ---------------------------------------------------------------------------
+# Refresh the source branch.
+# ---------------------------------------------------------------------------
+info "Refresh source branch '${SOURCE_BRANCH}'"
+run "${GIT}" checkout "${SOURCE_BRANCH}"
+run_remote "${GIT}" fetch --all --prune
+run_remote "${GIT}" pull --rebase
+
+# ---------------------------------------------------------------------------
+# PHASE 1 — release
+# ---------------------------------------------------------------------------
+info "PHASE 1 — release ${RELEASE_VERSION}"
+run "${GIT}" checkout -b "${RELEASE_BRANCH}" "${SOURCE_BRANCH}"
+run_set_version "${RELEASE_VERSION}" release
+run "${GIT}" add -A
+run "${GIT}" commit -m "${RELEASE_COMMIT}"
+
+info "PHASE 1 — publish (remote)"
+run_remote "${GIT}" push -u origin "${RELEASE_BRANCH}"
+run_remote "${GH}" pr create --fill --base "${SOURCE_BRANCH}" --title "${RELEASE_COMMIT}"
+run_remote sleep 10
+run_remote "${GH}" pr checks --watch --interval 10 --fail-fast
+run_remote sleep 10
+run_remote "${GH}" pr merge --rebase --delete-branch --admin
+run_remote "${GIT}" remote prune origin
+
+info "PHASE 1 — tag ${RELEASE_VERSION}"
+run "${GIT}" checkout "${SOURCE_BRANCH}"
+run_remote "${GIT}" pull --ff-only origin "${SOURCE_BRANCH}"
+run_remote "${GIT}" tag "${RELEASE_VERSION}"
+run_remote "${GIT}" push origin "${RELEASE_VERSION}"
+
+# ---------------------------------------------------------------------------
+# PHASE 2 — post-release (set next dev version)
+# ---------------------------------------------------------------------------
+info "PHASE 2 — post-release ${NEXT_DEV_VERSION}"
+run "${GIT}" checkout "${SOURCE_BRANCH}"
+run "${GIT}" checkout -b "${POST_BRANCH}" "${SOURCE_BRANCH}"
+run_set_version "${NEXT_DEV_VERSION}" post-release
+run "${GIT}" add -A
+run "${GIT}" commit -m "${POST_COMMIT}"
+
+info "PHASE 2 — publish (remote)"
+run_remote "${GIT}" push -u origin "${POST_BRANCH}"
+run_remote "${GH}" pr create --fill --base "${SOURCE_BRANCH}" --title "${POST_COMMIT}"
+run_remote sleep 10
+run_remote "${GH}" pr checks --watch --interval 10 --fail-fast
+run_remote sleep 10
+run_remote "${GH}" pr merge --rebase --delete-branch --admin
+run_remote "${GIT}" remote prune origin
+
+info "Finished release ${RELEASE_VERSION} (next dev ${NEXT_DEV_VERSION})"
+if [ "${EXECUTE}" -eq 0 ] && [ "${DRY_RUN}" -eq 0 ]; then
+    note "Remote operations were SKIPPED. Re-run with --execute to publish."
+fi

--- a/bin/set-version
+++ b/bin/set-version
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+
+#
+# set-version — apply a version across the academic-extensions mono repository.
+#
+# Applies a version (and its derived variants) to every relevant file: the
+# runTests.sh COMPOSER_ROOT_VERSION, each split extension (composer.json,
+# ext_emconf.php, VERSION, tailor, branch-alias), the functional-test fixture
+# extensions, the monorepo-shared meta package, the ddev instances and the root
+# composer.json (path-repository version maps + monorepo-shared requirement).
+#
+# The set of academic packages, their extension keys and their inter-package
+# dependencies are discovered dynamically from the repository — nothing about the
+# package list is hardcoded here.
+#
+# Usage:
+#   bin/set-version <version> <type> [options]
+#
+#   <version>   MAJOR.MINOR.PATCH, e.g. 2.4.0
+#   <type>      release | post-release | dev
+#                 release      : tag/release version  (X.Y.Z, deps X.Y.Z@dev)
+#                 post-release : next dev version      (X.Y.W-dev, deps ~X.Y.W@dev,
+#                                branch-alias X.Y.x-dev) — the version passed is
+#                                already the next version; no +1 happens here.
+#                 dev          : force a plain dev version everywhere (X.Y.Z-dev),
+#                                thin variant of post-release (branching / forced
+#                                minor/major bumps).
+#
+# Options:
+#   --source-branch=<name>   git branch the branch-alias is keyed to (default: main)
+#   --dry-run                print every change without touching a file
+#   -h, --help               show this help
+#
+# This script only edits working-tree files. It performs no git or network
+# operations — orchestration (branch/commit/PR/tag) lives in bin/release.
+#
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate the repository root (this script lives in <root>/bin) and cd into it so
+# every relative path below resolves against the mono-repo root.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT_DIR}"
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+DRY_RUN=0
+
+info()  { printf '>> %s\n' "$*"; }
+step()  { printf '   [%s] %s\n' "$1" "$2"; }
+die()   { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '3,44p' "${BASH_SOURCE[0]}" | sed 's/^#\{0,1\} \{0,1\}//'
+}
+
+# Execute a command, or in dry-run mode only print it.
+run() {
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        printf '   [dry-run] %s\n' "$*"
+        return 0
+    fi
+    "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+PASSED_VERSION=""
+TYPE=""
+SOURCE_BRANCH="main"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)            DRY_RUN=1 ;;
+        --source-branch=*)    SOURCE_BRANCH="${1#*=}" ;;
+        --source-branch)      shift; SOURCE_BRANCH="${1:-}" ;;
+        -h|--help)            usage; exit 0 ;;
+        -*)                   die "Unknown option: $1 (see --help)" ;;
+        *)
+            if [ -z "${PASSED_VERSION}" ]; then
+                PASSED_VERSION="$1"
+            elif [ -z "${TYPE}" ]; then
+                TYPE="$1"
+            else
+                die "Unexpected extra argument: $1 (see --help)"
+            fi
+            ;;
+    esac
+    shift
+done
+
+[ -n "${PASSED_VERSION}" ] || die "Missing <version> argument (see --help)"
+[ -n "${TYPE}" ]           || die "Missing <type> argument (see --help)"
+
+# ---------------------------------------------------------------------------
+# Validate version + type
+# ---------------------------------------------------------------------------
+if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+fi
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+case "${TYPE}" in
+    release|post-release|dev) : ;;
+    *) die "Invalid type '${TYPE}': expected release | post-release | dev" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Resolve + verify binaries (fail early with a clear message). External override
+# is intentionally not offered yet.
+# ---------------------------------------------------------------------------
+resolve_bin() {
+    local var="$1" name="$2" path
+    path="$(command -v "${name}" 2>/dev/null || true)"
+    [ -n "${path}" ] || die "Required tool '${name}' not found on PATH."
+    printf -v "${var}" '%s' "${path}"
+    step "tool" "${name} -> ${path}"
+}
+
+info "Resolving tools"
+resolve_bin COMPOSER composer
+resolve_bin PHP      php
+resolve_bin TAILOR   tailor
+resolve_bin PKW      pkw
+resolve_bin JQ       jq
+resolve_bin SED      sed
+
+# tailor and pkw are PHP applications and are invoked through php (matches the
+# manual release workflow and is robust regardless of the bin proxy's shebang).
+TAILOR_CMD=("${PHP}" "${TAILOR}")
+PKW_CMD=("${PHP}" "${PKW}")
+
+# ---------------------------------------------------------------------------
+# Derive the per-type version variants.
+#
+#   RUNTESTS_VERSION      -> Build/Scripts/runTests.sh COMPOSER_ROOT_VERSION
+#   MAP_VERSION           -> jq path-repository version maps (packages[-dev])
+#   VERSION_FILE_VALUE    -> split extension VERSION file
+#   EMCONF_VERSION        -> ext_emconf.php 'version' (pkw extemconf:set)
+#   EMCONF_CONSTRAINT     -> ext_emconf.php depends/suggests (pkw constraints:set)
+#   TAILOR_VERSION        -> tailor set-version
+#   ACADEMIC_CONSTRAINT   -> composer require constraint for academic package deps
+#   DDEV_SHARED_CONSTRAINT-> composer require academics-monorepo-shared in ddev
+#   ROOT_SHARED_CONSTRAINT-> composer require academics-monorepo-shared in root
+#   SET_BRANCH_ALIAS/ALIAS-> extra.branch-alias.dev-<source-branch>
+# ---------------------------------------------------------------------------
+BRANCH_ALIAS="${MAJOR}.${MINOR}.x-dev"
+
+if [ "${TYPE}" = "release" ]; then
+    RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+    RUNTESTS_VERSION="${RELEASE_VERSION}"
+    MAP_VERSION="${RELEASE_VERSION}"
+    VERSION_FILE_VALUE="${RELEASE_VERSION}"
+    EMCONF_VERSION="${RELEASE_VERSION}"
+    EMCONF_CONSTRAINT="${RELEASE_VERSION}"
+    TAILOR_VERSION="${RELEASE_VERSION}"
+    ACADEMIC_CONSTRAINT="${RELEASE_VERSION}@dev"
+    DDEV_SHARED_CONSTRAINT="${RELEASE_VERSION}@dev"
+    ROOT_SHARED_CONSTRAINT="~${RELEASE_VERSION}@dev"
+    SET_BRANCH_ALIAS=0
+else
+    # post-release and dev share the -dev derivation; the passed version is the
+    # dev version to apply directly (no +1 here).
+    DEV_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+    RUNTESTS_VERSION="${DEV_VERSION}-dev"
+    MAP_VERSION="${DEV_VERSION}-dev"
+    VERSION_FILE_VALUE="${DEV_VERSION}-dev"
+    EMCONF_VERSION="${DEV_VERSION}"
+    EMCONF_CONSTRAINT="${DEV_VERSION}"
+    TAILOR_VERSION="${DEV_VERSION}"
+    ACADEMIC_CONSTRAINT="~${DEV_VERSION}@dev"
+    DDEV_SHARED_CONSTRAINT="~${DEV_VERSION}@dev"
+    ROOT_SHARED_CONSTRAINT="~${DEV_VERSION}@dev"
+    SET_BRANCH_ALIAS=1
+fi
+
+info "set-version ${PASSED_VERSION} (${TYPE})$([ "${DRY_RUN}" -eq 1 ] && echo '  [DRY-RUN]')"
+step "info" "runTests COMPOSER_ROOT_VERSION = ${RUNTESTS_VERSION}"
+step "info" "version maps                   = ${MAP_VERSION}"
+step "info" "ext_emconf version             = ${EMCONF_VERSION}"
+step "info" "academic dep constraint        = ${ACADEMIC_CONSTRAINT}"
+[ "${SET_BRANCH_ALIAS}" -eq 1 ] && step "info" "branch-alias dev-${SOURCE_BRANCH}      = ${BRANCH_ALIAS}"
+
+# ---------------------------------------------------------------------------
+# Discover the academic package set: composer name <-> extension key <-> path.
+# Split extensions are packages/fgtclb/*/ carrying both composer.json and
+# ext_emconf.php.
+# ---------------------------------------------------------------------------
+declare -a SPLIT_DIRS=()
+declare -a ACADEMIC_NAMES=()     # composer package names, e.g. fgtclb/academic-base
+declare -a ACADEMIC_EXTKEYS=()   # extension keys, e.g. academic_base
+
+for dir in packages/fgtclb/*/; do
+    dir="${dir%/}"
+    [ -f "${dir}/composer.json" ] || continue
+    [ -f "${dir}/ext_emconf.php" ] || continue
+    name="$("${JQ}" -r '.name // empty' "${dir}/composer.json")"
+    extkey="$("${JQ}" -r '.extra."typo3/cms"."extension-key" // empty' "${dir}/composer.json")"
+    [ -n "${name}" ]   || die "No composer name in ${dir}/composer.json"
+    [ -n "${extkey}" ] || die "No typo3/cms.extension-key in ${dir}/composer.json"
+    SPLIT_DIRS+=("${dir}")
+    ACADEMIC_NAMES+=("${name}")
+    ACADEMIC_EXTKEYS+=("${extkey}")
+done
+
+[ "${#SPLIT_DIRS[@]}" -gt 0 ] || die "No split packages discovered under packages/fgtclb/*"
+info "Discovered ${#SPLIT_DIRS[@]} split extensions"
+
+# Fixture extensions live below each package's Tests/Functional/Fixtures/Extensions.
+declare -a FIXTURE_DIRS=()
+while IFS= read -r fdir; do
+    FIXTURE_DIRS+=("${fdir}")
+done < <(find packages/fgtclb/*/Tests/Functional/Fixtures/Extensions -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+info "Discovered ${#FIXTURE_DIRS[@]} fixture extensions"
+
+# Collect every ext_emconf.php (splits + fixtures) for the bulk pkw operations.
+declare -a EMCONF_FILES=()
+for dir in "${SPLIT_DIRS[@]}" "${FIXTURE_DIRS[@]}"; do
+    [ -f "${dir}/ext_emconf.php" ] && EMCONF_FILES+=("${dir}/ext_emconf.php")
+done
+
+# ---------------------------------------------------------------------------
+# Helper: is $1 one of the academic composer names?
+# ---------------------------------------------------------------------------
+is_academic_name() {
+    local candidate="$1" n
+    for n in "${ACADEMIC_NAMES[@]}"; do
+        [ "${n}" = "${candidate}" ] && return 0
+    done
+    return 1
+}
+
+# Helper: rewrite the academic composer dependencies of one package to $2, keeping
+# each dependency in its existing section (require / require-dev). Only academic
+# packages actually declared by the target are touched (dynamic).
+apply_academic_composer_deps() {
+    local dir="$1" constraint="$2"
+    local f="${dir}/composer.json"
+    [ -f "${f}" ] || return 0
+
+    local -a hard=() soft=()
+    local key
+    while IFS= read -r key; do
+        is_academic_name "${key}" && hard+=("${key}:${constraint}")
+    done < <("${JQ}" -r '(.require // {}) | keys[]' "${f}")
+    while IFS= read -r key; do
+        is_academic_name "${key}" && soft+=("${key}:${constraint}")
+    done < <("${JQ}" -r '(."require-dev" // {}) | keys[]' "${f}")
+
+    if [ "${#hard[@]}" -gt 0 ]; then
+        step "${dir}" "composer require ${hard[*]}"
+        run "${COMPOSER}" require -d "${dir}" --no-update "${hard[@]}"
+    fi
+    if [ "${#soft[@]}" -gt 0 ]; then
+        step "${dir}" "composer require --dev ${soft[*]}"
+        run "${COMPOSER}" require -d "${dir}" --no-update --dev "${soft[@]}"
+    fi
+    if [ "${#hard[@]}" -eq 0 ] && [ "${#soft[@]}" -eq 0 ]; then
+        step "${dir}" "no academic composer dependencies"
+    fi
+}
+
+# Helper: set a composer require constraint for a single package name in a dir.
+apply_single_composer_require() {
+    local dir="$1" name="$2" constraint="$3"
+    step "${dir}" "composer require ${name}:${constraint}"
+    run "${COMPOSER}" require -d "${dir}" --no-update "${name}:${constraint}"
+}
+
+# Helper: set the branch-alias for a package (or the root when dir is '.').
+apply_branch_alias() {
+    local dir="$1"
+    step "${dir}" "config extra.branch-alias.dev-${SOURCE_BRANCH} = ${BRANCH_ALIAS}"
+    run "${COMPOSER}" config -d "${dir}" \
+        "extra.branch-alias.dev-${SOURCE_BRANCH}" "${BRANCH_ALIAS}"
+}
+
+# Helper: rewrite a jq version map in place (temp file + mv; never self-redirect).
+apply_version_map() {
+    local file="$1" map="$2"   # map: packages | packages-dev
+    # shellcheck disable=SC2016  # $M/$SV are jq variables, must stay unexpanded
+    "${JQ}" -e --arg M "${map}" '.repositories[$M].options.versions' "${file}" >/dev/null 2>&1 || return 0
+    step "${file}" "repositories.${map}.options.versions[] = ${MAP_VERSION}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        printf '   [dry-run] jq set repositories.%s.options.versions[] = %s in %s\n' \
+            "${map}" "${MAP_VERSION}" "${file}"
+        return 0
+    fi
+    local tmp
+    tmp="$(mktemp)"
+    # shellcheck disable=SC2016  # $M/$SV are jq variables, must stay unexpanded
+    "${JQ}" --arg SV "${MAP_VERSION}" --arg M "${map}" --indent 4 \
+        '.repositories[$M].options.versions[] |= $SV' "${file}" > "${tmp}"
+    mv "${tmp}" "${file}"
+}
+
+# Helper: write a VERSION file.
+apply_version_file() {
+    local dir="$1"
+    step "${dir}" "VERSION = ${VERSION_FILE_VALUE}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        printf '   [dry-run] echo %s > %s/VERSION\n' "${VERSION_FILE_VALUE}" "${dir}"
+        return 0
+    fi
+    printf '%s\n' "${VERSION_FILE_VALUE}" > "${dir}/VERSION"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Build/Scripts/runTests.sh COMPOSER_ROOT_VERSION
+# ---------------------------------------------------------------------------
+info "Build/Scripts/runTests.sh"
+step "Build/Scripts/runTests.sh" "COMPOSER_ROOT_VERSION = ${RUNTESTS_VERSION}"
+run "${SED}" -i \
+    "s/^COMPOSER_ROOT_VERSION.*/COMPOSER_ROOT_VERSION=\"${RUNTESTS_VERSION}\"/" \
+    Build/Scripts/runTests.sh
+
+# ---------------------------------------------------------------------------
+# 2. Split extensions: composer deps, branch-alias, tailor, VERSION file
+# ---------------------------------------------------------------------------
+info "Split extensions"
+for dir in "${SPLIT_DIRS[@]}"; do
+    apply_academic_composer_deps "${dir}" "${ACADEMIC_CONSTRAINT}"
+    [ "${SET_BRANCH_ALIAS}" -eq 1 ] && apply_branch_alias "${dir}"
+    # docs-presence decides the --no-docs flag; all current splits ship docs.
+    if [ -d "${dir}/Documentation" ]; then
+        step "${dir}" "tailor set-version ${TAILOR_VERSION}"
+        run "${TAILOR_CMD[@]}" --path="${dir}" set-version -- "${TAILOR_VERSION}"
+    else
+        step "${dir}" "tailor set-version --no-docs ${TAILOR_VERSION}"
+        run "${TAILOR_CMD[@]}" --path="${dir}" set-version --no-docs -- "${TAILOR_VERSION}"
+    fi
+    apply_version_file "${dir}"
+done
+
+# ---------------------------------------------------------------------------
+# 3. Fixture extensions: composer deps only (no tailor, no VERSION, no alias).
+#    ext_emconf version + constraints are handled by the bulk pkw pass below.
+# ---------------------------------------------------------------------------
+info "Fixture extensions"
+for dir in "${FIXTURE_DIRS[@]}"; do
+    apply_academic_composer_deps "${dir}" "${ACADEMIC_CONSTRAINT}"
+done
+
+# ---------------------------------------------------------------------------
+# 4. ext_emconf.php: version + depends/suggests constraints (splits + fixtures).
+# ---------------------------------------------------------------------------
+info "ext_emconf.php version + constraints"
+step "ext_emconf" "version = ${EMCONF_VERSION} (${#EMCONF_FILES[@]} files)"
+run "${PKW_CMD[@]}" extemconf:set --ext-version="${EMCONF_VERSION}" -- "${EMCONF_FILES[@]}"
+
+for extkey in "${ACADEMIC_EXTKEYS[@]}"; do
+    step "ext_emconf" "depends/suggests ${extkey} = ${EMCONF_CONSTRAINT}"
+    run "${PKW_CMD[@]}" extemconf:constraints:set \
+        --constraint="${EMCONF_CONSTRAINT}" --update-only \
+        -- depends "${extkey}" "${EMCONF_FILES[@]}"
+    run "${PKW_CMD[@]}" extemconf:constraints:set \
+        --constraint="${EMCONF_CONSTRAINT}" --update-only \
+        -- suggests "${extkey}" "${EMCONF_FILES[@]}"
+done
+
+# ---------------------------------------------------------------------------
+# 5. monorepo-shared: academic deps + packages version map.
+# ---------------------------------------------------------------------------
+info "packages-dev/monorepo-shared"
+apply_academic_composer_deps "packages-dev/monorepo-shared" "${ACADEMIC_CONSTRAINT}"
+apply_version_map "packages-dev/monorepo-shared/composer.json" "packages"
+
+# ---------------------------------------------------------------------------
+# 6. ddev instances: both version maps + academics-monorepo-shared require.
+# ---------------------------------------------------------------------------
+for dir in ddev-instances/core-12 ddev-instances/core-13; do
+    [ -f "${dir}/composer.json" ] || continue
+    info "${dir}"
+    apply_version_map "${dir}/composer.json" "packages"
+    apply_version_map "${dir}/composer.json" "packages-dev"
+    apply_single_composer_require "${dir}" \
+        "fgtclb/academics-monorepo-shared" "${DDEV_SHARED_CONSTRAINT}"
+done
+
+# ---------------------------------------------------------------------------
+# 7. root composer.json: both version maps + monorepo-shared require + alias.
+# ---------------------------------------------------------------------------
+info "root composer.json"
+apply_version_map "composer.json" "packages"
+apply_version_map "composer.json" "packages-dev"
+step "." "composer require fgtclb/academics-monorepo-shared:${ROOT_SHARED_CONSTRAINT}"
+run "${COMPOSER}" require --no-update \
+    "fgtclb/academics-monorepo-shared:${ROOT_SHARED_CONSTRAINT}"
+[ "${SET_BRANCH_ALIAS}" -eq 1 ] && apply_branch_alias "."
+
+info "Finished set-version ${PASSED_VERSION} (${TYPE})"


### PR DESCRIPTION
Introduce two committed, dry-run-capable bash scripts that replace the
hand-maintained release command blobs for the academic-extensions mono
repository.

**`bin/set-version <version> <release|post-release|dev>`** applies a version and
its per-type variants across every relevant file: the `runTests.sh`
`COMPOSER_ROOT_VERSION`, each split extension (composer.json dependency
constraints, `ext_emconf.php` version and depends/suggests constraints, `VERSION`
file, tailor, branch-alias), the functional-test fixture extensions, the
`monorepo-shared` meta package, the ddev instances and the root `composer.json`
path-repository version maps. The package set, extension keys and inter-package
dependencies are discovered dynamically from the repository rather than
hardcoded; `require`/`require-dev` sections are handled independently. Supports a
`--dry-run` preview.

**`bin/release <release-version>`** orchestrates the full two-phase GitHub release
workflow and delegates the file changes to `bin/set-version` for each phase. It
validates the version, refuses to re-release an existing tag, derives the next
development version (patch + 1) and owns all git and `gh` operations. Every
remote or irreversible operation (push, pull-request create/checks/merge, tag and
tag push) is gated behind an explicit `--execute` flag, and a full `--dry-run`
mode prints the entire plan without changing anything.

Branch-alias updates are applied only in the `post-release`/`dev` phases, never
during `release`.