### PR TITLE
[TASK] Remove dead TYPO3 v12 runtime branches

### DIFF
--- a/packages/fgtclb/academic-partners/ext_localconf.php
+++ b/packages/fgtclb/academic-partners/ext_localconf.php
@@ -3,22 +3,9 @@
 declare(strict_types=1);
 
 use FGTCLB\AcademicPartners\Controller\PartnerController;
-use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 (static function (): void {
-    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-
-    // Starting with TYPO3 v13.0 Configuration/user.tsconfig in an Extension is automatically loaded during build time
-    // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101807-ExtensionManagementUtilityaddUserTSConfig.html
-    if ($versionInformation->getMajorVersion() < 13) {
-        ExtensionManagementUtility::addUserTSConfig('
-            @import \'EXT:academic_partners/Configuration/user.tsconfig\'
-        ');
-    }
-
     ExtensionUtility::configurePlugin(
         'AcademicPartners',
         'List',

--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -23,7 +23,6 @@ use FGTCLB\AcademicPersons\Event\ModifySelectedProfilesEvent;
 use FGTCLB\AcademicPersons\PageTitle\ProfileTitleProvider;
 use GeorgRinger\NumberedPagination\NumberedPagination;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Cache\CacheDataCollector;
 use TYPO3\CMS\Core\Cache\CacheTag;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -391,22 +390,10 @@ final class ProfileController extends ActionController
     /**
      * Add cache tags to the current page.
      *
-     * This method adds provided $tags to the current page,
-     * using the correct API based on the current TYPO3
-     * version.
-     *
-     * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Deprecation-102422-TypoScriptFrontendController-addCacheTags.html
-     *
      * @param string ...$tags
      */
     private function addCacheTags(string ...$tags): void
     {
-        // @todo Remove if-block when dropping `typo3/cms-*` v12 support
-        if (!class_exists(CacheDataCollector::class)) {
-            $this->getCurrentContentObjectRenderer()?->getTypoScriptFrontendController()?->addCacheTags($tags);
-            return;
-        }
-        // TYPO3 v13+
         $cacheCollector = $this->request->getAttribute('frontend.cache.collector');
         foreach ($tags as $tag) {
             $cacheCollector?->addCacheTags(new CacheTag($tag));

--- a/packages/fgtclb/academic-programs/ext_localconf.php
+++ b/packages/fgtclb/academic-programs/ext_localconf.php
@@ -4,24 +4,11 @@ declare(strict_types=1);
 
 use FGTCLB\AcademicPrograms\Controller\DetailsController;
 use FGTCLB\AcademicPrograms\Controller\ProgramController;
-use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
-    $versionInformation = new Typo3Version();
-
-    // Starting with TYPO3 v13.0 Configuration/user.tsconfig in an Extension is automatically loaded during build time
-    // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101807-ExtensionManagementUtilityaddUserTSConfig.html
-    if ($versionInformation->getMajorVersion() < 13) {
-        // Allow backend users to drag and drop the new page type:
-        ExtensionManagementUtility::addUserTSConfig('
-            @import \'EXT:academic_programs/Configuration/user.tsconfig\'
-        ');
-    }
-
     ExtensionUtility::configurePlugin(
         'AcademicPrograms',
         'ProgramList',

--- a/packages/fgtclb/academic-projects/ext_localconf.php
+++ b/packages/fgtclb/academic-projects/ext_localconf.php
@@ -1,23 +1,9 @@
 <?php
 
 use FGTCLB\AcademicProjects\Controller\ProjectController;
-use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 (static function (): void {
-    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-
-    // Starting with TYPO3 v13.0 Configuration/user.tsconfig in an Extension is automatically loaded during build time
-    // @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101807-ExtensionManagementUtilityaddUserTSConfig.html
-    if ($versionInformation->getMajorVersion() < 13) {
-        // Allow backend users to drag and drop the new page type:
-        ExtensionManagementUtility::addUserTSConfig('
-            @import \'EXT:academic_projects/Configuration/user.tsconfig\'
-        ');
-    }
-
     ExtensionUtility::configurePlugin(
         'AcademicProjects',
         'ProjectList',


### PR DESCRIPTION
## What

Part A / PR 2 of the TYPO3 v13 clean-up. Removes two clusters of code guarded behind `TYPO3 major < 13` that never run on the v13-only 3.x line and call APIs deprecated in v13.

### 2a — `addUserTSConfig()` guards (`ext_localconf.php`)
`academic_partners`, `academic_programs`, `academic_projects` imported their `Configuration/user.tsconfig` via `ExtensionManagementUtility::addUserTSConfig()` inside a `< 13` guard. TYPO3 v13.0 auto-loads that file, so the guard is dead and the call is deprecated (`Deprecation-101807`). Dropped the guard and the now-unused `Typo3Version` / `ExtensionManagementUtility` / `GeneralUtility` imports. The `user.tsconfig` files are kept (auto-loaded).

### 2b — `addCacheTags()` v12 branch (`academic_persons` `ProfileController`)
Removed the `!class_exists(CacheDataCollector::class)` fallback that called the deprecated `TypoScriptFrontendController::addCacheTags()` (`Deprecation-102422`). The `frontend.cache.collector` request-attribute path (v13) is the only one left; dropped the `CacheDataCollector` import.

## Why

Clears v12 residue and the associated v13 deprecations in one step.

## Changelog

Covered by the existing `Breaking: Removed TYPO3 v12 support` note — no new entry.

## Tests

TYPO3 v13 / PHP 8.2: `lintPhp`, `cgl -n`, `phpstan`, `unit`, `functional` (413, 2 pre-existing skips) all green.