### PR TITLE
[TASK] Remove FileUploadConverter v12 property path

### DIFF
--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,21 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$priority\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
-			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$sourceTypes\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
-			message: "#^Access to an undefined property FGTCLB\\\\AcademicBase\\\\Extbase\\\\Property\\\\TypeConverter\\\\FileUploadConverter\\:\\:\\$targetType\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
 			message: "#^Property FGTCLB\\\\AcademicBase\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php

--- a/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+++ b/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
@@ -7,7 +7,6 @@ namespace FGTCLB\AcademicBase\Extbase\Property\TypeConverter;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Http\UploadedFile;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Resource\DuplicationBehavior;
@@ -50,11 +49,7 @@ final class FileUploadConverter extends AbstractTypeConverter
         private readonly ResourceFactory $resourceFactory,
         private readonly LanguageServiceFactory $languageServiceFactory,
         private readonly LoggerInterface $logger,
-    ) {
-        // @todo Remove method call and method when TYPO3 v12 support is dropped.
-        //       https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-94117-RegisterExtbaseTypeConvertersAsServices.html
-        $this->configureProperties();
-    }
+    ) {}
 
     /**
      * @param array<string, mixed>|null $options
@@ -333,22 +328,6 @@ final class FileUploadConverter extends AbstractTypeConverter
             return $this->languageServiceFactory->createFromSiteLanguage($request->getAttribute('site')->getDefaultLanguage());
         }
         return $this->languageServiceFactory->create('default');
-    }
-
-    /**
-     * Set deprecated properties for TYPO3 v12 in cases some code will request deprecated methods to retrieve the
-     * information. Properties are now configured within `EXT:academic_base/Configuration/Services.yaml`.
-     *
-     * @todo Remove method together with call in {@see self::__construct()} when TYPO3 v12 support is dropped.
-     *       https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-94117-RegisterExtbaseTypeConvertersAsServices.html
-     */
-    private function configureProperties(): void
-    {
-        if ((new Typo3Version())->getMajorVersion() < 13) {
-            $this->sourceTypes = ['array'];
-            $this->targetType = ExtbaseFileReference::class;
-            $this->priority = 10;
-        }
     }
 
     /**


### PR DESCRIPTION
## What

Part A / PR 3 of the TYPO3 v13 clean-up.

`academic_base` `FileUploadConverter` assigned its Extbase type-converter properties (`sourceTypes`, `targetType`, `priority`) at runtime via a private `configureProperties()` call guarded by `TYPO3 major < 13`. Since v13 the converter is registered purely through the `extbase.type_converter` tag in `Configuration/Services.yaml`, so on the v13-only 3.x line the runtime assignment is dead code that only produced dynamic-property access.

- Removed `configureProperties()`, its constructor call and the now-unused `Typo3Version` import.
- Dropped the three matching phpstan baseline entries for the `FileUploadConverter` dynamic properties (`$priority`, `$sourceTypes`, `$targetType`), which no longer occur.

The `Services.yaml` registration is untouched.

## Note

PR 3 removes only the converter's dead **v12 branch**; it keeps the converter. The separate PR 9 spike evaluates replacing the whole custom converter with native Extbase `#[FileUpload]` — if positive, it supersedes what remains here.

## Changelog

Covered by the existing `Breaking: Removed TYPO3 v12 support` note — no new entry.

## Tests

TYPO3 v13 / PHP 8.2: `lintPhp`, `cgl -n`, `phpstan` (baseline entries verified matched), `unit`, `functional` (413, 2 pre-existing skips) all green.