### PR TITLE
[TASK] Remove dead TYPO3 v12 phpstan excludes

### DIFF
--- a/Build/phpstan/Core13/phpstan.neon
+++ b/Build/phpstan/Core13/phpstan.neon
@@ -16,5 +16,3 @@ parameters:
   excludePaths:
     - ../../../packages/fgtclb/*/ext_emconf.php
     - ../../../packages/fgtclb/*/Migrations/*
-    - ../../../packages/fgtclb/*/Classes/Core12/*
-    - ../../../packages/fgtclb/*/Tests/*/Core12/*


### PR DESCRIPTION
## What

Part A / PR 4 of the TYPO3 v13 clean-up. Small, low-risk removal of dead phpstan config.

- Removed the two `Build/phpstan/Core13/phpstan.neon` `excludePaths` for `Classes/Core12/*` and `Tests/*/Core12/*`. No such directories exist anymore on the v13-only 3.x line, so the excludes were inert. The `ext_emconf.php` and `Migrations/*` excludes stay.

## Kept on request

The disabled `.github/workflows/core-11.yml` and `core-12.yml` stubs are **kept** (they are referenced by status badges) and remain disabled — they are not removed. (Reverted from the initial version of this PR.)

## Merge order

Best merged after PR #314 (FlexForm flatten); no hard code dependency.

## Changelog

Covered by the existing `Breaking: Removed TYPO3 v12 support` note — no new entry.

## Tests

TYPO3 v13 / PHP 8.2: `phpstan` green.