### PR TITLE
[TASK] Migrate custom ViewHelpers off renderStatic()

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
@@ -2,14 +2,10 @@
 
 namespace FGTCLB\AcademicProjects\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 class ReplaceViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
@@ -19,32 +15,28 @@ class ReplaceViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param array<string, mixed> $arguments
      * @return mixed
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
-    ): mixed {
-        $content = $renderChildrenClosure();
+    public function render(): mixed
+    {
+        $content = $this->arguments['content'] ?? $this->renderChildren();
         /** @var string|array<string, mixed> $content */
         $content = is_scalar($content) || $content === null ? (string)$content : (array)$content;
 
-        $substring = $arguments['substring'];
+        $substring = $this->arguments['substring'];
         /** @var string|array<string, mixed> $substring */
         $substring = is_scalar($substring) ? (string)$substring : (array)$substring;
 
-        $replacement = $arguments['replacement'];
+        $replacement = $this->arguments['replacement'];
         /** @var string|array<string, mixed> $replacement */
         $replacement = is_scalar($replacement) ? (string)$replacement : (array)$replacement;
 
         $count = 0;
-        $caseSensitive = (bool)$arguments['caseSensitive'];
+        $caseSensitive = (bool)$this->arguments['caseSensitive'];
         $function = $caseSensitive ? 'str_replace' : 'str_ireplace';
         $replaced = $function($substring, $replacement, $content, $count);
 
-        if ($arguments['returnCount'] ?? false) {
+        if ($this->arguments['returnCount'] ?? false) {
             return $count;
         }
 

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
@@ -6,14 +6,10 @@ namespace FGTCLB\CategoryTypes\ViewHelpers\Be;
 
 use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 class CategoryViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     protected $escapeOutput = false;
 
     public function initializeArguments(): void
@@ -43,27 +39,17 @@ class CategoryViewHelper extends AbstractViewHelper
         $this->registerArguments($arguments);
     }
 
-    /**
-     * @param array{
-     *     page: int,
-     *     group: string,
-     *     as: string
-     * } $arguments
-     */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
-    ): string {
-        $templateVariableContainer = $renderingContext->getVariableProvider();
+    public function render(): string
+    {
+        $templateVariableContainer = $this->renderingContext->getVariableProvider();
 
         /** @var CategoryRepository $repository */
         $repository = GeneralUtility::makeInstance(CategoryRepository::class);
-        $categories = $repository->findByGroupAndPageId($arguments['group'], $arguments['page'], true);
+        $categories = $repository->findByGroupAndPageId($this->arguments['group'], $this->arguments['page'], true);
 
-        $templateVariableContainer->add($arguments['as'], $categories);
-        $output = $renderChildrenClosure();
-        $templateVariableContainer->remove($arguments['as']);
+        $templateVariableContainer->add($this->arguments['as'], $categories);
+        $output = $this->renderChildren();
+        $templateVariableContainer->remove($this->arguments['as']);
 
         return $output;
     }


### PR DESCRIPTION
## What

Part B / PR 5 of the TYPO3 v13 clean-up — a genuine v13 deprecation migration.

`renderStatic()` and the `CompileWith*RenderStatic` traits are deprecated for Fluid ViewHelpers and are removed with Fluid v5 (TYPO3 v14). Both custom ViewHelpers are converted to an instance `render()`:

- **`academic_projects` `Format\ReplaceViewHelper`** — drops `CompileWithContentArgumentAndRenderStatic`. The content argument is resolved faithfully as *content argument, else rendered children* (`$this->arguments['content'] ?? $this->renderChildren()`); remaining arguments come from `$this->arguments`.
- **`typo3-category-types` `Be\CategoryViewHelper`** — drops `CompileWithRenderStatic`; reads the rendering context via `$this->renderingContext` and children via `$this->renderChildren()`. Argument registration and `$escapeOutput = false` are unchanged.

Only the internal implementation changes — the ViewHelper arguments and rendered output are identical.

## Changelog

Internal implementation only, no public API/behaviour change — no changelog entry.

## Related

`Deprecation-104789-RenderStaticForFluidViewHelpers`.

## Tests

TYPO3 v13 / PHP 8.2: `lintPhp`, `cgl -n`, `phpstan`, `unit`, `functional` (413, 2 pre-existing skips) all green.