### PR TITLE
[TASK] Read page id from frontend.page.information

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Controller/GetSelectItemsForTcaManagedTableFieldMethodTrait.php
+++ b/packages/fgtclb/academic-base/Classes/Controller/GetSelectItemsForTcaManagedTableFieldMethodTrait.php
@@ -45,7 +45,7 @@ trait GetSelectItemsForTcaManagedTableFieldMethodTrait
         string $fieldName,
         array $removeItemByValue = [''],
     ): array {
-        $currentPageId = $request->getAttribute('frontend.controller')?->id ?? $request->getAttribute('site')?->getRootPageId() ?? 0;
+        $currentPageId = $request->getAttribute('frontend.page.information')?->getId() ?? $request->getAttribute('site')?->getRootPageId() ?? 0;
         $items = $GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['items'] ?? [];
         $itemProcFunc = (string)($GLOBALS['TCA'][$tableName]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
         if ($itemProcFunc !== '') {

--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -30,7 +30,6 @@ use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 final class JobController extends ActionController
 {
@@ -432,11 +431,7 @@ final class JobController extends ActionController
      */
     private function determineCurrentPageId(): int
     {
-        $frontendController = $this->request->getAttribute('frontend.controller');
-        if ($frontendController instanceof TypoScriptFrontendController) {
-            return (int)$frontendController->id;
-        }
-        return 0;
+        return (int)($this->request->getAttribute('frontend.page.information')?->getId() ?? 0);
     }
 
     /**


### PR DESCRIPTION
## What

Part B / PR 6 of the TYPO3 v13 clean-up — a genuine v13 deprecation migration.

`TypoScriptFrontendController` and `$GLOBALS['TSFE']` are deprecated in v13 (removed v14). Reading the current page id from the TSFE instance moves to the `frontend.page.information` request attribute (`PageInformation::getId()`).

- **`academic_jobs` `JobController::determineCurrentPageId()`** — dropped the `TypoScriptFrontendController instanceof` check and its import; now `$this->request->getAttribute('frontend.page.information')?->getId()` with the same `0` fallback.
- **`academic_base` `GetSelectItemsForTcaManagedTableFieldMethodTrait`** — reads the page id from `frontend.page.information`; the existing `site->getRootPageId()` and `0` fallbacks are kept.

`frontend.page.information` exists from TYPO3 v13.3+, and the branch floor is `^13.4`, so no version fallback is needed. Internal implementation only — no behaviour change.

## Changelog

Internal implementation only — no changelog entry.

## Related

`Deprecation-105230-TypoScriptFrontendControllerAndGLOBALSTSFE` (context: `Breaking-102621`).

## Tests

TYPO3 v13 / PHP 8.2: `lintPhp`, `cgl -n`, `phpstan`, `unit`, `functional` (413, 2 pre-existing skips) all green — including the jobs plugin and the academic_base TCA select-items trait exercised in FE context.