### PR TITLE
[TASK] Drop deprecated TCA list sub-type registrations

### DIFF
--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -38,7 +38,6 @@ if (!defined('TYPO3')) {
         sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/Plugin_NewJobForm.xml', $typo3MajorVersion),
         'academicjobs_newjobform'
     );
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_newjobform'] = 'pi_flexform';
 
     //==================================================================================================================
     // Plugin: academicjobs_list
@@ -67,8 +66,6 @@ if (!defined('TYPO3')) {
         sprintf('FILE:EXT:academic_jobs/Configuration/Flexforms/Core%s/PluginList.xml', $typo3MajorVersion),
         'academicjobs_list'
     );
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicjobs_list'] = 'pages,layout,select_key,recursive';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academicjobs_list'] = 'pi_flexform';
 
     //==================================================================================================================
     // Plugin: academicjobs_detail

--- a/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/tt_content.php
@@ -30,11 +30,6 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons_edit'
     );
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileediting'] = implode(',', [
-        'pages',
-        'recursive',
-        'select_key',
-    ]);
 
     //==================================================================================================================
     // Plugin: academicpersonsedit_profileswitcher
@@ -49,10 +44,5 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
         ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons_edit'
     );
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileswitcher'] = implode(',', [
-        'pages',
-        'recursive',
-        'select_key',
-    ]);
 
 })();


### PR DESCRIPTION
## What

Part B / PR 7 of the TYPO3 v13 clean-up — the most behaviour-sensitive migration.

`$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']` and `['subtypes_excludelist']` are deprecated in v13.4 and removed in v14. They belong to the legacy `list`/`list_type` sub-type mechanism, which these plugins do **not** use — `academic_jobs` and `academic_persons_edit` register their plugins as their own `CType` (`PLUGIN_TYPE_CONTENT_ELEMENT`), so the sub-type entries never take effect and are orphaned config.

- **academic_jobs** — drop `subtypes_addlist`/`subtypes_excludelist` for `academicjobs_newjobform` and `academicjobs_list`.
- **academic_persons_edit** — drop `subtypes_excludelist` for `academicpersonsedit_profileediting` and `academicpersonsedit_profileswitcher`.

## Verification (why no showitem change is needed)

I dumped the **effective runtime TCA** for the affected CTypes. Each plugin CType showitem:
- already contains `pi_flexform` where required (added via `addToAllTCAtypes`), so `subtypes_addlist` was redundant;
- never contained the excludelist fields (`pages`, `layout`, `select_key`, `recursive`) — those are not part of the default plugin CType showitem — so `subtypes_excludelist` excluded fields that are not present.

Removing the entries therefore leaves every CType showitem **byte-for-byte unchanged**. This is why the plan's suggested "move fields into showitem" step is unnecessary here.

## Changelog

Internal registration only, no public behaviour change — no changelog entry.

## Related

`Deprecation-105213-TCASubTypes` (root cause `Deprecation-105076`).

## Merge order

Touches `academic-jobs/.../tt_content.php`, which PR #314 (FlexForm flatten) also edits (different lines). Whichever merges second may need a trivial rebase.

## Tests

TYPO3 v13 / PHP 8.2: `lintPhp`, `cgl -n`, `phpstan`, `unit`, `functional` (413, 2 pre-existing skips) all green, incl. the jobs FormEngine `TypeItemsTest`.