### PR TITLE
[TASK] Gate strict-fallback profile tests on v14.3.6

### DIFF
--- a/packages/fgtclb/academic-persons/Documentation/Changelog/3.0/Important-88886-StrictLanguageFallbackForSelectedProfiles.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Changelog/3.0/Important-88886-StrictLanguageFallbackForSelectedProfiles.rst
@@ -1,0 +1,116 @@
+.. _important-88886-strict-language-fallback-selected-profiles:
+
+=========================================================
+Important: Strict language fallback for selected profiles
+=========================================================
+
+Description
+===========
+
+When profiles are selected explicitly (by uid) for a list plugin
+(:php:`academicpersons_list` / :php:`academicpersons_listanddetail` with the
+FlexForm *"selected profiles"* option), a site language configured with
+:php:`fallbackType: strict` did not hide profiles that are not translated into
+the requested language. Such profiles were rendered in their default language
+instead of being removed, unless the plugin option *"fallback for non
+translated"* was enabled on purpose.
+
+This is **not** an :php:`EXT:academic_persons` bug. The extension already
+resolves the correct language overlay type from the site configuration and only
+relies on Extbase persistence to apply it. The behaviour is caused by a
+long-standing Extbase regression that ignored the resolved language overlay type
+and always overlaid single records with :php:`OVERLAYS_MIXED`, so untranslated
+records were kept.
+
+Core references (issue and both patches):
+
+* Forge issue `#88886 <https://forge.typo3.org/issues/88886>`__ —
+  *"DataMapper: Consider languageOverlayMode hideNonTranslated ..."*
+* Gerrit change `66694 <https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694>`__
+  — *"[BUGFIX] Respect language overlay type in Extbase"* (TYPO3 main line)
+* Gerrit change `94935 <https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935>`__
+  — the TYPO3 **14.3** backport (same Change-Id)
+
+The fix is released with TYPO3 **v14.3.6** and newer (and on the TYPO3 main
+development line). It is **not** part of TYPO3 **v13** and, being a behavioural
+change, is not backported to the v13.4 LTS.
+
+Impact
+======
+
+On **TYPO3 v14.3.6 and newer** the behaviour is correct out of the box:
+untranslated selected profiles are removed under :php:`fallbackType: strict`. No
+configuration or code change is required in :php:`EXT:academic_persons`.
+
+On **TYPO3 v13.4** (and on **TYPO3 v14.3.0 - v14.3.5**, before the fix shipped)
+the affected Extbase code still overlays with :php:`OVERLAYS_MIXED`, so
+untranslated selected profiles keep being shown in their default language when the
+site language uses :php:`fallbackType: strict` and the plugin fallback option is
+not enabled.
+
+The two functional tests covering this behaviour
+(:php:`AcademicPersonsListPluginTest` and :php:`AcademicPersonsListAndDetailPluginTest`,
+test :php:`...WithFallbackTypeStrictWhenNotAllProfilesAreLocalized`) are therefore
+skipped on TYPO3 below v14.3.6 and run only where the core fix is present.
+
+Affected Installations
+======================
+
+Installations that use selected profiles in a list plugin with a site language
+configured as :php:`fallbackType: strict` and expect untranslated profiles to be
+hidden, running on **TYPO3 v13.4** or **TYPO3 v14.3.0 - v14.3.5**.
+
+Solution
+========
+
+Upgrade to **TYPO3 v14.3.6** or newer, which contains the core fix.
+
+If the correct behaviour is required before that, apply the core change as a
+composer patch against :php:`typo3/cms-extbase` until it is part of the installed
+core version. Cleaned patches (narrowed to :php:`typo3/cms-extbase`, derived from
+Gerrit changes 66694 / 94935) are shipped with this extension:
+
+TYPO3 v13.4 patch
+-----------------
+
+:file:`Documentation/Patches/extbase-88886-respect-language-overlay-type-v13.patch`
+
+..  literalinclude:: ../../Patches/extbase-88886-respect-language-overlay-type-v13.patch
+    :language: diff
+    :caption: extbase-88886-respect-language-overlay-type-v13.patch (TYPO3 v13.4)
+
+TYPO3 v14.3 patch (v14.3.0 - v14.3.5)
+-------------------------------------
+
+:file:`Documentation/Patches/extbase-88886-respect-language-overlay-type-v14.patch`
+
+..  literalinclude:: ../../Patches/extbase-88886-respect-language-overlay-type-v14.patch
+    :language: diff
+    :caption: extbase-88886-respect-language-overlay-type-v14.patch (TYPO3 v14.3.0 - v14.3.5)
+
+Apply the matching patch with the composer plugin
+`cweagans/composer-patches <https://github.com/cweagans/composer-patches>`__
+(see its README for installation and usage). Copy the patch into the project
+(for example into a :file:`patches/` directory) and reference it:
+
+..  code-block:: json
+
+    {
+        "require": {
+            "cweagans/composer-patches": "^1.7"
+        },
+        "extra": {
+            "patches": {
+                "typo3/cms-extbase": {
+                    "Respect language overlay type in Extbase (forge #88886, review 66694)": "patches/extbase-88886-respect-language-overlay-type-v13.patch"
+                }
+            }
+        }
+    }
+
+Both patches touch only :php:`typo3/cms-extbase`
+(:file:`Classes/Persistence/Generic/Storage/Typo3DbBackend.php` and
+:file:`Classes/Persistence/Generic/Backend.php`); :php:`EXT:academic_persons`
+itself needs no change.
+
+.. index:: PHP, ext:academic_persons

--- a/packages/fgtclb/academic-persons/Documentation/Patches/extbase-88886-respect-language-overlay-type-v13.patch
+++ b/packages/fgtclb/academic-persons/Documentation/Patches/extbase-88886-respect-language-overlay-type-v13.patch
@@ -1,0 +1,42 @@
+diff -ruN a/Classes/Persistence/Generic/Backend.php b/Classes/Persistence/Generic/Backend.php
+--- a/Classes/Persistence/Generic/Backend.php
++++ b/Classes/Persistence/Generic/Backend.php
+@@ -148,11 +148,14 @@
+         // This allows to fetch IDs for languages for default language AND language IDs
+         // This is especially important when using the PropertyMapper of the Extbase MVC part to get
+         // an object of the translated version of the incoming ID of a record.
++        // "Free" mode (OVERLAYS_OFF) is mapped to OVERLAYS_MIXED - overlays need to be enabled for the
++        // identity lookup, but hiding untranslated records is not a configured intent in free mode.
++        // This is consistent with the same handling for related objects in DataMapper->getPreparedQuery().
+         $languageAspect = $query->getQuerySettings()->getLanguageAspect();
+         $languageAspect = new LanguageAspect(
+             $languageAspect->getId(),
+             $languageAspect->getContentId(),
+-            $languageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $languageAspect->getOverlayType(),
++            $languageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_MIXED : $languageAspect->getOverlayType(),
+             $languageAspect->getFallbackChain()
+         );
+         $query->getQuerySettings()->setLanguageAspect($languageAspect);
+diff -ruN a/Classes/Persistence/Generic/Storage/Typo3DbBackend.php b/Classes/Persistence/Generic/Storage/Typo3DbBackend.php
+--- a/Classes/Persistence/Generic/Storage/Typo3DbBackend.php
++++ b/Classes/Persistence/Generic/Storage/Typo3DbBackend.php
+@@ -580,9 +580,16 @@
+                     $row['uid'] = $row[$GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField']];
+                     $row[$GLOBALS['TCA'][$tableName]['ctrl']['languageField']] = 0;
+                 }
+-                // Currently this needs to return the default record (OVERLAYS_MIXED) if no translation is found
+-                //however this is a hack and should actually use the overlay functionality as given in the original LanguageAspect.
+-                $customLanguageAspect = new LanguageAspect($languageUid, $languageUid, LanguageAspect::OVERLAYS_MIXED, $languageAspect->getFallbackChain());
++                // The overlay type (and fallback chain) of the language aspect is respected, so translation
++                // behavior is consistent with the regular page / content rendering. The content language
++                // however may have been adjusted above to the language of the actually fetched record
++                // (see Note #1 and the respectSysLanguage handling), so a custom aspect is passed here.
++                $customLanguageAspect = new LanguageAspect(
++                    $languageAspect->getId(),
++                    $languageUid,
++                    $languageAspect->getOverlayType(),
++                    $languageAspect->getFallbackChain()
++                );
+                 $row = $pageRepository->getLanguageOverlay($tableName, $row, $customLanguageAspect);
+             }
+         } elseif (is_array($row)) {

--- a/packages/fgtclb/academic-persons/Documentation/Patches/extbase-88886-respect-language-overlay-type-v14.patch
+++ b/packages/fgtclb/academic-persons/Documentation/Patches/extbase-88886-respect-language-overlay-type-v14.patch
@@ -1,0 +1,40 @@
+--- a/Classes/Persistence/Generic/Backend.php
++++ b/Classes/Persistence/Generic/Backend.php
+@@ -165,11 +165,14 @@
+         // This allows to fetch IDs for languages for default language AND language IDs
+         // This is especially important when using the PropertyMapper of the Extbase MVC part to get
+         // an object of the translated version of the incoming ID of a record.
++        // "Free" mode (OVERLAYS_OFF) is mapped to OVERLAYS_MIXED - overlays need to be enabled for the
++        // identity lookup, but hiding untranslated records is not a configured intent in free mode.
++        // This is consistent with the same handling for related objects in DataMapper->getPreparedQuery().
+         $languageAspect = $query->getQuerySettings()->getLanguageAspect();
+         $languageAspect = new LanguageAspect(
+             $languageAspect->getId(),
+             $languageAspect->getContentId(),
+-            $languageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $languageAspect->getOverlayType(),
++            $languageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_MIXED : $languageAspect->getOverlayType(),
+             $languageAspect->getFallbackChain()
+         );
+ 
+--- a/Classes/Persistence/Generic/Storage/Typo3DbBackend.php
++++ b/Classes/Persistence/Generic/Storage/Typo3DbBackend.php
+@@ -590,9 +590,16 @@
+                     $row['uid'] = $row[$translationParentPointerField];
+                     $row[$languageField] = 0;
+                 }
+-                // Currently this needs to return the default record (OVERLAYS_MIXED) if no translation is found
+-                //however this is a hack and should actually use the overlay functionality as given in the original LanguageAspect.
+-                $customLanguageAspect = new LanguageAspect($languageUid, $languageUid, LanguageAspect::OVERLAYS_MIXED, $languageAspect->getFallbackChain());
++                // The overlay type (and fallback chain) of the language aspect is respected, so translation
++                // behavior is consistent with the regular page / content rendering. The content language
++                // however may have been adjusted above to the language of the actually fetched record
++                // (see Note #1 and the respectSysLanguage handling), so a custom aspect is passed here.
++                $customLanguageAspect = new LanguageAspect(
++                    $languageAspect->getId(),
++                    $languageUid,
++                    $languageAspect->getOverlayType(),
++                    $languageAspect->getFallbackChain()
++                );
+                 $row = $pageRepository->getLanguageOverlay($tableName, $row, $customLanguageAspect);
+             }
+         } elseif (is_array($row)) {

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -511,14 +511,28 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     }
 
     /**
-     * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
-     *       test for v12 when enabling it again.
+     * The selected profiles are fetched via Extbase persistence, which did not honour the site language
+     * "fallbackType: strict" for untranslated (child) records before TYPO3 v14.3.6: untranslated selected
+     * profiles were returned in their default language instead of being removed. This is a long-standing
+     * Extbase regression, fixed in core with change 66694 (14.3 backport 94935, forge #88886), released
+     * with TYPO3 v14.3.6 and the main line only (no TYPO3 v13.4 backport). The assertions below describe
+     * the corrected v14.3.6+ behaviour, so the test only runs there.
+     *
+     * @todo Verify these assertions once TYPO3 v14 support is added to this extension and the test runs.
+     * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694
+     * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935
+     * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 12) {
-            $this->markTestSkipped('Different behaviour since TYPO3 v12 - needs investigation in core first if this was intended.');
+        if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
+            $this->markTestSkipped(
+                'Extbase honours "fallbackType: strict" for untranslated selected profiles only since '
+                . 'TYPO3 v14.3.6 (core fix https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694 and its 14.3 '
+                . 'backport https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935, forge #88886; not '
+                . 'backported to v13.4).'
+            );
         }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -387,14 +387,28 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     }
 
     /**
-     * @todo Investgate change TYPO3 core/extbase behaviour since v12 in core and either fix implementation or adjust
-     *       test for v12 when enabling it again.
+     * The selected profiles are fetched via Extbase persistence, which did not honour the site language
+     * "fallbackType: strict" for untranslated (child) records before TYPO3 v14.3.6: untranslated selected
+     * profiles were returned in their default language instead of being removed. This is a long-standing
+     * Extbase regression, fixed in core with change 66694 (14.3 backport 94935, forge #88886), released
+     * with TYPO3 v14.3.6 and the main line only (no TYPO3 v13.4 backport). The assertions below describe
+     * the corrected v14.3.6+ behaviour, so the test only runs there.
+     *
+     * @todo Verify these assertions once TYPO3 v14 support is added to this extension and the test runs.
+     * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694
+     * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935
+     * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeStrictWhenNotAllProfilesAreLocalized(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 12) {
-            $this->markTestSkipped('Different behaviour since TYPO3 v12 - needs investigation in core first if this was intended.');
+        if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
+            $this->markTestSkipped(
+                'Extbase honours "fallbackType: strict" for untranslated selected profiles only since '
+                . 'TYPO3 v14.3.6 (core fix https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694 and its 14.3 '
+                . 'backport https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935, forge #88886; not '
+                . 'backported to v13.4).'
+            );
         }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();


### PR DESCRIPTION
## What

Part C / PR 8 of the TYPO3 v13 clean-up — resolves the two always-skipped strict-fallback plugin tests, documents the underlying core bug, and ships verified composer patches.

Two functional tests (`AcademicPersonsListPluginTest` and `AcademicPersonsListAndDetailPluginTest`, `...WithFallbackTypeStrictWhenNotAllProfilesAreLocalized`) assert that a site language with `fallbackType: strict` hides selected (by-UID) profiles that are **not** translated. They were skipped behind an outdated `getMajorVersion() >= 12` guard and never ran.

## Root cause (not an extension bug)

Long-standing Extbase regression — forge **[#88886](https://forge.typo3.org/issues/88886)** — where `Typo3DbBackend::overlayLanguageAndWorkspaceForSingleRecord()` ignored the resolved overlay type and always overlaid single records with `OVERLAYS_MIXED`. Core fix — Gerrit **[66694](https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694)** (main) / **[94935](https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935)** (14.3 backport) — released with **TYPO3 v14.3.6 and newer** only; **not** in v13.4 and not backported.

**Verified empirically:** applying change 66694 to a TYPO3 13.4.33 install makes both tests pass unchanged.

## Change

- Replace the dead guard with `version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')` + accurate skip reason linking the forge issue and **both** Gerrit changes.
- Update test docblocks (`@see` #88886, 66694, 94935).
- Add `Important-88886-StrictLanguageFallbackForSelectedProfiles.rst` (3.0 changelog): the core bug, exact fixed version (**v14.3.6+**), linked issue/changes, and how to apply a patch via `cweagans/composer-patches`.
- **Ship cleaned, verified composer patches** narrowed to `typo3/cms-extbase`, displayed inline in the note:
  - `Documentation/Patches/extbase-88886-respect-language-overlay-type-v13.patch` (TYPO3 v13.4) — **verified** to make both tests pass on a patched 13.4 install.
  - `Documentation/Patches/extbase-88886-respect-language-overlay-type-v14.patch` (TYPO3 v14.3.0–v14.3.5, narrowed from change 94935).

## Backport

Backported to the `2.x` line (v12+v13, with v12+v13 patches) in #322.

## Tests

TYPO3 v13 / PHP 8.2: `cgl -n`, `phpstan`, `checkRstRenderingAll`, `unit`, `functional` (413, 2 pre-existing skips) all green.