### PR TITLE
[TASK] Require environment-state-manager ^2.0.1@dev

### DIFF
--- a/packages-dev/monorepo-shared/composer.json
+++ b/packages-dev/monorepo-shared/composer.json
@@ -22,7 +22,7 @@
         "fgtclb/academic-projects": "~3.0.0@dev",
         "fgtclb/academic-study-plan": "~3.0.0@dev",
         "fgtclb/category-types": "~3.0.0@dev",
-        "fgtclb/environment-state-manager": "^1.0",
+        "fgtclb/environment-state-manager": "^2.0.1@dev",
         "typo3/cms-backend": "^13.4",
         "typo3/cms-belog": "^13.4",
         "typo3/cms-beuser": "^13.4",

--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -22,7 +22,7 @@
         "typo3/cms-core": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -22,7 +22,7 @@
         "typo3/cms-core": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -24,7 +24,7 @@
         "typo3/cms-rte-ckeditor": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -48,7 +48,7 @@
         "typo3/cms-fluid": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -23,7 +23,7 @@
         "typo3/cms-install": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -24,7 +24,7 @@
         "typo3/cms-extbase": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-base": "~3.0.0@dev",
-        "fgtclb/environment-state-manager": "^1.0",
+        "fgtclb/environment-state-manager": "^2.0.1@dev",
         "typo3/cms-core": "^13.4",
         "typo3/cms-extbase": "^13.4",
         "typo3/cms-fluid": "^13.4",

--- a/packages/fgtclb/academic-persons/ext_emconf.php
+++ b/packages/fgtclb/academic-persons/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
             'frontend' => '13.4.0-13.4.99',
             'install' => '13.4.0-13.4.99',
             'rte_ckeditor' => '13.4.0-13.4.99',
-            'environment_state_manager' => '1.0.0-1.99.99',
+            'environment_state_manager' => '2.0.1-2.99.99',
             'academic_base' => '3.0.0',
         ],
         'suggests' => [

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -49,7 +49,7 @@
         "typo3/cms-frontend": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -26,7 +26,7 @@
         "typo3/cms-install": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/academic-study-plan/composer.json
+++ b/packages/fgtclb/academic-study-plan/composer.json
@@ -25,7 +25,7 @@
         "typo3/cms-install": "^13.4"
     },
     "require-dev": {
-        "fgtclb/environment-state-manager": "^1.0"
+        "fgtclb/environment-state-manager": "^2.0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -15,7 +15,7 @@
     "typo3/cms-core": "^13.4"
   },
   "require-dev": {
-    "fgtclb/environment-state-manager": "^1.0"
+    "fgtclb/environment-state-manager": "^2.0.1@dev"
   },
   "extra": {
     "typo3/cms": {


### PR DESCRIPTION
## What

Raise the `fgtclb/environment-state-manager` (EXT:`environment_state_manager`) constraint from `^1.0` to **`^2.0.1@dev`** across the mono repo, matching the 2.0.1 release that supports the dual **TYPO3 v13 + v14** target.

The dependency **section is preserved per package**:

- **hard `require`** (2): `packages/fgtclb/academic-persons`, `packages-dev/monorepo-shared` (`fgtclb/academics-monorepo-shared`)
- **`require-dev`** (10): `academic-bite-jobs`, `academic-partners`, `academic-projects`, `academic-contact4pages`, `academic-jobs`, `academic-persons-edit`, `academic-study-plan`, `typo3-category-types`, `academic-programs`, `academic-persons-sync`

`academic_persons/ext_emconf.php` `depends` raised accordingly: `1.0.0-1.99.99` → `2.0.1-2.99.99` (only package declaring it as a hard TYPO3 dependency).

## Exact composer commands used

All `composer.json` edits were done with `composer require … --no-update` **per package folder** — so **no `composer.lock` files or installs were created in any subdirectory** — dispatched through the containerized harness (`Build/Scripts/runTests.sh -s composer -- <args>` runs `composer <args>` in the test image):

```bash
# hard require (require):
Build/Scripts/runTests.sh -s composer -- require --no-update \
  --working-dir=packages/fgtclb/academic-persons \
  "fgtclb/environment-state-manager:^2.0.1@dev"
Build/Scripts/runTests.sh -s composer -- require --no-update \
  --working-dir=packages-dev/monorepo-shared \
  "fgtclb/environment-state-manager:^2.0.1@dev"

# dev require (require-dev), once per package folder
# (academic-bite-jobs, academic-partners, academic-projects,
#  academic-contact4pages, academic-jobs, academic-persons-edit,
#  academic-study-plan, typo3-category-types, academic-programs,
#  academic-persons-sync):
Build/Scripts/runTests.sh -s composer -- require --dev --no-update \
  --working-dir=packages/fgtclb/<package> \
  "fgtclb/environment-state-manager:^2.0.1@dev"
```

`ext_emconf.php` is not composer-managed and was edited directly.

## Validation

- `Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate` → resolves & installs **environment-state-manager 2.0.1**.
- `cgl -n`, `lintPhp`, `phpstan`, `unit`, `functional` (413, 2 pre-existing skips) all green — 2.0.1 is API-compatible.

13 files changed (12 `composer.json` + 1 `ext_emconf.php`), constraint-only.
