### PR TITLE
[TASK] Upgrade shared test tooling for TYPO3 v14

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -604,7 +604,7 @@ case ${TEST_SUITE} in
         ;;
     functional)
         PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests.xml"
-        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS},not-core-${CORE_VERSION} "$@")
+        COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} --exclude-group not-core-${CORE_VERSION} "$@")
         case ${DBMS} in
             mariadb)
                 echo "Using driver: ${DATABASE_DRIVER}"

--- a/composer.json
+++ b/composer.json
@@ -56,14 +56,14 @@
         "friendsofphp/php-cs-fixer": "^3.80.0",
         "friendsoftypo3/phpstan-typo3": "^0.9.0",
         "georgringer/numbered-pagination": "^2.1",
-        "phpstan/phpdoc-parser": "^1.29.0",
+        "phpstan/phpdoc-parser": "^1.29.0 || ^2.1",
         "phpstan/phpstan": "^1.12.21",
         "phpstan/phpstan-phpunit": "^1.4.0",
-        "phpunit/phpunit": "^10.5.45",
+        "phpunit/phpunit": "^11.2.5",
         "sbuerk/fixture-packages": ">=0.1.1 <2.0.0",
-        "sbuerk/typo3-site-based-test-trait": "^1.0.2 || ^2.0.1",
+        "sbuerk/typo3-site-based-test-trait": "^2.0.1 || ^3.0.0",
         "typo3/tailor": "^1.6",
-        "typo3/testing-framework": "^8.2.7"
+        "typo3/testing-framework": "^9.3"
     },
     "repositories": {
         "packages-dev": {


### PR DESCRIPTION
## What

Second step of the **TYPO3 v14 support round** (after #324 widened constraints).
Installing v14.3 is impossible until the shared **test/analysis tooling** is
raised — v14.3 pulls newer majors of testing-framework, PHPUnit and phpdoc-parser
than the mono repo pins. This PR does the minimal set of bumps that lets **both**
v13 and v14 resolve. As a side effect the whole suite (v13 included) moves to the
newer test-tool majors.

No v14 CI is wired here — the `-t 13` CI validates the upgrade end to end. The
`-t 14` build tooling (runTests `-t 14`, phpstan `Core14`, ddev `core-14`, compat
trait) follows in the next PR.

## Root `require-dev` bumps

| Package | Before | After | Why |
|---|---|---|---|
| `phpunit/phpunit` | `^10.5.45` | `^11.2.5` | testing-framework 9 requires phpunit `^11 \|\| ^12 \|\| ^13` |
| `typo3/testing-framework` | `^8.2.7` | `^9.3` | 8.x is v12/v13-only; 9.x supports **v13 + v14** |
| `phpstan/phpdoc-parser` | `^1.29.0` | `^1.29.0 \|\| ^2.1` | `typo3/cms-extbase` v14.3 requires `^2.1`; v13 keeps `^1` |
| `sbuerk/typo3-site-based-test-trait` | `^1.0.2 \|\| ^2.0.1` | `^2.0.1 \|\| ^3.0.0` | major tracks the core (2→v13, 3→v14); dead v12 `^1.0.2` dropped |

`phpstan/phpstan` stays at `^1.12` — `friendsoftypo3/phpstan-typo3` 0.9.0 caps at
phpstan `^1.2`, and the phar's bundled phpdoc-parser is independent of the
project's, so analysis is unaffected by phpdoc-parser 2.x in the install.

## runTests.sh

PHPUnit 11 deprecates comma-separated `--exclude-group` values, which the
functional suite used (`--exclude-group not-<dbms>,not-core-<v>`) — the warning
turned the run red via fail-on-warning. Now two separate `--exclude-group` flags.

## Composer discipline

```bash
Build/Scripts/runTests.sh -s composer -- require --dev --no-update \
  --working-dir=. \
  "phpunit/phpunit:^11.2.5" \
  "typo3/testing-framework:^9.3" \
  "phpstan/phpdoc-parser:^1.29.0 || ^2.1" \
  "sbuerk/typo3-site-based-test-trait:^2.0.1 || ^3.0.0"
```

## Verification (local, `-t 13 -p 8.2`)

Installs **testing-framework 9.6.0, phpunit 11.5.56, phpdoc-parser 2.3.3,
site-based-test-trait 2.0.1, cms-core v13.4.33**.

| Gate | Result |
|------|--------|
| `cgl -n` | green |
| `lintPhp` | green |
| `phpstan` | green |
| `unit` | **76 tests** green |
| `functional` (sqlite) | **413 tests**, 2 skipped |
