### PR TITLE
[TASK] Register plugins as CType for TYPO3 v14

### DIFF
--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
 
 		-
-			message: "#^Parameter \\#1 \\$uid of method TYPO3\\\\CMS\\\\Core\\\\Resource\\\\StorageRepository\\:\\:getStorageObject\\(\\) expects int\\<0, max\\>\\|string, int given\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
 			message: "#^Property FGTCLB\\\\AcademicBase\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
@@ -24,11 +19,6 @@ parameters:
 			message: "#^Static property FGTCLB\\\\AcademicBase\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions is never read, only written\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicBiteJobs\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
@@ -44,11 +34,6 @@ parameters:
 			message: "#^Method FGTCLB\\\\AcademicContacts4pages\\\\Domain\\\\Repository\\\\ContactRepository\\:\\:findByPid\\(\\) return type with generic interface TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-contact4pages/Classes/Domain/Repository/ContactRepository.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicContacts4pages\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
@@ -69,11 +54,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$recordId of method FGTCLB\\\\AcademicJobs\\\\Controller\\\\JobController\\:\\:sendEmail\\(\\) expects int, int\\<1, max\\>\\|null given\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 3
-			path: ../../../packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicJobs\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
@@ -126,11 +106,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-partners/Classes/Domain/Repository/PartnershipRepository.php
 
 		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 4
-			path: ../../../packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
-
-		-
 			message: "#^Property FGTCLB\\\\AcademicPartners\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-partners/Tests/Functional/ExtensionLoadedTest.php
@@ -144,16 +119,6 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Domain/Model/Dto/ProfileInformationFormData.php
-
-		-
-			message: "#^Access to an undefined property TYPO3\\\\CMS\\\\Core\\\\DataHandling\\\\DataHandler\\:\\:\\$neverHideAtCopy\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-persons-edit/Classes/Profile/ProfileTranslator.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicPersonsEdit\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
@@ -196,11 +161,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-persons/Classes/Event/ModifyListProfilesEvent.php
 
 		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 6
-			path: ../../../packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
-
-		-
 			message: "#^Property FGTCLB\\\\AcademicPersons\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-persons/Tests/Functional/ExtensionLoadedTest.php
@@ -214,11 +174,6 @@ parameters:
 			message: "#^Method FGTCLB\\\\AcademicPrograms\\\\Domain\\\\Repository\\\\ProgramRepository\\:\\:findByDemand\\(\\) should return TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\QueryResult\\<FGTCLB\\\\AcademicPrograms\\\\Domain\\\\Model\\\\Program\\> but returns TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-programs/Classes/Domain/Repository/ProgramRepository.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicPrograms\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
@@ -244,11 +199,6 @@ parameters:
 			message: "#^Method FGTCLB\\\\AcademicProjects\\\\Domain\\\\Repository\\\\ProjectRepository\\:\\:findByDemand\\(\\) should return TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\QueryResult\\<FGTCLB\\\\AcademicProjects\\\\Domain\\\\Model\\\\Project\\> but returns TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
-
-		-
-			message: "#^Static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\ExtensionManagementUtility\\:\\:addPlugin\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
 
 		-
 			message: "#^Property FGTCLB\\\\AcademicProjects\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"

--- a/packages/fgtclb/academic-base/Classes/TcaManipulator.php
+++ b/packages/fgtclb/academic-base/Classes/TcaManipulator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicBase;
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Schema\Struct\SelectItem;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 /**
  * Provides additional methods to manipulate TCA not possible with TYPO3 Core utilities.
@@ -71,6 +73,34 @@ final class TcaManipulator
         }
         $additionalTypeInformation['showitem'] = $showItemList;
         $GLOBALS['TCA'][$table]['types'][$selectItem->getValue()] = $additionalTypeInformation;
+    }
+
+    /**
+     * Register an Extbase plugin as a content element (CType) in a way that works
+     * on both TYPO3 v13 and v14.
+     *
+     * TYPO3 v13 `ExtensionManagementUtility::addPlugin()` takes
+     * `($item, $type, $extensionKey)` and only registers a CType when
+     * `$type === ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT`. TYPO3 v14 removed
+     * the `list_type` sub-type concept: `addPlugin()` now takes `($item, $flexForm)`
+     * and always registers the plugin value as a first-class CType, so passing the
+     * old `$type`/`$extensionKey` arguments is both wrong and a signature error.
+     *
+     * The arguments are collected in an array and spread so the version-specific
+     * argument count is resolved at runtime (and not flagged by static analysis).
+     *
+     * FOR USE IN files in `Configuration/TCA/Overrides/*.php`.
+     *
+     * @param array{label: string, value: int|string|null, description?: string|string[]|null, icon?: string|null, group?: string|null}|SelectItem $item
+     */
+    public function addContentElementPlugin(array|SelectItem $item, string $extensionKey): void
+    {
+        $arguments = [$item];
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            $arguments[] = ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT;
+            $arguments[] = $extensionKey;
+        }
+        ExtensionManagementUtility::addPlugin(...$arguments);
     }
 
     /**

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -2,21 +2,20 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
 
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:plugin.bite.list.label',
             'value' => 'academicbitejobs_list',
             'icon' => 'bitejobs_list',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_bite_jobs'
     );
 

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tt_content.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 if (!defined('TYPO3')) {
     die('Not authorized');
@@ -11,7 +11,7 @@ if (!defined('TYPO3')) {
 
 (static function (): void {
 
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf:plugin.contacts_list.title',
             'value' => 'academiccontacts4pages_list',
@@ -19,7 +19,6 @@ if (!defined('TYPO3')) {
             'group' => 'academic',
             'description' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf:plugin.contacts_list.description',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_contacts4pages'
     );
 

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -1,7 +1,7 @@
 <?php
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 if (!defined('TYPO3')) {
     die('Not authorized');
@@ -11,14 +11,13 @@ if (!defined('TYPO3')) {
     //==================================================================================================================
     // Plugin: academicjobs_newjobform
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.newjobform.label',
             'value' => 'academicjobs_newjobform',
             'icon' => 'academic_jobs_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_jobs'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -39,14 +38,13 @@ if (!defined('TYPO3')) {
     //==================================================================================================================
     // Plugin: academicjobs_list
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.list.label',
             'value' => 'academicjobs_list',
             'icon' => 'academic_jobs_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_jobs'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -67,14 +65,13 @@ if (!defined('TYPO3')) {
     //==================================================================================================================
     // Plugin: academicjobs_detail
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:plugin.detail.label',
             'value' => 'academicjobs_detail',
             'icon' => 'academic_jobs_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_jobs'
     );
 })();

--- a/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
@@ -1,0 +1,46 @@
+..  _breaking-plugins-require-ctype-on-typo3-v14:
+
+======================================================
+Breaking: Extbase plugins require `CType` on TYPO3 v14
+======================================================
+
+Description
+===========
+
+TYPO3 v14 removed the `tt_content` sub-type feature (the `list_type` column) and
+changed `ExtensionManagementUtility::addPlugin()` accordingly. The academic
+plugins have been registered as first-class content elements (`CType`) since the
+`2.1` version line (see the `2.1` breaking note about migrating from `list_type`
+to `CType`); for TYPO3 v14 support the internal registration was adapted to the
+new `addPlugin()` signature and the vestigial `list_type` handling was dropped.
+
+Impact
+======
+
+On TYPO3 v14 the `tt_content.list_type` column no longer exists. Any content
+records still stored as `CType=list` with a `list_type` of one of the plugins
+below will no longer resolve, and custom TypoScript, TSconfig, page TSconfig or
+SQL that references `list_type` for these plugins stops working.
+
+The change relates to the following plugins:
+
+* `academicjobs_newjobform`
+* `academicjobs_list`
+* `academicjobs_detail`
+
+Affected Installations
+======================
+
+Installations that upgrade to TYPO3 v14 and still hold content elements stored
+as `CType=list` + `list_type=<plugin>`, or that reference `list_type` for these
+plugins in their own configuration.
+
+Migration
+=========
+
+Run the provided upgrade wizard `academicJobs_pluginContent` **before** upgrading
+to TYPO3 v14 (it requires the `list_type` column, which v14 removes) to migrate
+the `tt_content` records to the dedicated `CType` values. Update any custom
+configuration referencing `list_type` to match on `CType` instead.
+
+.. index:: Database, TCA, ext_localconf, TSConfig

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
@@ -2,21 +2,20 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
     // Plugin: academicpartners_list
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_list.title',
             'value' => 'academicpartners_list',
             'icon' => 'academic-partners',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_partners'
     );
     ExtensionManagementUtility::addPiFlexFormValue(
@@ -26,14 +25,13 @@ defined('TYPO3') or die;
     );
 
     // Plugin: academicpartners_map
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_map.title',
             'value' => 'academicpartners_map',
             'icon' => 'academic-partners',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_partners'
     );
     ExtensionManagementUtility::addPiFlexFormValue(
@@ -58,26 +56,24 @@ defined('TYPO3') or die;
     );
 
     // Plugin: academicpartners_partnershipslist
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_partnershipslist.title',
             'value' => 'academicpartners_partnershipslist',
             'icon' => 'academic-partners',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_partners'
     );
 
     // Plugin: academicpartners_partnershipsteaser
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:plugin.partner_partnershipsteaser.title',
             'value' => 'academicpartners_partnershipsteaser',
             'icon' => 'academic-partners',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_partners'
     );
 })();

--- a/packages/fgtclb/academic-persons-edit/Classes/Profile/ProfileTranslator.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Profile/ProfileTranslator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Profile;
 
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -27,7 +28,11 @@ final class ProfileTranslator
     public function translateTo(int $profileUid, int $languageUid): int
     {
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->neverHideAtCopy = true;
+        // Keep the localized (internally copied) record visible instead of
+        // auto-hiding it. TYPO3 v13 exposes this as DataHandler::$neverHideAtCopy.
+        if (property_exists($dataHandler, 'neverHideAtCopy')) {
+            $dataHandler->neverHideAtCopy = true;
+        }
 
         $dataHandler->start([], [
             'tx_academicpersons_domain_model_profile' => [
@@ -36,6 +41,14 @@ final class ProfileTranslator
                 ],
             ],
         ]);
+
+        // TYPO3 v14 removed the property and reads the flag from the backend
+        // user's uc settings instead (BE_USER is populated by start()).
+        // See https://docs.typo3.org/permalink/changelog:breaking-107856-1763715381
+        if (!property_exists($dataHandler, 'neverHideAtCopy') && $dataHandler->BE_USER instanceof BackendUserAuthentication) {
+            $dataHandler->BE_USER->uc['neverHideAtCopy'] = true;
+        }
+
         $dataHandler->process_cmdmap();
 
         return $dataHandler->copyMappingArray_merged['tx_academicpersons_domain_model_profile'][$profileUid];

--- a/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/TCA/Overrides/tt_content.php
@@ -9,8 +9,7 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+use FGTCLB\AcademicBase\TcaManipulator;
 
 (static function (): void {
 
@@ -20,28 +19,26 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersonsedit_profileediting
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:plugin.profile_editing.label',
             'value' => 'academicpersonsedit_profileediting',
             'icon' => 'persons_edit_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons_edit'
     );
 
     //==================================================================================================================
     // Plugin: academicpersonsedit_profileswitcher
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:plugin.profile_switcher.label',
             'value' => 'academicpersonsedit_profileswitcher',
             'icon' => 'persons_edit_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons_edit'
     );
 

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
@@ -1,0 +1,45 @@
+..  _breaking-plugins-require-ctype-on-typo3-v14:
+
+======================================================
+Breaking: Extbase plugins require `CType` on TYPO3 v14
+======================================================
+
+Description
+===========
+
+TYPO3 v14 removed the `tt_content` sub-type feature (the `list_type` column) and
+changed `ExtensionManagementUtility::addPlugin()` accordingly. The academic
+plugins have been registered as first-class content elements (`CType`) since the
+`2.1` version line (see the `2.1` breaking note about migrating from `list_type`
+to `CType`); for TYPO3 v14 support the internal registration was adapted to the
+new `addPlugin()` signature and the vestigial `list_type` handling was dropped.
+
+Impact
+======
+
+On TYPO3 v14 the `tt_content.list_type` column no longer exists. Any content
+records still stored as `CType=list` with a `list_type` of one of the plugins
+below will no longer resolve, and custom TypoScript, TSconfig, page TSconfig or
+SQL that references `list_type` for these plugins stops working.
+
+The change relates to the following plugins:
+
+* `academicpersonsedit_profileediting`
+* `academicpersonsedit_profileswitcher`
+
+Affected Installations
+======================
+
+Installations that upgrade to TYPO3 v14 and still hold content elements stored
+as `CType=list` + `list_type=<plugin>`, or that reference `list_type` for these
+plugins in their own configuration.
+
+Migration
+=========
+
+Run the provided upgrade wizard `academicPersonsEdit_pluginContent` **before**
+upgrading to TYPO3 v14 (it requires the `list_type` column, which v14 removes) to
+migrate the `tt_content` records to the dedicated `CType` values. Update any
+custom configuration referencing `list_type` to match on `CType` instead.
+
+.. index:: Database, TCA, ext_localconf, TSConfig

--- a/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
@@ -9,22 +9,21 @@ declare(strict_types=1);
  * LICENSE file that was distributed with this source code.
  */
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 (static function (): void {
 
     //==================================================================================================================
     // Plugin: academicpersons_list
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:plugin.list.label',
             'value' => 'academicpersons_list',
             'icon' => 'persons_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -46,14 +45,13 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersons_listanddetail
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:plugin.listAndDetail.label',
             'value' => 'academicpersons_listanddetail',
             'icon' => 'persons_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -75,14 +73,13 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersons_detail
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:plugin.detail.label',
             'value' => 'academicpersons_detail',
             'icon' => 'persons_icon',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -103,14 +100,13 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersons_card
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:newContentElement.wizardItems.academic.card.title',
             'value' => 'academicpersons_card',
             'icon' => '',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -131,14 +127,13 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersons_selectedprofiles
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:plugin.selectedprofiles.label',
             'value' => 'academicpersons_selectedprofiles',
             'icon' => '',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(
@@ -159,14 +154,13 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     //==================================================================================================================
     // Plugin: academicpersons_selectedcontracts
     //==================================================================================================================
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:plugin.selectedcontracts.label',
             'value' => 'academicpersons_selectedcontracts',
             'icon' => '',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_persons'
     );
     ExtensionManagementUtility::addToAllTCAtypes(

--- a/packages/fgtclb/academic-persons/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
@@ -1,0 +1,50 @@
+..  _breaking-plugins-require-ctype-on-typo3-v14:
+
+======================================================
+Breaking: Extbase plugins require `CType` on TYPO3 v14
+======================================================
+
+Description
+===========
+
+TYPO3 v14 removed the `tt_content` sub-type feature (the `list_type` column) and
+changed `ExtensionManagementUtility::addPlugin()` accordingly. The academic
+plugins have been registered as first-class content elements (`CType`) since the
+`2.0` version line (see the `2.0` breaking note about migrating from `list_type`
+to `CType`); for TYPO3 v14 support the internal registration was adapted to the
+new `addPlugin()` signature and the vestigial `list_type` handling was dropped.
+
+Impact
+======
+
+On TYPO3 v14 the `tt_content.list_type` column no longer exists. Any content
+records still stored as `CType=list` with a `list_type` of one of the plugins
+below will no longer resolve, and custom TypoScript, TSconfig, page TSconfig or
+SQL that references `list_type` for these plugins stops working.
+
+The change relates to the following plugins:
+
+* `academicpersons_card`
+* `academicpersons_detail`
+* `academicpersons_list`
+* `academicpersons_listanddetail`
+* `academicpersons_selectedcontracts`
+* `academicpersons_selectedprofiles`
+
+Affected Installations
+======================
+
+Installations that upgrade to TYPO3 v14 and still hold content elements stored
+as `CType=list` + `list_type=<plugin>`, or that reference `list_type` for these
+plugins in their own configuration.
+
+Migration
+=========
+
+Run the provided upgrade wizard
+`academicPersons_MigrateListTypeToCTypeContentElements` **before** upgrading to
+TYPO3 v14 (it requires the `list_type` column, which v14 removes) to migrate the
+`tt_content` records to the dedicated `CType` values. Update any custom
+configuration referencing `list_type` to match on `CType` instead.
+
+.. index:: Database, TCA, ext_localconf, TSConfig

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/fullyLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_detail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_listanddetail","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_list","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_selectedcontracts","","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_selectedcontracts","Contracts","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedContracts""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv
@@ -4,8 +4,8 @@
 ,2,1,1,0,0,0,0,0,"/home","Home (EN)"
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,2,0,0,0,0,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">2</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv
@@ -7,9 +7,9 @@
 ,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
 ,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
 "tt_content",
-,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
-,1,3,0,0,0,0,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
-,2,3,0,0,1,1,"academicpersons_selectedprofiles","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_selectedprofiles","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.selectedProfiles""><value index=""vDEF"">3,1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
 "tx_academicpersons_domain_model_profile",
 ,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
 ,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
@@ -2,20 +2,19 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
 (static function (): void {
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:plugin.program_list.title',
             'value' => 'academicprograms_programlist',
             'icon' => 'EXT:academic_programs/Resources/Public/Icons/Extension.svg',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_programs'
     );
 
@@ -37,14 +36,13 @@ defined('TYPO3') or die;
         'academicprograms_programlist',
     );
 
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:plugin.program_details.title',
             'value' => 'academicprograms_programdetails',
             'icon' => 'EXT:academic_programs/Resources/Public/Icons/Extension.svg',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
         'academic_programs'
     );
 })();

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use FGTCLB\AcademicBase\TcaManipulator;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
@@ -17,15 +17,14 @@ defined('TYPO3') or die;
     // ------------------------------------------------------------------------
 
     // Add plugin to the CType selection
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_list.name',
             'value' => 'academicprojects_projectlist',
             'icon' => 'actions-code-merge',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
-        'academicprojects_projectlist'
+        'academic_projects'
     );
 
     // Add a configuration tab and the FlexForm configuration to plugin
@@ -52,15 +51,14 @@ defined('TYPO3') or die;
     // ------------------------------------------------------------------------
 
     // Add plugin to the CType selection
-    ExtensionManagementUtility::addPlugin(
+    (new TcaManipulator())->addContentElementPlugin(
         [
             'label' => 'LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_selected.name',
             'value' => 'academicprojects_projectlistsingle',
             'icon' => 'actions-code-merge',
             'group' => 'academic',
         ],
-        ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
-        'academicprojects_projectlistsingle'
+        'academic_projects'
     );
 
     ExtensionManagementUtility::addToAllTCAtypes(

--- a/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
+++ b/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
@@ -6,8 +6,7 @@ mod.wizards {
                 title = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_list.name
                 description = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_list.description
                 tt_content_defValues {
-                    CType = list
-                    list_type = academicprojects_projectlist
+                    CType = academicprojects_projectlist
                 }
             }
             academicprojects_projectlistsingle {
@@ -15,8 +14,7 @@ mod.wizards {
                 title = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_selected.name
                 description = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_selected.description
                 tt_content_defValues {
-                    CType = list
-                    list_type = academicprojects_projectlistsingle
+                    CType = academicprojects_projectlistsingle
                 }
             }
         }

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/3.0/Breaking-PluginsRequireCTypeOnTYPO3V14.rst
@@ -1,0 +1,50 @@
+..  _breaking-plugins-require-ctype-on-typo3-v14:
+
+======================================================
+Breaking: Extbase plugins require `CType` on TYPO3 v14
+======================================================
+
+Description
+===========
+
+TYPO3 v14 removed the `tt_content` sub-type feature (the `list_type` column) and
+changed `ExtensionManagementUtility::addPlugin()` accordingly. The academic
+plugins have been registered as first-class content elements (`CType`) since the
+`2.0` version line (see the `2.0` breaking note about migrating from `list_type`
+to `CType`); for TYPO3 v14 support the internal registration was adapted to the
+new `addPlugin()` signature and the vestigial `list_type` handling was dropped.
+
+In addition the "New Content Element" wizard TSconfig still created the plugins
+as `CType=list` with a `list_type`, contradicting the `CType` registration; it
+now creates them with the dedicated `CType` directly.
+
+Impact
+======
+
+On TYPO3 v14 the `tt_content.list_type` column no longer exists. Any content
+records still stored as `CType=list` with a `list_type` of one of the plugins
+below will no longer resolve, and custom TypoScript, TSconfig, page TSconfig or
+SQL that references `list_type` for these plugins stops working.
+
+The change relates to the following plugins:
+
+* `academicprojects_projectlist`
+* `academicprojects_projectlistsingle`
+
+Affected Installations
+======================
+
+Installations that upgrade to TYPO3 v14 and still hold content elements stored
+as `CType=list` + `list_type=<plugin>` (including elements created through the
+previous "New Content Element" wizard), or that reference `list_type` for these
+plugins in their own configuration.
+
+Migration
+=========
+
+Run the provided upgrade wizard `academicProjects_pluginUpgradeWizard` **before**
+upgrading to TYPO3 v14 (it requires the `list_type` column, which v14 removes) to
+migrate the `tt_content` records to the dedicated `CType` values. Update any
+custom configuration referencing `list_type` to match on `CType` instead.
+
+.. index:: Database, TCA, ext_localconf, TSConfig


### PR DESCRIPTION
## What

**PR 2c-1** of the TYPO3 v14 support round (part 1 of the plugin/CType work).
TYPO3 v14 removed the `tt_content` sub-type feature: the `list_type` column is
gone, `ExtensionManagementUtility::addPlugin()` changed from
`($item, $type, $extensionKey)` to `($item, $flexForm)`, and the plugin value is
always a first-class `CType`.

The academic plugins have been registered as `CType` (via
`PLUGIN_TYPE_CONTENT_ELEMENT` in **both** `addPlugin()` and `configurePlugin()`)
since the `2.0`/`2.1` lines — verified across every extension. So this is the v14
**compatibility adaptation** of that registration, not a new migration.

## Changes

- **`academic_base`**: new `TcaManipulator::addContentElementPlugin()` — a dual
  v13/v14 wrapper. The `addPlugin()` arguments are collected and **spread**, so
  the version-specific argument count resolves at runtime (v13 passes
  `PLUGIN_TYPE_CONTENT_ELEMENT` + extension key; v14 passes neither).
- **8 × `Configuration/TCA/Overrides/tt_content.php`** now register through the
  helper (`(new TcaManipulator())->addContentElementPlugin(...)`) instead of
  calling `addPlugin()` directly. `academic_projects` also passed the plugin
  value where the extension key belongs — corrected to `academic_projects`.
- **`academic_projects` `NewContentElement.tsconfig`**: created plugins as
  `CType=list` + `list_type=<plugin>`, contradicting the CType registration — now
  sets the dedicated `CType` directly. *(This bug also exists on branch `2` and
  will be backported as a standalone `[BUGFIX]`.)*
- **`ProfileTranslator`**: `DataHandler::$neverHideAtCopy` was removed in v14. Set
  on the property on v13 (`property_exists()` guard) and on
  `BE_USER->uc['neverHideAtCopy']` on v14 — the DataHandler reads the flag from
  the backend user's uc settings there (set after `start()` populates `BE_USER`).
  Verified v14.3's DataHandler still reads it; the v14.2 `UserSettings` object
  (#108832) only wraps profile settings and doesn't affect this flag.
- **30 plugin fixtures** (`academic_persons/Tests/Functional/Plugins`) carried a
  now-removed **empty** `list_type` column — stripped so they import on v14 and
  stay valid on v13 (column defaults to `''`). Surgical, block-aware strip; only
  the `tt_content` column removed.
- **`Build/phpstan/Core14/phpstan-baseline.neon`** regenerated: the `addPlugin()`
  arg-count and `neverHideAtCopy` findings are resolved and no longer baselined.
- **Breaking changelog notes** for the four extensions with a `list_type` history
  (persons, jobs, persons-edit, projects), pointing at the existing upgrade
  wizards.

The `list_type → CType` **data** migration stays covered by the existing upgrade
wizards; running them before upgrading to v14 is required because v14 removes the
`list_type` column they read from (wizard v14-guarding is PR 2c-2).

## TYPO3 references

- Plugin subtypes removed / `addPlugin()` + `list_type`:
  https://docs.typo3.org/permalink/changelog:important-105538-1730752784
- `DataHandler::$neverHideAtCopy` removed:
  https://docs.typo3.org/permalink/changelog:breaking-107856-1763715381

## Verification

| Gate | v14 | v13 |
|------|-----|-----|
| `cgl -n` | ✅ | ✅ |
| `lintPhp` | ✅ | ✅ |
| `phpstan` | ✅ | ✅ |
| `unit` | ✅ | ✅ |
| `functional` | plugin `list_type` errors **fixed** (remaining v14 deprecations/failures → PR 2c-2/2c-3) | ✅ 425, 2 skipped |
| `checkRstRenderingSingle` | ✅ | — |

v14 CI stays off until the plugin round completes; `-t 13` CI validates this PR.
