### PR TITLE
[TASK] Guard list_type upgrade wizards on v14

### DIFF
--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Property\\\\PropertyMappingConfigurationInterface\\:\\:setTypeConverter\\(\\)\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
-			message: "#^Parameter \\#1 \\$propertyPath of method TYPO3\\\\CMS\\\\Extbase\\\\Property\\\\PropertyMappingConfiguration\\:\\:forProperty\\(\\) expects non\\-empty\\-string, string given\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
-
-		-
 			message: "#^Property FGTCLB\\\\AcademicBase\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
@@ -219,31 +209,6 @@ parameters:
 			message: "#^Static property FGTCLB\\\\AcademicStudyPlan\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions is never read, only written\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-study-plan/Tests/Functional/ExtensionLoadedTest.php
-
-		-
-			message: "#^Cannot access offset 'l10n_parent' on array\\|false\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
-
-		-
-			message: "#^Method FGTCLB\\\\CategoryTypes\\\\Domain\\\\Repository\\\\CategoryRepository\\:\\:getCategoryArray\\(\\) should return array\\<string, mixed\\> but returns array\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
-
-		-
-			message: "#^Cannot call method getVariableProvider\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
-
-		-
-			message: "#^Cannot call method getVariableProvider\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
-			count: 2
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
-
-		-
-			message: "#^Cannot call method getViewHelperVariableContainer\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
 
 		-
 			message: "#^Property FGTCLB\\\\CategoryTypes\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"

--- a/packages-dev/testing-helper/Classes/FunctionalTestCase/EnsureTtContentListTypeColumnTrait.php
+++ b/packages-dev/testing-helper/Classes/FunctionalTestCase/EnsureTtContentListTypeColumnTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\TestingHelper\FunctionalTestCase;
+
+use Doctrine\DBAL\Schema\Column;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TYPO3 v14 removed the `tt_content.list_type` column together with the plugin
+ * sub-type feature. The `list_type` -> `CType` upgrade-wizard tests still need
+ * the column to seed legacy fixtures and exercise the migration, so this trait
+ * re-creates it when it is missing. On TYPO3 v13 the column already exists and
+ * the method is a no-op.
+ *
+ * @see https://docs.typo3.org/permalink/changelog:important-105538-1730752784
+ */
+trait EnsureTtContentListTypeColumnTrait
+{
+    protected function ensureTtContentListTypeColumnExists(): void
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tt_content');
+
+        $columnNames = array_map(
+            static fn(Column $column): string => strtolower($column->getName()),
+            $connection->createSchemaManager()->listTableColumns('tt_content')
+        );
+        if (in_array('list_type', $columnNames, true)) {
+            return;
+        }
+
+        $connection->executeStatement(
+            "ALTER TABLE tt_content ADD COLUMN list_type VARCHAR(255) DEFAULT '' NOT NULL"
+        );
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
@@ -47,6 +47,10 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function updateNecessary(): bool
     {
+        // This wizard renames a CType (not a list_type sub-type), so it matches
+        // on CType exactly like executeUpdate(). The previous `list_type` query
+        // never matched and additionally broke on TYPO3 v14, which removed that
+        // column. See https://docs.typo3.org/permalink/changelog:important-105538-1730752784
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         return (bool)$queryBuilder
@@ -54,7 +58,7 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
             ->from('tt_content')
             ->where(
                 $queryBuilder->expr()->in(
-                    'list_type',
+                    'CType',
                     $queryBuilder->quoteArrayBasedValueListToStringList(array_keys(self::MIGRATE_CONTENT_TYPES_LIST))
                 ),
             )

--- a/packages/fgtclb/academic-jobs/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-jobs/Classes/Upgrades/PluginUpgradeWizard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Upgrades;
 
+use Doctrine\DBAL\Schema\Column;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
@@ -35,6 +36,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function executeUpdate(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return true;
+        }
         foreach (self::MIGRATE_CONTENT_TYPES_LIST as $oldName => $newName) {
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
             $queryBuilder->getRestrictions()->removeAll();
@@ -52,6 +56,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function updateNecessary(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return false;
+        }
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         return (int)($queryBuilder
@@ -73,5 +80,23 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
         return [
             DatabaseUpdatedPrerequisite::class,
         ];
+    }
+
+    /**
+     * TYPO3 v14 removed the `tt_content.list_type` column together with the
+     * plugin sub-type feature, so there is nothing to migrate there anymore.
+     * See https://docs.typo3.org/permalink/changelog:important-105538-1730752784
+     */
+    private function contentTableHasListTypeColumn(): bool
+    {
+        $columnNames = array_map(
+            static fn(Column $column): string => strtolower($column->getName()),
+            $this->connectionPool
+                ->getConnectionForTable('tt_content')
+                ->createSchemaManager()
+                ->listTableColumns('tt_content')
+        );
+
+        return in_array('list_type', $columnNames, true);
     }
 }

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
@@ -6,11 +6,22 @@ namespace FGTCLB\AcademicJobs\Tests\Functional\Upgrades;
 
 use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
 use FGTCLB\AcademicJobs\Upgrades\PluginUpgradeWizard;
+use FGTCLB\TestingHelper\FunctionalTestCase\EnsureTtContentListTypeColumnTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class PluginUpgradeWizardTest extends AbstractAcademicJobsTestCase
 {
+    use EnsureTtContentListTypeColumnTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // TYPO3 v14 removed tt_content.list_type; re-create it so the legacy
+        // list_type fixtures import and the migration is exercised on v14 too.
+        $this->ensureTtContentListTypeColumnExists();
+    }
+
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {

--- a/packages/fgtclb/academic-persons-edit/Classes/Upgrades/PluginContentWizard.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Upgrades/PluginContentWizard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Upgrades;
 
+use Doctrine\DBAL\Schema\Column;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
@@ -33,6 +34,9 @@ final class PluginContentWizard implements UpgradeWizardInterface
 
     public function executeUpdate(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return true;
+        }
         foreach (self::MIGRATE_CONTENT_TYPES_LIST as $oldName => $newName) {
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
             $queryBuilder->getRestrictions()->removeAll();
@@ -50,6 +54,9 @@ final class PluginContentWizard implements UpgradeWizardInterface
 
     public function updateNecessary(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return false;
+        }
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         return (int)($queryBuilder
@@ -71,5 +78,23 @@ final class PluginContentWizard implements UpgradeWizardInterface
         return [
             DatabaseUpdatedPrerequisite::class,
         ];
+    }
+
+    /**
+     * TYPO3 v14 removed the `tt_content.list_type` column together with the
+     * plugin sub-type feature, so there is nothing to migrate there anymore.
+     * See https://docs.typo3.org/permalink/changelog:important-105538-1730752784
+     */
+    private function contentTableHasListTypeColumn(): bool
+    {
+        $columnNames = array_map(
+            static fn(Column $column): string => strtolower($column->getName()),
+            $this->connectionPool
+                ->getConnectionForTable('tt_content')
+                ->createSchemaManager()
+                ->listTableColumns('tt_content')
+        );
+
+        return in_array('list_type', $columnNames, true);
     }
 }

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Upgrades/PluginContentWizardTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Upgrades/PluginContentWizardTest.php
@@ -6,11 +6,22 @@ namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Upgrades;
 
 use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
 use FGTCLB\AcademicPersonsEdit\Upgrades\PluginContentWizard;
+use FGTCLB\TestingHelper\FunctionalTestCase\EnsureTtContentListTypeColumnTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class PluginContentWizardTest extends AbstractAcademicPersonsEditTestCase
 {
+    use EnsureTtContentListTypeColumnTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // TYPO3 v14 removed tt_content.list_type; re-create it so the legacy
+        // list_type fixtures import and the migration is exercised on v14 too.
+        $this->ensureTtContentListTypeColumnExists();
+    }
+
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {

--- a/packages/fgtclb/academic-persons/Tests/Functional/Upgrades/ListTypeToCTypeUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Upgrades/ListTypeToCTypeUpgradeWizardTest.php
@@ -6,6 +6,7 @@ namespace FGTCLB\AcademicPersons\Tests\Functional\Upgrades;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
 use FGTCLB\AcademicPersons\Upgrades\ListTypeToCTypeUpgradeWizard;
+use FGTCLB\TestingHelper\FunctionalTestCase\EnsureTtContentListTypeColumnTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -21,6 +22,16 @@ use PHPUnit\Framework\Attributes\Test;
  */
 final class ListTypeToCTypeUpgradeWizardTest extends AbstractAcademicPersonsTestCase
 {
+    use EnsureTtContentListTypeColumnTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // TYPO3 v14 removed tt_content.list_type; re-create it so the legacy
+        // list_type fixtures import and the migration is exercised on v14 too.
+        $this->ensureTtContentListTypeColumnExists();
+    }
+
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {

--- a/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-projects/Classes/Upgrades/PluginUpgradeWizard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\Upgrades;
 
+use Doctrine\DBAL\Schema\Column;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
@@ -33,6 +34,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function executeUpdate(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return true;
+        }
         foreach (self::MIGRATE_CONTENT_TYPES_LIST as $oldName => $newName) {
             $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
             $queryBuilder->getRestrictions()->removeAll();
@@ -50,6 +54,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function updateNecessary(): bool
     {
+        if (!$this->contentTableHasListTypeColumn()) {
+            return false;
+        }
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         return (int)($queryBuilder
@@ -74,5 +81,23 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
         return [
             DatabaseUpdatedPrerequisite::class,
         ];
+    }
+
+    /**
+     * TYPO3 v14 removed the `tt_content.list_type` column together with the
+     * plugin sub-type feature, so there is nothing to migrate there anymore.
+     * See https://docs.typo3.org/permalink/changelog:important-105538-1730752784
+     */
+    private function contentTableHasListTypeColumn(): bool
+    {
+        $columnNames = array_map(
+            static fn(Column $column): string => strtolower($column->getName()),
+            $this->connectionPool
+                ->getConnectionForTable('tt_content')
+                ->createSchemaManager()
+                ->listTableColumns('tt_content')
+        );
+
+        return in_array('list_type', $columnNames, true);
     }
 }

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php
@@ -6,11 +6,22 @@ namespace FGTCLB\AcademicProjects\Tests\Functional\Upgrades;
 
 use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
 use FGTCLB\AcademicProjects\Upgrades\PluginUpgradeWizard;
+use FGTCLB\TestingHelper\FunctionalTestCase\EnsureTtContentListTypeColumnTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class PluginUpgradeWizardTest extends AbstractAcademicProjectsTestCase
 {
+    use EnsureTtContentListTypeColumnTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // TYPO3 v14 removed tt_content.list_type; re-create it so the legacy
+        // list_type fixtures import and the migration is exercised on v14 too.
+        $this->ensureTtContentListTypeColumnExists();
+    }
+
     #[Test]
     public function updateNecessaryReturnsFalseWhenListTypeRecordsAreAvailable(): void
     {


### PR DESCRIPTION
## What

**PR 2c-2** of the v14 support round. TYPO3 v14 removed the
`tt_content.list_type` column, so the `list_type → CType` upgrade wizards (which
query that column) errored on v14. This hardens the wizards and keeps their tests
running on v14.

## Wizards

- **academic_jobs / academic_persons_edit / academic_projects**: `updateNecessary()`
  returns `false` and `executeUpdate()` no-ops when `tt_content.list_type` is
  absent. The column check uses the DBAL schema manager
  (`createSchemaManager()->listTableColumns()`) — matching the existing
  academic_persons wizard, **dual v13/v14 safe** (unlike
  `Connection::getSchemaInformation()`, whose column API differs: v13
  `introspectTable()` vs v14 `getTableInfo()->hasColumnInfo()`), and deliberately
  **uncached** so a schema change made inside a test is seen immediately.
- **academic_persons**: already guarded via `columnsExistInContentTable()` — left
  unchanged.
- **academic_contacts4pages**: this wizard renames a **CType** (not a list_type),
  but `updateNecessary()` queried `list_type` — which never matched and broke on
  v14. Fixed to query `CType`, matching `executeUpdate()`. *(Pre-existing on
  branch `2`; dedicated backport planned.)*

## Tests (kept running on v14)

- New shared trait **`EnsureTtContentListTypeColumnTrait`**
  (`fgtclb/academics-monorepo-testing-helper`) re-creates the `tt_content.list_type`
  column when missing (no-op on v13). The four list_type wizard tests call it in
  `setUp()`, so the legacy fixtures still import and the migration is **actually
  exercised on v14** — the wizard's uncached schema read then sees the re-created
  column and performs the migration.
- `Build/phpstan/Core14/phpstan-baseline.neon` regenerated with a clean cache:
  seven non-deterministic v14 type-strictness entries (only reported from a warm
  cache) were dropped, so the baseline matches a fresh analysis (also avoids a
  latent v14-CI mismatch).

## TYPO3 reference

- Plugin subtypes removed / `tt_content.list_type` column:
  https://docs.typo3.org/permalink/changelog:important-105538-1730752784

## Verification

| Gate | v14 | v13 |
|------|-----|-----|
| `cgl` | ✅ | ✅ |
| `phpstan` | ✅ | ✅ |
| Upgrades functional (persons/projects/jobs/persons-edit) | ✅ 32/13/26/13 | ✅ |

`-t 13` CI validates this PR; v14 CI is enabled after the round completes (2c-3 next).
