### PR TITLE
[TASK] Clear v14 deprecations: version, Cascade, TCA

### DIFF
--- a/Build/phpstan/Core13/phpstan-constants.php
+++ b/Build/phpstan/Core13/phpstan-constants.php
@@ -14,3 +14,8 @@
  */
 
 define('ORIGINAL_ROOT', dirname(__FILE__, 2) . '/');
+
+// Mirrors packages/fgtclb/academic-persons/EXT_CONSTANTS.php for static analysis.
+// On TYPO3 v13 the Extbase #[Cascade] attribute still takes the array form.
+defined('ACADEMIC_PERSONS_CASCADE_REMOVE') || define('ACADEMIC_PERSONS_CASCADE_REMOVE', ['value' => 'remove']);
+defined('ACADEMIC_JOBS_CASCADE_REMOVE') || define('ACADEMIC_JOBS_CASCADE_REMOVE', ['value' => 'remove']);

--- a/Build/phpstan/Core13/phpstan.neon
+++ b/Build/phpstan/Core13/phpstan.neon
@@ -5,6 +5,8 @@ includes:
   - ../../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
+  bootstrapFiles:
+    - phpstan-constants.php
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.Build/.cache/phpstan
 
@@ -15,4 +17,5 @@ parameters:
 
   excludePaths:
     - ../../../packages/fgtclb/*/ext_emconf.php
+    - ../../../packages/fgtclb/*/EXT_CONSTANTS.php
     - ../../../packages/fgtclb/*/Migrations/*

--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Property\\\\PropertyMappingConfigurationInterface\\:\\:setTypeConverter\\(\\)\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$propertyPath of method TYPO3\\\\CMS\\\\Extbase\\\\Property\\\\PropertyMappingConfiguration\\:\\:forProperty\\(\\) expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+
+		-
 			message: "#^Property FGTCLB\\\\AcademicBase\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php
@@ -209,6 +219,31 @@ parameters:
 			message: "#^Static property FGTCLB\\\\AcademicStudyPlan\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions is never read, only written\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/academic-study-plan/Tests/Functional/ExtensionLoadedTest.php
+
+		-
+			message: "#^Cannot access offset 'l10n_parent' on array\\|false\\|null\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+
+		-
+			message: "#^Method FGTCLB\\\\CategoryTypes\\\\Domain\\\\Repository\\\\CategoryRepository\\:\\:getCategoryArray\\(\\) should return array\\<string, mixed\\> but returns array\\|null\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+
+		-
+			message: "#^Cannot call method getVariableProvider\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
+
+		-
+			message: "#^Cannot call method getVariableProvider\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
+			count: 2
+			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+
+		-
+			message: "#^Cannot call method getViewHelperVariableContainer\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
+			count: 1
+			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
 
 		-
 			message: "#^Property FGTCLB\\\\CategoryTypes\\\\Tests\\\\Functional\\\\ExtensionLoadedTest\\:\\:\\$expectedLoadedExtensions has no type specified\\.$#"

--- a/Build/phpstan/Core14/phpstan-constants.php
+++ b/Build/phpstan/Core14/phpstan-constants.php
@@ -14,3 +14,8 @@
  */
 
 define('ORIGINAL_ROOT', dirname(__FILE__, 2) . '/');
+
+// Mirrors packages/fgtclb/academic-persons/EXT_CONSTANTS.php for static analysis.
+// On TYPO3 v14 the Extbase #[Cascade] attribute takes the plain string form.
+defined('ACADEMIC_PERSONS_CASCADE_REMOVE') || define('ACADEMIC_PERSONS_CASCADE_REMOVE', 'remove');
+defined('ACADEMIC_JOBS_CASCADE_REMOVE') || define('ACADEMIC_JOBS_CASCADE_REMOVE', 'remove');

--- a/Build/phpstan/Core14/phpstan.neon
+++ b/Build/phpstan/Core14/phpstan.neon
@@ -5,6 +5,8 @@ includes:
   - ../../../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
+  bootstrapFiles:
+    - phpstan-constants.php
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.Build/.cache/phpstan
 
@@ -15,4 +17,5 @@ parameters:
 
   excludePaths:
     - ../../../packages/fgtclb/*/ext_emconf.php
+    - ../../../packages/fgtclb/*/EXT_CONSTANTS.php
     - ../../../packages/fgtclb/*/Migrations/*

--- a/bin/set-version
+++ b/bin/set-version
@@ -282,6 +282,17 @@ apply_branch_alias() {
         "extra.branch-alias.dev-${SOURCE_BRANCH}" "${BRANCH_ALIAS}"
 }
 
+# Helper: set extra.typo3/cms.version for a split extension composer.json. TYPO3
+# v14 reads the extension version from composer.json (ext_emconf.php is
+# deprecated), so it must track the path-repository version. Only applied when
+# the key already exists (composer config preserves the file formatting).
+apply_extension_composer_version() {
+    local dir="$1"
+    "${JQ}" -e '.extra."typo3/cms".version' "${dir}/composer.json" >/dev/null 2>&1 || return 0
+    step "${dir}" "config extra.typo3/cms.version = ${MAP_VERSION}"
+    run "${COMPOSER}" config -d "${dir}" "extra.typo3/cms.version" "${MAP_VERSION}"
+}
+
 # Helper: rewrite a jq version map in place (temp file + mv; never self-redirect).
 apply_version_map() {
     local file="$1" map="$2"   # map: packages | packages-dev
@@ -327,6 +338,7 @@ run "${SED}" -i \
 info "Split extensions"
 for dir in "${SPLIT_DIRS[@]}"; do
     apply_academic_composer_deps "${dir}" "${ACADEMIC_CONSTRAINT}"
+    apply_extension_composer_version "${dir}"
     [ "${SET_BRANCH_ALIAS}" -eq 1 ] && apply_branch_alias "${dir}"
     # docs-presence decides the --no-docs flag; all current splits ship docs.
     if [ -d "${dir}/Documentation" ]; then

--- a/packages/fgtclb/academic-base/Tests/Functional/Fixtures/Extensions/test_base_dependency_injection/composer.json
+++ b/packages/fgtclb/academic-base/Tests/Functional/Fixtures/Extensions/test_base_dependency_injection/composer.json
@@ -21,7 +21,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "test_base_dependency_injection"
+            "extension-key": "test_base_dependency_injection",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
         }
     }
 }

--- a/packages/fgtclb/academic-base/composer.json
+++ b/packages/fgtclb/academic-base/composer.json
@@ -24,7 +24,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "academic_base"
+            "extension-key": "academic_base",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -44,7 +44,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_bite_jobs"
+            "extension-key": "academic_bite_jobs",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -36,7 +36,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "academic_contacts4pages"
+            "extension-key": "academic_contacts4pages",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
+++ b/packages/fgtclb/academic-jobs/Classes/Domain/Model/Job.php
@@ -13,7 +13,7 @@ class Job extends AbstractEntity
     protected string $title = '';
     protected ?\DateTime $employmentStartDate = null;
     protected string $description = '';
-    #[Extbase\ORM\Cascade(['value' => 'remove'])]
+    #[Extbase\ORM\Cascade(ACADEMIC_JOBS_CASCADE_REMOVE)]
     protected ?FileReference $image = null;
     protected string $companyName = '';
     protected string $sector = '';

--- a/packages/fgtclb/academic-jobs/EXT_CONSTANTS.php
+++ b/packages/fgtclb/academic-jobs/EXT_CONSTANTS.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_jobs" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+/*
+ * @todo Remove this file — its `autoload.files` entry in composer.json, the
+ *       require_once in ext_localconf.php and the ACADEMIC_JOBS_CASCADE_REMOVE
+ *       constant — once TYPO3 v13 support is dropped (typo3/cms-core:>13), and
+ *       replace `#[Cascade(ACADEMIC_JOBS_CASCADE_REMOVE)]` in the domain models
+ *       with the plain string form `#[Cascade('remove')]`.
+ *
+ *       Background: TYPO3 v14 expects the string argument for the Extbase
+ *       `#[Cascade]` attribute, while TYPO3 v13 still requires the array form
+ *       (`['value' => 'remove']`) and passing the string there is a fatal error.
+ *       PHP attribute arguments must be constant expressions and cannot contain
+ *       a runtime version switch, so the version-specific value is provided via
+ *       this constant. It is loaded through both `autoload.files` (Composer mode)
+ *       and a require in ext_localconf.php (Classic mode), guarded by
+ *       `defined()` so the double include is harmless.
+ */
+defined('ACADEMIC_JOBS_CASCADE_REMOVE')
+    || define(
+        'ACADEMIC_JOBS_CASCADE_REMOVE',
+        (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 14
+            ? 'remove'
+            : ['value' => 'remove']
+    );

--- a/packages/fgtclb/academic-jobs/Tests/Functional/AbstractAcademicJobsTestCase.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/AbstractAcademicJobsTestCase.php
@@ -9,6 +9,7 @@ use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
 abstract class AbstractAcademicJobsTestCase extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [
+        'typo3/cms-fluid-styled-content',
         'typo3/cms-install',
         'typo3/cms-rte-ckeditor',
     ];

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Fixtures/Extensions/test_jobcontact_schema/composer.json
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Fixtures/Extensions/test_jobcontact_schema/composer.json
@@ -17,7 +17,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "test_jobcontact_schema"
+            "extension-key": "test_jobcontact_schema",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
         }
     }
 }

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -29,7 +29,10 @@
     "autoload": {
         "psr-4": {
             "FGTCLB\\AcademicJobs\\": "Classes/"
-        }
+        },
+        "files": [
+            "EXT_CONSTANTS.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -46,7 +49,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_jobs"
+            "extension-key": "academic_jobs",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-jobs/ext_localconf.php
+++ b/packages/fgtclb/academic-jobs/ext_localconf.php
@@ -7,6 +7,15 @@ if (!defined('TYPO3')) {
     die('Not authorized');
 }
 
+// Define ACADEMIC_JOBS_CASCADE_REMOVE for Classic (non-Composer) mode, where
+// composer.json `autoload.files` is not processed. In Composer mode the constant
+// is already defined via autoload.files, so this is skipped. ext_localconf.php is
+// cached/concatenated by TYPO3 (so __DIR__ is unreliable) — use extPath().
+// @todo Remove together with EXT_CONSTANTS.php once TYPO3 v13 support is dropped.
+if (!defined('ACADEMIC_JOBS_CASCADE_REMOVE')) {
+    require_once \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academic_jobs') . 'EXT_CONSTANTS.php';
+}
+
 (static function (): void {
     ExtensionUtility::configurePlugin(
         'AcademicJobs',

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -32,7 +32,11 @@
             "extension-key": "academic_partners",
             "ignore-as-root": false,
             "web-dir": ".Build/public",
-            "app-dir": ".Build"
+            "app-dir": ".Build",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -45,7 +45,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_persons_edit"
+            "extension-key": "academic_persons_edit",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -46,7 +46,11 @@
         "typo3/cms": {
             "web-dir": ".Build/public",
             "app-dir": ".Build",
-            "extension-key": "academic_persons_sync"
+            "extension-key": "academic_persons_sync",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-persons/Classes/Backend/FormEngine/ProfileShowFieldsItems.php
+++ b/packages/fgtclb/academic-persons/Classes/Backend/FormEngine/ProfileShowFieldsItems.php
@@ -6,7 +6,7 @@ namespace FGTCLB\AcademicPersons\Backend\FormEngine;
 
 use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -63,6 +63,19 @@ final class ProfileShowFieldsItems
     }
 
     /**
+     * BackendUtility::getItemLabel() was deprecated in TYPO3 v14.0 (removed in
+     * v15.0); resolve the field label through the TCA schema instead, which is
+     * available on both TYPO3 v13 and v14.
+     */
+    private function getFieldLabel(string $table, string $field): string
+    {
+        return GeneralUtility::makeInstance(TcaSchemaFactory::class)
+            ->get($table)
+            ->getField($field)
+            ->getLabel();
+    }
+
+    /**
      * @return array<int, array{
      *     label: string|null,
      *     value: string,
@@ -73,47 +86,47 @@ final class ProfileShowFieldsItems
     {
         return [
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_profile', 'image'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_profile', 'image'),
                 'value' => 'profile.image',
                 'group' => 'profile',
             ],
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'position'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'position'),
                 'value' => 'contracts.position',
                 'group' => 'contracts',
             ],
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'organisational_unit'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'organisational_unit'),
                 'value' => 'contracts.organisationalUnit',
                 'group' => 'contracts',
             ],
             [
-                'label' =>  BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'room'),
+                'label' =>  $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'room'),
                 'value' => 'contracts.room',
                 'group' => 'contracts',
             ],
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'office_hours'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'office_hours'),
                 'value' => 'contracts.officeHours',
                 'group' => 'contracts',
             ],
             [
-                'label' =>  BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'physical_addresses'),
+                'label' =>  $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'physical_addresses'),
                 'value' => 'contracts.physicalAddresses',
                 'group' => 'contracts',
             ],
             [
-                'label' =>  BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'email_addresses'),
+                'label' =>  $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'email_addresses'),
                 'value' => 'contracts.emailAddresses',
                 'group' => 'contracts',
             ],
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'phone_numbers'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'phone_numbers'),
                 'value' => 'contracts.phoneNumbers',
                 'group' => 'contracts',
             ],
             [
-                'label' => BackendUtility::getItemLabel('tx_academicpersons_domain_model_contract', 'location'),
+                'label' => $this->getFieldLabel('tx_academicpersons_domain_model_contract', 'location'),
                 'value' => 'contracts.location',
                 'group' => 'contracts',
             ],

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Contract.php
@@ -35,23 +35,23 @@ class Contract extends AbstractEntity
 
     /**
      * @var ObjectStorage<Address>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $physicalAddresses;
 
     /**
      * @var ObjectStorage<Email>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $emailAddresses;
 
     /**
      * @var ObjectStorage<PhoneNumber>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $phoneNumbers;
 
     public function __construct()

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/OrganisationalUnit.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/OrganisationalUnit.php
@@ -33,9 +33,9 @@ class OrganisationalUnit extends AbstractEntity
 
     /**
      * @var ObjectStorage<Contract>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $contracts;
 
     public function __construct()

--- a/packages/fgtclb/academic-persons/Classes/Domain/Model/Profile.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Model/Profile.php
@@ -29,15 +29,13 @@ class Profile extends AbstractEntity
     protected string $middleName = '';
     protected string $lastName = '';
     protected string $lastNameAlpha = '';
-    /**
-     * @Cascade("remove")
-     */
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ?FileReference $image = null;
     /**
      * @var ObjectStorage<Contract>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $contracts;
     protected string $websiteTitle = '';
     protected string $website = '';
@@ -45,50 +43,50 @@ class Profile extends AbstractEntity
     protected string $coreCompetences = '';
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $memberships;
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $pressMedia;
     protected string $supervisedThesis = '';
     protected string $supervisedDoctoralThesis = '';
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $vita;
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $publications;
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $scientificResearch;
     protected string $publicationsLink = '';
     protected string $publicationsLinkTitle = '';
     protected string $miscellaneous = '';
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $cooperation;
     /**
      * @var ObjectStorage<ProfileInformation>
-     * @Lazy
-     * @Cascade("remove")
      */
+    #[Lazy]
+    #[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]
     protected ObjectStorage $lectures;
     /**
      * @var ObjectStorage<FrontendUser>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Detail.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Detail.xml
@@ -12,16 +12,16 @@
                     <valuePicker>
                         <items>
                             <numIndex index="0" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
-                                <numIndex index="1"></numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</label>
+                                <value></value>
                             </numIndex>
                             <numIndex index="1" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
-                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</label>
+                                <value>%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</value>
                             </numIndex>
                             <numIndex index="2" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
-                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</label>
+                                <value>%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</value>
                             </numIndex>
                         </items>
                     </valuePicker>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/List.xml
@@ -13,16 +13,16 @@
                     <valuePicker>
                         <items>
                             <numIndex index="0" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</numIndex>
-                                <numIndex index="1"></numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.none</label>
+                                <value></value>
                             </numIndex>
                             <numIndex index="1" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</numIndex>
-                                <numIndex index="1">%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname</label>
+                                <value>%%TITLE%% %%FIRST_NAME%% %%MIDDLE_NAME%% %%LAST_NAME%%</value>
                             </numIndex>
                             <numIndex index="2" type="array">
-                                <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</numIndex>
-                                <numIndex index="1">%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</numIndex>
+                                <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.pageTitleFormat.items.lastcommafirstmiddlename</label>
+                                <value>%%LAST_NAME%%, %%FIRST_NAME%% %%MIDDLE_NAME%%</value>
                             </numIndex>
                         </items>
                     </valuePicker>

--- a/packages/fgtclb/academic-persons/EXT_CONSTANTS.php
+++ b/packages/fgtclb/academic-persons/EXT_CONSTANTS.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+/*
+ * @todo Remove this file — its `autoload.files` entry in composer.json, the
+ *       require_once in ext_localconf.php and the ACADEMIC_PERSONS_CASCADE_REMOVE
+ *       constant — once TYPO3 v13 support is dropped (typo3/cms-core:>13), and
+ *       replace `#[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]` in the domain
+ *       models with the plain string form `#[Cascade('remove')]`.
+ *
+ *       Background: TYPO3 v14 expects the string argument for the Extbase
+ *       `#[Cascade]` attribute, while TYPO3 v13 still requires the array form
+ *       (`['value' => 'remove']`) and passing the string there is a fatal error.
+ *       PHP attribute arguments must be constant expressions and cannot contain
+ *       a runtime version switch, so the version-specific value is provided via
+ *       this constant. It is loaded through both `autoload.files` (Composer mode)
+ *       and a require in ext_localconf.php (Classic mode), guarded by
+ *       `defined()` so the double include is harmless.
+ */
+defined('ACADEMIC_PERSONS_CASCADE_REMOVE')
+    || define(
+        'ACADEMIC_PERSONS_CASCADE_REMOVE',
+        (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 14
+            ? 'remove'
+            : ['value' => 'remove']
+    );

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/composer.json
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/composer.json
@@ -16,7 +16,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "test_language_files"
+            "extension-key": "test_language_files",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
         }
     }
 }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_messy_profile_factory/composer.json
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_messy_profile_factory/composer.json
@@ -16,7 +16,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "test_messy_profile_factory"
+            "extension-key": "test_messy_profile_factory",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
         }
     },
     "autoload": {

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_plugin_templates/composer.json
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_plugin_templates/composer.json
@@ -16,7 +16,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "test_plugin_templates"
+            "extension-key": "test_plugin_templates",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
         }
     }
 }

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -29,7 +29,10 @@
     "autoload": {
         "psr-4": {
             "FGTCLB\\AcademicPersons\\": "Classes/"
-        }
+        },
+        "files": [
+            "EXT_CONSTANTS.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -46,7 +49,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_persons"
+            "extension-key": "academic_persons",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-persons/ext_localconf.php
+++ b/packages/fgtclb/academic-persons/ext_localconf.php
@@ -14,6 +14,15 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die;
 
+// Define ACADEMIC_PERSONS_CASCADE_REMOVE for Classic (non-Composer) mode, where
+// composer.json `autoload.files` is not processed. In Composer mode the constant
+// is already defined via autoload.files, so this is skipped. ext_localconf.php is
+// cached/concatenated by TYPO3 (so __DIR__ is unreliable) — use extPath().
+// @todo Remove together with EXT_CONSTANTS.php once TYPO3 v13 support is dropped.
+if (!defined('ACADEMIC_PERSONS_CASCADE_REMOVE')) {
+    require_once \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academic_persons') . 'EXT_CONSTANTS.php';
+}
+
 (static function (): void {
 
     $GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['profile'] = 'EXT:academic_persons/Configuration/CKEditor/Profile.yaml';

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -32,7 +32,11 @@
             "extension-key": "academic_programs",
             "ignore-as-root": false,
             "web-dir": ".Build/public",
-            "app-dir": ".Build"
+            "app-dir": ".Build",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -48,7 +48,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_projects"
+            "extension-key": "academic_projects",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/academic-study-plan/composer.json
+++ b/packages/fgtclb/academic-study-plan/composer.json
@@ -47,7 +47,11 @@
         "typo3/cms": {
             "web-dir": ".Build/Web",
             "app-dir": ".Build",
-            "extension-key": "academic_study_plan"
+            "extension-key": "academic_study_plan",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": {}
+            }
         },
         "branch-alias": {
             "dev-main": "3.0.x-dev"

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -24,8 +24,10 @@
       "ignore-as-root": false,
       "web-dir": ".Build/Web",
       "app-dir": ".Build",
+      "version": "3.0.0-dev",
       "Package": {
-        "serviceProvider": "FGTCLB\\CategoryTypes\\ServiceProvider"
+        "serviceProvider": "FGTCLB\\CategoryTypes\\ServiceProvider",
+        "providesPackages": {}
       }
     },
     "branch-alias": {


### PR DESCRIPTION
## What

**PR 2c-3a** — first batch of the v14 functional **deprecation** clean-up
(`failOnDeprecation` stays on; the code is fixed, no fail* option disabled).

### Extension metadata — deprecation [#108345](https://docs.typo3.org/permalink/changelog:deprecation-108345-1774126701)
- Add `extra.typo3/cms.version` (`3.0.0-dev`) + `Package.providesPackages` to all
  12 split extensions and the 5 functional-test fixture extensions.
- `bin/set-version` keeps `extra.typo3/cms.version` in sync with the
  path-repository version map on every bump (new format-preserving helper).
- With a version present, testing-framework 9 resolves each extension's composer
  `require` strictly — `academic_jobs` needs `typo3/cms-fluid-styled-content`,
  added to its test base `$coreExtensionsToLoad`. *(This was the cause of a
  transient 42-error regression during development — now 0.)*

### Extbase `#[Cascade]` (v14 deprecates the array config form)
- v14 wants `#[Cascade('remove')]` (string); v13 still requires the array form,
  and a PHP attribute arg can't hold a runtime switch. Value supplied via a
  per-extension constant (`ACADEMIC_PERSONS_CASCADE_REMOVE` /
  `ACADEMIC_JOBS_CASCADE_REMOVE`) in a new `EXT_CONSTANTS.php`, loaded via
  `autoload.files` (Composer) **and** a guarded `require` in `ext_localconf.php`
  (Classic mode, `extPath()`). phpstan gets it per core version (array v13 /
  string v14) via `bootstrapFiles`; `EXT_CONSTANTS.php` excluded from analysis.
  `@todo` to simplify to the string form once v13 is dropped.
- **Bonus:** this also fixes the 2 v14 "exclude pids" relation-removal test
  failures — the deprecated docblock `@Cascade` wasn't applying the cascade.

### TCA / FlexForm
- `ProfileShowFieldsItems`: `BackendUtility::getItemLabel()` (deprecated v14) →
  `TcaSchema` (v13 + v14).
- `Detail`/`List` FlexForms: `pageTitleFormat` valuePicker legacy numeric items →
  associative `label`/`value`.

## Verification

| Gate | v14 | v13 |
|------|-----|-----|
| cgl / lintPhp / phpstan | ✅ | ✅ |
| functional | **0 errors, 0 failures**, deprecations 33→13 | ✅ 425, 2 skipped |

Remaining v14 deprecations (13) — `ext_tables.php`/`PageDoktypeRegistry`,
`addPiFlexFormValue`, and third-party `numbered_pagination` — are the next batch
(2c-3b). `-t 13` CI validates this PR.
