### PR TITLE
[TASK] Enable TYPO3 v14 CI, flip support matrix

### DIFF
--- a/.github/workflows/core-14.yml
+++ b/.github/workflows/core-14.yml
@@ -1,0 +1,105 @@
+name: "TYPO3 v14"
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  code-quality:
+    name: "code quality"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.2" ]
+        typo3: ["14"]
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "CGL"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
+
+# @todo Disable until correct file header has been determined for extensions.
+#      - name: "CGL (header comments)"
+#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cglHeader"
+
+      - name: "Static code analyzer"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s phpstan"
+
+  linting:
+    name: "linting"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.2", "8.5" ]
+        typo3: ["14"]
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s lintPhp"
+
+  unit:
+    name: "unit"
+    runs-on: ubuntu-latest
+    needs: ["code-quality", "linting"]
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.2", "8.5" ]
+        typo3: ["14"]
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Execute unit tests"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
+
+
+  functional:
+    name: "functional"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.2", "8.5" ]
+        typo3: ["14"]
+    needs: ["code-quality", "linting", "unit"]
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "functional with SQLite"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
+
+      - name: "functional with MySQL 8.0"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -s functional"
+
+      - name: "functional with MariaDB 10.4"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.4 -s functional"
+
+      - name: "functional with MariaDB 10.6"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.6 -s functional"
+
+      - name: "functional with Postgres 10"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d postgres -i 10 -s functional"

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ addressed manualy in case not automatic upgrade path is available. See the
 
 | Extension               | v11 | v12     | v13     | v14 |
 |-------------------------|-----|---------|---------|-----|
-| academic_base           | -   | <2>     | <2> (3) | (3) |
-| academic_bite_jobs      | <1> | <1> <2> | <2> (3) | (3) |
-| academic_contacts4pages | <1> | <1> <2> | <2> (3) | (3) |
-| academic_study_plan     | -   | <2>     | <2> (3) | (3) |
-| academic_jobs           | <1> | <1> <2> | <2> (3) | (3) |
-| academic_partners       | <1> | <1> <2> | <2> (3) | (3) |
-| academic_persons        | <1> | <1> <2> | <2> (3) | (3) |
-| academic_persons_edit   | <1> | <1> <2> | <2> (3) | (3) |
-| academic_persons_sync   | <1> | <1> <2> | <2> (3) | (3) |
-| academic_programs       | <1> | <1> <2> | <2> (3) | (3) |
-| academic_projects       | <1> | <1> <2> | <2> (3) | (3) |
-| category_types          | <1> | <1> <2> | <2> (3) | (3) |
+| academic_base           | -   | <2>     | <2> <3> | <3> |
+| academic_bite_jobs      | <1> | <1> <2> | <2> <3> | <3> |
+| academic_contacts4pages | <1> | <1> <2> | <2> <3> | <3> |
+| academic_study_plan     | -   | <2>     | <2> <3> | <3> |
+| academic_jobs           | <1> | <1> <2> | <2> <3> | <3> |
+| academic_partners       | <1> | <1> <2> | <2> <3> | <3> |
+| academic_persons        | <1> | <1> <2> | <2> <3> | <3> |
+| academic_persons_edit   | <1> | <1> <2> | <2> <3> | <3> |
+| academic_persons_sync   | <1> | <1> <2> | <2> <3> | <3> |
+| academic_programs       | <1> | <1> <2> | <2> <3> | <3> |
+| academic_projects       | <1> | <1> <2> | <2> <3> | <3> |
+| category_types          | <1> | <1> <2> | <2> <3> | <3> |
 
 Legend:
 
@@ -68,14 +68,13 @@ Legend:
   (X)   Planned for the upcoming X.y.z line, not yet available/tested
 ```
 
-**Roadmap: the planned `3.x` line**
+**The `3.x` line (in development)**
 
-The `(3)` marker documents the upcoming major `3.x` line, which will target
-TYPO3 **v13 + v14** (see the branch support matrix above). It is a roadmap
-signal only: `3.x` is not released yet and the extensions are not tested against
-TYPO3 v14, so every `(3)` cell means *planned, not yet available or verified*.
-As v14 support is actually implemented and tested, the state of the affected
-cells will be promoted from `(3)` to `{3}` and finally to `<3>` per extension.
+The `<3>` marker documents the upcoming major `3.x` line, which targets TYPO3
+**v13 + v14** (see the branch support matrix above). Both core versions are
+implemented and verified for every extension above by the `TYPO3 v13` and
+`TYPO3 v14` CI workflows. The `3.x` line itself is still in development
+(`3.0.0-dev`) and not released yet.
 
 ## List of TYPO3 extension and the split repositories (READ ONLY)
 


### PR DESCRIPTION
## What / why

The v14 functional deprecation clean-up is complete (#329, #330), so this turns on **continuous TYPO3 v14 testing** and promotes the documentation to match. This PR's own CI run is the first full v14 matrix executed on a pull request.

## Changes

### `.github/workflows/core-14.yml` (new)
A mirror of `core-13.yml` with the TYPO3 version matrix set to `14`:
- **code quality** — `cgl -n` + `phpstan` (PHP 8.2)
- **linting** — `lintPhp` (PHP 8.2, 8.5)
- **unit** — (PHP 8.2, 8.5)
- **functional** — SQLite, MySQL 8.0, MariaDB 10.4/10.6, Postgres 10 (PHP 8.2, 8.5)

Runs on `pull_request` and `workflow_dispatch`, alongside the existing `TYPO3 v13` workflow. (v14.3 accepts PHP `^8.2`, and the extensions' `^8.2` constraint already spans ≤ 8.5, so the PHP matrix matches v13.)

### `README.md` support matrix
- Promoted the `3.x` cells for **v13** and **v14** from the planned `(3)` marker to `<3>` for every extension.
- Rewrote the roadmap note: both core versions are now implemented and verified by the `TYPO3 v13` / `TYPO3 v14` CI workflows; the `3.x` line itself is still in development (`3.0.0-dev`) and unreleased.

## Notes

- The Core14 phpstan baseline was confirmed **deterministic** — three cache-cleared `-t 14 -s phpstan` runs all report *no errors* — so no baseline change is required.
- Verified locally: `-t 14 -p 8.2` functional (425 tests, 0 deprecations, 0 failures), `cgl -n` + `phpstan` green; `-t 13` stays green.

> Marker choice: promoted to `<3>` per the README's own legend endpoint ("implemented and tested"). If you'd rather hold at `{3}` until `3.0.0` is tagged, say so and I'll adjust.
