### PR TITLE
[BUGFIX] Correct academic_projects wizard CType

### DIFF
--- a/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
+++ b/packages/fgtclb/academic-projects/Configuration/TsConfig/Wizards/NewContentElement.tsconfig
@@ -6,8 +6,7 @@ mod.wizards {
                 title = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_list.name
                 description = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_list.description
                 tt_content_defValues {
-                    CType = list
-                    list_type = academicprojects_projectlist
+                    CType = academicprojects_projectlist
                 }
             }
             academicprojects_projectlistsingle {
@@ -15,8 +14,7 @@ mod.wizards {
                 title = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_selected.name
                 description = LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:plugin.project_selected.description
                 tt_content_defValues {
-                    CType = list
-                    list_type = academicprojects_projectlistsingle
+                    CType = academicprojects_projectlistsingle
                 }
             }
         }


### PR DESCRIPTION
## What / why

Backport to branch `2` of the fix already on `main` (3.x).

The academic_projects **New Content Element** wizard (`Configuration/TsConfig/Wizards/NewContentElement.tsconfig`) set the content-element defaults to `CType = list` + `list_type = academicprojects_projectlist` / `academicprojects_projectlistsingle` — a leftover from legacy plugin sub-type registration.

Both plugins are registered as **dedicated content types**, though: `Configuration/TCA/Overrides/tt_content.php` `addPlugin(…, PLUGIN_TYPE_CONTENT_ELEMENT)` and `ext_localconf.php` `configurePlugin(…, PLUGIN_TYPE_CONTENT_ELEMENT)`. So the wizard created records with the wrong `CType` (`list`) and a stray `list_type`, which never matched the registered content type.

## Fix

Set `tt_content_defValues.CType` to the plugin's own content type and drop the obsolete `list_type` default, so wizard-created elements match the registration (identical to the main-branch fix).

Pure TsConfig change — no PHP/test impact.