### PR TITLE
[BUGFIX] Fix contacts4pages upgrade wizard match

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Upgrades/PluginUpgradeWizard.php
@@ -47,6 +47,9 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
 
     public function updateNecessary(): bool
     {
+        // This wizard renames a CType (not a list_type sub-type), so it must
+        // detect records by CType exactly like executeUpdate() migrates them.
+        // The previous `list_type` query never matched, so the wizard never ran.
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
         $queryBuilder->getRestrictions()->removeAll();
         return (bool)$queryBuilder
@@ -54,7 +57,7 @@ final class PluginUpgradeWizard implements UpgradeWizardInterface
             ->from('tt_content')
             ->where(
                 $queryBuilder->expr()->in(
-                    'list_type',
+                    'CType',
                     $queryBuilder->quoteArrayBasedValueListToStringList(array_keys(self::MIGRATE_CONTENT_TYPES_LIST))
                 ),
             )


### PR DESCRIPTION
## What / why

Backport to branch `2` of the fix already on `main` (3.x).

`academicContact4pages_pluginUpgradeWizard` renames a content type — `academiccontact4pages_contactslist` → `academiccontacts4pages_list` — and `executeUpdate()` performs the migration on the **`CType`** column. But `updateNecessary()` queried the **`list_type`** column, which never held these values, so the wizard always reported "nothing to do" and never ran (the migration was silently unavailable to integrators).

## Fix

Query `CType` in `updateNecessary()` too, matching what `executeUpdate()` migrates. One-line column change plus an explanatory comment.

## Verification

Branch `2`, `-t 13 -p 8.2`: `lintPhp`, `cgl -n`, `phpstan`, `unit` (90) all green.