### PR TITLE
[TASK] ACE-249: Sync release scripts with main

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -34,7 +34,7 @@
 #   <release-version>        MAJOR.MINOR.PATCH, e.g. 2.4.0
 #
 # Options:
-#   --source-branch=<name>   base/source branch (default: main)
+#   --source-branch=<name>   base/source branch (default: 2)
 #   --dry-run                print the whole plan, change nothing
 #   --execute                enable remote/irreversible operations
 #   -h, --help               show this help
@@ -106,7 +106,7 @@ run_set_version() {
 # Argument parsing
 # ---------------------------------------------------------------------------
 PASSED_VERSION=""
-SOURCE_BRANCH="main"
+SOURCE_BRANCH="2"
 
 while [ $# -gt 0 ]; do
     case "$1" in

--- a/bin/set-version
+++ b/bin/set-version
@@ -27,7 +27,7 @@
 #                                minor/major bumps).
 #
 # Options:
-#   --source-branch=<name>   git branch the branch-alias is keyed to (default: main)
+#   --source-branch=<name>   git branch the branch-alias is keyed to (default: 2)
 #   --dry-run                print every change without touching a file
 #   -h, --help               show this help
 #
@@ -72,7 +72,7 @@ run() {
 # ---------------------------------------------------------------------------
 PASSED_VERSION=""
 TYPE=""
-SOURCE_BRANCH="main"
+SOURCE_BRANCH="2"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -282,6 +282,17 @@ apply_branch_alias() {
         "extra.branch-alias.dev-${SOURCE_BRANCH}" "${BRANCH_ALIAS}"
 }
 
+# Helper: set extra.typo3/cms.version for a split extension composer.json. TYPO3
+# v14 reads the extension version from composer.json (ext_emconf.php is
+# deprecated), so it must track the path-repository version. Only applied when
+# the key already exists (composer config preserves the file formatting).
+apply_extension_composer_version() {
+    local dir="$1"
+    "${JQ}" -e '.extra."typo3/cms".version' "${dir}/composer.json" >/dev/null 2>&1 || return 0
+    step "${dir}" "config extra.typo3/cms.version = ${MAP_VERSION}"
+    run "${COMPOSER}" config -d "${dir}" "extra.typo3/cms.version" "${MAP_VERSION}"
+}
+
 # Helper: rewrite a jq version map in place (temp file + mv; never self-redirect).
 apply_version_map() {
     local file="$1" map="$2"   # map: packages | packages-dev
@@ -327,6 +338,7 @@ run "${SED}" -i \
 info "Split extensions"
 for dir in "${SPLIT_DIRS[@]}"; do
     apply_academic_composer_deps "${dir}" "${ACADEMIC_CONSTRAINT}"
+    apply_extension_composer_version "${dir}"
     [ "${SET_BRANCH_ALIAS}" -eq 1 ] && apply_branch_alias "${dir}"
     # docs-presence decides the --no-docs flag; all current splits ship docs.
     if [ -d "${dir}/Documentation" ]; then


### PR DESCRIPTION
## Why

`bin/release` and `bin/set-version` drifted from their `main` counterparts.
This aligns branch `2` with the current implementation state of `main`, keeping
only the differences that *must* differ per branch.

## What

* **Port `apply_extension_composer_version()`** (+ its call site in the split
  extension loop) from `main`. It keeps `extra.typo3/cms.version` of a split
  extension `composer.json` in sync with the path-repository version.
  It is guarded by a `jq -e` key-existence check, so on this branch it is a
  **no-op** — no package declares that key, because TYPO3 v12/v13 still read the
  extension version from `ext_emconf.php`. Ported anyway so both scripts stay
  identical to `main` apart from the branch defaults and future changes can be
  carried over verbatim.
* **Default `--source-branch` to `2`** (was `main`) in *both* scripts — help
  text and variable. With the `main` default, `bin/set-version` wrote a
  `dev-main` branch-alias and `bin/release` branched/pushed/merged against the
  wrong base branch.

Deliberately **not** changed: the `MAJOR.MINOR.PATCH` examples stay at `2.4.0`,
which is inside this branch's `2.4.x` range.

After this change, `bin/release` and `bin/set-version` are identical to `main`
except for the four intended default-branch lines:

```
bin/release      --source-branch help + SOURCE_BRANCH=  ->  2
bin/set-version  --source-branch help + SOURCE_BRANCH=  ->  2
```

## Verification

* `bash -n` clean on both scripts.
* `bin/set-version 2.4.1 dev --dry-run` → exit 0, no file touched, and the
  branch-alias now correctly resolves to `dev-2` = `2.4.x-dev` (matches the
  root `composer.json` of this branch).
* Positive control: temporarily added `extra.typo3/cms.version` to one package
  and re-ran the dry-run — the ported helper fires and sets it to the map
  version, exactly as on `main`. Reverted afterwards.

Shell-script-only change; no runtime/extension code is touched, so CI serves as
a pure no-regression proof.
