### PR TITLE
[TASK] ACE-249: Sync release scripts with main

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@
 # release — orchestrate the two-phase GitHub release of the academic-extensions
 # mono repository.
 #
-# Given a single release version (e.g. 2.4.0) this drives the full workflow:
+# Given a single release version (e.g. 2.2.2) this drives the full workflow:
 #
 #   PHASE 1 (release)
 #     - branch release-X.Y.Z off the source branch
@@ -31,7 +31,7 @@
 # Usage:
 #   bin/release <release-version> [options]
 #
-#   <release-version>        MAJOR.MINOR.PATCH, e.g. 2.4.0
+#   <release-version>        MAJOR.MINOR.PATCH, e.g. 2.2.2
 #
 # Options:
 #   --source-branch=<name>   base/source branch (default: 2.2)
@@ -134,7 +134,7 @@ fi
 # Validate version and derive the next dev (post-release) version (patch + 1).
 # ---------------------------------------------------------------------------
 if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.2.2)"
 fi
 MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"

--- a/bin/set-version
+++ b/bin/set-version
@@ -16,7 +16,7 @@
 # Usage:
 #   bin/set-version <version> <type> [options]
 #
-#   <version>   MAJOR.MINOR.PATCH, e.g. 2.4.0
+#   <version>   MAJOR.MINOR.PATCH, e.g. 2.2.2
 #   <type>      release | post-release | dev
 #                 release      : tag/release version  (X.Y.Z, deps X.Y.Z@dev)
 #                 post-release : next dev version      (X.Y.W-dev, deps ~X.Y.W@dev,
@@ -101,7 +101,7 @@ done
 # Validate version + type
 # ---------------------------------------------------------------------------
 if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.2.2)"
 fi
 MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"
@@ -282,6 +282,17 @@ apply_branch_alias() {
         "extra.branch-alias.dev-${SOURCE_BRANCH}" "${BRANCH_ALIAS}"
 }
 
+# Helper: set extra.typo3/cms.version for a split extension composer.json. TYPO3
+# v14 reads the extension version from composer.json (ext_emconf.php is
+# deprecated), so it must track the path-repository version. Only applied when
+# the key already exists (composer config preserves the file formatting).
+apply_extension_composer_version() {
+    local dir="$1"
+    "${JQ}" -e '.extra."typo3/cms".version' "${dir}/composer.json" >/dev/null 2>&1 || return 0
+    step "${dir}" "config extra.typo3/cms.version = ${MAP_VERSION}"
+    run "${COMPOSER}" config -d "${dir}" "extra.typo3/cms.version" "${MAP_VERSION}"
+}
+
 # Helper: rewrite a jq version map in place (temp file + mv; never self-redirect).
 apply_version_map() {
     local file="$1" map="$2"   # map: packages | packages-dev
@@ -327,6 +338,7 @@ run "${SED}" -i \
 info "Split extensions"
 for dir in "${SPLIT_DIRS[@]}"; do
     apply_academic_composer_deps "${dir}" "${ACADEMIC_CONSTRAINT}"
+    apply_extension_composer_version "${dir}"
     [ "${SET_BRANCH_ALIAS}" -eq 1 ] && apply_branch_alias "${dir}"
     # docs-presence decides the --no-docs flag; all current splits ship docs.
     if [ -d "${dir}/Documentation" ]; then


### PR DESCRIPTION
## Why

`bin/release` and `bin/set-version` drifted from their `main` counterparts.
This aligns branch `2.2` with the current implementation state of `main`,
keeping only the differences that *must* differ per branch.

## What

* **Port `apply_extension_composer_version()`** (+ its call site in the split
  extension loop) from `main`. It keeps `extra.typo3/cms.version` of a split
  extension `composer.json` in sync with the path-repository version.
  It is guarded by a `jq -e` key-existence check, so on this branch it is a
  **no-op** — no package declares that key, because TYPO3 v12/v13 still read the
  extension version from `ext_emconf.php`. Ported anyway so both scripts stay
  identical to `main` apart from the branch defaults and future changes can be
  carried over verbatim.
* **Retarget the version examples** from `2.4.0` to `2.2.2` (the next patch
  level of this branch) in both scripts — usage help and the invalid-version
  error message. `2.4.0` is outside this branch's `2.2.x` range.

Deliberately **not** changed: the `--source-branch` defaults, which already
point at `2.2` and are correct.

After this change, `bin/release` and `bin/set-version` are identical to `main`
except for the intended per-branch lines (default branch `2.2`, examples
`2.2.2`).

## Verification

* `bash -n` clean on both scripts.
* `bin/set-version 2.2.2 dev --dry-run` → exit 0, no file touched, branch-alias
  resolves to `dev-2.2` = `2.2.x-dev`.
* `bin/set-version 9 dev` → `ERROR: Invalid version '9': expected
  MAJOR.MINOR.PATCH (e.g. 2.2.2)` — the retargeted example reaches the user.
* Positive control: temporarily added `extra.typo3/cms.version` to one package
  and re-ran the dry-run — the ported helper fires and sets it to the map
  version, exactly as on `main`. Reverted afterwards.

Shell-script-only change; no runtime/extension code is touched, so CI serves as
a pure no-regression proof.

## Note (not addressed here, out of scope)

The root `composer.json` on this branch still carries
`extra.branch-alias.dev-main = 2.2.1-dev` rather than `dev-2.2`. With the
`--source-branch=2.2` default, `bin/set-version` writes `dev-2.2` and leaves the
stale `dev-main` entry in place. Flagging only — no data change in this PR.
