### PR TITLE
[TASK] ACE-249: Document release process, align examples

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -80,11 +80,23 @@ Test discovery: phpunit globs `packages/*/*/Tests/Unit/` and
 
 ## CI (`.github/workflows/`)
 
-`core-12.yml` / `core-13.yml` run the same `runTests.sh` suites (CGL `-n`,
-phpstan, lintPhp, unit, functional) across the PHP matrix. `core-11.yml` is
-disabled. `publish.yml` triggers on a version tag matching `X.Y.Z`: it builds a
-TER artifact per extension with `typo3/tailor` and publishes. **The tag version
-must match each extension's `ext_emconf.php` version or publish fails.**
+`core-13.yml` / `core-14.yml` run the same `runTests.sh` suites (CGL `-n`,
+phpstan, lintPhp, unit, functional) across the PHP matrix on every pull request.
+`core-11.yml` and `core-12.yml` are disabled (`workflow_dispatch` only) and kept
+solely for their status badges — do not delete them.
+
+`publish.yml` triggers on a version tag matching `X.Y.Z`: it builds a TER
+artifact per extension with `typo3/tailor` and creates the GitHub release. It
+does **not** publish to the TER — the mono repository is a composer `project`,
+not an extension. **The tag version must match each extension's
+`ext_emconf.php` version or the artifact step fails.**
+
+TER publishing happens one step later, per extension: the external splitter
+mirrors the tagged state into the read-only split repositories, where each
+package's own `publish` workflow runs `tailor ter:publish`. That workflow is
+maintained here as `packages/fgtclb/<package>/.github/workflows/publish.yml` and
+is split out with the package, so it is changed in this repository, never
+downstream. See the "Releasing (maintainers)" section of `README.md`.
 
 ## Quality gates
 

--- a/README.md
+++ b/README.md
@@ -92,3 +92,118 @@ implemented and verified for every extension above by the `TYPO3 v13` and
 | fgtclb/academic-programs       | academic_programs       | [packages/fgtclb/academic-programs](packages/fgtclb/academic-programs/README.md)           | [fgtclb/academic-programs](https://github.com/fgtclb/academic-programs)              |
 | fgtclb/academic-projects       | academic_projects       | [packages/fgtclb/academic-projects](packages/fgtclb/academic-projects/README.md)           | [fgtclb/academic-projects](https://github.com/fgtclb/academic-projects)              |
 | fgtclb/category-types          | category_types          | [packages/fgtclb/typo3-category-types](packages/fgtclb/typo3-category-types/README.md)     | [fgtclb/fgtclb/typo3-category-types](https://github.com/fgtclb/typo3-category-types) |
+
+## Releasing (maintainers)
+
+A release is always cut from the branch owning that version line (see the
+[branch support matrix](#repository-version-support)) using the two scripts in
+`bin/`. All extensions of the mono repository are released together, sharing one
+version number.
+
+| Branch | Release line | Example version | Release tooling                             |
+|--------|--------------|-----------------|---------------------------------------------|
+| main   | `3.x`        | `3.0.0`         | `bin/release`, `bin/set-version`            |
+| 2      | `2.x`        | `2.4.0`         | `bin/release`, `bin/set-version`            |
+| 2.2    | `2.2.x`      | `2.2.2`         | `bin/release`, `bin/set-version`            |
+| 1      | `1.x`        | -               | none — that branch has no `bin/` scripts    |
+
+Both scripts are kept as the *same* implementation on every branch. Only two
+things legitimately differ per branch: the `--source-branch` default (which
+equals the branch itself) and the version examples in the help output (which
+must lie inside that branch's version range).
+
+### Required tooling
+
+`bin/set-version` resolves `composer`, `php`, `tailor`, `pkw`, `jq` and `sed`
+from `PATH`; `bin/release` additionally needs `git` and an authenticated `gh`.
+Both abort with an explicit error if a tool is missing, before changing
+anything.
+
+### `bin/set-version` — apply a version across the mono repository
+
+```shell
+bin/set-version <version> <type> [--source-branch=<name>] [--dry-run]
+```
+
+`<type>` selects how the version is written:
+
+| Type           | Result                                                                   |
+|----------------|--------------------------------------------------------------------------|
+| `release`      | tag/release version — `X.Y.Z`, academic deps `X.Y.Z@dev`                  |
+| `post-release` | next dev version — `X.Y.W-dev`, deps `~X.Y.W@dev`, branch-alias `X.Y.x-dev`; the version passed is *already* the next one, no `+1` happens here |
+| `dev`          | force a plain dev version everywhere (`X.Y.Z-dev`); thin variant of `post-release`, used for branching and forced minor/major bumps |
+
+It rewrites, in one pass:
+
+1. `Build/Scripts/runTests.sh` → `COMPOSER_ROOT_VERSION`
+2. split extensions → academic composer deps, `extra.typo3/cms.version`,
+   branch-alias, `tailor set-version`, `VERSION` file
+3. functional-test fixture extensions → composer deps only
+4. `ext_emconf.php` → `version` plus `depends`/`suggests` constraints
+5. `packages-dev/monorepo-shared` → academic deps + packages version map
+6. `ddev-instances/*` → both version maps + `academics-monorepo-shared` require
+7. root `composer.json` → both version maps, `monorepo-shared` require, alias
+
+The script only edits working-tree files — it performs no git and no network
+operations. `--dry-run` prints every single change without touching a file and
+is the safe way to rehearse a bump.
+
+### `bin/release` — orchestrate the full release
+
+```shell
+bin/release <release-version> [--source-branch=<name>] [--dry-run|--execute]
+```
+
+It runs two phases, delegating all version rewriting to `bin/set-version`:
+
+* **Phase 1 (release)** — branch `release-X.Y.Z`, `set-version X.Y.Z release`,
+  commit `[RELEASE] X.Y.Z`, push, open a PR, wait for the checks, admin
+  rebase-merge, then tag `X.Y.Z` on the refreshed source branch and push the tag.
+* **Phase 2 (post-release)** — branch `set-version-X.Y.W` (`W = Z+1`),
+  `set-version X.Y.W post-release`, commit `[TASK] Set version X.Y.W`, push,
+  PR, checks, admin rebase-merge.
+
+Two independent safety gates control how far a run goes:
+
+| Invocation  | Local steps | Remote/irreversible steps (push, PR, merge, tag) |
+|-------------|-------------|--------------------------------------------------|
+| *(bare)*    | executed    | **only printed** — a bare run can never mutate the remote or create a tag |
+| `--dry-run` | printed     | printed                                          |
+| `--execute` | executed    | executed                                         |
+
+`--dry-run` and `--execute` are mutually exclusive. Pre-flight checks refuse to
+run outside a git work tree or when the target tag already exists; a dirty
+working tree is fatal for `--execute` and only a warning otherwise, so the flow
+stays rehearsable.
+
+### What the pushed tag triggers
+
+Pushing the tag starts the `publish` workflow
+([`.github/workflows/publish.yml`](.github/workflows/publish.yml)), which:
+
+1. verifies the tag matches `MAJOR.MINOR.PATCH`,
+2. builds one TER upload artifact per extension via
+   `tailor create-artefact` — **this step fails when the tag does not match an
+   extension's `ext_emconf.php` version**, which is exactly what
+   `bin/set-version` keeps in sync, and
+3. creates the GitHub release `[RELEASE] <version>` with generated release notes
+   and attaches the artifacts plus `LICENSE`.
+
+The mono repository itself is **not** published to the TER — it is a composer
+`project`, not an extension. TER publishing happens per extension, one step
+later in the chain:
+
+1. the tag is pushed here and the workflow above creates the GitHub release,
+2. the (external) splitter mirrors the tagged state into the read-only split
+   repositories listed above,
+3. each split repository carries its **own** `publish` workflow, which reacts to
+   the tag arriving there and runs `tailor ter:publish` for that single
+   extension.
+
+That per-extension workflow is maintained in this repository as
+`packages/fgtclb/<package>/.github/workflows/publish.yml` (all 12 packages ship
+one) and is split out together with the package — so TER publishing is changed
+here, never in a split repository.
+
+Note that the documentation-rendering step of the root workflow is currently
+commented out.

--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@
 # release — orchestrate the two-phase GitHub release of the academic-extensions
 # mono repository.
 #
-# Given a single release version (e.g. 2.4.0) this drives the full workflow:
+# Given a single release version (e.g. 3.0.0) this drives the full workflow:
 #
 #   PHASE 1 (release)
 #     - branch release-X.Y.Z off the source branch
@@ -31,7 +31,7 @@
 # Usage:
 #   bin/release <release-version> [options]
 #
-#   <release-version>        MAJOR.MINOR.PATCH, e.g. 2.4.0
+#   <release-version>        MAJOR.MINOR.PATCH, e.g. 3.0.0
 #
 # Options:
 #   --source-branch=<name>   base/source branch (default: main)
@@ -134,7 +134,7 @@ fi
 # Validate version and derive the next dev (post-release) version (patch + 1).
 # ---------------------------------------------------------------------------
 if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 3.0.0)"
 fi
 MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"

--- a/bin/set-version
+++ b/bin/set-version
@@ -16,7 +16,7 @@
 # Usage:
 #   bin/set-version <version> <type> [options]
 #
-#   <version>   MAJOR.MINOR.PATCH, e.g. 2.4.0
+#   <version>   MAJOR.MINOR.PATCH, e.g. 3.0.0
 #   <type>      release | post-release | dev
 #                 release      : tag/release version  (X.Y.Z, deps X.Y.Z@dev)
 #                 post-release : next dev version      (X.Y.W-dev, deps ~X.Y.W@dev,
@@ -101,7 +101,7 @@ done
 # Validate version + type
 # ---------------------------------------------------------------------------
 if ! [[ "${PASSED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 2.4.0)"
+    die "Invalid version '${PASSED_VERSION}': expected MAJOR.MINOR.PATCH (e.g. 3.0.0)"
 fi
 MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"


### PR DESCRIPTION
Three commits, all about release information on `main`.

## 1. `[TASK]` Align version examples with `3.x`

`bin/release` and `bin/set-version` still used `2.4.0` in their
`MAJOR.MINOR.PATCH` examples, a version outside the range this branch releases.
`main` is the `3.x` line (`3.0.0-dev`), so the examples now name `3.0.0` — usage
help, the `bin/release` intro line and the invalid-version error message of both
scripts.

This completes the per-branch alignment done for `2` (#334) and `2.2` (#335):
both scripts stay the same implementation everywhere, differing only in the
`--source-branch` default and the version examples.

## 2. `[DOCS]` Document the release process in `README.md`

The release tooling was undocumented — the README said nothing about how a
release is cut, which branch releases which line, or what pushing a tag does.
New "Releasing (maintainers)" section covering:

* which branch owns which release line (incl. that branch `1` has no `bin/`
  scripts),
* the tooling both scripts resolve from `PATH`,
* `bin/set-version` — the three types and the seven areas it rewrites, plus the
  working-tree-only guarantee,
* `bin/release` — the two phases, and a table of the three invocation modes and
  how far each goes (the bare run executing local steps while only *printing*
  remote ones is easy to get wrong),
* what the pushed tag triggers, including the complete publishing chain.

### The publishing chain is documented end to end

The root workflow alone tells only half the story, so the section spells out
that the mono repository is a composer `project` and is never published to the
TER itself:

1. the tag is pushed here → root `publish.yml` creates the GitHub release with
   one TER artifact per extension (`tailor create-artefact`, which fails if the
   tag does not match an extension's `ext_emconf.php` version — exactly what
   `bin/set-version` keeps in sync),
2. the external splitter mirrors the tagged state into the read-only split
   repositories,
3. each split repository's **own** `publish` workflow reacts to the arriving tag
   and runs `tailor ter:publish` for that single extension.

That per-extension workflow is maintained here as
`packages/fgtclb/<package>/.github/workflows/publish.yml` (all 12 packages ship
one) and is split out with the package, so TER publishing is changed in this
repository, never downstream.

## 3. `[DOCS]` Fix CI and publish notes in `AGENT.md`

`AGENT.md` (tracked symlink `CLAUDE.md`) still described the pre-v14 state and
claimed the root `publish.yml` publishes to the TER:

* the workflows running on every pull request are `core-13.yml` + `core-14.yml`,
  not `core-12.yml` / `core-13.yml`; `core-11.yml` **and** `core-12.yml` are
  disabled (`workflow_dispatch` only) and kept for their status badges — now
  stated explicitly, because they look deletable,
* the root workflow builds the artifacts and creates the GitHub release but does
  not publish to the TER, so the tag/`ext_emconf.php` match guards the *artifact*
  step, and the real `tailor ter:publish` lives in the split repositories.

Same chain as documented in `README.md` above, kept consistent between both
files.

## Verification

* `bash -n` clean on both scripts; no `2.4.0` left in `bin/`.
* `bin/set-version 3.0.0 dev --dry-run` → exit 0, nothing touched.
* `bin/release 3.0.0 --dry-run` → confirms the documented behaviour end to end:
  phases, `release-3.0.0` / `set-version-3.0.1` branch names, the
  `[RELEASE] 3.0.0` / `[TASK] Set version 3.0.1` commit subjects, the mode
  banner and the pre-flight guards.
* Publishing chain verified against the actual files: the root workflow, the
  per-package `publish.yml` in all 12 packages, and the live split repository
  `fgtclb/academic-persons`, whose `publish.yml` carries the real
  `Publish to TER` step.

No PHP or runtime code is touched, so CI is a pure no-regression proof.
