### PR TITLE
[TASK] ACE-249: Key branch-alias to the 2.2 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
             }
         },
         "branch-alias": {
-            "dev-main": "2.2.1-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "require-dev": {

--- a/packages/fgtclb/academic-base/composer.json
+++ b/packages/fgtclb/academic-base/composer.json
@@ -28,7 +28,7 @@
             "extension-key": "academic_base"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         },
         "sbuerk/release": {
             "tailor": {

--- a/packages/fgtclb/academic-bite-jobs/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/composer.json
@@ -44,7 +44,7 @@
             "extension-key": "academic_bite_jobs"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -36,7 +36,7 @@
             "extension-key": "academic_contacts4pages"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "config": {

--- a/packages/fgtclb/academic-jobs/composer.json
+++ b/packages/fgtclb/academic-jobs/composer.json
@@ -46,7 +46,7 @@
             "extension-key": "academic_jobs"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/academic-partners/composer.json
+++ b/packages/fgtclb/academic-partners/composer.json
@@ -35,7 +35,7 @@
             "app-dir": ".Build"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "require": {

--- a/packages/fgtclb/academic-persons-edit/composer.json
+++ b/packages/fgtclb/academic-persons-edit/composer.json
@@ -45,7 +45,7 @@
             "extension-key": "academic_persons_edit"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/academic-persons-sync/composer.json
+++ b/packages/fgtclb/academic-persons-sync/composer.json
@@ -46,7 +46,7 @@
             "extension-key": "academic_persons_sync"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/academic-persons/composer.json
+++ b/packages/fgtclb/academic-persons/composer.json
@@ -48,7 +48,7 @@
             "extension-key": "academic_persons"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "conflict": {

--- a/packages/fgtclb/academic-programs/composer.json
+++ b/packages/fgtclb/academic-programs/composer.json
@@ -35,7 +35,7 @@
             "app-dir": ".Build"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "require": {

--- a/packages/fgtclb/academic-projects/composer.json
+++ b/packages/fgtclb/academic-projects/composer.json
@@ -48,7 +48,7 @@
             "extension-key": "academic_projects"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     },
     "conflict": {

--- a/packages/fgtclb/academic-study-plan/composer.json
+++ b/packages/fgtclb/academic-study-plan/composer.json
@@ -47,7 +47,7 @@
             "extension-key": "academic_study_plan"
         },
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         }
     }
 }

--- a/packages/fgtclb/typo3-category-types/composer.json
+++ b/packages/fgtclb/typo3-category-types/composer.json
@@ -26,7 +26,7 @@
       }
     },
     "branch-alias": {
-      "dev-main": "2.1.x-dev"
+      "dev-2.2": "2.2.x-dev"
     }
   },
   "config": {


### PR DESCRIPTION
Closes the last straggler from the ACE-249 release-tooling round (#334, #335,
#336).

## Problem

The composer branch-alias on this branch was still keyed to `dev-main`:

| File | Before | After |
|------|--------|-------|
| root `composer.json` | `"dev-main": "2.2.1-dev"` | `"dev-2.2": "2.2.x-dev"` |
| all 12 `packages/fgtclb/*/composer.json` | `"dev-main": "2.1.x-dev"` | `"dev-2.2": "2.2.x-dev"` |

## What this does and does not change

**It does not change resolution behaviour.** Composer derives the version of a
version-like branch name from the branch itself, so a branch-alias is only
applied to branches that are *not* version-like, such as `main`. Verified
against packagist.org, which already publishes these branches correctly and
ignores the alias where the branch name is version-like:

| Branch | Published on packagist as | `extra.branch-alias` recorded |
|--------|---------------------------|-------------------------------|
| `main` | `dev-main`                | `dev-main` → `3.0.x-dev`      |
| `2`    | **`2.x-dev`**             | `dev-2` → `2.4.x-dev` — not applied |
| `2.2`  | **`2.2.x-dev`**           | `dev-main` → `2.1.x-dev` — no effect |
| `1`    | `1.x-dev`                 | `dev-1` → `1.2.x-dev` — not applied |

(consistent across `academic-persons`, `academic-base` and `category-types`).
Branch `2` is the clearest case: it declares `2.4.x-dev` but is published as
`2.x-dev`. So the old `dev-main` entry here was inert, and the new `dev-2.2`
entry is inert too.

**It is still worth correcting**, because the stale entry:

* named a branch that does not exist on this line, and
* claimed `2.1.x` on a `2.2` branch — misleading to anyone reading the file,

and because `2.2.x-dev` is exactly what `bin/set-version` derives for this
branch (`BRANCH_ALIAS="${MAJOR}.${MINOR}.x-dev"`, written for the root *and*
every split extension). The branch therefore stops drifting from its own release
tooling and mirrors branch `2`.

## How

Per folder, via composer — no hand-edited JSON:

```shell
composer config --json extra.branch-alias '{"dev-2.2":"2.2.x-dev"}'
composer config -d packages/fgtclb/<package> --json \
  extra.branch-alias '{"dev-2.2":"2.2.x-dev"}'
```

Setting the whole object replaces the stale key atomically, so nothing is left
behind. No lock file and no dependency resolution is involved.

## Verification

* No `"dev-main"` remains anywhere on this branch.
* The diff is exactly 13 files, 13 insertions, 13 deletions — every changed line
  is a branch-alias line, confirmed by filtering the diff for anything else.
* Composer's own formatting is preserved (written by `composer config`).
* `composer config` was confirmed to handle the dotted key `dev-2.2` correctly
  rather than splitting it into a nested `dev-2` → `2` object — which also means
  `bin/set-version --source-branch=2.2` writes this same key correctly.
* Unlike #334–#336 this change lives inside `packages/fgtclb/*`, so it *will*
  propagate to the read-only split repositories once merged.
