### PR TITLE
[BUGFIX] ACE-267: Fix empty mime type allow-list

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
+++ b/packages/fgtclb/academic-base/Classes/Extbase/Property/TypeConverter/FileUploadConverter.php
@@ -199,7 +199,10 @@ final class FileUploadConverter extends AbstractTypeConverter
     {
         $languageService = $this->getLanguageService();
         $maxFileSizeInBytes = GeneralUtility::getBytesFromSizeMeasurement($maxFileSize);
-        $allowedMimeTypesArray = GeneralUtility::trimExplode(',', $allowedMimeTypes);
+        // Empty values must be dropped: `trimExplode(',', '')` returns `['']`, which would
+        // never match a real mime type and thus reject every upload. An empty allow-list
+        // means "no mime type restriction", matching the unrestricted file size default.
+        $allowedMimeTypesArray = GeneralUtility::trimExplode(',', $allowedMimeTypes, true);
 
         if ($uploadedFileInformation['size'] > $maxFileSizeInBytes) {
             throw new TypeConverterException(
@@ -210,7 +213,7 @@ final class FileUploadConverter extends AbstractTypeConverter
             );
         }
 
-        if (!in_array($uploadedFileInformation['type'], $allowedMimeTypesArray, true)) {
+        if ($allowedMimeTypesArray !== [] && !in_array($uploadedFileInformation['type'], $allowedMimeTypesArray, true)) {
             throw new TypeConverterException(
                 sprintf(
                     $languageService->sL(


### PR DESCRIPTION
Resolves **ACE-267**.

## The bug

`FileUploadConverter` rejects **every** upload when no allowed mime types are
configured — and that is the default.

```php
$allowedMimeTypesArray = GeneralUtility::trimExplode(',', $allowedMimeTypes);
if (!in_array($uploadedFileInformation['type'], $allowedMimeTypesArray, true)) {
    throw new TypeConverterException(/* invalid mime type */);
}
```

`trimExplode()` keeps empty values unless told otherwise, so an empty setting
yields `['']` — a list holding one empty string — not an empty list. The
`in_array()` can therefore never match. Verified against the installed core
(13.4.33):

```
trimExplode(',', '')               => [""]
in_array('image/jpeg', [""], true) => false
```

The empty value is the documented default: the option defaults to `''` in
`setArgumentTypeConverterConfiguration()`, and both consumers fall back to
`null`/`''` when their TypoScript setting is absent —
`JobController::initializeCreateAction()` (`EXT:academic_jobs`) and
`ProfileController::initializeAddImageAction()` (`EXT:academic_persons_edit`).

**Impact:** any installation that does not explicitly configure allowed mime
types can upload neither a job image nor a profile image.

## The fix

Drop empty values when exploding, and only validate when an allow-list is
actually configured. Empty now means "no mime type restriction", matching the
file size option whose default is unrestricted (`PHP_INT_MAX`).

## Why there is no test

The only public entry point, `convertFrom()`, ends up in
`ResourceStorage::assureFileUploadPermissions()`, which requires
`is_uploaded_file()` to be `true`. That is only ever the case for a real HTTP
POST upload, never in a CLI functional test, and the validating method itself is
`private` — so the happy path cannot be exercised without mocking FAL wholesale.
The behaviour was verified by executing the two expressions above against the
installed core instead. The class has no pre-existing test coverage.

## Affected branches

| Branch | Affected | Handled |
|--------|----------|---------|
| `main` (3.0.0-dev) | yes | this PR |
| `2` (2.4.0-dev) | yes — identical logic | separate PR, same issue ref |
| `2.2` | yes — identical logic | not yet, pending decision |
| `1` | no — does not ship the converter | — |

## Verification

`composerUpdate`, `lintPhp`, `cgl -n`, `phpstan` and `unit` run green for **both**
supported core versions (`-t 13` and `-t 14`, PHP 8.2).

## Context

Found while running the deferred native `#[FileUpload]` spike (item 9 of the v13
clean-up round). The planned migration to the native Extbase file upload API
would delete this class entirely; this is the standalone fix so the bug is not
blocked behind that larger change.
