### PR TITLE
[DOCS] Document maintained backport targets

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -32,8 +32,18 @@ The extension directory name does not always equal the extension key: e.g.
 ## Version support
 
 - Branch `main` = version `3.0.0-dev`, supporting **TYPO3 v13 + v14**, PHP 8.2–8.5.
-- Branch `2` = `^2` (`2.4.x-dev), v12+v13. Branch `1` = `^1`, v11+v12 (legacy).
+- Branch `2` = `^2` (`2.4.x-dev`), v12+v13. Branch `1` = `^1`, v11+v12 (legacy).
 - The per-extension support/test status matrix is in `README.md` — consult it before assuming an extension works on a given core/PHP combination; many `2.x` combinations are explicitly "not tested yet".
+
+### Backport targets
+
+**The only maintained backport targets are `main` and `2`.**
+
+**Branch `2.2` is no longer maintained.** Never backport to it, and do not
+propose it as a target — not even when it demonstrably carries the same defect —
+unless it is explicitly requested for that specific change. Branch `1` is legacy
+and is treated the same way. Stating factually which branches contain a defect is
+fine; proposing work on `2.2` is not.
 
 ## Build / test / lint — `Build/Scripts/runTests.sh`
 


### PR DESCRIPTION
`AGENT.md` documented which branch supports which TYPO3 versions, but never said
which branches are still **maintained**. Nothing in the repo recorded that `2.2`
is dead, so it kept getting surfaced as a backport candidate for defects it
happens to share (most recently the ACE-249 branch-alias and the ACE-267 mime
allow-list fix) — wasted review attention on a branch nobody ships from.

## Change

New "Backport targets" subsection under "Version support":

* `main` and `2` are the only maintained backport targets.
* `2.2` is no longer maintained — never backport to it, and do not propose it as
  a target even when it demonstrably carries the same defect, unless explicitly
  requested for that specific change.
* `1` is legacy and treated the same way.
* Stating factually which branches contain a defect stays fine; *proposing work*
  on them does not.

Also closes an unterminated inline code span in the branch list
(`` `2.4.x-dev) `` → `` `2.4.x-dev`) ``).

## Note

`CLAUDE.md` is a **tracked symlink** to `AGENT.md` on this branch, so this one
edit covers both entry points and the symlink itself is untouched (the diff is
`AGENT.md` only).

Docs-only; no code, no build or runtime behaviour affected.
