### PR TITLE
[TASK] ACE-268: Use native Extbase file upload

### DIFF
--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -6,7 +6,6 @@ namespace FGTCLB\AcademicJobs\Controller;
 
 use FGTCLB\AcademicBase\Controller\GetSelectItemsForTcaManagedTableFieldMethodTrait;
 use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
-use FGTCLB\AcademicBase\Extbase\Property\TypeConverter\FileUploadConverter;
 use FGTCLB\AcademicJobs\Domain\Model\Job;
 use FGTCLB\AcademicJobs\Domain\Repository\JobRepository;
 use FGTCLB\AcademicJobs\Domain\Validator\JobValidator;
@@ -26,10 +25,13 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Mvc\Controller\FileUploadConfiguration;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Extbase\Validation\Validator\FileSizeValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\MimeTypeValidator;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 final class JobController extends ActionController
@@ -172,18 +174,50 @@ final class JobController extends ActionController
                     );
             }
 
-            GeneralUtility::makeInstance(FileUploadConverter::class)
-                ->setArgumentTypeConverterConfiguration(
-                    $this->arguments,
-                    'job',
-                    'image',
-                    [
-                        FileUploadConverter::CONFIGURATION_UPLOAD_FOLDER => $this->settings['jobAvatarImage']['uploadFolder'] ?? '1:user_upload/',
-                        FileUploadConverter::CONFIGURATION_VALIDATION_FILESIZE_MAXIMUM => $this->settings['jobAvatarImage']['validation']['fileSize']['maximum'] ?? PHP_INT_MAX . 'B',
-                        FileUploadConverter::CONFIGURATION_VALIDATION_MIME_TYPE_ALLOWED_MIME_TYPES => $this->settings['jobAvatarImage']['validation']['mimeType']['allowedMimeTypes'] ?? null,
-                    ],
-                );
+            $this->configureImageFileUpload();
         }
+    }
+
+    /**
+     * Registers the native Extbase file upload handling for the job avatar image.
+     *
+     * The upload folder and both validation limits stay TypoScript driven
+     * (`settings.jobAvatarImage.*`), which is why the configuration is built here
+     * instead of using the static `#[FileUpload]` attribute on the domain model.
+     */
+    private function configureImageFileUpload(): void
+    {
+        $jobArgument = $this->arguments->getArgument('job');
+
+        $fileUploadConfiguration = (new FileUploadConfiguration('image'))
+            ->setMaxFiles(1)
+            ->setUploadFolder(
+                (string)($this->settings['jobAvatarImage']['uploadFolder'] ?? '1:/user_upload/')
+            );
+
+        $fileSizeValidator = GeneralUtility::makeInstance(FileSizeValidator::class);
+        $fileSizeValidator->setOptions([
+            'maximum' => (string)($this->settings['jobAvatarImage']['validation']['fileSize']['maximum'] ?? PHP_INT_MAX . 'B'),
+        ]);
+        $fileUploadConfiguration->addValidator($fileSizeValidator);
+
+        // An empty list means "no mime type restriction". `MimeTypeValidator` throws
+        // for an empty `allowedMimeTypes` option, so it is only added when configured.
+        $allowedMimeTypes = GeneralUtility::trimExplode(
+            ',',
+            (string)($this->settings['jobAvatarImage']['validation']['mimeType']['allowedMimeTypes'] ?? ''),
+            true
+        );
+        if ($allowedMimeTypes !== []) {
+            $mimeTypeValidator = GeneralUtility::makeInstance(MimeTypeValidator::class);
+            $mimeTypeValidator->setOptions(['allowedMimeTypes' => $allowedMimeTypes]);
+            $fileUploadConfiguration->addValidator($mimeTypeValidator);
+        }
+
+        $jobArgument->getFileHandlingServiceConfiguration()
+            ->addFileUploadConfiguration($fileUploadConfiguration);
+        // The upload is handled by the file handling service, not by the property mapper.
+        $jobArgument->getPropertyMappingConfiguration()->skipProperties('image');
     }
 
     /**

--- a/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Important-MigratedJobImageUploadToNativeExtbaseFileUploadHandling.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Important-MigratedJobImageUploadToNativeExtbaseFileUploadHandling.rst
@@ -1,0 +1,67 @@
+..  _important-migrated-job-image-upload-to-native-extbase-file-upload-handling:
+
+===============================================================
+Important: Job image upload uses native Extbase upload handling
+===============================================================
+
+Description
+===========
+
+The job avatar image upload of the `academicjobs_newjobform` plugin was handled
+by the custom type converter
+`FGTCLB\\AcademicBase\\Extbase\\Property\\TypeConverter\\FileUploadConverter`
+(`EXT:academic_base`). It has been replaced with the native Extbase file upload
+handling introduced in TYPO3 v13.3 (`FileUploadConfiguration`, see TYPO3 feature
+:issue:`103511`).
+
+The TypoScript configuration is unchanged. `settings.jobAvatarImage.uploadFolder`,
+`settings.jobAvatarImage.validation.fileSize.maximum` and
+`settings.jobAvatarImage.validation.mimeType.allowedMimeTypes` keep their names
+and meaning and are now mapped onto the core `FileSizeValidator` and
+`MimeTypeValidator`. The form template, the `Job` domain model and the plugin
+itself are untouched, so no integration or template change is required.
+
+Impact
+======
+
+The upload behaves differently in three ways:
+
+*   **Stored file names change.** The custom converter stored the file under the
+    name supplied by the client and replaced an existing file of the same name.
+    The native handling appends a random suffix and renames on conflict instead,
+    so two visitors uploading `logo.png` no longer overwrite each other in the
+    shared upload folder.
+
+*   **The mime type is detected from the file content.** The custom converter
+    trusted the media type sent by the browser, which can be spoofed. The core
+    `MimeTypeValidator` inspects the uploaded file itself and additionally
+    cross-checks the file extension. An upload whose real content does not match
+    an allowed mime type is now rejected, even if the browser announced an
+    allowed one. Uploads that only passed because of a faked header stop working
+    — this is intended.
+
+*   **The file is only stored once the whole form validates.** Previously the
+    file was imported into FAL while mapping the request, so a job that failed
+    validation afterwards left an unreferenced file behind in the upload folder.
+    The file is now imported after successful validation, which avoids those
+    orphaned files but requires the visitor to select the file again when the
+    form is redisplayed with validation errors.
+
+An empty `allowedMimeTypes` setting continues to mean "no mime type
+restriction".
+
+Affected Installations
+======================
+
+Installations using the job creation form (`academicjobs_newjobform`) with image
+uploads. Installations that rely on the uploaded file keeping its original name
+— for example when referencing those files by a fixed path outside of FAL — need
+to review that assumption.
+
+Migration
+=========
+
+No configuration change is required. Files uploaded before this change keep
+their existing names and references.
+
+.. index:: Fluid, TypoScript, ext_localconf, NotScanned


### PR DESCRIPTION
Resolves **ACE-268** (subtask of ACE-249). First step of the native file upload
migration. `main` / `3.0.0-dev` only — not backported.

## What

`academicjobs_newjobform` no longer uses the hand-rolled `FileUploadConverter`
from `EXT:academic_base`. `JobController::initializeCreateAction()` now registers
a native `FileUploadConfiguration` for the `image` property and tells the
property mapper to skip it. The `DateTimeConverter` setup in that method is
untouched, and the converter itself stays for now — `EXT:academic_persons_edit`
still uses it, its removal is the last step.

## Why not the `#[FileUpload]` attribute

The upload folder and both validation limits come from TypoScript at runtime
(`settings.jobAvatarImage.*`), which a static attribute cannot read. It would
also have to sit on `Job::$image`, a persistence model, putting an upload folder
into the domain layer. The manual configuration API in `initialize*Action` is the
documented alternative; the setting names and their meaning are unchanged and are
mapped onto the core `FileSizeValidator` and `MimeTypeValidator`.

`MimeTypeValidator` throws on an empty `allowedMimeTypes`, so it is only
registered when configured — keeping "empty means no restriction" as fixed in
ACE-267.

## Behaviour changes (Important changelog entry included)

* **File names change.** Native defaults add a random suffix and rename on
  conflict, instead of keeping the client name and replacing. Two visitors
  uploading `logo.png` no longer overwrite each other. Deliberate improvement
  over strict behaviour parity.
* **Mime type is detected from file content** rather than the spoofable client
  header, with a file extension cross-check.
* **Import happens after validation.** No more orphaned files from a failed
  `JobValidator` run, but the visitor must re-pick the file on redisplay.

## Verification

`cgl`, `lintPhp`, `phpstan`, `unit` and `functional` are green for **both** v13
and v14 (PHP 8.2).

## Why no upload test in this PR

A happy-path functional test is possible on **v14 only**:
`ResourceStorage::assureFileUploadPermissions()` calls `is_uploaded_file()`
unconditionally on v13, while v14 runs that check only for the legacy string path
argument and skips it for an `UploadedFile`. TYPO3 core added its own
`FileUploadControllerTest` on the v14 branch for exactly that reason.

Such a test is written (core's technique, `#[Group('not-core-13')]`) but blocked
by an unrelated pre-existing defect: dispatching `createAction` triggers two v15
deprecations from this controller's `#[Validate]` attribute, which fail the run
under `failOnDeprecation`. The documented fix — moving the attribute to the
method parameter — is a fatal error on v13, whose `Annotation\Validate` has no
`TARGET_PARAMETER`. Tracked separately; the test lands once that is resolved.
