### PR TITLE
[TASK] ACE-269: Register job validator in code

### DIFF
--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -22,7 +22,6 @@ use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Controller\FileUploadConfiguration;
@@ -30,6 +29,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\FileSizeValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\MimeTypeValidator;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -175,6 +175,7 @@ final class JobController extends ActionController
             }
 
             $this->configureImageFileUpload();
+            $this->addJobValidator();
         }
     }
 
@@ -221,13 +222,49 @@ final class JobController extends ActionController
     }
 
     /**
+     * Adds the `JobValidator` to the validators Extbase already built for the
+     * `job` argument.
+     *
+     * This is done programmatically instead of with a `#[Validate]` attribute,
+     * because both attribute forms usable on TYPO3 v13 are deprecated on v14 and
+     * will be removed in v15: passing an array of configuration values, and
+     * naming the validated parameter. The documented replacement — placing the
+     * attribute on the method parameter — requires `Attribute::TARGET_PARAMETER`,
+     * which TYPO3 v13 does not declare, so it cannot be used while v13 is
+     * supported. The API used here emits no deprecation on either version.
+     *
+     * `initializeActionMethodValidators()` runs before this method and already
+     * put a `ConjunctionValidator` holding the base validation on the argument,
+     * so it is extended rather than replaced — replacing it would silently drop
+     * the model level validation.
+     */
+    private function addJobValidator(): void
+    {
+        $jobArgument = $this->arguments->getArgument('job');
+        $jobValidator = $this->validatorResolver->createValidator(JobValidator::class);
+        if ($jobValidator === null) {
+            return;
+        }
+
+        $validator = $jobArgument->getValidator();
+        if ($validator instanceof ConjunctionValidator) {
+            $validator->addValidator($jobValidator);
+            return;
+        }
+
+        /** @var ConjunctionValidator $conjunctionValidator */
+        $conjunctionValidator = $this->validatorResolver->createValidator(ConjunctionValidator::class);
+        if ($validator !== null) {
+            $conjunctionValidator->addValidator($validator);
+        }
+        $conjunctionValidator->addValidator($jobValidator);
+        $jobArgument->setValidator($conjunctionValidator);
+    }
+
+    /**
      * @todo It's not a really good practice to use persisting extbase models directly, this should be a DTO object,
      *       see `EXT:academic_persons_edit` for examples.
      */
-    #[Validate([
-        'param' => 'job',
-        'validator' => JobValidator::class,
-    ])]
     public function createAction(?Job $job = null): ResponseInterface
     {
         if ($job === null) {


### PR DESCRIPTION
Resolves **ACE-269** (subtask of ACE-249). `main` / `3.0.0-dev` only.

## Problem

Dispatching `JobController::createAction()` triggers two TYPO3 v15 deprecations on
v14, raised by the `#[Validate]` attribute it carried:

* passing an array of configuration values to Extbase attributes
* naming the validated parameter in the attribute

`Build/phpunit/FunctionalTests.xml` sets `failOnDeprecation="true"`, so any
functional test reaching that action fails. It went unnoticed because no test
dispatched it — the upload test written for ACE-268 was the first, and this is
what it hit.

## Why the documented fix is unusable here

| Version | `Validate` attribute targets |
|---|---|
| v13.4 (`Annotation\Validate`) | `TARGET_PROPERTY \| TARGET_METHOD \| IS_REPEATABLE` |
| v14 (`Attribute\Validate`) | additionally `TARGET_PARAMETER` |

Moving the attribute to the method parameter would fatal on v13. Switching the
array to explicit constructor parameters would silence only one of the two.

## Solution

Register the validator programmatically in `initializeCreateAction()` and drop the
attribute — no attribute, no deprecation. Verified deprecation-free on both
versions:

* `Argument::getValidator()` / `setValidator()` — v13.4 `:228/239`, v14 `:134/140`
* `ActionController::$validatorResolver` — v13.4 `:126`, v14 `:121`
* `AbstractCompositeValidator::addValidator()` — both
* no `trigger_error` in `Argument`, `ValidatorResolver` or `ConjunctionValidator`
  in either version

Call order holds in both: `initializeActionMethodValidators()` →
`initialize<Action>Action()` → `mapRequestArgumentsToControllerArguments()`
(v13.4 `371/375-377/381`, v14 `365/370-374/376`).

Two details that matter:

* Extbase **already** set a `ConjunctionValidator` carrying the base validation on
  the argument. It is **extended, not replaced** — replacing it would silently drop
  model level validation.
* `JobValidator` is created via `validatorResolver->createValidator()`, exactly as
  the attribute path did, because it depends on `injectSettingsRegistry()`.

## Verification

All gates green for **both** v13 and v14: `cgl`, `lintPhp`, `phpstan`, `unit`,
`functional`. Confirmed against the (still unlanded) upload test: the run that
previously reported *"1 test triggered 2 deprecations"* now reports none.

No behaviour change — same validator, same argument, only the registration moved.
No changelog entry for that reason.

## Not included

* The upload test still cannot land: it is now blocked by **ACE-270**, a TYPO3 v14
  regression where `fluid_styled_content`'s header partial requires a `record`
  object that Extbase plugin views do not provide. Six templates across five
  extensions are affected.
* The other **11** usages of the deprecated array form live in
  `EXT:academic_persons_edit` and are untouched — latent (no test dispatches those
  actions) and worth their own change.
