### PR TITLE
[BUGFIX] ACE-270: Assign record to plugin views

### DIFF
--- a/packages/fgtclb/academic-base/Classes/Controller/GetCurrentContentRecordMethodTrait.php
+++ b/packages/fgtclb/academic-base/Classes/Controller/GetCurrentContentRecordMethodTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Controller;
+
+use TYPO3\CMS\Core\Domain\RecordFactory;
+use TYPO3\CMS\Core\Domain\RecordInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Provides method {@see self::getCurrentContentRecord()} to be used in extbase action controllers to assign
+ * the `record` view variable next to the already assigned `data` array.
+ *
+ * TYPO3 v14 rewrote the `EXT:fluid_styled_content` header partial: `Header/All.fluid.html` renders the header
+ * and subheader with `{record -> f:render.text(...)}` instead of reading `{data.header}`, and that ViewHelper
+ * requires a record object. Content elements based on `lib.contentElement` get it from the
+ * `record-transformation` data processor, but an extbase plugin view assigns only `data`, so templates
+ * rendering that partial fail with an exception on TYPO3 v14 unless the record is provided.
+ *
+ * TYPO3 v13 ignores the variable, its header partial reads `data`, so assigning it is version agnostic.
+ *
+ * @api considered API and to be used in projects or extension extending academic extensions.
+ */
+trait GetCurrentContentRecordMethodTrait
+{
+    /**
+     * Builds the record of the current content element to be assigned as `record` view variable.
+     *
+     * Pass the content object renderer the controller already uses to determine the `data` array, for
+     * example `$this->getCurrentContentRecord($this->getCurrentContentObjectRenderer())`.
+     *
+     * `RecordFactory` is identical in TYPO3 v13 and v14, therefore no core version aware handling is needed.
+     */
+    protected function getCurrentContentRecord(?ContentObjectRenderer $contentObjectRenderer): ?RecordInterface
+    {
+        $row = $contentObjectRenderer?->data;
+        if (!is_array($row) || $row === []) {
+            return null;
+        }
+
+        return GeneralUtility::makeInstance(RecordFactory::class)
+            ->createResolvedRecordFromDatabaseRow('tt_content', $row);
+    }
+}

--- a/packages/fgtclb/academic-base/Documentation/Changelog/3.0/Feature-GetCurrentContentRecordMethodTrait.rst
+++ b/packages/fgtclb/academic-base/Documentation/Changelog/3.0/Feature-GetCurrentContentRecordMethodTrait.rst
@@ -1,0 +1,41 @@
+..  _feature-get-current-content-record-method-trait:
+
+=========================================================
+Feature: `GetCurrentContentRecordMethodTrait` for plugins
+=========================================================
+
+Description
+===========
+
+The new trait
+`FGTCLB\\AcademicBase\\Controller\\GetCurrentContentRecordMethodTrait` provides
+`getCurrentContentRecord()` for Extbase action controllers. It builds the record
+of the current content element from the `tt_content` row of the content object
+renderer, so it can be assigned as `record` view variable next to the usual
+`data` array:
+
+..  code-block:: php
+
+    $this->view->assignMultiple([
+        'data' => $this->getCurrentContentObjectRenderer()?->data,
+        'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
+    ]);
+
+TYPO3 v14 renders the header of the shared `EXT:fluid_styled_content` header
+partial with `{record -> f:render.text(...)}`, which requires a record object.
+Content elements based on `lib.contentElement` get it from the
+`record-transformation` data processor, Extbase plugin views do not. Without the
+variable, plugin templates that render that partial abort on TYPO3 v14.
+
+`TYPO3\\CMS\\Core\\Domain\\RecordFactory` behaves identically in TYPO3 v13 and
+v14, therefore the trait needs no core version aware handling. TYPO3 v13 ignores
+the variable, because its header partial reads `data`.
+
+Impact
+======
+
+Extensions building on `EXT:academic_base` can use the trait to make their
+plugins render on TYPO3 v14 and to give their templates access to a record
+object.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
+++ b/packages/fgtclb/academic-bite-jobs/Classes/Controller/BiteJobsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicBiteJobs\Controller;
 
+use FGTCLB\AcademicBase\Controller\GetCurrentContentRecordMethodTrait;
 use FGTCLB\AcademicBiteJobs\Services\BiteJobsService;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -11,6 +12,8 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class BiteJobsController extends ActionController
 {
+    use GetCurrentContentRecordMethodTrait;
+
     public function __construct(
         protected readonly BiteJobsService $biteJobsService
     ) {}
@@ -21,6 +24,7 @@ class BiteJobsController extends ActionController
 
         $this->view->assignMultiple([
             'data' => $contentElementData,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'jobs' => $this->biteJobsService->fetchBiteJobs($this->request),
         ]);
 

--- a/packages/fgtclb/academic-bite-jobs/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
+++ b/packages/fgtclb/academic-bite-jobs/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
@@ -1,0 +1,49 @@
+..  _important-bite-jobs-plugins-assign-record-view-variable:
+
+==================================================
+Important: Plugins assign a `record` view variable
+==================================================
+
+Description
+===========
+
+TYPO3 v14 rewrote the header partial of `EXT:fluid_styled_content`. Where v13
+`Header/All.html` reads `{data.header}`, the v14 `Header/All.fluid.html` renders
+header and subheader with `{record -> f:render.text(...)}`, and that ViewHelper
+requires a record object.
+
+Content elements based on `lib.contentElement` receive that record from the
+`record-transformation` data processor, but an Extbase plugin view assigns only
+the `data` array. Templates of this extension render the shared header partial,
+so on TYPO3 v14 they aborted with
+
+..  code-block:: text
+
+    The record argument must be an instance of ... Given: null
+
+The plugin controllers now assign an additional `record` view variable, built
+from the `tt_content` row of the current content element. TYPO3 v13 ignores it,
+its header partial keeps reading `data`, so one implementation serves both core
+versions.
+
+Impact
+======
+
+The affected plugins render again on TYPO3 v14. Nothing was removed or renamed,
+so no configuration or template override needs to be adapted.
+
+Custom templates and template overrides may use the new `{record}` variable, for
+example with `<f:render.text record="{record}" field="header" />`.
+
+Affected Installations
+======================
+
+Installations running the plugins of this extension on TYPO3 v14. TYPO3 v13
+installations are unaffected.
+
+Migration
+=========
+
+None required.
+
+.. index:: Fluid, Frontend, NotScanned

--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicJobs\Controller;
 
+use FGTCLB\AcademicBase\Controller\GetCurrentContentRecordMethodTrait;
 use FGTCLB\AcademicBase\Controller\GetSelectItemsForTcaManagedTableFieldMethodTrait;
 use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
 use FGTCLB\AcademicJobs\Domain\Model\Job;
@@ -36,6 +37,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 final class JobController extends ActionController
 {
+    use GetCurrentContentRecordMethodTrait;
     use GetSelectItemsForTcaManagedTableFieldMethodTrait;
 
     public function __construct(
@@ -62,6 +64,7 @@ final class JobController extends ActionController
         $this->view->assignMultiple([
             'jobs' => $jobs,
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
         ]);
 
         return $this->htmlResponse();
@@ -106,6 +109,7 @@ final class JobController extends ActionController
         $this->view->assignMultiple([
             'job' => $job,
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
         ]);
 
         return $this->htmlResponse();
@@ -135,6 +139,7 @@ final class JobController extends ActionController
                 [''],
             ),
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
         ]);
 
         // As an object is passed to this event and objects are passed by reference in PHP,

--- a/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
@@ -1,0 +1,49 @@
+..  _important-jobs-plugins-assign-record-view-variable:
+
+==================================================
+Important: Plugins assign a `record` view variable
+==================================================
+
+Description
+===========
+
+TYPO3 v14 rewrote the header partial of `EXT:fluid_styled_content`. Where v13
+`Header/All.html` reads `{data.header}`, the v14 `Header/All.fluid.html` renders
+header and subheader with `{record -> f:render.text(...)}`, and that ViewHelper
+requires a record object.
+
+Content elements based on `lib.contentElement` receive that record from the
+`record-transformation` data processor, but an Extbase plugin view assigns only
+the `data` array. Templates of this extension render the shared header partial,
+so on TYPO3 v14 they aborted with
+
+..  code-block:: text
+
+    The record argument must be an instance of ... Given: null
+
+The plugin controllers now assign an additional `record` view variable, built
+from the `tt_content` row of the current content element. TYPO3 v13 ignores it,
+its header partial keeps reading `data`, so one implementation serves both core
+versions.
+
+Impact
+======
+
+The affected plugins render again on TYPO3 v14. Nothing was removed or renamed,
+so no configuration or template override needs to be adapted.
+
+Custom templates and template overrides may use the new `{record}` variable, for
+example with `<f:render.text record="{record}" field="header" />`.
+
+Affected Installations
+======================
+
+Installations running the plugins of this extension on TYPO3 v14. TYPO3 v13
+installations are unaffected.
+
+Migration
+=========
+
+None required.
+
+.. index:: Fluid, Frontend, NotScanned

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormPluginTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormPluginTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Renders the `academicjobs_newjobform` plugin in the frontend.
+ *
+ * This guards the `record` view variable: TYPO3 v14 renders the header of the
+ * `EXT:fluid_styled_content` `Header/All` partial with `{record -> f:render.text(...)}`,
+ * which raises an exception when no record object is available. Extbase plugin views
+ * assign only `data`, so without the record the whole plugin fails to render on v14,
+ * while it still renders on v13 whose partial reads `data`.
+ */
+final class AcademicJobsNewJobFormPluginTest extends AbstractAcademicJobsTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'MAIL' => [
+            'transport' => 'null',
+        ],
+        'FE' => [
+            'debug' => false,
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpFrontendRootPageForTestCase(): void
+    {
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_jobs/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_jobs/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+    }
+
+    private function setUpTestCase(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicJobsNewJobFormPlugin/newJobFormPage.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: 'https://www.acme.com/',
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+            ],
+        );
+    }
+
+    private function renderHomePage(): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('https://www.acme.com/home'),
+            new InternalRequestContext(),
+        );
+        $this->assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    #[Test]
+    public function newJobFormPluginIsRendered(): void
+    {
+        $this->setUpTestCase();
+
+        $content = $this->renderHomePage();
+
+        $this->assertMatchesRegularExpression('@<form [^>]*enctype="multipart/form-data"@', $content);
+        $this->assertStringContainsString('tx_academicjobs_newjobform[job][title]', $content);
+    }
+
+    #[Test]
+    public function newJobFormPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase();
+        // Rendering a header is what requires the `record` view variable on TYPO3 v14.
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => 'Post a new job'], ['uid' => 1]);
+
+        $this->assertStringContainsString('Post a new job', $this->renderHomePage());
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsNewJobFormPlugin/newJobFormPage.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsNewJobFormPlugin/newJobFormPage.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header"
+,1,2,0,0,0,0,"academicjobs_newjobform",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript
@@ -1,0 +1,21 @@
+plugin.tx_academicjobs {
+    persistence {
+        storagePid = 100
+    }
+    email {
+        from = sender@example.com
+        recipientEmail = recipient@example.com
+        subject = New job application
+    }
+    jobAvatarImage {
+        uploadFolder = 1:/job-logos/
+        validation {
+            fileSize {
+                maximum = 2M
+            }
+            mimeType {
+                allowedMimeTypes = image/jpeg,image/png
+            }
+        }
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Controller;
 
+use FGTCLB\AcademicBase\Controller\GetCurrentContentRecordMethodTrait;
 use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
 use FGTCLB\AcademicPersonsEdit\Attributes\ListSortingMode;
 use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData;
@@ -42,6 +43,7 @@ use TYPO3\CMS\Frontend\Controller\ErrorController;
  */
 abstract class AbstractActionController extends ActionController
 {
+    use GetCurrentContentRecordMethodTrait;
     public const FLASH_MESSAGE_QUEUE_IDENTIFIER = 'academic_profile';
 
     protected const DATETIME_ARGUMENTS = [

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -54,6 +54,7 @@ final class ContractController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
         ]);
         return $this->htmlResponse();
@@ -73,6 +74,7 @@ final class ContractController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             // Load including hidden records so the owner can always see and toggle the visibility
@@ -93,6 +95,7 @@ final class ContractController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'contractFormData' => new ContractFormData(),
             'functionTypes' => $this->functionTypeRepository->findAll(),
@@ -143,6 +146,7 @@ final class ContractController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'contractFormData' => ContractFormData::createFromContract($contract),
@@ -211,6 +215,7 @@ final class ContractController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'contract' => $contract,
         ]);
         return $this->htmlResponse();

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -43,6 +43,7 @@ final class EmailAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'emailAddresses' => $contract->getEmailAddresses(),
@@ -56,6 +57,7 @@ final class EmailAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $emailAddress->getContract()?->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,
@@ -71,6 +73,7 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $contract,
@@ -120,6 +123,7 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $emailAddress->getContract()?->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $emailAddress->getContract(),
@@ -189,6 +193,7 @@ final class EmailAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $emailAddress->getContract()?->getProfile(),
             'contract' => $emailAddress->getContract(),
             'emailAddress' => $emailAddress,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -43,6 +43,7 @@ final class PhoneNumberController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'phoneNumbers' => $contract->getPhoneNumbers(),
@@ -56,6 +57,7 @@ final class PhoneNumberController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $phoneNumber->getContract()?->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,
@@ -71,6 +73,7 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $contract,
@@ -120,6 +123,7 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $phoneNumber->getContract()?->getProfile(),
             'availableTypes' => $this->getAvailableTypes(),
             'contract' => $phoneNumber->getContract(),
@@ -189,6 +193,7 @@ final class PhoneNumberController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $phoneNumber->getContract()?->getProfile(),
             'contract' => $phoneNumber->getContract(),
             'phoneNumber' => $phoneNumber,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -43,6 +43,7 @@ final class PhysicalAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'physicalAddresses' => $contract->getPhysicalAddresses(),
@@ -56,6 +57,7 @@ final class PhysicalAddressController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
@@ -71,6 +73,7 @@ final class PhysicalAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $contract->getProfile(),
             'contract' => $contract,
             'addressFormData' => new AddressFormData(),
@@ -120,6 +123,7 @@ final class PhysicalAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,
@@ -189,6 +193,7 @@ final class PhysicalAddressController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $physicalAddress->getContract()?->getProfile(),
             'contract' => $physicalAddress->getContract(),
             'physicalAddress' => $physicalAddress,

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -49,6 +49,7 @@ final class ProfileController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profiles' => $profiles,
         ]);
 
@@ -64,6 +65,7 @@ final class ProfileController extends AbstractActionController
         $this->userSessionService->saveRefererToSession($this->request);
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'profileFormData' => $this->profileFormDataFactory->createFromProfile($pluginControllerActionContext, $profile),
             'cancelUrl' => $cancelUrl,
@@ -80,6 +82,7 @@ final class ProfileController extends AbstractActionController
         $pluginControllerActionContext = new PluginControllerActionContext($this->request, $this->settings);
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'profileFormData' => $this->profileFormDataFactory->createFromProfile($pluginControllerActionContext, $profile),
             'genderOptions' => $this->getAvailableGenderSelectItems(),
@@ -134,6 +137,7 @@ final class ProfileController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),
         ]);

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -46,6 +46,7 @@ final class ProfileInformationController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'type' => $type,
             'profileInformations' => $profile->_getProperty($type),
@@ -59,6 +60,7 @@ final class ProfileInformationController extends AbstractActionController
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profileInformation->getProfile(),
             'type' => $profileInformation->getType(),
             'profileInformation' => $profileInformation,
@@ -76,6 +78,7 @@ final class ProfileInformationController extends AbstractActionController
         $profileInformationFormData = $this->profileInformationFormDataClassName::createEmptyForType($mappedType);
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profile,
             'type' => $type,
             'profileInformationFormData' => $profileInformationFormData,
@@ -131,6 +134,7 @@ final class ProfileInformationController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profileInformation->getProfile(),
             'profileInformation' => $profileInformation,
             'profileInformationFormData' => $this->profileInformationFormDataClassName::createFromProfileInformation($profileInformation),
@@ -205,6 +209,7 @@ final class ProfileInformationController extends AbstractActionController
     {
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
             'profile' => $profileInformation->getProfile(),
             'profileInformation' => $profileInformation,
             'cancelUrl' => $this->userSessionService->loadRefererFromSession($this->request),

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Important-PluginsAssignRecordViewVariable.rst
@@ -1,0 +1,49 @@
+..  _important-persons-edit-plugins-assign-record-view-variable:
+
+==================================================
+Important: Plugins assign a `record` view variable
+==================================================
+
+Description
+===========
+
+TYPO3 v14 rewrote the header partial of `EXT:fluid_styled_content`. Where v13
+`Header/All.html` reads `{data.header}`, the v14 `Header/All.fluid.html` renders
+header and subheader with `{record -> f:render.text(...)}`, and that ViewHelper
+requires a record object.
+
+Content elements based on `lib.contentElement` receive that record from the
+`record-transformation` data processor, but an Extbase plugin view assigns only
+the `data` array. Templates of this extension render the shared header partial,
+so on TYPO3 v14 they aborted with
+
+..  code-block:: text
+
+    The record argument must be an instance of ... Given: null
+
+The plugin controllers now assign an additional `record` view variable, built
+from the `tt_content` row of the current content element. TYPO3 v13 ignores it,
+its header partial keeps reading `data`, so one implementation serves both core
+versions.
+
+Impact
+======
+
+The affected plugins render again on TYPO3 v14. Nothing was removed or renamed,
+so no configuration or template override needs to be adapted.
+
+Custom templates and template overrides may use the new `{record}` variable, for
+example with `<f:render.text record="{record}" field="header" />`.
+
+Affected Installations
+======================
+
+Installations running the plugins of this extension on TYPO3 v14. TYPO3 v13
+installations are unaffected.
+
+Migration
+=========
+
+None required.
+
+.. index:: Fluid, Frontend, NotScanned


### PR DESCRIPTION
Resolves **ACE-270** (subtask of ACE-249). `main` / `3.0.0-dev` only.

## The bug

Extbase plugins of `academic_jobs`, `academic_bite_jobs` and
`academic_persons_edit` **abort rendering on TYPO3 v14**:

```
The record argument must be an instance of TYPO3\CMS\Frontend\Page\PageInformation
or TYPO3\CMS\Core\Domain\RecordInterface or TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface.
Given: null
```

| Version | `fluid_styled_content` header partial |
|---|---|
| v13.4 (`Header/All.html`) | `{data.header}` — works with the `data` array |
| v14 (`Header/All.fluid.html`) | `{record -> f:render.text(field: 'header')}` — needs a record object |

`lib.contentElement` supplies that record via the `record-transformation` data
processor. An Extbase plugin view assigns only `data`, so the five templates
rendering the shared partial crash.

## The fix

New `GetCurrentContentRecordMethodTrait` in `EXT:academic_base` builds the record
of the current content element from the `tt_content` row via `RecordFactory`, and
the affected controllers assign it as `record` next to each existing `data`
assignment (32 sites, 9 controllers, 3 extensions).

`RecordFactory` is **identical in v13.4 and v14**, so this is one implementation
with no core-version-aware code. v13 ignores the variable (its partial reads
`data`), so there is no behaviour change there. Nothing is removed or renamed —
not breaking; template overrides and TypoScript are untouched, and overrides may
now use `{record}`.

### Why per-action assignment rather than a central hook

* `initializeView()` no longer exists in v13.4/v14 `ActionController`.
* `resolveView()` cannot be overridden for both: v13.4 returns
  `FluidStandaloneViewInterface|ViewInterface`, v14 returns `ViewInterface` —
  widening a return type is not allowed.

## Scope correction

`EXT:academic_study_plan` renders the same partial but is **not affected**: its
content element derives from `lib.contentElement` and only *adds* a data
processor, so the inherited `record-transformation` stays in place. Five
templates in three extensions, not six in five.

## Tests

Two functional tests render the `academicjobs_newjobform` plugin — one asserts
the **content element header** renders, which is precisely what needs the record
on v14. They run on **both** v13 and v14.

That no functional test rendered these plugins is exactly why this regression
shipped unnoticed with the v14 support round; this closes that gap for the jobs
form. Equivalent rendering tests for the bite-jobs and persons-edit plugins are
worth adding separately.

## Verification

All gates green for **both** v13 and v14: `cgl`, `lintPhp`, `phpstan`, `unit`,
`functional`. `checkRstRenderingAll` green for the four changelog entries.

## Changelog

`Important` entry per plugin extension (v14 fix + the new `{record}` variable for
template overrides) and a `Feature` entry in `EXT:academic_base` for the trait.
