### PR TITLE
[TASK] ACE-271: Add bite jobs plugin rendering test

### DIFF
--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/Classes/Http/StubHttpHandler.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/Classes/Http/StubHttpHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TESTS\TestBitejobsStub\Http;
+
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Guzzle handler answering every request with a canned b-ite API response, so functional
+ * tests rendering the `academicbitejobs_list` plugin perform no outgoing HTTP request.
+ *
+ * Stubbing happens at handler level on purpose. Neither `RequestFactory` nor
+ * `GuzzleClientFactory` can be subclassed for both supported core versions: TYPO3 v13
+ * declares them as normal classes while v14 declares them `readonly`, and a readonly class
+ * can neither extend nor be extended by a non-readonly one. `BiteJobsService` itself is
+ * `final` and type hinted in the controller, so it cannot be replaced either.
+ *
+ * The handler is registered in `ext_localconf.php` through
+ * `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler']`, which TYPO3 v13 and v14 evaluate
+ * identically.
+ */
+final class StubHttpHandler
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        return Create::promiseFor(
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                (string)json_encode([
+                    'jobPostings' => [
+                        [
+                            'id' => 4711,
+                            'title' => 'Stubbed job posting',
+                        ],
+                    ],
+                ]),
+            )
+        );
+    }
+}

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/composer.json
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "tests/test-bitejobs-stub",
+    "description": "Extension stubbing outgoing HTTP requests for tests",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan B\u00fcrk",
+            "email": "stefan@buerk.tech",
+            "role": "Maintainer"
+        }
+    ],
+    "require": {
+        "typo3/cms-core": "~13.4.0@dev || ~14.3.0@dev",
+        "fgtclb/academic-bite-jobs": "~3.0.0@dev"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_bitejobs_stub",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "TESTS\\TestBitejobsStub\\": "Classes/"
+        }
+    }
+}

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/ext_emconf.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/ext_emconf.php
@@ -1,0 +1,18 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'TESTS: Academic Bite Jobs HTTP stub',
+    'description' => 'Extension stubbing outgoing HTTP requests for tests',
+    'version' => '3.0.0',
+    'category' => 'misc',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-14.3.99',
+            'academic_bite_jobs' => '3.0.0',
+        ],
+    ],
+];

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/ext_localconf.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Fixtures/Extensions/test_bitejobs_stub/ext_localconf.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+// Answer every outgoing HTTP request with a canned response, so functional tests never
+// reach the b-ite API. Evaluated identically by TYPO3 v13 and v14.
+$GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'] = \GuzzleHttp\HandlerStack::create(
+    new \TESTS\TestBitejobsStub\Http\StubHttpHandler()
+);

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/AcademicBiteJobsListPluginTest.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/AcademicBiteJobsListPluginTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBiteJobs\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicBiteJobs\Tests\Functional\AbstractAcademicBiteJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Renders the `academicbitejobs_list` plugin in the frontend.
+ *
+ * This guards the `record` view variable: TYPO3 v14 renders the header of the
+ * `EXT:fluid_styled_content` `Header/All` partial with `{record -> f:render.text(...)}`,
+ * which raises an exception when no record object is available. Extbase plugin views
+ * assign only `data`, so without the record the plugin fails to render on v14, while it
+ * still renders on v13 whose partial reads `data`.
+ *
+ * The `test_bitejobs_stub` fixture extension replaces the core request factory, so no
+ * outgoing HTTP request to the b-ite API is performed.
+ */
+final class AcademicBiteJobsListPluginTest extends AbstractAcademicBiteJobsTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'debug' => false,
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            'typo3/cms-fluid-styled-content',
+        ]);
+        $this->testExtensionsToLoad = array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            'tests/test-bitejobs-stub',
+        ]);
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicBiteJobsListPlugin/biteJobsListPage.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_bite_jobs/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_bite_jobs/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_bite_jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: 'https://www.acme.com/',
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+            ],
+        );
+    }
+
+    private function renderHomePage(): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('https://www.acme.com/home'),
+            new InternalRequestContext(),
+        );
+        $this->assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    #[Test]
+    public function biteJobsListPluginIsRendered(): void
+    {
+        $this->setUpTestCase();
+
+        $this->assertStringContainsString('academic-bite-jobs-list', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function biteJobsListPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase();
+        // Rendering a header is what requires the `record` view variable on TYPO3 v14.
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => 'Open positions'], ['uid' => 1]);
+
+        $this->assertStringContainsString('Open positions', $this->renderHomePage());
+    }
+}

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/Fixtures/AcademicBiteJobsListPlugin/biteJobsListPage.csv
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/Fixtures/AcademicBiteJobsListPlugin/biteJobsListPage.csv
@@ -1,0 +1,7 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicbitejobs_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.jobs.jobListingKey""><value index=""vDEF"">test-key</value></field><field index=""settings.jobs.sortBy""><value index=""vDEF"">title</value></field><field index=""settings.jobs.sortingDirection""><value index=""vDEF"">asc</value></field><field index=""settings.jobs.view""><value index=""vDEF"">List</value></field><field index=""settings.jobs.limit""><value index=""vDEF"">10</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}


### PR DESCRIPTION
Resolves **ACE-271** (subtask of ACE-249). `main` / `3.0.0-dev` only.

## Why

ACE-270 fixed the TYPO3 v14 crash of the Extbase plugins (rewritten
`fluid_styled_content` header partial requiring a `record` object) but shipped a
rendering test only for the jobs form. `academicbitejobs_list` was fixed **without
coverage**, so the same regression could return unnoticed — which is exactly how
it shipped in the first place.

## What

A functional test rendering the `academicbitejobs_list` plugin, one case
asserting the **content element header** renders — the part that requires the
record on v14. Runs on **v13 and v14**.

## The stub, and why it sits at Guzzle handler level

`BiteJobsService::fetchBiteJobs()` POSTs to `https://jobs.b-ite.com/...`, which a
test must not do. Nothing above the handler can be replaced for both core
versions:

* `BiteJobsService` is `final` and type hinted in the controller → DI cannot
  substitute it.
* `RequestFactory` and `GuzzleClientFactory` are plain classes on **v13.4** but
  **`readonly`** on **v14**. A readonly class can neither extend nor be extended
  by a non-readonly one, so no subclass serves both.

So the new `test_bitejobs_stub` fixture extension registers a Guzzle handler via
`$GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler']` in its `ext_localconf.php`,
answering every request with a canned `{"jobPostings": [...]}`. That config is
evaluated by identical code in v13.4 and v14, so no version-aware handling is
needed, and the real `BiteJobsService` including its response decoding stays in
the tested path.

## Verification

All gates green for **both** v13 and v14: `cgl`, `lintPhp`, `phpstan`, `unit`,
`functional`. No network access from the suite.

Worth noting the first gate run was green on v14 and **fatal on v13** — that is
what surfaced the readonly split above.

## Not included

The `academicpersonsedit_profileediting` rendering test is written and its harness
works (frontend user login via `withFrontendUserId()`, profile linked through the
`tx_academicpersons_feuser_mm` fixture), but rendering that plugin dispatches
actions still using the deprecated array form of `#[Validate]`, which fails under
`failOnDeprecation`. Tracked in **ACE-272** together with that test.
