### PR TITLE
[TASK] ACE-272: Register form validators in code

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/AbstractActionController.php
@@ -32,6 +32,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\ErrorController;
 
@@ -111,6 +113,46 @@ abstract class AbstractActionController extends ActionController
 
         $response = $this->htmlResponse($this->getFlattenedValidationErrorMessage());
         return $response->withStatus(400);
+    }
+
+    /**
+     * Adds a validator to the validators Extbase already built for an action argument.
+     *
+     * Used from `initialize<Action>Action()` methods instead of a `#[Validate]` attribute,
+     * because both attribute forms usable on TYPO3 v13 are deprecated on v14 and will be
+     * removed in v15: passing an array of configuration values, and naming the validated
+     * parameter. The documented replacement, placing the attribute on the method parameter,
+     * requires `Attribute::TARGET_PARAMETER`, which TYPO3 v13 does not declare. The API used
+     * here emits no deprecation on either version.
+     *
+     * `initializeActionMethodValidators()` runs before the action specific initialize method
+     * and already put a `ConjunctionValidator` holding the base validation on the argument,
+     * so it is extended rather than replaced — replacing it would silently drop the model
+     * level validation.
+     *
+     * @param class-string<ValidatorInterface> $validatorClassName
+     */
+    protected function addArgumentValidator(string $argumentName, string $validatorClassName): void
+    {
+        $argument = $this->arguments->getArgument($argumentName);
+        $additionalValidator = $this->validatorResolver->createValidator($validatorClassName);
+        if ($additionalValidator === null) {
+            return;
+        }
+
+        $validator = $argument->getValidator();
+        if ($validator instanceof ConjunctionValidator) {
+            $validator->addValidator($additionalValidator);
+            return;
+        }
+
+        /** @var ConjunctionValidator $conjunctionValidator */
+        $conjunctionValidator = $this->validatorResolver->createValidator(ConjunctionValidator::class);
+        if ($validator !== null) {
+            $conjunctionValidator->addValidator($validator);
+        }
+        $conjunctionValidator->addValidator($additionalValidator);
+        $argument->setValidator($conjunctionValidator);
     }
 
     public function initializeAction(): void

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ContractController.php
@@ -26,7 +26,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
 use FGTCLB\AcademicPersonsEdit\Domain\Validator\ContractFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -107,10 +106,16 @@ final class ContractController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'contractFormData',
-        'validator' => ContractFormDataValidator::class,
-    ])]
+    public function initializeCreateAction(): void
+    {
+        $this->addArgumentValidator('contractFormData', ContractFormDataValidator::class);
+    }
+
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('contractFormData', ContractFormDataValidator::class);
+    }
+
     public function createAction(Profile $profile, ContractFormData $contractFormData): ResponseInterface
     {
         $contract = $this->contractFactory->createFromFormData(
@@ -159,10 +164,6 @@ final class ContractController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'contractFormData',
-        'validator' => ContractFormDataValidator::class,
-    ])]
     public function updateAction(Contract $contract, ContractFormData $contractFormData): ResponseInterface
     {
         $this->contractRepository->update(

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/EmailAddressController.php
@@ -21,7 +21,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\EmailFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -84,10 +83,16 @@ final class EmailAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'emailAddressFormData',
-        'validator' => EmailFormDataValidator::class,
-    ])]
+    public function initializeCreateAction(): void
+    {
+        $this->addArgumentValidator('emailAddressFormData', EmailFormDataValidator::class);
+    }
+
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('emailAddressFormData', EmailFormDataValidator::class);
+    }
+
     public function createAction(Contract $contract, EmailFormData $emailAddressFormData): ResponseInterface
     {
         $emailAddress = $this->emailAddressFactory->createFromFormData(
@@ -135,10 +140,6 @@ final class EmailAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'emailAddressFormData',
-        'validator' => EmailFormDataValidator::class,
-    ])]
     public function updateAction(
         Email $emailAddress,
         EmailFormData $emailAddressFormData

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhoneNumberController.php
@@ -21,7 +21,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\PhoneNumberFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -84,10 +83,16 @@ final class PhoneNumberController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'phoneNumberFormData',
-        'validator' => PhoneNumberFormDataValidator::class,
-    ])]
+    public function initializeCreateAction(): void
+    {
+        $this->addArgumentValidator('phoneNumberFormData', PhoneNumberFormDataValidator::class);
+    }
+
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('phoneNumberFormData', PhoneNumberFormDataValidator::class);
+    }
+
     public function createAction(Contract $contract, PhoneNumberFormData $phoneNumberFormData): ResponseInterface
     {
         $phoneNumber = $this->phoneNumberFactory->createFromFormData(
@@ -135,10 +140,6 @@ final class PhoneNumberController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'phoneNumberFormData',
-        'validator' => PhoneNumberFormDataValidator::class,
-    ])]
     public function updateAction(
         PhoneNumber $phoneNumber,
         PhoneNumberFormData $phoneNumberFormData

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/PhysicalAddressController.php
@@ -21,7 +21,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\AddressFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -84,10 +83,16 @@ final class PhysicalAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'addressFormData',
-        'validator' => AddressFormDataValidator::class,
-    ])]
+    public function initializeCreateAction(): void
+    {
+        $this->addArgumentValidator('addressFormData', AddressFormDataValidator::class);
+    }
+
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('addressFormData', AddressFormDataValidator::class);
+    }
+
     public function createAction(Contract $contract, AddressFormData $addressFormData): ResponseInterface
     {
         $physicalAddress = $this->addressFactory->createFromFormData(
@@ -135,10 +140,6 @@ final class PhysicalAddressController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'addressFormData',
-        'validator' => AddressFormDataValidator::class,
-    ])]
     public function updateAction(
         Address $physicalAddress,
         AddressFormData $addressFormData

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -22,7 +22,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -92,10 +91,11 @@ final class ProfileController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'profileFormData',
-        'validator' => ProfileFormDataValidator::class,
-    ])]
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('profileFormData', ProfileFormDataValidator::class);
+    }
+
     public function updateAction(Profile $profile, ProfileFormData $profileFormData): ResponseInterface
     {
         $this->profileRepository->update(

--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileInformationController.php
@@ -20,7 +20,6 @@ use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
 use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileInformationFormDataValidator;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Extbase\Annotation\Validate;
 
 /**
  * @internal to be used only in `EXT:academic_person_edit` and not part of public API.
@@ -89,10 +88,16 @@ final class ProfileInformationController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'profileInformationFormData',
-        'validator' => ProfileInformationFormDataValidator::class,
-    ])]
+    public function initializeCreateAction(): void
+    {
+        $this->addArgumentValidator('profileInformationFormData', ProfileInformationFormDataValidator::class);
+    }
+
+    public function initializeUpdateAction(): void
+    {
+        $this->addArgumentValidator('profileInformationFormData', ProfileInformationFormDataValidator::class);
+    }
+
     public function createAction(Profile $profile, ProfileInformationFormData $profileInformationFormData): ResponseInterface
     {
         $profileInformation = $this->profileInformationFactory->createFromFormData(
@@ -144,10 +149,6 @@ final class ProfileInformationController extends AbstractActionController
         return $this->htmlResponse();
     }
 
-    #[Validate([
-        'param' => 'profileInformationFormData',
-        'validator' => ProfileInformationFormDataValidator::class,
-    ])]
     public function updateAction(
         ProfileInformation $profileInformation,
         ProfileInformationFormData $profileInformationFormData,

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfilePluginTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfilePluginTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Renders the `academicpersonsedit_profileediting` plugin in the frontend.
+ *
+ * This guards the `record` view variable: TYPO3 v14 renders the header of the
+ * `EXT:fluid_styled_content` `Header/All` partial with `{record -> f:render.text(...)}`,
+ * which raises an exception when no record object is available. Extbase plugin views
+ * assign only `data`, so without the record the plugin fails to render on v14, while it
+ * still renders on v13 whose partial reads `data`.
+ *
+ * The plugin requires a logged in frontend user, otherwise its controllers stop before
+ * rendering, which is why the request is executed with a frontend user context.
+ */
+final class AcademicPersonsEditProfilePluginTest extends AbstractAcademicPersonsEditTestCase
+{
+    use SiteBasedTestTrait;
+
+    private const FRONTEND_USER_ID = 1;
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'debug' => false,
+        ],
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            'typo3/cms-fluid-styled-content',
+        ]);
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsEditProfilePlugin/profileEditingPage.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons_edit/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons_edit/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons_edit/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: 'https://www.acme.com/',
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+            ],
+        );
+    }
+
+    private function renderHomePageAsFrontendUser(): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('https://www.acme.com/home'),
+            (new InternalRequestContext())->withFrontendUserId(self::FRONTEND_USER_ID),
+        );
+        $this->assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    #[Test]
+    public function profileEditingPluginIsRenderedForLoggedInFrontendUser(): void
+    {
+        $this->setUpTestCase();
+
+        $this->assertStringContainsString('Müllermann', $this->renderHomePageAsFrontendUser());
+    }
+
+    #[Test]
+    public function profileEditingPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase();
+        // Rendering a header is what requires the `record` view variable on TYPO3 v14.
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => 'Edit your profile'], ['uid' => 1]);
+
+        $this->assertStringContainsString('Edit your profile', $this->renderHomePageAsFrontendUser());
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/Fixtures/AcademicPersonsEditProfilePlugin/profileEditingPage.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/Fixtures/AcademicPersonsEditProfilePlugin/profileEditingPage.csv
@@ -1,0 +1,17 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header"
+,1,2,0,0,0,0,"academicpersonsedit_profileediting",""
+"fe_users",
+,"uid","pid","username","password","deleted","disable","usergroup","tx_extbase_type","first_name","last_name","email"
+,1,100,"editor","",0,0,"","Tx_Academicpersonsedit_Domain_Model_FrontendUser","Max","Müllermann","max@example.com"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug","frontend_users"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann",1
+"tx_academicpersons_feuser_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,1,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}


### PR DESCRIPTION
Resolves **ACE-272** (subtask of ACE-249). `main` / `3.0.0-dev` only.

## Problem

Every form-validating action of `EXT:academic_persons_edit` used the array form of
the Extbase `Validate` attribute — **11 places across 6 controllers**. On TYPO3 v14
each dispatch raises two deprecations slated for removal in v15 (array
configuration values; naming the validated parameter), and `failOnDeprecation`
turns them into test failures.

It went unnoticed because no functional test dispatched those actions. The
rendering test written for ACE-271 was the first, and it hit exactly this.

## Why the documented fix is unusable

| Version | `Validate` attribute targets |
|---|---|
| v13.4 (`Annotation\Validate`) | `TARGET_PROPERTY \| TARGET_METHOD \| IS_REPEATABLE` |
| v14 (`Attribute\Validate`) | additionally `TARGET_PARAMETER` |

Moving the attribute to the method parameter is a fatal error on v13.

## Solution

Drop the attribute; register the validators in `initialize<Action>Action()`:

| Controller | Actions | Argument |
|---|---|---|
| `ContractController` | create, update | `contractFormData` |
| `EmailAddressController` | create, update | `emailAddressFormData` |
| `PhoneNumberController` | create, update | `phoneNumberFormData` |
| `PhysicalAddressController` | create, update | `addressFormData` |
| `ProfileInformationController` | create, update | `profileInformationFormData` |
| `ProfileController` | update | `profileFormData` |

The shared part is `AbstractActionController::addArgumentValidator()`, since all
six extend it. Two details carried over from ACE-269:

* it **extends** the `ConjunctionValidator` Extbase already built rather than
  replacing it — replacing would silently drop model-level validation;
* validators are created via `validatorResolver->createValidator()`, exactly as
  the attribute path did.

Deprecation-free on both versions: no `trigger_error` in `Argument`,
`ValidatorResolver` or `ConjunctionValidator` in v13.4 or v14, and
`initializeActionMethodValidators()` runs before the action-specific initialize
method in both.

**No behaviour change** — same validators, same arguments, only the registration
moved. No changelog entry for that reason.

## Also included: the blocked rendering test

`AcademicPersonsEditProfilePluginTest` renders the
`academicpersonsedit_profileediting` plugin and asserts the **content element
header** renders — the part requiring the `record` variable from ACE-270. It needs
a logged-in frontend user (`InternalRequestContext::withFrontendUserId()`) with the
profile linked through a `tx_academicpersons_feuser_mm` fixture.

This test is also the proof of the fix: the identical test failed on the two
deprecations before this change and passes on **v13 and v14** after it.

## Verification

All gates green for both v13 and v14: `cgl`, `lintPhp`, `phpstan`, `unit`,
`functional`.
