### PR TITLE
[DOCS] Fix runTests.sh flag documentation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -22,7 +22,7 @@ together.
 - `packages-dev/testing-helper/` — `fgtclb/academics-monorepo-testing-helper`: shared functional-test traits (`ExtensionsLoadedTestsTrait`, `TcaHelperMethodsTrait`, `ExtensionCoreVersionCompatTestsTrait`).
 - `Build/` — test harness, phpunit/phpstan/php-cs-fixer configs, docs build.
 - `.Build/` — generated composer install target (`vendor-dir`, `bin-dir`, `Web/`). Not committed.
-- `ddev-instances/core-12`, `ddev-instances/core-13` — DDEV setups per core version.
+- `ddev-instances/core-13`, `ddev-instances/core-14` — DDEV setups per core version.
 
 The extension directory name does not always equal the extension key: e.g.
 `packages/fgtclb/academic-contact4pages/` ships extension key
@@ -51,13 +51,19 @@ All checks run through the containerized harness (docker or podman, auto-selecte
 override with `-b docker|podman`). It mirrors the TYPO3 Core `runTests.sh`. Key flags:
 
 - `-s <suite>` — suite to run.
-- `-t <13|14>` — TYPO3 core version (default 13). Drives `composerUpdate`/install and which `Build/phpstan/Core12|Core13` config is used.
+- `-t <13|14>` — TYPO3 core version (default 13). Drives `composerUpdate`/install and which `Build/phpstan/Core13|Core14` config is used.
 - `-p <8.2|8.3|8.4|8.5>` — PHP version (default 8.2).
 - `-d <sqlite|mariadb|mysql|postgres>` — DBMS for functional tests (default sqlite).
+- `-i <version>` — DBMS version, when the default of the selected `-d` does not fit.
+- `-a <driver>` — database driver, e.g. `pdo_mysql` or `mysqli` (default: driver of `-d`).
 - `-n` — dry-run for `cgl` (report only, don't modify).
 - `-x` / `-y <port>` — enable xdebug to a host IDE (default port 9003).
-- `-e "<args>"` — pass extra args through to phpunit (e.g. `--filter`).
+- `-o <seed>` — random order seed for `unitRandom`.
+- `-u` — update the `typo3/core-testing-*` container images.
 - Trailing `[file]` — restrict phpunit to a path.
+
+There is **no option to pass extra arguments through to phpunit** — no `-e`, and
+no `--` passthrough. Restrict a run with the trailing path only.
 
 Typical workflow — **always prepare deps first** for the target core version:
 
@@ -73,12 +79,17 @@ Build/Scripts/runTests.sh -t 13 -p 8.3 -s unit       # unit tests
 Build/Scripts/runTests.sh -t 13 -p 8.3 -s functional # functional tests (sqlite)
 ```
 
-Run a single test / filter:
+Restrict a run to a directory or a single test file:
 
 ```bash
-Build/Scripts/runTests.sh -t 13 -s unit -e "--filter someTestMethod"
 Build/Scripts/runTests.sh -t 13 -s functional packages/fgtclb/academic-persons/Tests/Functional/Domain
+Build/Scripts/runTests.sh -t 13 -s unit packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
 ```
+
+`-t` selects configuration only, it does **not** reinstall dependencies. After a
+`composerUpdate` for one core version, a run for the other one silently uses the
+wrong vendor tree and fails in confusing ways — always `composerUpdate` for the
+version you are about to test.
 
 Other suites: `composer` (dispatch arbitrary composer command), `composerUpdate`,
 `unitRandom`, `phpstanGenerateBaseline`, `checkRstRenderingAll`,

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -329,18 +329,14 @@ Examples:
     # Run all core units tests and enable xdebug (have a PhpStorm listening on port 9003!)
     ./Build/Scripts/runTests.sh -x
 
-    # Run unit tests in phpunit verbose mode with xdebug on PHP 8.3 and filter for test canRetrieveValueWithGP
-    ./Build/Scripts/runTests.sh -x -p 8.3 -e "-v --filter canRetrieveValueWithGP"
-
-    # Run functional tests in phpunit with a filtered test method name in a specified file
-    # example will currently execute two tests, both of which start with the search term
-    ./Build/Scripts/runTests.sh -s functional -e "--filter deleteContent" typo3/sysext/core/Tests/Functional/DataHandling/Regular/Modify/ActionTest.php
+    # Run the unit tests of a single test file with xdebug on PHP 8.3
+    ./Build/Scripts/runTests.sh -x -p 8.3 -s unit packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
 
     # Run functional tests on postgres with xdebug, php 8.3 and execute a restricted set of tests
-    ./Build/Scripts/runTests.sh -x -p 8.3 -s functional -d postgres typo3/sysext/core/Tests/Functional/Authentication
+    ./Build/Scripts/runTests.sh -x -p 8.3 -s functional -d postgres packages/fgtclb/academic-persons/Tests/Functional/Domain
 
-    # Run functional tests on postgres 11
-    ./Build/Scripts/runTests.sh -s functional -d postgres -k 11
+    # Run functional tests on postgres 16
+    ./Build/Scripts/runTests.sh -s functional -d postgres -i 16
 EOF
 }
 


### PR DESCRIPTION
`AGENT.md` documented a `-e "<args>"` option to pass extra arguments through to
phpunit. That option does not exist in this harness — its `getopts` string is
`a:b:s:d:i:p:t:xy:o:nhu`, and passing `-e` aborts the run with
"Invalid option(s)". A run can only be restricted with the trailing path
argument.

This came up while working on the upload tests: the documented invocation is what
one reaches for first when isolating a single test, and it fails in a way that
looks like a broken environment rather than a wrong flag.

### Changed

* **`AGENT.md`** — `-e` removed and replaced with an explicit statement that there
  is no phpunit argument passthrough. The example that used it now restricts by
  path. Flag list completed with `-a`, `-i`, `-o` and `-u` (supported but
  undocumented). Two stale references corrected: phpstan configuration
  directories are `Core13|Core14` (not `Core12|Core13`) and the DDEV instances are
  `core-13`/`core-14` (not `core-12`/`core-13`). Added a note that `-t` selects
  configuration only and does **not** reinstall dependencies.
* **`Build/Scripts/runTests.sh`** — the same wrong claim appeared in two of its own
  `-h` examples, plus a third using `-k` for the DBMS version, which is `-i` here.
  All three were inherited from the TYPO3 Core script this harness was derived
  from; they now use paths from this repository instead of `typo3/sysext/`.

Every flag now listed in `AGENT.md` was checked against the `getopts` string, and
both new example invocations were executed.

### Not changed

The "Core-version-aware code (v12 vs v13)" section is also outdated for a v13+v14
branch, but rewriting it is a larger edit than this fix and is left for a separate
change.
