### PR TITLE
[BUGFIX] ACE-289: Declare EXT:install dependency

### DIFF
--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -19,7 +19,8 @@
         "php": "^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-base": "~3.0.0@dev",
         "fgtclb/academic-persons": "~3.0.0@dev",
-        "typo3/cms-core": "~13.4.0@dev || ~14.3.0@dev"
+        "typo3/cms-core": "~13.4.0@dev || ~14.3.0@dev",
+        "typo3/cms-install": "~13.4.0@dev || ~14.3.0@dev"
     },
     "require-dev": {
         "fgtclb/environment-state-manager": "^2.0.1@dev"

--- a/packages/fgtclb/academic-contact4pages/ext_emconf.php
+++ b/packages/fgtclb/academic-contact4pages/ext_emconf.php
@@ -12,6 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '13.4.0-14.3.99',
+            'install' => '13.4.0-14.3.99',
             'academic_base' => '3.0.0',
             'academic_persons' => '3.0.0',
         ],


### PR DESCRIPTION
`academic_contacts4pages` ships `Classes/Upgrades/PluginUpgradeWizard.php`
implementing `TYPO3\CMS\Install\Updates\UpgradeWizardInterface`, but declared no
dependency on EXT:install. TYPO3 can run without that extension since v13, so on
such an instance the wizard class cannot be loaded.

Found during the TYPO3 v14 changelog audit (finding A3). Resolves ACE-289.

## Before / after

| Extension | `composer.json` | `ext_emconf.php` |
|---|---|---|
| academic_jobs | ✅ | ✅ |
| academic_persons | ✅ | ✅ |
| academic_persons_edit | ✅ | ✅ |
| academic_projects | ✅ | ✅ |
| **academic_contacts4pages** | ❌ → ✅ | ❌ → ✅ |

The audit note only mentioned `composer.json`; the classic-mode constraints in
`ext_emconf.php` were missing the `install` entry as well, so both are added
here to match the four siblings.

## Follow-up

This requirement disappears again once the upgrade wizards move to the
`TYPO3\CMS\Core\Upgrades\*` namespace, deprecated in favour of exactly that
since v14 (#106947). Blocked for now — that namespace does not exist in v13.

Also affects branch `2` (wizard present, dependency missing there too), so a
backport follows.

## Verification

Full local gates, both core versions, PHP 8.2, SQLite — 12/12 green
(`composerUpdate`, `cgl -n`, `lintPhp`, `phpstan`, `unit`, `functional`).