### PR TITLE
[BUGFIX] ACE-290: Detect v14 short-form tab label

### DIFF
--- a/packages/fgtclb/academic-base/Classes/TcaManipulator.php
+++ b/packages/fgtclb/academic-base/Classes/TcaManipulator.php
@@ -18,6 +18,35 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 final class TcaManipulator
 {
     /**
+     * The "extended" tab, in both spellings that can occur in a `showitem` string.
+     *
+     * TYPO3 v14 moved the core TCA `showitem` definitions to short form label
+     * references (breaking #107789): `core.form.tabs:extended` instead of the
+     * full `LLL:EXT:core/...` path. TYPO3 v14.3 core `pages` TCA contains no
+     * occurrence of the long form at all, so matching only that form silently
+     * stops detecting the tab there.
+     *
+     * Both forms have to be *recognised*. Only `EXTENDED_TAB` is ever *written*:
+     * `EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf` still exists
+     * in TYPO3 v14 and still carries the `extended` label, so the long form
+     * resolves on both supported core versions, while the short form does not
+     * resolve on TYPO3 v13.
+     *
+     * @todo typo3/cms-core >=14 Emit `EXTENDED_TAB_SHORT` and drop the long form
+     *       once TYPO3 v13 support is removed.
+     */
+    private const EXTENDED_TAB = '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended';
+    private const EXTENDED_TAB_SHORT = '--div--;core.form.tabs:extended';
+
+    /**
+     * @return string[]
+     */
+    private function extendedTabVariants(): array
+    {
+        return [self::EXTENDED_TAB, self::EXTENDED_TAB_SHORT];
+    }
+
+    /**
      * Convenience method so you don't have to deal with strings and arrays and $GLOBALS[TCA] directly that much.
      *
      * Adds a new entry to an existing TCA DB table that has a type field configured (via $TCA[$table][ctrl][type])
@@ -65,8 +94,17 @@ final class TcaManipulator
         ExtensionManagementUtility::addTcaSelectItem($table, $typeField, $selectItem->toArray(), $relativeInformation[0] ?? '', $relativeInformation[1] ?? '');
         $showItemList = trim($showItemList, ', ');
         // Add the extended tab if not already added manually at the very end.
-        if ($showItemList !== '' && !str_contains($showItemList, '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended')) {
-            $showItemList .= ',--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended';
+        // Both spellings count as "already added", otherwise a caller using the
+        // TYPO3 v14 short form would end up with two extended tabs.
+        $hasExtendedTab = false;
+        foreach ($this->extendedTabVariants() as $extendedTab) {
+            if (str_contains($showItemList, $extendedTab)) {
+                $hasExtendedTab = true;
+                break;
+            }
+        }
+        if ($showItemList !== '' && !$hasExtendedTab) {
+            $showItemList .= ',' . self::EXTENDED_TAB;
         }
         if ($showItemList !== '') {
             $showItemList .= ',';
@@ -198,7 +236,7 @@ final class TcaManipulator
         $extendedParts = [];
         $addFields = false;
         foreach ($showItemFiltered as $key => $part) {
-            if ($part === '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended') {
+            if (in_array($part, $this->extendedTabVariants(), true)) {
                 $extendedParts[] = $part;
                 $addFields = true;
                 unset($showItemFiltered[$key]);

--- a/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
@@ -454,6 +454,88 @@ final class TcaManipulatorTest extends UnitTestCase
                 ],
             ],
         ];
+
+        // The three data sets above use the TYPO3 v13 spelling of the core tab
+        // labels and place the extended tab last, where extracting it and
+        // appending it again cannot be told apart from doing nothing.
+        //
+        // The two below put a further tab *after* the extended tab, so the
+        // extraction is observable, and cover both spellings: TYPO3 v14 moved
+        // the core `showitem` definitions to short form label references
+        // (breaking #107789), and matching only the long form silently stopped
+        // detecting the tab there.
+
+        yield 'extended tab is moved to the end, TYPO3 v14 short form label' => [
+            'tca' => [
+                'pages' => [
+                    'types' => [
+                        1 => [
+                            'showitem' => '
+                                --div--;core.form.tabs:general,
+                                    --palette--;;standard,
+                                --div--;core.form.tabs:extended,
+                                    extendedFieldA,
+                                --div--;core.form.tabs:notes,
+                                    rowDescription,
+                            ',
+                        ],
+                    ],
+                ],
+            ],
+            'definitionToAdd' => '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project, project_info, project_date,',
+            'types' => [],
+            'excludeTypes' => [],
+            'expected' => [
+                'pages' => [
+                    'types' => [
+                        1 => [
+                            'showitem' => '
+--div--;core.form.tabs:general,
+--palette--;;standard,
+--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project, project_info, project_date,
+--div--;core.form.tabs:notes,rowDescription,
+--div--;core.form.tabs:extended,extendedFieldA,',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'extended tab is moved to the end, TYPO3 v13 long form label' => [
+            'tca' => [
+                'pages' => [
+                    'types' => [
+                        1 => [
+                            'showitem' => '
+                                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+                                    --palette--;;standard,
+                                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+                                    extendedFieldA,
+                                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+                                    rowDescription,
+                            ',
+                        ],
+                    ],
+                ],
+            ],
+            'definitionToAdd' => '--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project, project_info, project_date,',
+            'types' => [],
+            'excludeTypes' => [],
+            'expected' => [
+                'pages' => [
+                    'types' => [
+                        1 => [
+                            'showitem' => '
+--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+--palette--;;standard,
+--div--;LLL:EXT:academic_projects/Resources/Private/Language/locallang_be.xlf:pages.div.project, project_info, project_date,
+--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,rowDescription,
+--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,extendedFieldA,',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
TYPO3 v14 moved the core TCA `showitem` definitions to short-form label
references (breaking #107789): `--div--;core.form.tabs:extended` instead of the
full `LLL:EXT:core/…locallang_tabs.xlf:extended`. Verified — `typo3/cms-core`
v14.3.5 `Configuration/TCA/pages.php` contains **zero** occurrences of the long
form.

Found during the TYPO3 v14 changelog audit (finding A2). Resolves ACE-290.

## What was wrong

`TcaManipulator` compared against the long form only, in **two** places — the
audit had only recorded one:

| Site | Effect on v14 |
|---|---|
| `addRecordType()`, `str_contains()` guard | a caller supplying the short form is not recognised → **second** extended tab appended |
| `extractExtendedParts()`, exact comparison | never matches → extended tab no longer extracted and re-appended |

**Neither had a visible effect yet.** No caller passes the short form, and the
extended tab is already the last entry of core's `pages` definition, which makes
extracting and re-appending it indistinguishable from doing nothing. It diverges
as soon as anything is registered after that tab.

## The fix

Both spellings are now recognised. **Only the long form is still written:**
`EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf` still exists in v14
and still carries the `extended` label (checked in the installed v14.3.5 tree),
so it resolves on both supported core versions — while the short form does *not*
resolve on v13. A `@todo` records the switch for when v13 support is dropped.

## Closing the blind spot

The unit test used the long form **60 times** and the short form **never**, so
the v14 data shape was entirely uncovered. That is why this went unnoticed.

Two data sets are added, one per spelling, and both deliberately place a further
tab *after* the extended tab so the extraction is actually observable — the three
existing sets put it last, where a no-op looks identical to correct behaviour.

I verified the new short-form set genuinely fails against the previous
implementation rather than passing either way:

```
1) …TcaManipulatorTest::returnsExpectedTcaArray with data set
   "extended tab is moved to the end, TYPO3 v14 short form label"
Failed asserting that two arrays are identical.
```

## Verification

Full local gates, both core versions, PHP 8.2, SQLite — 12/12 green
(`composerUpdate`, `cgl -n`, `lintPhp`, `phpstan`, `unit`, `functional`).
Consumers of `addToPageTypesGeneralTab()` sanity-checked: academic_partners (2×),
academic_projects, academic_contacts4pages, academic_programs.

## Scope note

`main` only. Branch `2` (v12+v13) never sees the short form, so there is nothing
to backport.