### PR TITLE
[BUGFIX] ACE-289: Declare EXT:install dependency

### DIFF
--- a/packages/fgtclb/academic-contact4pages/composer.json
+++ b/packages/fgtclb/academic-contact4pages/composer.json
@@ -19,7 +19,8 @@
         "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "fgtclb/academic-base": "~2.4.0@dev",
         "fgtclb/academic-persons": "~2.4.0@dev",
-        "typo3/cms-core": "^12.4.22 || ^13.4"
+        "typo3/cms-core": "^12.4.22 || ^13.4",
+        "typo3/cms-install": "^12.4.22 || ^13.4"
     },
     "require-dev": {
         "fgtclb/environment-state-manager": "^1.0"

--- a/packages/fgtclb/academic-contact4pages/ext_emconf.php
+++ b/packages/fgtclb/academic-contact4pages/ext_emconf.php
@@ -12,6 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.22-13.4.99',
+            'install' => '12.4.22-13.4.99',
             'academic_base' => '2.4.0',
             'academic_persons' => '2.4.0',
         ],


### PR DESCRIPTION
Backport of #353 (merged to `main` as `920fb24f`) to the `2` maintenance branch.

Resolves ACE-289.

`academic_contacts4pages` ships `Classes/Upgrades/PluginUpgradeWizard.php`
implementing `TYPO3\CMS\Install\Updates\UpgradeWizardInterface`, but declared no
dependency on EXT:install. TYPO3 can run without that extension since v13, so on
such an instance the wizard class cannot be loaded.

Confirmed present on this branch as well: the wizard file exists here and neither
manifest declared the dependency.

| Extension | `composer.json` | `ext_emconf.php` |
|---|---|---|
| academic_jobs | ✅ | ✅ |
| academic_persons | ✅ | ✅ |
| academic_persons_edit | ✅ | ✅ |
| academic_projects | ✅ | ✅ |
| **academic_contacts4pages** | ❌ → ✅ | ❌ → ✅ |

Constraints use this branch's format (`^12.4.22 || ^13.4` and
`12.4.22-13.4.99`), matching the four siblings here.

Unlike on `main`, there is no follow-up: the `TYPO3\CMS\Core\Upgrades\*`
namespace that supersedes EXT:install in v14 exists on neither core version
supported by this branch, so the dependency stays for good.

## Verification

Full local gates, both core versions (v12 and v13), PHP 8.2, SQLite — 12/12 green
(`composerUpdate`, `cgl -n`, `lintPhp`, `phpstan`, `unit`, `functional`).