### PR TITLE
[BUGFIX] ACE-291: Join wrapped XLIFF label content

### DIFF
--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
@@ -164,8 +164,7 @@
 
 			<trans-unit id="tx_academicjobs.fe.alert.job_created.body">
 				<source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
-				<target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.
-				</target>
+				<target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.</target>
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created.title">
 				<source>Your job advert has been successfully created</source>
@@ -173,9 +172,7 @@
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
 				<source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
-				<target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre
-					Stellenanzeige freischalten zu lassen.
-				</target>
+				<target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre Stellenanzeige freischalten zu lassen.</target>
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
 				<source>Notification email could not be sent</source>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
@@ -73,10 +73,7 @@
 				<source>Default categories</source>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
@@ -32,14 +32,8 @@
 				<target>Standard-Kategorien</target>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
-				<target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B.
-					"Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp
-					auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).
-				</target>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+				<target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B. "Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
@@ -27,10 +27,7 @@
 				<source>Default categories</source>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>


### PR DESCRIPTION
Six translation labels in four XLF files wrap across several lines for
readability in the source file. TYPO3 v12 and v13 do **not** collapse that
whitespace, so the rendered label carries a literal newline plus the file
indentation in the middle of a sentence:

```
… (e.g. ‘Master’ with ‘Master of\n\t\t\t\t\tArts’), these are …
```

Found during the TYPO3 v14 changelog audit (finding A4). Resolves ACE-291.

## Affected

| File | Label |
|---|---|
| `academic_jobs/…/de.locallang.xlf` | `tx_academicjobs.fe.alert.job_created.body` |
| `academic_jobs/…/de.locallang.xlf` | `tx_academicjobs.fe.alert.job_created_no_email.body` |
| `academic_partners/…/locallang_be.xlf` | `flexform.categories.description` |
| `academic_programs/…/locallang_be.xlf` | `flexform.categories.description` |
| `academic_programs/…/de.locallang_be.xlf` | `flexform.categories.description` (source **and** target) |

The `academic_jobs` two are frontend alerts shown after a job posting is
submitted; the others are backend FlexForm field descriptions.

> The audit recorded this as *two* labels. A stricter scan — matching every
> `<source>`/`<target>` inside a trans-unit rather than only the first — finds
> **six**, in four files rather than two.

## Why joining, not `xml:space="preserve"`

TYPO3 v14 already renders these correctly: since #70867 the XLIFF parser honours
`xml:space` and collapses whitespace where the attribute is absent. So the
defect is visible on the v13 side of this branch only.

The line breaks are an artefact of how the files were written, not intended
content, so collapsing them is the correct reading — and it makes v13 agree with
what v14 does at runtime anyway. No file in the repository uses `xml:space`.

## Scope

Indentation is deliberately **untouched**. TYPO3 v14 normalised core XLF files to
two-space indentation (#107971), but that is cosmetic and has no effect on
parsing, so it is tracked separately as ACE-292 and scoped to `main` only.

Branch `2` carries the identical six labels on both its supported core versions,
so a backport follows.

## Verification

All six labels joined, no multi-line `<source>`/`<target>` content left anywhere,
and every XLF file still parses. Full local gates, both core versions, PHP 8.2,
SQLite — 12/12 green.