### PR TITLE
[BUGFIX] ACE-291: Join wrapped XLIFF label content

### DIFF
--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
@@ -164,8 +164,7 @@
 
 			<trans-unit id="tx_academicjobs.fe.alert.job_created.body">
 				<source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
-				<target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.
-				</target>
+				<target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.</target>
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created.title">
 				<source>Your job advert has been successfully created</source>
@@ -173,9 +172,7 @@
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
 				<source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
-				<target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre
-					Stellenanzeige freischalten zu lassen.
-				</target>
+				<target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre Stellenanzeige freischalten zu lassen.</target>
 			</trans-unit>
 			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
 				<source>Notification email could not be sent</source>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
@@ -73,10 +73,7 @@
 				<source>Default categories</source>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
@@ -32,14 +32,8 @@
 				<target>Standard-Kategorien</target>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
-				<target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B.
-					"Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp
-					auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).
-				</target>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+				<target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B. "Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
@@ -27,10 +27,7 @@
 				<source>Default categories</source>
 			</trans-unit>
 			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of
-					Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all
-					other selected category types (AND).
-				</source>
+				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
 			</trans-unit>
 			<trans-unit id="flexform.showHiddenRecords.label">
 				<source>Show hidden records</source>


### PR DESCRIPTION
Backport of #356 (merged to `main` as `4799e71c`) to the `2` maintenance branch.

Resolves ACE-291.

Six translation labels in four XLF files wrap across several lines for
readability in the source file. TYPO3 v12 and v13 do **not** collapse that
whitespace, so the rendered label carries a literal newline plus the file
indentation in the middle of a sentence:

```
… (e.g. ‘Master’ with ‘Master of\n\t\t\t\t\tArts’), these are …
```

| File | Label |
|---|---|
| `academic_jobs/…/de.locallang.xlf` | `tx_academicjobs.fe.alert.job_created.body` |
| `academic_jobs/…/de.locallang.xlf` | `tx_academicjobs.fe.alert.job_created_no_email.body` |
| `academic_partners/…/locallang_be.xlf` | `flexform.categories.description` |
| `academic_programs/…/locallang_be.xlf` | `flexform.categories.description` |
| `academic_programs/…/de.locallang_be.xlf` | `flexform.categories.description` (source **and** target) |

The `academic_jobs` two are frontend alerts shown after a job posting is
submitted; the others are backend FlexForm field descriptions.

**This branch is affected more than `main`.** TYPO3 v14 fixes this by itself —
since #70867 the XLIFF parser honours `xml:space` and collapses whitespace where
the attribute is absent. On `main` the defect therefore only shows on the v13
side; here neither supported core version collapses it, so both are affected.

The wrapped lines are joined into single-line content. `xml:space="preserve"` is
deliberately not used: the line breaks are an artefact of how the files were
written, not intended content.

## Scope

Indentation is **untouched**. The two-space convention TYPO3 v14 introduced
(#107971) comes from a core version this branch does not support, has no effect
on parsing, and reformatting every XLF file here would only create conflicts for
later backports. It is tracked as ACE-292, scoped to `main`.

## Verification

Same script as on `main`, identical outcome: all six labels joined, no multi-line
`<source>`/`<target>` content left, every XLF file still parses. Full local gates,
both core versions (v12 and v13), PHP 8.2, SQLite — 12/12 green.