### PR TITLE
[TASK] ACE-292: Normalise XLF to two-space indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-base/.editorconfig
+++ b/packages/fgtclb/academic-base/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang_be.xlf
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_base/Resources/Private/Language/locallang_be.xlf"
-		product-name="academic_base"
-	>
-		<header/>
-		<body>
-			<trans-unit id="content.ctype.group.label">
-				<source>Academic</source>
-				<target>Academic</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_base/Resources/Private/Language/locallang_be.xlf"
+    product-name="academic_base"
+  >
+    <header/>
+    <body>
+      <trans-unit id="content.ctype.group.label">
+        <source>Academic</source>
+        <target>Academic</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-base/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/locallang_be.xlf
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_base/Resources/Private/Language/locallang_be.xlf"
-		product-name="academic_base"
-	>
-		<header/>
-		<body>
-			<trans-unit id="content.ctype.group.label">
-				<source>Academic</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_base/Resources/Private/Language/locallang_be.xlf"
+    product-name="academic_base"
+  >
+    <header/>
+    <body>
+      <trans-unit id="content.ctype.group.label">
+        <source>Academic</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-bite-jobs/.editorconfig
+++ b/packages/fgtclb/academic-bite-jobs/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang.xlf
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_bite_jobs/Resources/Private/Language/locallang.xlf"
-		date="2023-09-15T08:53:00Z"
-		product-name="academic_bite_jobs"
-	>
-		<header/>
-		<body>
-			<trans-unit id="no-jobs">
-				<source>There are currently no job vacancies.</source>
-				<target>Zur Zeit gibt es keine aktuellen Ausschreibungen.</target>
-			</trans-unit>
-			<trans-unit id="jobs.bite.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="jobs.bite.endsOn">
-				<source>Ends on</source>
-				<target>Endet am</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_bite_jobs/Resources/Private/Language/locallang.xlf"
+    date="2023-09-15T08:53:00Z"
+    product-name="academic_bite_jobs"
+  >
+    <header/>
+    <body>
+      <trans-unit id="no-jobs">
+        <source>There are currently no job vacancies.</source>
+        <target>Zur Zeit gibt es keine aktuellen Ausschreibungen.</target>
+      </trans-unit>
+      <trans-unit id="jobs.bite.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="jobs.bite.endsOn">
+        <source>Ends on</source>
+        <target>Endet am</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/de.locallang_be.xlf
@@ -1,93 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf"
-		date="2023-09-15T08:53:00Z"
-		product-name="academic_bite_jobs"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.bite.list.label">
-				<source>Bite Jobs List</source>
-				<target>Bite Jobs Liste</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf"
+    date="2023-09-15T08:53:00Z"
+    product-name="academic_bite_jobs"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.bite.list.label">
+        <source>Bite Jobs List</source>
+        <target>Bite Jobs Liste</target>
+      </trans-unit>
 
-			<trans-unit id="plugin.bite.list.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
+      <trans-unit id="plugin.bite.list.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
 
-			<trans-unit id="flexform.tab.settings">
-				<source>Settings</source>
-				<target>Einstellungen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.key.label">
-				<source>Job listing key</source>
-				<target>Stellenangebotsschlüssel</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.key.description">
-				<source>Unique key from B-Ite Application</source>
-				<target>Eindeutiger Schlüssel aus der B-Ite Anwendung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.label">
-				<source>Select view</source>
-				<target>Ansicht auswählen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.list">
-				<source>List</source>
-				<target>Liste</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.card">
-				<source>Card</source>
-				<target>Karten</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.table">
-				<source>Table</source>
-				<target>Tabelle</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.label">
-				<source>Sort by</source>
-				<target>Sortiere nach</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.none">
-				<source>No sorting</source>
-				<target>Keine Sortierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.ends_on">
-				<source>Ends on</source>
-				<target>Endet am</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.label">
-				<source>Sort direction</source>
-				<target>Sortierreihenfolge</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.asc">
-				<source>Ascending</source>
-				<target>Aufsteigend</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.desc">
-				<source>Descending</source>
-				<target>Absteigend</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.limit.label">
-				<source>Maximum number of job offers</source>
-				<target>Maximale Anzahl an Stellenangeboten</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.limit.description">
-				<source>(0 = show all)</source>
-				<target>(0 = Alle anzeigen)</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.all">
-				<source>All</source>
-				<target>Alle</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="flexform.tab.settings">
+        <source>Settings</source>
+        <target>Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.key.label">
+        <source>Job listing key</source>
+        <target>Stellenangebotsschlüssel</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.key.description">
+        <source>Unique key from B-Ite Application</source>
+        <target>Eindeutiger Schlüssel aus der B-Ite Anwendung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.label">
+        <source>Select view</source>
+        <target>Ansicht auswählen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.list">
+        <source>List</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.card">
+        <source>Card</source>
+        <target>Karten</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.table">
+        <source>Table</source>
+        <target>Tabelle</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.label">
+        <source>Sort by</source>
+        <target>Sortiere nach</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.none">
+        <source>No sorting</source>
+        <target>Keine Sortierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.ends_on">
+        <source>Ends on</source>
+        <target>Endet am</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.label">
+        <source>Sort direction</source>
+        <target>Sortierreihenfolge</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.asc">
+        <source>Ascending</source>
+        <target>Aufsteigend</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.desc">
+        <source>Descending</source>
+        <target>Absteigend</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.limit.label">
+        <source>Maximum number of job offers</source>
+        <target>Maximale Anzahl an Stellenangeboten</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.limit.description">
+        <source>(0 = show all)</source>
+        <target>(0 = Alle anzeigen)</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.all">
+        <source>All</source>
+        <target>Alle</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang.xlf
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_bite_jobs/Resources/Private/Language/locallang.xlf"
-		date="2023-09-15T08:53:00Z"
-		product-name="academic_bite_jobs"
-	>
-		<header/>
-		<body>
-			<trans-unit id="no-jobs">
-				<source>There are currently no job vacancies.</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_bite_jobs/Resources/Private/Language/locallang.xlf"
+    date="2023-09-15T08:53:00Z"
+    product-name="academic_bite_jobs"
+  >
+    <header/>
+    <body>
+      <trans-unit id="no-jobs">
+        <source>There are currently no job vacancies.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-bite-jobs/Resources/Private/Language/locallang_be.xlf
@@ -1,73 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf"
-		date="2023-09-15T08:53:00Z"
-		product-name="academic_bite_jobs"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.bite.list.label">
-				<source>Bite Jobs List</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf"
+    date="2023-09-15T08:53:00Z"
+    product-name="academic_bite_jobs"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.bite.list.label">
+        <source>Bite Jobs List</source>
+      </trans-unit>
 
-			<trans-unit id="plugin.bite.list.configuration">
-				<source>Configuration</source>
-			</trans-unit>
+      <trans-unit id="plugin.bite.list.configuration">
+        <source>Configuration</source>
+      </trans-unit>
 
-			<trans-unit id="flexform.tab.settings">
-				<source>Settings</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.key.label">
-				<source>Job listing key</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.key.description">
-				<source>Unique key from B-Ite Application</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.label">
-				<source>Select view</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.list">
-				<source>List</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.card">
-				<source>Card</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.view.items.table">
-				<source>Table</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.label">
-				<source>Sort by</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.none">
-				<source>No sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.ends_on">
-				<source>Ends on</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.title">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.label">
-				<source>Sort direction</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.asc">
-				<source>Ascending</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.desc">
-				<source>Descending</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.limit.label">
-				<source>Maximum number of job offers</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.jobs.limit.description">
-				<source>(0 = show all)</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.all">
-				<source>All</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="flexform.tab.settings">
+        <source>Settings</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.key.label">
+        <source>Job listing key</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.key.description">
+        <source>Unique key from B-Ite Application</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.label">
+        <source>Select view</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.list">
+        <source>List</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.card">
+        <source>Card</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.view.items.table">
+        <source>Table</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.label">
+        <source>Sort by</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.none">
+        <source>No sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.ends_on">
+        <source>Ends on</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.title">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.label">
+        <source>Sort direction</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.asc">
+        <source>Ascending</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.desc">
+        <source>Descending</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.limit.label">
+        <source>Maximum number of job offers</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.jobs.limit.description">
+        <source>(0 = show all)</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.all">
+        <source>All</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-contact4pages/.editorconfig
+++ b/packages/fgtclb/academic-contact4pages/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_be.xlf
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf"
-		date="2022-08-26T11:27:17Z"
-		product-name="academic_contacts4pages"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.contacts_list.title">
-				<source>Contacts for this Page</source>
-				<target>Kontakte für diese Seite</target>
-			</trans-unit>
-			<trans-unit id="plugin.contacts_list.description">
-				<source>List the contacts assigned to this page</source>
-				<target>Liste der Kontakte, die dieser Seite zugeordnet sind</target>
-			</trans-unit>
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf"
+    date="2022-08-26T11:27:17Z"
+    product-name="academic_contacts4pages"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.contacts_list.title">
+        <source>Contacts for this Page</source>
+        <target>Kontakte für diese Seite</target>
+      </trans-unit>
+      <trans-unit id="plugin.contacts_list.description">
+        <source>List the contacts assigned to this page</source>
+        <target>Liste der Kontakte, die dieser Seite zugeordnet sind</target>
+      </trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_db.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_db.xlf
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf"
-		date="2022-08-26T11:27:17Z"
-		product-name="academic_contacts4pages"
-	>
-		<header/>
-		<body>
-			<trans-unit id="pages.tx_academiccontacts4pages_contacts">
-				<source>Contacts</source>
-				<target>Kontakte</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_contacts">
-				<source>Linked pages</source>
-				<target>Verknüpfte Seiten</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf"
+    date="2022-08-26T11:27:17Z"
+    product-name="academic_contacts4pages"
+  >
+    <header/>
+    <body>
+      <trans-unit id="pages.tx_academiccontacts4pages_contacts">
+        <source>Contacts</source>
+        <target>Kontakte</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_contacts">
+        <source>Linked pages</source>
+        <target>Verknüpfte Seiten</target>
+      </trans-unit>
 
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact">
-				<source>Contact</source>
-				<target>Kontakt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button">
-				<source>Create new Linked page</source>
-				<target>Neue Verknüpfte Seite</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.page">
-				<source>Page</source>
-				<target>Seite</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.contract">
-				<source>Contract</source>
-				<target>Vertrag</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.role">
-				<source>Role</source>
-				<target>Rolle</target>
-			</trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact">
+        <source>Contact</source>
+        <target>Kontakt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button">
+        <source>Create new Linked page</source>
+        <target>Neue Verknüpfte Seite</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.page">
+        <source>Page</source>
+        <target>Seite</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.contract">
+        <source>Contract</source>
+        <target>Vertrag</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.role">
+        <source>Role</source>
+        <target>Rolle</target>
+      </trans-unit>
 
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role">
-				<source>Role</source>
-				<target>Rolle</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.name">
-				<source>Name</source>
-				<target>Name</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.description">
-				<source>Description</source>
-				<target>Beschreibung</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.doktypes">
-				<source>Page types</source>
-				<target>Seitentypen</target>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.contacts">
-				<source>Contacts</source>
-				<target>Kontakte</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role">
+        <source>Role</source>
+        <target>Rolle</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.name">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.description">
+        <source>Description</source>
+        <target>Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.doktypes">
+        <source>Page types</source>
+        <target>Seitentypen</target>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.contacts">
+        <source>Contacts</source>
+        <target>Kontakte</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_be.xlf
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf"
-		date="2022-08-26T11:27:17Z"
-		product-name="academic_contacts4pages"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.contacts_list.title">
-				<source>Contacts for this page</source>
-			</trans-unit>
-			<trans-unit id="plugin.contacts_list.description">
-				<source>List the contacts assigned to the page</source>
-			</trans-unit>
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_be.xlf"
+    date="2022-08-26T11:27:17Z"
+    product-name="academic_contacts4pages"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.contacts_list.title">
+        <source>Contacts for this page</source>
+      </trans-unit>
+      <trans-unit id="plugin.contacts_list.description">
+        <source>List the contacts assigned to the page</source>
+      </trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_db.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_db.xlf
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf"
-		date="2022-08-26T11:27:17Z"
-		product-name="academic_contacts4pages"
-	>
-		<header/>
-		<body>
-			<trans-unit id="pages.tx_academiccontacts4pages_contacts">
-				<source>Contacts</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_contacts">
-				<source>Linked pages</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf"
+    date="2022-08-26T11:27:17Z"
+    product-name="academic_contacts4pages"
+  >
+    <header/>
+    <body>
+      <trans-unit id="pages.tx_academiccontacts4pages_contacts">
+        <source>Contacts</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_contacts">
+        <source>Linked pages</source>
+      </trans-unit>
 
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact">
-				<source>Contact</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button">
-				<source>Create new Linked page</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.page">
-				<source>Page</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.contract">
-				<source>Contract</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.role">
-				<source>Role</source>
-			</trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact">
+        <source>Contact</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academiccontacts4pages_domain_model_contact.button">
+        <source>Create new Linked page</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.page">
+        <source>Page</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.contract">
+        <source>Contract</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_contact.role">
+        <source>Role</source>
+      </trans-unit>
 
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role">
-				<source>Role</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.name">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.description">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.doktypes">
-				<source>Page types</source>
-			</trans-unit>
-			<trans-unit id="tx_academiccontacts4pages_domain_model_role.contacts">
-				<source>Contacts</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role">
+        <source>Role</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.name">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.description">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.doktypes">
+        <source>Page types</source>
+      </trans-unit>
+      <trans-unit id="tx_academiccontacts4pages_domain_model_role.contacts">
+        <source>Contacts</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-jobs/.editorconfig
+++ b/packages/fgtclb/academic-jobs/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang.xlf
@@ -1,297 +1,297 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf"
-		date="2023-09-02T12:17:09Z"
-		product-name="academic_jobs"
-	>
-		<header/>
-		<body>
-			<!-- Backend: TypoScript Constants Editor -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf"
+    date="2023-09-02T12:17:09Z"
+    product-name="academic_jobs"
+  >
+    <header/>
+    <body>
+      <!-- Backend: TypoScript Constants Editor -->
 
-			<trans-unit id="saveForm.flashMessageCreationMode.label">
-				<source>Flashmessage creation mode when persisting new jobs (FE)</source>
-				<target>Flashmessage creation mode when persisting new jobs (FE)</target>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_always">
-				<source>always</source>
-				<target>immer</target>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_never">
-				<source>never</source>
-				<target>niemals</target>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenListPidSelected">
-				<source>suppress when list pid has been configured</source>
-				<target>Nur wenn keine listPid gesetzt wurde.</target>
-			</trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.label">
+        <source>Flashmessage creation mode when persisting new jobs (FE)</source>
+        <target>Flashmessage creation mode when persisting new jobs (FE)</target>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_always">
+        <source>always</source>
+        <target>immer</target>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_never">
+        <source>never</source>
+        <target>niemals</target>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenListPidSelected">
+        <source>suppress when list pid has been configured</source>
+        <target>Nur wenn keine listPid gesetzt wurde.</target>
+      </trans-unit>
 
-			<!-- Frontend -->
+      <!-- Frontend -->
 
-			<trans-unit id="jobs.back">
-				<source>Back to job list</source>
-				<target>Zurück zu den Stellenangeboten</target>
-			</trans-unit>
-			<trans-unit id="create.job.contactName.label">
-				<source>Contact name</source>
-				<target>Kontakt Name</target>
-			</trans-unit>
-			<trans-unit id="create.job.contactEmail.label">
-				<source>E-Mail</source>
-				<target>E-Mail</target>
-			</trans-unit>
-			<trans-unit id="create.job.contactPhone.label">
-				<source>Phone number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
-			<trans-unit id="create.job.contactAdditionalInformation.label">
-				<source>Additional information</source>
-				<target>Zusatzinformation</target>
-			</trans-unit>
-			<trans-unit id="create.job.starttime.label">
-				<source>When</source>
-				<target>Ab wann</target>
-			</trans-unit>
-			<trans-unit id="create.job.endtime.label">
-				<source>Application deadline</source>
-				<target>Bewerbungsfrist</target>
-			</trans-unit>
-			<trans-unit id="create.job.companyName.label">
-				<source>Organization</source>
-				<target>Organisation</target>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.label">
-				<source>Working hours</source>
-				<target>Arbeitszeit</target>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.1">
-				<source>Full-Time</source>
-				<target>Vollzeit</target>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.2">
-				<source>Part-Time</source>
-				<target>Teilzeit</target>
-			</trans-unit>
-			<trans-unit id="create.job.workLocation.label">
-				<source>Location</source>
-				<target>Ort</target>
-			</trans-unit>
-			<trans-unit id="create.job.employmentStartDate.label">
-				<source>Employment Start Date</source>
-				<target>Arbeitsbeginn</target>
-			</trans-unit>
-			<trans-unit id="create.job.type.label">
-				<source>Job Type</source>
-				<target>Jobtyp</target>
-			</trans-unit>
-			<trans-unit id="create.job.type.1">
-				<source>Type of job</source>
-				<target>Art des Stellenangebots</target>
-			</trans-unit>
-			<trans-unit id="create.job.type.2">
-				<source>Sidejob</source>
-				<target>Nebenjob</target>
-			</trans-unit>
-			<trans-unit id="create.job.type.3">
-				<source>Thesis</source>
-				<target>Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="create.job.image.label">
-				<source>Logo</source>
-				<target>Logo</target>
-			</trans-unit>
-			<trans-unit id="create.job.title.label">
-				<source>Job title / Thesis title</source>
-				<target>Stellenbezeichnung / Titel der Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="create.job.sector.label">
-				<source>Industry</source>
-				<target>Branche</target>
-			</trans-unit>
-			<trans-unit id="create.job.requiredDegree.label">
-				<source>Required degree</source>
-				<target>Benötigter Abschluss</target>
-			</trans-unit>
-			<trans-unit id="create.job.contractualRelationship.label">
-				<source>Contractual relationship</source>
-				<target>Vertragsverhältnis</target>
-			</trans-unit>
-			<trans-unit id="create.job.description.label">
-				<source>Job description</source>
-				<target>Stellenbeschreibung</target>
-			</trans-unit>
-			<trans-unit id="create.job.link.label">
-				<source>Link</source>
-				<target>Link</target>
-			</trans-unit>
-			<trans-unit id="create.job.alumniRecommend.label">
-				<source>Created by Alumni</source>
-				<target>Erstellt von Alumni</target>
-			</trans-unit>
-			<trans-unit id="create.job.incorrectValues">
-				<source>One or more fields have not been filled out correctly.</source>
-				<target>Ein oder mehrere Felder wurden nicht korrekt ausgefüllt.</target>
-			</trans-unit>
-			<trans-unit id="jobs.submit">
-				<source>Submit</source>
-				<target>Absenden</target>
-			</trans-unit>
-			<trans-unit id="upload.error.150530345">
-				<source>Maximum file size exceeded.</source>
-				<target>Maximale Dateigröße überschritten.</target>
-			</trans-unit>
-			<trans-unit id="upload.error.150530346">
-				<source>Upload failed. The file was only partially uploaded, please try again.</source>
-				<target>Fehler beim Hochladen. Die Datei wurde nur teilweise hochgeladen, bitte versuchen Sie es erneut.</target>
-			</trans-unit>
-			<trans-unit id="upload.error.150530347">
-				<source>No file was uploaded.</source>
-				<target>Keine Datei wurde hochgeladen.</target>
-			</trans-unit>
-			<trans-unit id="upload.error.150530348">
-				<source>Upload failed.</source>
-				<target>Das Hochladen ist fehlgeschlagen</target>
-			</trans-unit>
-			<trans-unit id="validation.error.1471708998">
-				<source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
-				<target>Sie haben einen falschen Medientyp eingegeben, "%s" ist für diese Datei nicht zulässig. Bitte beachten Sie die Beschreibung dieses Feldes.</target>
-			</trans-unit>
+      <trans-unit id="jobs.back">
+        <source>Back to job list</source>
+        <target>Zurück zu den Stellenangeboten</target>
+      </trans-unit>
+      <trans-unit id="create.job.contactName.label">
+        <source>Contact name</source>
+        <target>Kontakt Name</target>
+      </trans-unit>
+      <trans-unit id="create.job.contactEmail.label">
+        <source>E-Mail</source>
+        <target>E-Mail</target>
+      </trans-unit>
+      <trans-unit id="create.job.contactPhone.label">
+        <source>Phone number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
+      <trans-unit id="create.job.contactAdditionalInformation.label">
+        <source>Additional information</source>
+        <target>Zusatzinformation</target>
+      </trans-unit>
+      <trans-unit id="create.job.starttime.label">
+        <source>When</source>
+        <target>Ab wann</target>
+      </trans-unit>
+      <trans-unit id="create.job.endtime.label">
+        <source>Application deadline</source>
+        <target>Bewerbungsfrist</target>
+      </trans-unit>
+      <trans-unit id="create.job.companyName.label">
+        <source>Organization</source>
+        <target>Organisation</target>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.label">
+        <source>Working hours</source>
+        <target>Arbeitszeit</target>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.1">
+        <source>Full-Time</source>
+        <target>Vollzeit</target>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.2">
+        <source>Part-Time</source>
+        <target>Teilzeit</target>
+      </trans-unit>
+      <trans-unit id="create.job.workLocation.label">
+        <source>Location</source>
+        <target>Ort</target>
+      </trans-unit>
+      <trans-unit id="create.job.employmentStartDate.label">
+        <source>Employment Start Date</source>
+        <target>Arbeitsbeginn</target>
+      </trans-unit>
+      <trans-unit id="create.job.type.label">
+        <source>Job Type</source>
+        <target>Jobtyp</target>
+      </trans-unit>
+      <trans-unit id="create.job.type.1">
+        <source>Type of job</source>
+        <target>Art des Stellenangebots</target>
+      </trans-unit>
+      <trans-unit id="create.job.type.2">
+        <source>Sidejob</source>
+        <target>Nebenjob</target>
+      </trans-unit>
+      <trans-unit id="create.job.type.3">
+        <source>Thesis</source>
+        <target>Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="create.job.image.label">
+        <source>Logo</source>
+        <target>Logo</target>
+      </trans-unit>
+      <trans-unit id="create.job.title.label">
+        <source>Job title / Thesis title</source>
+        <target>Stellenbezeichnung / Titel der Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="create.job.sector.label">
+        <source>Industry</source>
+        <target>Branche</target>
+      </trans-unit>
+      <trans-unit id="create.job.requiredDegree.label">
+        <source>Required degree</source>
+        <target>Benötigter Abschluss</target>
+      </trans-unit>
+      <trans-unit id="create.job.contractualRelationship.label">
+        <source>Contractual relationship</source>
+        <target>Vertragsverhältnis</target>
+      </trans-unit>
+      <trans-unit id="create.job.description.label">
+        <source>Job description</source>
+        <target>Stellenbeschreibung</target>
+      </trans-unit>
+      <trans-unit id="create.job.link.label">
+        <source>Link</source>
+        <target>Link</target>
+      </trans-unit>
+      <trans-unit id="create.job.alumniRecommend.label">
+        <source>Created by Alumni</source>
+        <target>Erstellt von Alumni</target>
+      </trans-unit>
+      <trans-unit id="create.job.incorrectValues">
+        <source>One or more fields have not been filled out correctly.</source>
+        <target>Ein oder mehrere Felder wurden nicht korrekt ausgefüllt.</target>
+      </trans-unit>
+      <trans-unit id="jobs.submit">
+        <source>Submit</source>
+        <target>Absenden</target>
+      </trans-unit>
+      <trans-unit id="upload.error.150530345">
+        <source>Maximum file size exceeded.</source>
+        <target>Maximale Dateigröße überschritten.</target>
+      </trans-unit>
+      <trans-unit id="upload.error.150530346">
+        <source>Upload failed. The file was only partially uploaded, please try again.</source>
+        <target>Fehler beim Hochladen. Die Datei wurde nur teilweise hochgeladen, bitte versuchen Sie es erneut.</target>
+      </trans-unit>
+      <trans-unit id="upload.error.150530347">
+        <source>No file was uploaded.</source>
+        <target>Keine Datei wurde hochgeladen.</target>
+      </trans-unit>
+      <trans-unit id="upload.error.150530348">
+        <source>Upload failed.</source>
+        <target>Das Hochladen ist fehlgeschlagen</target>
+      </trans-unit>
+      <trans-unit id="validation.error.1471708998">
+        <source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
+        <target>Sie haben einen falschen Medientyp eingegeben, "%s" ist für diese Datei nicht zulässig. Bitte beachten Sie die Beschreibung dieses Feldes.</target>
+      </trans-unit>
 
-			<!-- Alerts -->
+      <!-- Alerts -->
 
-			<trans-unit id="tx_academicjobs.fe.alert.job_created.body">
-				<source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
-				<target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created.title">
-				<source>Your job advert has been successfully created</source>
-				<target>Ihre Stellenanzeige wurde erfolgreich erstellt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
-				<source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
-				<target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre Stellenanzeige freischalten zu lassen.</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
-				<source>Notification email could not be sent</source>
-				<target>Benachrichtigungs-E-Mail konnte nicht gesendet werden</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_created.body">
-				<source>An unknown error has occurred. Please try again. Please let us know if the problem persists.</source>
-				<target>Ein unbekannter Fehler ist aufgetreten. Bitte versuchen Sie es erneut. Bitte informieren Sie uns, wenn das Problem weiterhin besteht.</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_created.title">
-				<source>Your job advert could not be created</source>
-				<target>Ihre Stellenanzeige konnte nicht erstellt werden</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_found.body">
-				<source>No job advert could be found.</source>
-				<target>Es konnte keine Stellenanzeige gefunden werden.</target>
-			</trans-unit>
-			<trans-unit id="create.job.noLink">
-				<source>The link to this job avert is broken. Please contact us.</source>
-				<target>Der Link zu dieser Stellenanzeige ist defekt. Bitte kontaktieren Sie uns.</target>
-			</trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created.body">
+        <source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
+        <target>Wir werden automatisch darüber benachrichtigt, dass Sie eine Stellanzeige erstellt haben. Nach einer Überprüfung schalten wir Ihre Stellenanzeige frei.</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created.title">
+        <source>Your job advert has been successfully created</source>
+        <target>Ihre Stellenanzeige wurde erfolgreich erstellt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
+        <source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
+        <target>Ihre Stellenanzeige wurde erfolgreich erstellt, aber es konnte keine Benachrichtigung an uns verschickt werden. Bitte kontaktieren Sie uns, um ihre Stellenanzeige freischalten zu lassen.</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
+        <source>Notification email could not be sent</source>
+        <target>Benachrichtigungs-E-Mail konnte nicht gesendet werden</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_created.body">
+        <source>An unknown error has occurred. Please try again. Please let us know if the problem persists.</source>
+        <target>Ein unbekannter Fehler ist aufgetreten. Bitte versuchen Sie es erneut. Bitte informieren Sie uns, wenn das Problem weiterhin besteht.</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_created.title">
+        <source>Your job advert could not be created</source>
+        <target>Ihre Stellenanzeige konnte nicht erstellt werden</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_found.body">
+        <source>No job advert could be found.</source>
+        <target>Es konnte keine Stellenanzeige gefunden werden.</target>
+      </trans-unit>
+      <trans-unit id="create.job.noLink">
+        <source>The link to this job avert is broken. Please contact us.</source>
+        <target>Der Link zu dieser Stellenanzeige ist defekt. Bitte kontaktieren Sie uns.</target>
+      </trans-unit>
 
-			<!-- Job List -->
+      <!-- Job List -->
 
-			<trans-unit id="jobs.contactName">
-				<source>Contact name</source>
-				<target>Kontakt Name</target>
-			</trans-unit>
-			<trans-unit id="jobs.contactEmail">
-				<source>E-Mail</source>
-				<target>E-Mail</target>
-			</trans-unit>
-			<trans-unit id="jobs.contactPhone">
-				<source>Phone number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
-			<trans-unit id="jobs.contactAdditionalInformation">
-				<source>Additional information</source>
-				<target>Zusatzinformation</target>
-			</trans-unit>
-			<trans-unit id="jobs.starttime">
-				<source>When</source>
-				<target>Ab wann</target>
-			</trans-unit>
-			<trans-unit id="jobs.endtime">
-				<source>Application deadline</source>
-				<target>Bewerbungsfrist</target>
-			</trans-unit>
-			<trans-unit id="jobs.companyName">
-				<source>Organization</source>
-				<target>Organisation</target>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType">
-				<source>Working hours</source>
-				<target>Arbeitszeit</target>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType.1">
-				<source>Full-Time</source>
-				<target>Vollzeit</target>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType.2">
-				<source>Part-Time</source>
-				<target>Teilzeit</target>
-			</trans-unit>
-			<trans-unit id="jobs.workLocation">
-				<source>Location</source>
-				<target>Ort</target>
-			</trans-unit>
-			<trans-unit id="jobs.employmentStartDate">
-				<source>Employment Start Date</source>
-				<target>Arbeitsbeginn</target>
-			</trans-unit>
-			<trans-unit id="jobs.type">
-				<source>Type of job</source>
-				<target>Art des Stellenangebots</target>
-			</trans-unit>
-			<trans-unit id="jobs.type.1">
-				<source>Job</source>
-				<target>Job</target>
-			</trans-unit>
-			<trans-unit id="jobs.type.2">
-				<source>Sidejob</source>
-				<target>Nebenjob</target>
-			</trans-unit>
-			<trans-unit id="jobs.type.3">
-				<source>Thesis</source>
-				<target>Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="jobs.title">
-				<source>Job title / Thesis title</source>
-				<target>Stellenbezeichnung / Titel der Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="jobs.sector">
-				<source>Industry</source>
-				<target>Branche</target>
-			</trans-unit>
-			<trans-unit id="jobs.requiredDegree">
-				<source>Required degree</source>
-				<target>Benötigter Abschluss</target>
-			</trans-unit>
-			<trans-unit id="jobs.contractualRelationship">
-				<source>Contractual relationship</source>
-				<target>Vertragsverhältnis</target>
-			</trans-unit>
-			<trans-unit id="jobs.description">
-				<source>Job description</source>
-				<target>Stellenbeschreibung</target>
-			</trans-unit>
-			<trans-unit id="jobs.link">
-				<source>Link</source>
-				<target>Link</target>
-			</trans-unit>
+      <trans-unit id="jobs.contactName">
+        <source>Contact name</source>
+        <target>Kontakt Name</target>
+      </trans-unit>
+      <trans-unit id="jobs.contactEmail">
+        <source>E-Mail</source>
+        <target>E-Mail</target>
+      </trans-unit>
+      <trans-unit id="jobs.contactPhone">
+        <source>Phone number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
+      <trans-unit id="jobs.contactAdditionalInformation">
+        <source>Additional information</source>
+        <target>Zusatzinformation</target>
+      </trans-unit>
+      <trans-unit id="jobs.starttime">
+        <source>When</source>
+        <target>Ab wann</target>
+      </trans-unit>
+      <trans-unit id="jobs.endtime">
+        <source>Application deadline</source>
+        <target>Bewerbungsfrist</target>
+      </trans-unit>
+      <trans-unit id="jobs.companyName">
+        <source>Organization</source>
+        <target>Organisation</target>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType">
+        <source>Working hours</source>
+        <target>Arbeitszeit</target>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType.1">
+        <source>Full-Time</source>
+        <target>Vollzeit</target>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType.2">
+        <source>Part-Time</source>
+        <target>Teilzeit</target>
+      </trans-unit>
+      <trans-unit id="jobs.workLocation">
+        <source>Location</source>
+        <target>Ort</target>
+      </trans-unit>
+      <trans-unit id="jobs.employmentStartDate">
+        <source>Employment Start Date</source>
+        <target>Arbeitsbeginn</target>
+      </trans-unit>
+      <trans-unit id="jobs.type">
+        <source>Type of job</source>
+        <target>Art des Stellenangebots</target>
+      </trans-unit>
+      <trans-unit id="jobs.type.1">
+        <source>Job</source>
+        <target>Job</target>
+      </trans-unit>
+      <trans-unit id="jobs.type.2">
+        <source>Sidejob</source>
+        <target>Nebenjob</target>
+      </trans-unit>
+      <trans-unit id="jobs.type.3">
+        <source>Thesis</source>
+        <target>Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="jobs.title">
+        <source>Job title / Thesis title</source>
+        <target>Stellenbezeichnung / Titel der Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="jobs.sector">
+        <source>Industry</source>
+        <target>Branche</target>
+      </trans-unit>
+      <trans-unit id="jobs.requiredDegree">
+        <source>Required degree</source>
+        <target>Benötigter Abschluss</target>
+      </trans-unit>
+      <trans-unit id="jobs.contractualRelationship">
+        <source>Contractual relationship</source>
+        <target>Vertragsverhältnis</target>
+      </trans-unit>
+      <trans-unit id="jobs.description">
+        <source>Job description</source>
+        <target>Stellenbeschreibung</target>
+      </trans-unit>
+      <trans-unit id="jobs.link">
+        <source>Link</source>
+        <target>Link</target>
+      </trans-unit>
 
-			<!-- Details -->
+      <!-- Details -->
 
-			<trans-unit id="jobs.contact">
-				<source>Contact</source>
-				<target>Ansprechpartner</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="jobs.contact">
+        <source>Contact</source>
+        <target>Ansprechpartner</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/de.locallang_be.xlf
@@ -1,217 +1,217 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf"
-		date="2023-09-02T12:17:09Z"
-		product-name="academic_jobs"
-	>
-		<header/>
-		<body>
-			<!-- Flexform General -->
-			<trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
-				<source>Settings</source>
-				<target>Settings</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf"
+    date="2023-09-02T12:17:09Z"
+    product-name="academic_jobs"
+  >
+    <header/>
+    <body>
+      <!-- Flexform General -->
+      <trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
+        <source>Settings</source>
+        <target>Settings</target>
+      </trans-unit>
 
-			<!-- Flexform Plugin List -->
-			<trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
-				<source>Job Type</source>
-				<target>Job Type</target>
-			</trans-unit>
+      <!-- Flexform Plugin List -->
+      <trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
+        <source>Job Type</source>
+        <target>Job Type</target>
+      </trans-unit>
 
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>When enabled, hidden (disabled) records are included in the frontend output, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>When enabled, hidden (disabled) records are included in the frontend output, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
 
-			<!-- Flexform Plugin NewJobForm -->
-			<trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
-				<source>Redirect page after job creation</source>
-				<target>Weiterleitungsseite nach erfolgreichen anlegen eines Jobs</target>
-			</trans-unit>
+      <!-- Flexform Plugin NewJobForm -->
+      <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
+        <source>Redirect page after job creation</source>
+        <target>Weiterleitungsseite nach erfolgreichen anlegen eines Jobs</target>
+      </trans-unit>
 
-			<!-- /* shared */ -->
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
+      <!-- /* shared */ -->
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
 
-			<!-- /* academicjobs_newjobform */ -->
-			<trans-unit id="plugin.newjobform.label">
-				<source>Jobs New</source>
-				<target>Jobs New</target>
-			</trans-unit>
+      <!-- /* academicjobs_newjobform */ -->
+      <trans-unit id="plugin.newjobform.label">
+        <source>Jobs New</source>
+        <target>Jobs New</target>
+      </trans-unit>
 
-			<!-- /* academicjobs_list */ -->
-			<trans-unit id="plugin.list.label">
-				<source>Jobs List</source>
-				<target>Jobs List</target>
-			</trans-unit>
+      <!-- /* academicjobs_list */ -->
+      <trans-unit id="plugin.list.label">
+        <source>Jobs List</source>
+        <target>Jobs List</target>
+      </trans-unit>
 
-			<!-- /* academicjobs_detail */ -->
-			<trans-unit id="plugin.detail.label">
-				<source>Jobs Detail</source>
-				<target>Jobs Detail</target>
-			</trans-unit>
+      <!-- /* academicjobs_detail */ -->
+      <trans-unit id="plugin.detail.label">
+        <source>Jobs Detail</source>
+        <target>Jobs Detail</target>
+      </trans-unit>
 
-			<!-- /* newContentElement */ -->
-			<trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
-				<source>Jobs New</source>
-				<target>Jobs New</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
-				<source>Plugin providing new jobs form</source>
-				<target>Plugin providing new jobs form</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.title">
-				<source>Jobs List</source>
-				<target>Jobs List</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.description">
-				<source>Plugin for listing academic jobs</source>
-				<target>Plugin for listing academic jobs</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.title">
-				<source>Jobs Detail</source>
-				<target>Jobs Detail</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.description">
-				<source>Plugin for viewing single academic job</source>
-				<target>Plugin for viewing single academic job</target>
-			</trans-unit>
+      <!-- /* newContentElement */ -->
+      <trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
+        <source>Jobs New</source>
+        <target>Jobs New</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
+        <source>Plugin providing new jobs form</source>
+        <target>Plugin providing new jobs form</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.title">
+        <source>Jobs List</source>
+        <target>Jobs List</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.description">
+        <source>Plugin for listing academic jobs</source>
+        <target>Plugin for listing academic jobs</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+        <source>Jobs Detail</source>
+        <target>Jobs Detail</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+        <source>Plugin for viewing single academic job</source>
+        <target>Plugin for viewing single academic job</target>
+      </trans-unit>
 
-			<!-- Domain Model: Job -->
+      <!-- Domain Model: Job -->
 
-			<trans-unit id="tx_academicjobs_domain_model_job">
-				<source>Job</source>
-				<target>Job</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_title">
-				<source>Job Title</source>
-				<target>Jobtitel</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_start_date">
-				<source>Employment Start Date</source>
-				<target>Arbeitsbeginn</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_description">
-				<source>Job Description</source>
-				<target>Jobbeschreibung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.image">
-				<source>Image</source>
-				<target>Bild</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.company_name">
-				<source>Organization</source>
-				<target>Organisation</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.sector">
-				<source>Sector</source>
-				<target>Branche</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.required_degree">
-				<source>Required degree</source>
-				<target>Benötigter Abschluss</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contractual_relationship">
-				<source>Contractual relationship</source>
-				<target>Vertragsverhältnis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.alumni_recommend">
-				<source>Alumni recommends</source>
-				<target>Alumni empfiehlt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.internationals_welcome">
-				<source>Internationals welcome</source>
-				<target>Internationals willkommen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type">
-				<source>Employment Type</source>
-				<target>Art des Stellenangebots</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type.fulltime">
-				<source>Full-time</source>
-				<target>Vollzeit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type.parttime">
-				<source>Part-time</source>
-				<target>Teilzeit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.work_location">
-				<source>Work Location</source>
-				<target>Ort</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.work_location.description">
-				<source>ex. (Remote, Hybrid, Berlin)</source>
-				<target>e.g (Remote, Hybrid, Berlin)</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.link">
-				<source>Link</source>
-				<target>Link</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.link.description">
-				<source>Link to the announcement or website</source>
-				<target>Link zur Ausschreibung oder Website</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.slug">
-				<source>Slug</source>
-				<target>Slug</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_type">
-				<source>Job Type</source>
-				<target>Jobtyp</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact">
-				<source>Contact</source>
-				<target>Kontakt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
-				<source>None</source>
-				<target>Keine Auswahl</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
-				<source>Job</source>
-				<target>Job</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.sidejob">
-				<source>Sidejob</source>
-				<target>Nebenjob</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.thesis">
-				<source>Thesis</source>
-				<target>Abschlussarbeit</target>
-			</trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job">
+        <source>Job</source>
+        <target>Job</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_title">
+        <source>Job Title</source>
+        <target>Jobtitel</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_start_date">
+        <source>Employment Start Date</source>
+        <target>Arbeitsbeginn</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_description">
+        <source>Job Description</source>
+        <target>Jobbeschreibung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.image">
+        <source>Image</source>
+        <target>Bild</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.company_name">
+        <source>Organization</source>
+        <target>Organisation</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.sector">
+        <source>Sector</source>
+        <target>Branche</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.required_degree">
+        <source>Required degree</source>
+        <target>Benötigter Abschluss</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contractual_relationship">
+        <source>Contractual relationship</source>
+        <target>Vertragsverhältnis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.alumni_recommend">
+        <source>Alumni recommends</source>
+        <target>Alumni empfiehlt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.internationals_welcome">
+        <source>Internationals welcome</source>
+        <target>Internationals willkommen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type">
+        <source>Employment Type</source>
+        <target>Art des Stellenangebots</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type.fulltime">
+        <source>Full-time</source>
+        <target>Vollzeit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type.parttime">
+        <source>Part-time</source>
+        <target>Teilzeit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.work_location">
+        <source>Work Location</source>
+        <target>Ort</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.work_location.description">
+        <source>ex. (Remote, Hybrid, Berlin)</source>
+        <target>e.g (Remote, Hybrid, Berlin)</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.link">
+        <source>Link</source>
+        <target>Link</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.link.description">
+        <source>Link to the announcement or website</source>
+        <target>Link zur Ausschreibung oder Website</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.slug">
+        <source>Slug</source>
+        <target>Slug</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_type">
+        <source>Job Type</source>
+        <target>Jobtyp</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact">
+        <source>Contact</source>
+        <target>Kontakt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
+        <source>None</source>
+        <target>Keine Auswahl</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
+        <source>Job</source>
+        <target>Job</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.sidejob">
+        <source>Sidejob</source>
+        <target>Nebenjob</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.thesis">
+        <source>Thesis</source>
+        <target>Abschlussarbeit</target>
+      </trans-unit>
 
-			<!-- Domain Model: Contact -->
+      <!-- Domain Model: Contact -->
 
-			<trans-unit id="tx_academicjobs_domain_model_contact">
-				<source>Contact</source>
-				<target>Kontakt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.name">
-				<source>Name</source>
-				<target>Name</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.email">
-				<source>Email</source>
-				<target>E-Mail</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.phone">
-				<source>Phone</source>
-				<target>Telefon</target>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information">
-				<source>Additional Information</source>
-				<target>Zusätzliche Informationen</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicjobs_domain_model_contact">
+        <source>Contact</source>
+        <target>Kontakt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.name">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.email">
+        <source>Email</source>
+        <target>E-Mail</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.phone">
+        <source>Phone</source>
+        <target>Telefon</target>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information">
+        <source>Additional Information</source>
+        <target>Zusätzliche Informationen</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang.xlf
@@ -1,232 +1,232 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf"
-		date="2023-09-02T12:17:09Z"
-		product-name="academic_jobs"
-	>
-		<header/>
-		<body>
-			<!-- Backend: TypoScript Constants Editor -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_jobs/Resources/Private/Language/locallang.xlf"
+    date="2023-09-02T12:17:09Z"
+    product-name="academic_jobs"
+  >
+    <header/>
+    <body>
+      <!-- Backend: TypoScript Constants Editor -->
 
-			<trans-unit id="saveForm.flashMessageCreationMode.label">
-				<source>Flashmessage creation mode when persisting new jobs (FE)</source>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.use_global_setting">
-				<source>Fallback - Use TypoScript settings</source>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_always">
-				<source>always</source>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_never">
-				<source>never</source>
-			</trans-unit>
-			<trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected">
-				<source>suppress when list pid has been configured</source>
-			</trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.label">
+        <source>Flashmessage creation mode when persisting new jobs (FE)</source>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.use_global_setting">
+        <source>Fallback - Use TypoScript settings</source>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_always">
+        <source>always</source>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_never">
+        <source>never</source>
+      </trans-unit>
+      <trans-unit id="saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected">
+        <source>suppress when list pid has been configured</source>
+      </trans-unit>
 
-			<!-- Frontend -->
+      <!-- Frontend -->
 
-			<trans-unit id="jobs.back">
-				<source>Back to job list</source>
-			</trans-unit>
-			<trans-unit id="create.job.contactName.label">
-				<source>Contact name</source>
-			</trans-unit>
-			<trans-unit id="create.job.contactEmail.label">
-				<source>E-Mail</source>
-			</trans-unit>
-			<trans-unit id="create.job.contactPhone.label">
-				<source>Phone number</source>
-			</trans-unit>
-			<trans-unit id="create.job.contactAdditionalInformation.label">
-				<source>Additional information</source>
-			</trans-unit>
-			<trans-unit id="create.job.starttime.label">
-				<source>When</source>
-			</trans-unit>
-			<trans-unit id="create.job.endtime.label">
-				<source>Application deadline</source>
-			</trans-unit>
-			<trans-unit id="create.job.companyName.label">
-				<source>Organization</source>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.label">
-				<source>Working hours</source>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.1">
-				<source>Full-Time</source>
-			</trans-unit>
-			<trans-unit id="create.job.employmentType.2">
-				<source>Part-Time</source>
-			</trans-unit>
-			<trans-unit id="create.job.employmentStartDate.label">
-				<source>Employment Start Date</source>
-			</trans-unit>
-			<trans-unit id="create.job.type.label">
-				<source>Job Type</source>
-			</trans-unit>
-			<trans-unit id="create.job.type.1">
-				<source>Type of job</source>
-			</trans-unit>
-			<trans-unit id="create.job.type.2">
-				<source>Sidejob</source>
-			</trans-unit>
-			<trans-unit id="create.job.type.3">
-				<source>Thesis</source>
-			</trans-unit>
-			<trans-unit id="create.job.workLocation.label">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="create.job.image.label">
-				<source>Logo</source>
-			</trans-unit>
-			<trans-unit id="create.job.title.label">
-				<source>Job title / Thesis title</source>
-			</trans-unit>
-			<trans-unit id="create.job.sector.label">
-				<source>Industry</source>
-			</trans-unit>
-			<trans-unit id="create.job.requiredDegree.label">
-				<source>Required degree</source>
-			</trans-unit>
-			<trans-unit id="create.job.contractualRelationship.label">
-				<source>Contractual relationship</source>
-			</trans-unit>
-			<trans-unit id="create.job.description.label">
-				<source>Job description</source>
-			</trans-unit>
-			<trans-unit id="create.job.link.label">
-				<source>Link</source>
-			</trans-unit>
-			<trans-unit id="create.job.alumniRecommend.label">
-				<source>Created by Alumni</source>
-			</trans-unit>
-			<trans-unit id="create.job.incorrectValues">
-				<source>One or more fields have not been filled out correctly.</source>
-			</trans-unit>
-			<trans-unit id="jobs.submit">
-				<source>Submit</source>
-			</trans-unit>
-			<trans-unit id="upload.error.150530345">
-				<source>Maximum file size exceeded.</source>
-			</trans-unit>
-			<trans-unit id="upload.error.150530346">
-				<source>Upload failed. The file was only partially uploaded, please try again.</source>
-			</trans-unit>
-			<trans-unit id="upload.error.150530347">
-				<source>No file was uploaded.</source>
-			</trans-unit>
-			<trans-unit id="upload.error.150530348">
-				<source>Upload failed.</source>
-			</trans-unit>
-			<trans-unit id="validation.error.1471708998">
-				<source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
-			</trans-unit>
+      <trans-unit id="jobs.back">
+        <source>Back to job list</source>
+      </trans-unit>
+      <trans-unit id="create.job.contactName.label">
+        <source>Contact name</source>
+      </trans-unit>
+      <trans-unit id="create.job.contactEmail.label">
+        <source>E-Mail</source>
+      </trans-unit>
+      <trans-unit id="create.job.contactPhone.label">
+        <source>Phone number</source>
+      </trans-unit>
+      <trans-unit id="create.job.contactAdditionalInformation.label">
+        <source>Additional information</source>
+      </trans-unit>
+      <trans-unit id="create.job.starttime.label">
+        <source>When</source>
+      </trans-unit>
+      <trans-unit id="create.job.endtime.label">
+        <source>Application deadline</source>
+      </trans-unit>
+      <trans-unit id="create.job.companyName.label">
+        <source>Organization</source>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.label">
+        <source>Working hours</source>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.1">
+        <source>Full-Time</source>
+      </trans-unit>
+      <trans-unit id="create.job.employmentType.2">
+        <source>Part-Time</source>
+      </trans-unit>
+      <trans-unit id="create.job.employmentStartDate.label">
+        <source>Employment Start Date</source>
+      </trans-unit>
+      <trans-unit id="create.job.type.label">
+        <source>Job Type</source>
+      </trans-unit>
+      <trans-unit id="create.job.type.1">
+        <source>Type of job</source>
+      </trans-unit>
+      <trans-unit id="create.job.type.2">
+        <source>Sidejob</source>
+      </trans-unit>
+      <trans-unit id="create.job.type.3">
+        <source>Thesis</source>
+      </trans-unit>
+      <trans-unit id="create.job.workLocation.label">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="create.job.image.label">
+        <source>Logo</source>
+      </trans-unit>
+      <trans-unit id="create.job.title.label">
+        <source>Job title / Thesis title</source>
+      </trans-unit>
+      <trans-unit id="create.job.sector.label">
+        <source>Industry</source>
+      </trans-unit>
+      <trans-unit id="create.job.requiredDegree.label">
+        <source>Required degree</source>
+      </trans-unit>
+      <trans-unit id="create.job.contractualRelationship.label">
+        <source>Contractual relationship</source>
+      </trans-unit>
+      <trans-unit id="create.job.description.label">
+        <source>Job description</source>
+      </trans-unit>
+      <trans-unit id="create.job.link.label">
+        <source>Link</source>
+      </trans-unit>
+      <trans-unit id="create.job.alumniRecommend.label">
+        <source>Created by Alumni</source>
+      </trans-unit>
+      <trans-unit id="create.job.incorrectValues">
+        <source>One or more fields have not been filled out correctly.</source>
+      </trans-unit>
+      <trans-unit id="jobs.submit">
+        <source>Submit</source>
+      </trans-unit>
+      <trans-unit id="upload.error.150530345">
+        <source>Maximum file size exceeded.</source>
+      </trans-unit>
+      <trans-unit id="upload.error.150530346">
+        <source>Upload failed. The file was only partially uploaded, please try again.</source>
+      </trans-unit>
+      <trans-unit id="upload.error.150530347">
+        <source>No file was uploaded.</source>
+      </trans-unit>
+      <trans-unit id="upload.error.150530348">
+        <source>Upload failed.</source>
+      </trans-unit>
+      <trans-unit id="validation.error.1471708998">
+        <source>You entered an incorrect media type, "%s" is not allowed for this file. Please refer to the description of this field.</source>
+      </trans-unit>
 
-			<!-- Alerts -->
+      <!-- Alerts -->
 
-			<trans-unit id="tx_academicjobs.fe.alert.job_created.body">
-				<source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created.title">
-				<source>Your job advert has been successfully created</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
-				<source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
-				<source>Notification email could not be sent</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_created.body">
-				<source>An unknown error has occurred. Please try again. Please let us know if the problem persists.</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_created.title">
-				<source>Your job advert could not be created</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs.fe.alert.job_not_found.body">
-				<source>No job advert could be found.</source>
-			</trans-unit>
-			<trans-unit id="create.job.noLink">
-				<source>The link to this job avert is broken. Please contact us.</source>
-			</trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created.body">
+        <source>We are automatically notified that you have created a job advert. After a review, we will activate your job advert.</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created.title">
+        <source>Your job advert has been successfully created</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.body">
+        <source>Your job advert has been successfully created, but no notification could be sent to us. Please contact us to have your job advert activated.</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_created_no_email.title">
+        <source>Notification email could not be sent</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_created.body">
+        <source>An unknown error has occurred. Please try again. Please let us know if the problem persists.</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_created.title">
+        <source>Your job advert could not be created</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs.fe.alert.job_not_found.body">
+        <source>No job advert could be found.</source>
+      </trans-unit>
+      <trans-unit id="create.job.noLink">
+        <source>The link to this job avert is broken. Please contact us.</source>
+      </trans-unit>
 
-			<!-- Job List -->
+      <!-- Job List -->
 
-			<trans-unit id="jobs.contactName">
-				<source>Contact name</source>
-			</trans-unit>
-			<trans-unit id="jobs.contactEmail">
-				<source>E-Mail</source>
-			</trans-unit>
-			<trans-unit id="jobs.contactPhone">
-				<source>Phone number</source>
-			</trans-unit>
-			<trans-unit id="jobs.contactAdditionalInformation">
-				<source>Additional information</source>
-			</trans-unit>
-			<trans-unit id="jobs.starttime">
-				<source>When</source>
-			</trans-unit>
-			<trans-unit id="jobs.endtime">
-				<source>Application deadline</source>
-			</trans-unit>
-			<trans-unit id="jobs.companyName">
-				<source>Organization</source>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType">
-				<source>Working hours</source>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType.1">
-				<source>Full-Time</source>
-			</trans-unit>
-			<trans-unit id="jobs.employmentType.2">
-				<source>Part-Time</source>
-			</trans-unit>
-			<trans-unit id="jobs.workLocation">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="jobs.employmentStartDate">
-				<source>Employment Start Date</source>
-			</trans-unit>
-			<trans-unit id="jobs.type">
-				<source>Type of job</source>
-			</trans-unit>
-			<trans-unit id="jobs.type.1">
-				<source>Job</source>
-			</trans-unit>
-			<trans-unit id="jobs.type.2">
-				<source>Sidejob</source>
-			</trans-unit>
-			<trans-unit id="jobs.type.3">
-				<source>Thesis</source>
-			</trans-unit>
-			<trans-unit id="jobs.title">
-				<source>Job title / Thesis title</source>
-			</trans-unit>
-			<trans-unit id="jobs.sector">
-				<source>Industry</source>
-			</trans-unit>
-			<trans-unit id="jobs.requiredDegree">
-				<source>Required degree</source>
-			</trans-unit>
-			<trans-unit id="jobs.contractualRelationship">
-				<source>Contractual relationship</source>
-			</trans-unit>
-			<trans-unit id="jobs.description">
-				<source>Job description</source>
-			</trans-unit>
-			<trans-unit id="jobs.link">
-				<source>Link</source>
-			</trans-unit>
+      <trans-unit id="jobs.contactName">
+        <source>Contact name</source>
+      </trans-unit>
+      <trans-unit id="jobs.contactEmail">
+        <source>E-Mail</source>
+      </trans-unit>
+      <trans-unit id="jobs.contactPhone">
+        <source>Phone number</source>
+      </trans-unit>
+      <trans-unit id="jobs.contactAdditionalInformation">
+        <source>Additional information</source>
+      </trans-unit>
+      <trans-unit id="jobs.starttime">
+        <source>When</source>
+      </trans-unit>
+      <trans-unit id="jobs.endtime">
+        <source>Application deadline</source>
+      </trans-unit>
+      <trans-unit id="jobs.companyName">
+        <source>Organization</source>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType">
+        <source>Working hours</source>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType.1">
+        <source>Full-Time</source>
+      </trans-unit>
+      <trans-unit id="jobs.employmentType.2">
+        <source>Part-Time</source>
+      </trans-unit>
+      <trans-unit id="jobs.workLocation">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="jobs.employmentStartDate">
+        <source>Employment Start Date</source>
+      </trans-unit>
+      <trans-unit id="jobs.type">
+        <source>Type of job</source>
+      </trans-unit>
+      <trans-unit id="jobs.type.1">
+        <source>Job</source>
+      </trans-unit>
+      <trans-unit id="jobs.type.2">
+        <source>Sidejob</source>
+      </trans-unit>
+      <trans-unit id="jobs.type.3">
+        <source>Thesis</source>
+      </trans-unit>
+      <trans-unit id="jobs.title">
+        <source>Job title / Thesis title</source>
+      </trans-unit>
+      <trans-unit id="jobs.sector">
+        <source>Industry</source>
+      </trans-unit>
+      <trans-unit id="jobs.requiredDegree">
+        <source>Required degree</source>
+      </trans-unit>
+      <trans-unit id="jobs.contractualRelationship">
+        <source>Contractual relationship</source>
+      </trans-unit>
+      <trans-unit id="jobs.description">
+        <source>Job description</source>
+      </trans-unit>
+      <trans-unit id="jobs.link">
+        <source>Link</source>
+      </trans-unit>
 
-			<!-- Details -->
+      <!-- Details -->
 
-			<trans-unit id="jobs.contact">
-				<source>Contact</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="jobs.contact">
+        <source>Contact</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Language/locallang_be.xlf
@@ -1,183 +1,183 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf"
-		date="2023-09-02T12:17:09Z"
-		product-name="academic_jobs"
-	>
-		<header/>
-		<body>
-			<!-- Flexform General -->
-			<trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
-				<source>Settings</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf"
+    date="2023-09-02T12:17:09Z"
+    product-name="academic_jobs"
+  >
+    <header/>
+    <body>
+      <!-- Flexform General -->
+      <trans-unit id="tx_academicjobs_domain_model_job.pi_flexform.sheetGeneral">
+        <source>Settings</source>
+      </trans-unit>
 
-			<!-- Flexform Plugin List -->
-			<trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
-				<source>Job Type</source>
-			</trans-unit>
+      <!-- Flexform Plugin List -->
+      <trans-unit id="tx_academicjobs_domain_model_job.list.jobType.label">
+        <source>Job Type</source>
+      </trans-unit>
 
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>When enabled, hidden (disabled) records are included in the frontend output, independent of the backend preview settings.</source>
-			</trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>When enabled, hidden (disabled) records are included in the frontend output, independent of the backend preview settings.</source>
+      </trans-unit>
 
-			<!-- Flexform Plugin NewJobForm -->
-			<trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
-				<source>Redirect page after job creation</source>
-			</trans-unit>
+      <!-- Flexform Plugin NewJobForm -->
+      <trans-unit id="tx_academicjobs_domain_model_job.newJobForm.redirectPageId.label">
+        <source>Redirect page after job creation</source>
+      </trans-unit>
 
-			<!-- /* shared */ -->
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-			</trans-unit>
+      <!-- /* shared */ -->
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+      </trans-unit>
 
-			<!-- /* academicjobs_newjobform */ -->
-			<trans-unit id="plugin.newjobform.label">
-				<source>Jobs New</source>
-			</trans-unit>
+      <!-- /* academicjobs_newjobform */ -->
+      <trans-unit id="plugin.newjobform.label">
+        <source>Jobs New</source>
+      </trans-unit>
 
-			<!-- /* academicjobs_list */ -->
-			<trans-unit id="plugin.list.label">
-				<source>Jobs List</source>
-			</trans-unit>
+      <!-- /* academicjobs_list */ -->
+      <trans-unit id="plugin.list.label">
+        <source>Jobs List</source>
+      </trans-unit>
 
-			<!-- /* academicjobs_detail */ -->
-			<trans-unit id="plugin.detail.label">
-				<source>Jobs Detail</source>
-			</trans-unit>
+      <!-- /* academicjobs_detail */ -->
+      <trans-unit id="plugin.detail.label">
+        <source>Jobs Detail</source>
+      </trans-unit>
 
-			<!-- /* newContentElement */ -->
-			<trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
-				<source>Jobs New</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
-				<source>Plugin providing new jobs form</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.title">
-				<source>Jobs List</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.description">
-				<source>Plugin for listing academic jobs</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.title">
-				<source>Jobs Detail</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.description">
-				<source>Plugin for viewing single academic job</source>
-			</trans-unit>
+      <!-- /* newContentElement */ -->
+      <trans-unit id="newContentElement.wizardItems.academic.newjobform.title">
+        <source>Jobs New</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.newjobform.description">
+        <source>Plugin providing new jobs form</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.title">
+        <source>Jobs List</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.description">
+        <source>Plugin for listing academic jobs</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+        <source>Jobs Detail</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+        <source>Plugin for viewing single academic job</source>
+      </trans-unit>
 
-			<!-- Domain Model: Job -->
+      <!-- Domain Model: Job -->
 
-			<trans-unit id="tx_academicjobs_domain_model_job">
-				<source>Job</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_title">
-				<source>Job Title</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_start_date">
-				<source>Employment Start Date</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_description">
-				<source>Job Description</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.image">
-				<source>Image</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.company_name">
-				<source>Organization</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.sector">
-				<source>Sector</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.required_degree">
-				<source>Required degree</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contractual_relationship">
-				<source>Contractual relationship</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.alumni_recommend">
-				<source>Alumni recommends</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.internationals_welcome">
-				<source>Internationals welcome</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type">
-				<source>Employment Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type.fulltime">
-				<source>Full-time</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.employment_type.parttime">
-				<source>Part-time</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.work_location">
-				<source>Work Location</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.link">
-				<source>Link</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.link.description">
-				<source>Link to the announcement or website</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.slug">
-				<source>Slug</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.job_type">
-				<source>Job Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact">
-				<source>Contact</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
-				<source>None</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
-				<source>Job</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.sidejob">
-				<source>Sidejob</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.jobtype.thesis">
-				<source>Thesis</source>
-			</trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job">
+        <source>Job</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_title">
+        <source>Job Title</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_start_date">
+        <source>Employment Start Date</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_description">
+        <source>Job Description</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.image">
+        <source>Image</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.company_name">
+        <source>Organization</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.sector">
+        <source>Sector</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.required_degree">
+        <source>Required degree</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contractual_relationship">
+        <source>Contractual relationship</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.alumni_recommend">
+        <source>Alumni recommends</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.internationals_welcome">
+        <source>Internationals welcome</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type">
+        <source>Employment Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type.fulltime">
+        <source>Full-time</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.employment_type.parttime">
+        <source>Part-time</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.work_location">
+        <source>Work Location</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.link">
+        <source>Link</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.link.description">
+        <source>Link to the announcement or website</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.slug">
+        <source>Slug</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.job_type">
+        <source>Job Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact">
+        <source>Contact</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.none">
+        <source>None</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.job">
+        <source>Job</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.sidejob">
+        <source>Sidejob</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.jobtype.thesis">
+        <source>Thesis</source>
+      </trans-unit>
 
-			<!-- Domain Model: Contact -->
+      <!-- Domain Model: Contact -->
 
-			<trans-unit id="tx_academicjobs_domain_model_contact">
-				<source>Contact</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.description">
-				<source>Contact</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.name">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.name.description">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.email">
-				<source>Email</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.email.description">
-				<source>Email</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.phone">
-				<source>Phone</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.phone.description">
-				<source>Phone</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information">
-				<source>Additional Information</source>
-			</trans-unit>
-			<trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information.description">
-				<source>Additional Information</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicjobs_domain_model_contact">
+        <source>Contact</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.description">
+        <source>Contact</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.name">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.name.description">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.email">
+        <source>Email</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.email.description">
+        <source>Email</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.phone">
+        <source>Phone</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.phone.description">
+        <source>Phone</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information">
+        <source>Additional Information</source>
+      </trans-unit>
+      <trans-unit id="tx_academicjobs_domain_model_job.contact.additional_information.description">
+        <source>Additional Information</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/.editorconfig
+++ b/packages/fgtclb/academic-partners/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/Iso/countries.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/Iso/countries.xlf
@@ -1,1278 +1,1278 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/Iso/countries.xlf"
-		product-name="academic-partners"
-	>
-		<body>
-			<trans-unit id="AD.name" resname="AD.name">
-				<source>Andorra</source>
-			</trans-unit>
-			<trans-unit id="AD.official_name" resname="AD.official_name">
-				<source>Principality of Andorra</source>
-			</trans-unit>
-			<trans-unit id="AE.name" resname="AE.name">
-				<source>United Arab Emirates</source>
-			</trans-unit>
-			<trans-unit id="AF.name" resname="AF.name">
-				<source>Afghanistan</source>
-			</trans-unit>
-			<trans-unit id="AF.official_name" resname="AF.official_name">
-				<source>Islamic Republic of Afghanistan</source>
-			</trans-unit>
-			<trans-unit id="AG.name" resname="AG.name">
-				<source>Antigua and Barbuda</source>
-			</trans-unit>
-			<trans-unit id="AI.name" resname="AI.name">
-				<source>Anguilla</source>
-			</trans-unit>
-			<trans-unit id="AL.name" resname="AL.name">
-				<source>Albania</source>
-			</trans-unit>
-			<trans-unit id="AL.official_name" resname="AL.official_name">
-				<source>Republic of Albania</source>
-			</trans-unit>
-			<trans-unit id="AM.name" resname="AM.name">
-				<source>Armenia</source>
-			</trans-unit>
-			<trans-unit id="AM.official_name" resname="AM.official_name">
-				<source>Republic of Armenia</source>
-			</trans-unit>
-			<trans-unit id="AO.name" resname="AO.name">
-				<source>Angola</source>
-			</trans-unit>
-			<trans-unit id="AO.official_name" resname="AO.official_name">
-				<source>Republic of Angola</source>
-			</trans-unit>
-			<trans-unit id="AQ.name" resname="AQ.name">
-				<source>Antarctica</source>
-			</trans-unit>
-			<trans-unit id="AR.name" resname="AR.name">
-				<source>Argentina</source>
-			</trans-unit>
-			<trans-unit id="AR.official_name" resname="AR.official_name">
-				<source>Argentine Republic</source>
-			</trans-unit>
-			<trans-unit id="AS.name" resname="AS.name">
-				<source>American Samoa</source>
-			</trans-unit>
-			<trans-unit id="AT.name" resname="AT.name">
-				<source>Austria</source>
-			</trans-unit>
-			<trans-unit id="AT.official_name" resname="AT.official_name">
-				<source>Republic of Austria</source>
-			</trans-unit>
-			<trans-unit id="AU.name" resname="AU.name">
-				<source>Australia</source>
-			</trans-unit>
-			<trans-unit id="AW.name" resname="AW.name">
-				<source>Aruba</source>
-			</trans-unit>
-			<trans-unit id="AX.name" resname="AX.name">
-				<source>Åland Islands</source>
-			</trans-unit>
-			<trans-unit id="AZ.name" resname="AZ.name">
-				<source>Azerbaijan</source>
-			</trans-unit>
-			<trans-unit id="AZ.official_name" resname="AZ.official_name">
-				<source>Republic of Azerbaijan</source>
-			</trans-unit>
-			<trans-unit id="BA.name" resname="BA.name">
-				<source>Bosnia and Herzegovina</source>
-			</trans-unit>
-			<trans-unit id="BA.official_name" resname="BA.official_name">
-				<source>Republic of Bosnia and Herzegovina</source>
-			</trans-unit>
-			<trans-unit id="BB.name" resname="BB.name">
-				<source>Barbados</source>
-			</trans-unit>
-			<trans-unit id="BD.name" resname="BD.name">
-				<source>Bangladesh</source>
-			</trans-unit>
-			<trans-unit id="BD.official_name" resname="BD.official_name">
-				<source>People's Republic of Bangladesh</source>
-			</trans-unit>
-			<trans-unit id="BE.name" resname="BE.name">
-				<source>Belgium</source>
-			</trans-unit>
-			<trans-unit id="BE.official_name" resname="BE.official_name">
-				<source>Kingdom of Belgium</source>
-			</trans-unit>
-			<trans-unit id="BF.name" resname="BF.name">
-				<source>Burkina Faso</source>
-			</trans-unit>
-			<trans-unit id="BG.name" resname="BG.name">
-				<source>Bulgaria</source>
-			</trans-unit>
-			<trans-unit id="BG.official_name" resname="BG.official_name">
-				<source>Republic of Bulgaria</source>
-			</trans-unit>
-			<trans-unit id="BH.name" resname="BH.name">
-				<source>Bahrain</source>
-			</trans-unit>
-			<trans-unit id="BH.official_name" resname="BH.official_name">
-				<source>Kingdom of Bahrain</source>
-			</trans-unit>
-			<trans-unit id="BI.name" resname="BI.name">
-				<source>Burundi</source>
-			</trans-unit>
-			<trans-unit id="BI.official_name" resname="BI.official_name">
-				<source>Republic of Burundi</source>
-			</trans-unit>
-			<trans-unit id="BJ.name" resname="BJ.name">
-				<source>Benin</source>
-			</trans-unit>
-			<trans-unit id="BJ.official_name" resname="BJ.official_name">
-				<source>Republic of Benin</source>
-			</trans-unit>
-			<trans-unit id="BL.name" resname="BL.name">
-				<source>Saint Barthélemy</source>
-			</trans-unit>
-			<trans-unit id="BM.name" resname="BM.name">
-				<source>Bermuda</source>
-			</trans-unit>
-			<trans-unit id="BN.name" resname="BN.name">
-				<source>Brunei Darussalam</source>
-			</trans-unit>
-			<trans-unit id="BO.name" resname="BO.name">
-				<source>Bolivia, Plurinational State of</source>
-			</trans-unit>
-			<trans-unit id="BO.official_name" resname="BO.official_name">
-				<source>Plurinational State of Bolivia</source>
-			</trans-unit>
-			<trans-unit id="BQ.name" resname="BQ.name">
-				<source>Bonaire, Sint Eustatius and Saba</source>
-			</trans-unit>
-			<trans-unit id="BQ.official_name" resname="BQ.official_name">
-				<source>Bonaire, Sint Eustatius and Saba</source>
-			</trans-unit>
-			<trans-unit id="BR.name" resname="BR.name">
-				<source>Brazil</source>
-			</trans-unit>
-			<trans-unit id="BR.official_name" resname="BR.official_name">
-				<source>Federative Republic of Brazil</source>
-			</trans-unit>
-			<trans-unit id="BS.name" resname="BS.name">
-				<source>Bahamas</source>
-			</trans-unit>
-			<trans-unit id="BS.official_name" resname="BS.official_name">
-				<source>Commonwealth of the Bahamas</source>
-			</trans-unit>
-			<trans-unit id="BT.name" resname="BT.name">
-				<source>Bhutan</source>
-			</trans-unit>
-			<trans-unit id="BT.official_name" resname="BT.official_name">
-				<source>Kingdom of Bhutan</source>
-			</trans-unit>
-			<trans-unit id="BV.name" resname="BV.name">
-				<source>Bouvet Island</source>
-			</trans-unit>
-			<trans-unit id="BW.name" resname="BW.name">
-				<source>Botswana</source>
-			</trans-unit>
-			<trans-unit id="BW.official_name" resname="BW.official_name">
-				<source>Republic of Botswana</source>
-			</trans-unit>
-			<trans-unit id="BY.name" resname="BY.name">
-				<source>Belarus</source>
-			</trans-unit>
-			<trans-unit id="BY.official_name" resname="BY.official_name">
-				<source>Republic of Belarus</source>
-			</trans-unit>
-			<trans-unit id="BZ.name" resname="BZ.name">
-				<source>Belize</source>
-			</trans-unit>
-			<trans-unit id="CA.name" resname="CA.name">
-				<source>Canada</source>
-			</trans-unit>
-			<trans-unit id="CC.name" resname="CC.name">
-				<source>Cocos (Keeling) Islands</source>
-			</trans-unit>
-			<trans-unit id="CD.name" resname="CD.name">
-				<source>Congo, The Democratic Republic of the</source>
-			</trans-unit>
-			<trans-unit id="CF.name" resname="CF.name">
-				<source>Central African Republic</source>
-			</trans-unit>
-			<trans-unit id="CG.name" resname="CG.name">
-				<source>Congo</source>
-			</trans-unit>
-			<trans-unit id="CG.official_name" resname="CG.official_name">
-				<source>Republic of the Congo</source>
-			</trans-unit>
-			<trans-unit id="CH.name" resname="CH.name">
-				<source>Switzerland</source>
-			</trans-unit>
-			<trans-unit id="CH.official_name" resname="CH.official_name">
-				<source>Swiss Confederation</source>
-			</trans-unit>
-			<trans-unit id="CI.name" resname="CI.name">
-				<source>Côte d'Ivoire</source>
-			</trans-unit>
-			<trans-unit id="CI.official_name" resname="CI.official_name">
-				<source>Republic of Côte d'Ivoire</source>
-			</trans-unit>
-			<trans-unit id="CK.name" resname="CK.name">
-				<source>Cook Islands</source>
-			</trans-unit>
-			<trans-unit id="CL.name" resname="CL.name">
-				<source>Chile</source>
-			</trans-unit>
-			<trans-unit id="CL.official_name" resname="CL.official_name">
-				<source>Republic of Chile</source>
-			</trans-unit>
-			<trans-unit id="CM.name" resname="CM.name">
-				<source>Cameroon</source>
-			</trans-unit>
-			<trans-unit id="CM.official_name" resname="CM.official_name">
-				<source>Republic of Cameroon</source>
-			</trans-unit>
-			<trans-unit id="CN.name" resname="CN.name">
-				<source>China</source>
-			</trans-unit>
-			<trans-unit id="CN.official_name" resname="CN.official_name">
-				<source>People's Republic of China</source>
-			</trans-unit>
-			<trans-unit id="CO.name" resname="CO.name">
-				<source>Colombia</source>
-			</trans-unit>
-			<trans-unit id="CO.official_name" resname="CO.official_name">
-				<source>Republic of Colombia</source>
-			</trans-unit>
-			<trans-unit id="CR.name" resname="CR.name">
-				<source>Costa Rica</source>
-			</trans-unit>
-			<trans-unit id="CR.official_name" resname="CR.official_name">
-				<source>Republic of Costa Rica</source>
-			</trans-unit>
-			<trans-unit id="CU.name" resname="CU.name">
-				<source>Cuba</source>
-			</trans-unit>
-			<trans-unit id="CU.official_name" resname="CU.official_name">
-				<source>Republic of Cuba</source>
-			</trans-unit>
-			<trans-unit id="CV.name" resname="CV.name">
-				<source>Cabo Verde</source>
-			</trans-unit>
-			<trans-unit id="CV.official_name" resname="CV.official_name">
-				<source>Republic of Cabo Verde</source>
-			</trans-unit>
-			<trans-unit id="CW.name" resname="CW.name">
-				<source>Curaçao</source>
-			</trans-unit>
-			<trans-unit id="CW.official_name" resname="CW.official_name">
-				<source>Curaçao</source>
-			</trans-unit>
-			<trans-unit id="CX.name" resname="CX.name">
-				<source>Christmas Island</source>
-			</trans-unit>
-			<trans-unit id="CY.name" resname="CY.name">
-				<source>Cyprus</source>
-			</trans-unit>
-			<trans-unit id="CY.official_name" resname="CY.official_name">
-				<source>Republic of Cyprus</source>
-			</trans-unit>
-			<trans-unit id="CZ.name" resname="CZ.name">
-				<source>Czechia</source>
-			</trans-unit>
-			<trans-unit id="CZ.official_name" resname="CZ.official_name">
-				<source>Czech Republic</source>
-			</trans-unit>
-			<trans-unit id="DE.name" resname="DE.name">
-				<source>Germany</source>
-			</trans-unit>
-			<trans-unit id="DE.official_name" resname="DE.official_name">
-				<source>Federal Republic of Germany</source>
-			</trans-unit>
-			<trans-unit id="DJ.name" resname="DJ.name">
-				<source>Djibouti</source>
-			</trans-unit>
-			<trans-unit id="DJ.official_name" resname="DJ.official_name">
-				<source>Republic of Djibouti</source>
-			</trans-unit>
-			<trans-unit id="DK.name" resname="DK.name">
-				<source>Denmark</source>
-			</trans-unit>
-			<trans-unit id="DK.official_name" resname="DK.official_name">
-				<source>Kingdom of Denmark</source>
-			</trans-unit>
-			<trans-unit id="DM.name" resname="DM.name">
-				<source>Dominica</source>
-			</trans-unit>
-			<trans-unit id="DM.official_name" resname="DM.official_name">
-				<source>Commonwealth of Dominica</source>
-			</trans-unit>
-			<trans-unit id="DO.name" resname="DO.name">
-				<source>Dominican Republic</source>
-			</trans-unit>
-			<trans-unit id="DZ.name" resname="DZ.name">
-				<source>Algeria</source>
-			</trans-unit>
-			<trans-unit id="DZ.official_name" resname="DZ.official_name">
-				<source>People's Democratic Republic of Algeria</source>
-			</trans-unit>
-			<trans-unit id="EC.name" resname="EC.name">
-				<source>Ecuador</source>
-			</trans-unit>
-			<trans-unit id="EC.official_name" resname="EC.official_name">
-				<source>Republic of Ecuador</source>
-			</trans-unit>
-			<trans-unit id="EE.name" resname="EE.name">
-				<source>Estonia</source>
-			</trans-unit>
-			<trans-unit id="EE.official_name" resname="EE.official_name">
-				<source>Republic of Estonia</source>
-			</trans-unit>
-			<trans-unit id="EG.name" resname="EG.name">
-				<source>Egypt</source>
-			</trans-unit>
-			<trans-unit id="EG.official_name" resname="EG.official_name">
-				<source>Arab Republic of Egypt</source>
-			</trans-unit>
-			<trans-unit id="EH.name" resname="EH.name">
-				<source>Western Sahara</source>
-			</trans-unit>
-			<trans-unit id="ER.name" resname="ER.name">
-				<source>Eritrea</source>
-			</trans-unit>
-			<trans-unit id="ER.official_name" resname="ER.official_name">
-				<source>the State of Eritrea</source>
-			</trans-unit>
-			<trans-unit id="ES.name" resname="ES.name">
-				<source>Spain</source>
-			</trans-unit>
-			<trans-unit id="ES.official_name" resname="ES.official_name">
-				<source>Kingdom of Spain</source>
-			</trans-unit>
-			<trans-unit id="ET.name" resname="ET.name">
-				<source>Ethiopia</source>
-			</trans-unit>
-			<trans-unit id="ET.official_name" resname="ET.official_name">
-				<source>Federal Democratic Republic of Ethiopia</source>
-			</trans-unit>
-			<trans-unit id="FI.name" resname="FI.name">
-				<source>Finland</source>
-			</trans-unit>
-			<trans-unit id="FI.official_name" resname="FI.official_name">
-				<source>Republic of Finland</source>
-			</trans-unit>
-			<trans-unit id="FJ.name" resname="FJ.name">
-				<source>Fiji</source>
-			</trans-unit>
-			<trans-unit id="FJ.official_name" resname="FJ.official_name">
-				<source>Republic of Fiji</source>
-			</trans-unit>
-			<trans-unit id="FK.name" resname="FK.name">
-				<source>Falkland Islands (Malvinas)</source>
-			</trans-unit>
-			<trans-unit id="FM.name" resname="FM.name">
-				<source>Micronesia, Federated States of</source>
-			</trans-unit>
-			<trans-unit id="FM.official_name" resname="FM.official_name">
-				<source>Federated States of Micronesia</source>
-			</trans-unit>
-			<trans-unit id="FO.name" resname="FO.name">
-				<source>Faroe Islands</source>
-			</trans-unit>
-			<trans-unit id="FR.name" resname="FR.name">
-				<source>France</source>
-			</trans-unit>
-			<trans-unit id="FR.official_name" resname="FR.official_name">
-				<source>French Republic</source>
-			</trans-unit>
-			<trans-unit id="GA.name" resname="GA.name">
-				<source>Gabon</source>
-			</trans-unit>
-			<trans-unit id="GA.official_name" resname="GA.official_name">
-				<source>Gabonese Republic</source>
-			</trans-unit>
-			<trans-unit id="GB.name" resname="GB.name">
-				<source>United Kingdom</source>
-			</trans-unit>
-			<trans-unit id="GB.official_name" resname="GB.official_name">
-				<source>United Kingdom of Great Britain and Northern Ireland</source>
-			</trans-unit>
-			<trans-unit id="GD.name" resname="GD.name">
-				<source>Grenada</source>
-			</trans-unit>
-			<trans-unit id="GE.name" resname="GE.name">
-				<source>Georgia</source>
-			</trans-unit>
-			<trans-unit id="GF.name" resname="GF.name">
-				<source>French Guiana</source>
-			</trans-unit>
-			<trans-unit id="GG.name" resname="GG.name">
-				<source>Guernsey</source>
-			</trans-unit>
-			<trans-unit id="GH.name" resname="GH.name">
-				<source>Ghana</source>
-			</trans-unit>
-			<trans-unit id="GH.official_name" resname="GH.official_name">
-				<source>Republic of Ghana</source>
-			</trans-unit>
-			<trans-unit id="GI.name" resname="GI.name">
-				<source>Gibraltar</source>
-			</trans-unit>
-			<trans-unit id="GL.name" resname="GL.name">
-				<source>Greenland</source>
-			</trans-unit>
-			<trans-unit id="GM.name" resname="GM.name">
-				<source>Gambia</source>
-			</trans-unit>
-			<trans-unit id="GM.official_name" resname="GM.official_name">
-				<source>Republic of the Gambia</source>
-			</trans-unit>
-			<trans-unit id="GN.name" resname="GN.name">
-				<source>Guinea</source>
-			</trans-unit>
-			<trans-unit id="GN.official_name" resname="GN.official_name">
-				<source>Republic of Guinea</source>
-			</trans-unit>
-			<trans-unit id="GP.name" resname="GP.name">
-				<source>Guadeloupe</source>
-			</trans-unit>
-			<trans-unit id="GQ.name" resname="GQ.name">
-				<source>Equatorial Guinea</source>
-			</trans-unit>
-			<trans-unit id="GQ.official_name" resname="GQ.official_name">
-				<source>Republic of Equatorial Guinea</source>
-			</trans-unit>
-			<trans-unit id="GR.name" resname="GR.name">
-				<source>Greece</source>
-			</trans-unit>
-			<trans-unit id="GR.official_name" resname="GR.official_name">
-				<source>Hellenic Republic</source>
-			</trans-unit>
-			<trans-unit id="GS.name" resname="GS.name">
-				<source>South Georgia and the South Sandwich Islands</source>
-			</trans-unit>
-			<trans-unit id="GT.name" resname="GT.name">
-				<source>Guatemala</source>
-			</trans-unit>
-			<trans-unit id="GT.official_name" resname="GT.official_name">
-				<source>Republic of Guatemala</source>
-			</trans-unit>
-			<trans-unit id="GU.name" resname="GU.name">
-				<source>Guam</source>
-			</trans-unit>
-			<trans-unit id="GW.name" resname="GW.name">
-				<source>Guinea-Bissau</source>
-			</trans-unit>
-			<trans-unit id="GW.official_name" resname="GW.official_name">
-				<source>Republic of Guinea-Bissau</source>
-			</trans-unit>
-			<trans-unit id="GY.name" resname="GY.name">
-				<source>Guyana</source>
-			</trans-unit>
-			<trans-unit id="GY.official_name" resname="GY.official_name">
-				<source>Republic of Guyana</source>
-			</trans-unit>
-			<trans-unit id="HK.name" resname="HK.name">
-				<source>Hong Kong</source>
-			</trans-unit>
-			<trans-unit id="HK.official_name" resname="HK.official_name">
-				<source>Hong Kong Special Administrative Region of China</source>
-			</trans-unit>
-			<trans-unit id="HM.name" resname="HM.name">
-				<source>Heard Island and McDonald Islands</source>
-			</trans-unit>
-			<trans-unit id="HN.name" resname="HN.name">
-				<source>Honduras</source>
-			</trans-unit>
-			<trans-unit id="HN.official_name" resname="HN.official_name">
-				<source>Republic of Honduras</source>
-			</trans-unit>
-			<trans-unit id="HR.name" resname="HR.name">
-				<source>Croatia</source>
-			</trans-unit>
-			<trans-unit id="HR.official_name" resname="HR.official_name">
-				<source>Republic of Croatia</source>
-			</trans-unit>
-			<trans-unit id="HT.name" resname="HT.name">
-				<source>Haiti</source>
-			</trans-unit>
-			<trans-unit id="HT.official_name" resname="HT.official_name">
-				<source>Republic of Haiti</source>
-			</trans-unit>
-			<trans-unit id="HU.name" resname="HU.name">
-				<source>Hungary</source>
-			</trans-unit>
-			<trans-unit id="HU.official_name" resname="HU.official_name">
-				<source>Hungary</source>
-			</trans-unit>
-			<trans-unit id="ID.name" resname="ID.name">
-				<source>Indonesia</source>
-			</trans-unit>
-			<trans-unit id="ID.official_name" resname="ID.official_name">
-				<source>Republic of Indonesia</source>
-			</trans-unit>
-			<trans-unit id="IE.name" resname="IE.name">
-				<source>Ireland</source>
-			</trans-unit>
-			<trans-unit id="IL.name" resname="IL.name">
-				<source>Israel</source>
-			</trans-unit>
-			<trans-unit id="IL.official_name" resname="IL.official_name">
-				<source>State of Israel</source>
-			</trans-unit>
-			<trans-unit id="IM.name" resname="IM.name">
-				<source>Isle of Man</source>
-			</trans-unit>
-			<trans-unit id="IN.name" resname="IN.name">
-				<source>India</source>
-			</trans-unit>
-			<trans-unit id="IN.official_name" resname="IN.official_name">
-				<source>Republic of India</source>
-			</trans-unit>
-			<trans-unit id="IO.name" resname="IO.name">
-				<source>British Indian Ocean Territory</source>
-			</trans-unit>
-			<trans-unit id="IQ.name" resname="IQ.name">
-				<source>Iraq</source>
-			</trans-unit>
-			<trans-unit id="IQ.official_name" resname="IQ.official_name">
-				<source>Republic of Iraq</source>
-			</trans-unit>
-			<trans-unit id="IR.name" resname="IR.name">
-				<source>Iran, Islamic Republic of</source>
-			</trans-unit>
-			<trans-unit id="IR.official_name" resname="IR.official_name">
-				<source>Islamic Republic of Iran</source>
-			</trans-unit>
-			<trans-unit id="IS.name" resname="IS.name">
-				<source>Iceland</source>
-			</trans-unit>
-			<trans-unit id="IS.official_name" resname="IS.official_name">
-				<source>Republic of Iceland</source>
-			</trans-unit>
-			<trans-unit id="IT.name" resname="IT.name">
-				<source>Italy</source>
-			</trans-unit>
-			<trans-unit id="IT.official_name" resname="IT.official_name">
-				<source>Italian Republic</source>
-			</trans-unit>
-			<trans-unit id="JE.name" resname="JE.name">
-				<source>Jersey</source>
-			</trans-unit>
-			<trans-unit id="JM.name" resname="JM.name">
-				<source>Jamaica</source>
-			</trans-unit>
-			<trans-unit id="JO.name" resname="JO.name">
-				<source>Jordan</source>
-			</trans-unit>
-			<trans-unit id="JO.official_name" resname="JO.official_name">
-				<source>Hashemite Kingdom of Jordan</source>
-			</trans-unit>
-			<trans-unit id="JP.name" resname="JP.name">
-				<source>Japan</source>
-			</trans-unit>
-			<trans-unit id="KE.name" resname="KE.name">
-				<source>Kenya</source>
-			</trans-unit>
-			<trans-unit id="KE.official_name" resname="KE.official_name">
-				<source>Republic of Kenya</source>
-			</trans-unit>
-			<trans-unit id="KG.name" resname="KG.name">
-				<source>Kyrgyzstan</source>
-			</trans-unit>
-			<trans-unit id="KG.official_name" resname="KG.official_name">
-				<source>Kyrgyz Republic</source>
-			</trans-unit>
-			<trans-unit id="KH.name" resname="KH.name">
-				<source>Cambodia</source>
-			</trans-unit>
-			<trans-unit id="KH.official_name" resname="KH.official_name">
-				<source>Kingdom of Cambodia</source>
-			</trans-unit>
-			<trans-unit id="KI.name" resname="KI.name">
-				<source>Kiribati</source>
-			</trans-unit>
-			<trans-unit id="KI.official_name" resname="KI.official_name">
-				<source>Republic of Kiribati</source>
-			</trans-unit>
-			<trans-unit id="KM.name" resname="KM.name">
-				<source>Comoros</source>
-			</trans-unit>
-			<trans-unit id="KM.official_name" resname="KM.official_name">
-				<source>Union of the Comoros</source>
-			</trans-unit>
-			<trans-unit id="KN.name" resname="KN.name">
-				<source>Saint Kitts and Nevis</source>
-			</trans-unit>
-			<trans-unit id="KP.name" resname="KP.name">
-				<source>Korea, Democratic People's Republic of</source>
-			</trans-unit>
-			<trans-unit id="KP.official_name" resname="KP.official_name">
-				<source>Democratic People's Republic of Korea</source>
-			</trans-unit>
-			<trans-unit id="KR.name" resname="KR.name">
-				<source>Korea, Republic of</source>
-			</trans-unit>
-			<trans-unit id="KW.name" resname="KW.name">
-				<source>Kuwait</source>
-			</trans-unit>
-			<trans-unit id="KW.official_name" resname="KW.official_name">
-				<source>State of Kuwait</source>
-			</trans-unit>
-			<trans-unit id="KY.name" resname="KY.name">
-				<source>Cayman Islands</source>
-			</trans-unit>
-			<trans-unit id="KZ.name" resname="KZ.name">
-				<source>Kazakhstan</source>
-			</trans-unit>
-			<trans-unit id="KZ.official_name" resname="KZ.official_name">
-				<source>Republic of Kazakhstan</source>
-			</trans-unit>
-			<trans-unit id="LA.name" resname="LA.name">
-				<source>Lao People's Democratic Republic</source>
-			</trans-unit>
-			<trans-unit id="LB.name" resname="LB.name">
-				<source>Lebanon</source>
-			</trans-unit>
-			<trans-unit id="LB.official_name" resname="LB.official_name">
-				<source>Lebanese Republic</source>
-			</trans-unit>
-			<trans-unit id="LC.name" resname="LC.name">
-				<source>Saint Lucia</source>
-			</trans-unit>
-			<trans-unit id="LI.name" resname="LI.name">
-				<source>Liechtenstein</source>
-			</trans-unit>
-			<trans-unit id="LI.official_name" resname="LI.official_name">
-				<source>Principality of Liechtenstein</source>
-			</trans-unit>
-			<trans-unit id="LK.name" resname="LK.name">
-				<source>Sri Lanka</source>
-			</trans-unit>
-			<trans-unit id="LK.official_name" resname="LK.official_name">
-				<source>Democratic Socialist Republic of Sri Lanka</source>
-			</trans-unit>
-			<trans-unit id="LR.name" resname="LR.name">
-				<source>Liberia</source>
-			</trans-unit>
-			<trans-unit id="LR.official_name" resname="LR.official_name">
-				<source>Republic of Liberia</source>
-			</trans-unit>
-			<trans-unit id="LS.name" resname="LS.name">
-				<source>Lesotho</source>
-			</trans-unit>
-			<trans-unit id="LS.official_name" resname="LS.official_name">
-				<source>Kingdom of Lesotho</source>
-			</trans-unit>
-			<trans-unit id="LT.name" resname="LT.name">
-				<source>Lithuania</source>
-			</trans-unit>
-			<trans-unit id="LT.official_name" resname="LT.official_name">
-				<source>Republic of Lithuania</source>
-			</trans-unit>
-			<trans-unit id="LU.name" resname="LU.name">
-				<source>Luxembourg</source>
-			</trans-unit>
-			<trans-unit id="LU.official_name" resname="LU.official_name">
-				<source>Grand Duchy of Luxembourg</source>
-			</trans-unit>
-			<trans-unit id="LV.name" resname="LV.name">
-				<source>Latvia</source>
-			</trans-unit>
-			<trans-unit id="LV.official_name" resname="LV.official_name">
-				<source>Republic of Latvia</source>
-			</trans-unit>
-			<trans-unit id="LY.name" resname="LY.name">
-				<source>Libya</source>
-			</trans-unit>
-			<trans-unit id="LY.official_name" resname="LY.official_name">
-				<source>Libya</source>
-			</trans-unit>
-			<trans-unit id="MA.name" resname="MA.name">
-				<source>Morocco</source>
-			</trans-unit>
-			<trans-unit id="MA.official_name" resname="MA.official_name">
-				<source>Kingdom of Morocco</source>
-			</trans-unit>
-			<trans-unit id="MC.name" resname="MC.name">
-				<source>Monaco</source>
-			</trans-unit>
-			<trans-unit id="MC.official_name" resname="MC.official_name">
-				<source>Principality of Monaco</source>
-			</trans-unit>
-			<trans-unit id="MD.name" resname="MD.name">
-				<source>Moldova, Republic of</source>
-			</trans-unit>
-			<trans-unit id="MD.official_name" resname="MD.official_name">
-				<source>Republic of Moldova</source>
-			</trans-unit>
-			<trans-unit id="ME.name" resname="ME.name">
-				<source>Montenegro</source>
-			</trans-unit>
-			<trans-unit id="ME.official_name" resname="ME.official_name">
-				<source>Montenegro</source>
-			</trans-unit>
-			<trans-unit id="MF.name" resname="MF.name">
-				<source>Saint Martin (French part)</source>
-			</trans-unit>
-			<trans-unit id="MG.name" resname="MG.name">
-				<source>Madagascar</source>
-			</trans-unit>
-			<trans-unit id="MG.official_name" resname="MG.official_name">
-				<source>Republic of Madagascar</source>
-			</trans-unit>
-			<trans-unit id="MH.name" resname="MH.name">
-				<source>Marshall Islands</source>
-			</trans-unit>
-			<trans-unit id="MH.official_name" resname="MH.official_name">
-				<source>Republic of the Marshall Islands</source>
-			</trans-unit>
-			<trans-unit id="MK.name" resname="MK.name">
-				<source>North Macedonia</source>
-			</trans-unit>
-			<trans-unit id="MK.official_name" resname="MK.official_name">
-				<source>Republic of North Macedonia</source>
-			</trans-unit>
-			<trans-unit id="ML.name" resname="ML.name">
-				<source>Mali</source>
-			</trans-unit>
-			<trans-unit id="ML.official_name" resname="ML.official_name">
-				<source>Republic of Mali</source>
-			</trans-unit>
-			<trans-unit id="MM.name" resname="MM.name">
-				<source>Myanmar</source>
-			</trans-unit>
-			<trans-unit id="MM.official_name" resname="MM.official_name">
-				<source>Republic of Myanmar</source>
-			</trans-unit>
-			<trans-unit id="MN.name" resname="MN.name">
-				<source>Mongolia</source>
-			</trans-unit>
-			<trans-unit id="MO.name" resname="MO.name">
-				<source>Macao</source>
-			</trans-unit>
-			<trans-unit id="MO.official_name" resname="MO.official_name">
-				<source>Macao Special Administrative Region of China</source>
-			</trans-unit>
-			<trans-unit id="MP.name" resname="MP.name">
-				<source>Northern Mariana Islands</source>
-			</trans-unit>
-			<trans-unit id="MP.official_name" resname="MP.official_name">
-				<source>Commonwealth of the Northern Mariana Islands</source>
-			</trans-unit>
-			<trans-unit id="MQ.name" resname="MQ.name">
-				<source>Martinique</source>
-			</trans-unit>
-			<trans-unit id="MR.name" resname="MR.name">
-				<source>Mauritania</source>
-			</trans-unit>
-			<trans-unit id="MR.official_name" resname="MR.official_name">
-				<source>Islamic Republic of Mauritania</source>
-			</trans-unit>
-			<trans-unit id="MS.name" resname="MS.name">
-				<source>Montserrat</source>
-			</trans-unit>
-			<trans-unit id="MT.name" resname="MT.name">
-				<source>Malta</source>
-			</trans-unit>
-			<trans-unit id="MT.official_name" resname="MT.official_name">
-				<source>Republic of Malta</source>
-			</trans-unit>
-			<trans-unit id="MU.name" resname="MU.name">
-				<source>Mauritius</source>
-			</trans-unit>
-			<trans-unit id="MU.official_name" resname="MU.official_name">
-				<source>Republic of Mauritius</source>
-			</trans-unit>
-			<trans-unit id="MV.name" resname="MV.name">
-				<source>Maldives</source>
-			</trans-unit>
-			<trans-unit id="MV.official_name" resname="MV.official_name">
-				<source>Republic of Maldives</source>
-			</trans-unit>
-			<trans-unit id="MW.name" resname="MW.name">
-				<source>Malawi</source>
-			</trans-unit>
-			<trans-unit id="MW.official_name" resname="MW.official_name">
-				<source>Republic of Malawi</source>
-			</trans-unit>
-			<trans-unit id="MX.name" resname="MX.name">
-				<source>Mexico</source>
-			</trans-unit>
-			<trans-unit id="MX.official_name" resname="MX.official_name">
-				<source>United Mexican States</source>
-			</trans-unit>
-			<trans-unit id="MY.name" resname="MY.name">
-				<source>Malaysia</source>
-			</trans-unit>
-			<trans-unit id="MZ.name" resname="MZ.name">
-				<source>Mozambique</source>
-			</trans-unit>
-			<trans-unit id="MZ.official_name" resname="MZ.official_name">
-				<source>Republic of Mozambique</source>
-			</trans-unit>
-			<trans-unit id="NA.name" resname="NA.name">
-				<source>Namibia</source>
-			</trans-unit>
-			<trans-unit id="NA.official_name" resname="NA.official_name">
-				<source>Republic of Namibia</source>
-			</trans-unit>
-			<trans-unit id="NC.name" resname="NC.name">
-				<source>New Caledonia</source>
-			</trans-unit>
-			<trans-unit id="NE.name" resname="NE.name">
-				<source>Niger</source>
-			</trans-unit>
-			<trans-unit id="NE.official_name" resname="NE.official_name">
-				<source>Republic of the Niger</source>
-			</trans-unit>
-			<trans-unit id="NF.name" resname="NF.name">
-				<source>Norfolk Island</source>
-			</trans-unit>
-			<trans-unit id="NG.name" resname="NG.name">
-				<source>Nigeria</source>
-			</trans-unit>
-			<trans-unit id="NG.official_name" resname="NG.official_name">
-				<source>Federal Republic of Nigeria</source>
-			</trans-unit>
-			<trans-unit id="NI.name" resname="NI.name">
-				<source>Nicaragua</source>
-			</trans-unit>
-			<trans-unit id="NI.official_name" resname="NI.official_name">
-				<source>Republic of Nicaragua</source>
-			</trans-unit>
-			<trans-unit id="NL.name" resname="NL.name">
-				<source>Netherlands</source>
-			</trans-unit>
-			<trans-unit id="NL.official_name" resname="NL.official_name">
-				<source>Kingdom of the Netherlands</source>
-			</trans-unit>
-			<trans-unit id="NO.name" resname="NO.name">
-				<source>Norway</source>
-			</trans-unit>
-			<trans-unit id="NO.official_name" resname="NO.official_name">
-				<source>Kingdom of Norway</source>
-			</trans-unit>
-			<trans-unit id="NP.name" resname="NP.name">
-				<source>Nepal</source>
-			</trans-unit>
-			<trans-unit id="NP.official_name" resname="NP.official_name">
-				<source>Federal Democratic Republic of Nepal</source>
-			</trans-unit>
-			<trans-unit id="NR.name" resname="NR.name">
-				<source>Nauru</source>
-			</trans-unit>
-			<trans-unit id="NR.official_name" resname="NR.official_name">
-				<source>Republic of Nauru</source>
-			</trans-unit>
-			<trans-unit id="NU.name" resname="NU.name">
-				<source>Niue</source>
-			</trans-unit>
-			<trans-unit id="NU.official_name" resname="NU.official_name">
-				<source>Niue</source>
-			</trans-unit>
-			<trans-unit id="NZ.name" resname="NZ.name">
-				<source>New Zealand</source>
-			</trans-unit>
-			<trans-unit id="OM.name" resname="OM.name">
-				<source>Oman</source>
-			</trans-unit>
-			<trans-unit id="OM.official_name" resname="OM.official_name">
-				<source>Sultanate of Oman</source>
-			</trans-unit>
-			<trans-unit id="PA.name" resname="PA.name">
-				<source>Panama</source>
-			</trans-unit>
-			<trans-unit id="PA.official_name" resname="PA.official_name">
-				<source>Republic of Panama</source>
-			</trans-unit>
-			<trans-unit id="PE.name" resname="PE.name">
-				<source>Peru</source>
-			</trans-unit>
-			<trans-unit id="PE.official_name" resname="PE.official_name">
-				<source>Republic of Peru</source>
-			</trans-unit>
-			<trans-unit id="PF.name" resname="PF.name">
-				<source>French Polynesia</source>
-			</trans-unit>
-			<trans-unit id="PG.name" resname="PG.name">
-				<source>Papua New Guinea</source>
-			</trans-unit>
-			<trans-unit id="PG.official_name" resname="PG.official_name">
-				<source>Independent State of Papua New Guinea</source>
-			</trans-unit>
-			<trans-unit id="PH.name" resname="PH.name">
-				<source>Philippines</source>
-			</trans-unit>
-			<trans-unit id="PH.official_name" resname="PH.official_name">
-				<source>Republic of the Philippines</source>
-			</trans-unit>
-			<trans-unit id="PK.name" resname="PK.name">
-				<source>Pakistan</source>
-			</trans-unit>
-			<trans-unit id="PK.official_name" resname="PK.official_name">
-				<source>Islamic Republic of Pakistan</source>
-			</trans-unit>
-			<trans-unit id="PL.name" resname="PL.name">
-				<source>Poland</source>
-			</trans-unit>
-			<trans-unit id="PL.official_name" resname="PL.official_name">
-				<source>Republic of Poland</source>
-			</trans-unit>
-			<trans-unit id="PM.name" resname="PM.name">
-				<source>Saint Pierre and Miquelon</source>
-			</trans-unit>
-			<trans-unit id="PN.name" resname="PN.name">
-				<source>Pitcairn</source>
-			</trans-unit>
-			<trans-unit id="PR.name" resname="PR.name">
-				<source>Puerto Rico</source>
-			</trans-unit>
-			<trans-unit id="PS.name" resname="PS.name">
-				<source>Palestine, State of</source>
-			</trans-unit>
-			<trans-unit id="PS.official_name" resname="PS.official_name">
-				<source>the State of Palestine</source>
-			</trans-unit>
-			<trans-unit id="PT.name" resname="PT.name">
-				<source>Portugal</source>
-			</trans-unit>
-			<trans-unit id="PT.official_name" resname="PT.official_name">
-				<source>Portuguese Republic</source>
-			</trans-unit>
-			<trans-unit id="PW.name" resname="PW.name">
-				<source>Palau</source>
-			</trans-unit>
-			<trans-unit id="PW.official_name" resname="PW.official_name">
-				<source>Republic of Palau</source>
-			</trans-unit>
-			<trans-unit id="PY.name" resname="PY.name">
-				<source>Paraguay</source>
-			</trans-unit>
-			<trans-unit id="PY.official_name" resname="PY.official_name">
-				<source>Republic of Paraguay</source>
-			</trans-unit>
-			<trans-unit id="QA.name" resname="QA.name">
-				<source>Qatar</source>
-			</trans-unit>
-			<trans-unit id="QA.official_name" resname="QA.official_name">
-				<source>State of Qatar</source>
-			</trans-unit>
-			<trans-unit id="RE.name" resname="RE.name">
-				<source>Réunion</source>
-			</trans-unit>
-			<trans-unit id="RO.name" resname="RO.name">
-				<source>Romania</source>
-			</trans-unit>
-			<trans-unit id="RS.name" resname="RS.name">
-				<source>Serbia</source>
-			</trans-unit>
-			<trans-unit id="RS.official_name" resname="RS.official_name">
-				<source>Republic of Serbia</source>
-			</trans-unit>
-			<trans-unit id="RU.name" resname="RU.name">
-				<source>Russian Federation</source>
-			</trans-unit>
-			<trans-unit id="RW.name" resname="RW.name">
-				<source>Rwanda</source>
-			</trans-unit>
-			<trans-unit id="RW.official_name" resname="RW.official_name">
-				<source>Rwandese Republic</source>
-			</trans-unit>
-			<trans-unit id="SA.name" resname="SA.name">
-				<source>Saudi Arabia</source>
-			</trans-unit>
-			<trans-unit id="SA.official_name" resname="SA.official_name">
-				<source>Kingdom of Saudi Arabia</source>
-			</trans-unit>
-			<trans-unit id="SB.name" resname="SB.name">
-				<source>Solomon Islands</source>
-			</trans-unit>
-			<trans-unit id="SC.name" resname="SC.name">
-				<source>Seychelles</source>
-			</trans-unit>
-			<trans-unit id="SC.official_name" resname="SC.official_name">
-				<source>Republic of Seychelles</source>
-			</trans-unit>
-			<trans-unit id="SD.name" resname="SD.name">
-				<source>Sudan</source>
-			</trans-unit>
-			<trans-unit id="SD.official_name" resname="SD.official_name">
-				<source>Republic of the Sudan</source>
-			</trans-unit>
-			<trans-unit id="SE.name" resname="SE.name">
-				<source>Sweden</source>
-			</trans-unit>
-			<trans-unit id="SE.official_name" resname="SE.official_name">
-				<source>Kingdom of Sweden</source>
-			</trans-unit>
-			<trans-unit id="SG.name" resname="SG.name">
-				<source>Singapore</source>
-			</trans-unit>
-			<trans-unit id="SG.official_name" resname="SG.official_name">
-				<source>Republic of Singapore</source>
-			</trans-unit>
-			<trans-unit id="SH.name" resname="SH.name">
-				<source>Saint Helena, Ascension and Tristan da Cunha</source>
-			</trans-unit>
-			<trans-unit id="SI.name" resname="SI.name">
-				<source>Slovenia</source>
-			</trans-unit>
-			<trans-unit id="SI.official_name" resname="SI.official_name">
-				<source>Republic of Slovenia</source>
-			</trans-unit>
-			<trans-unit id="SJ.name" resname="SJ.name">
-				<source>Svalbard and Jan Mayen</source>
-			</trans-unit>
-			<trans-unit id="SK.name" resname="SK.name">
-				<source>Slovakia</source>
-			</trans-unit>
-			<trans-unit id="SK.official_name" resname="SK.official_name">
-				<source>Slovak Republic</source>
-			</trans-unit>
-			<trans-unit id="SL.name" resname="SL.name">
-				<source>Sierra Leone</source>
-			</trans-unit>
-			<trans-unit id="SL.official_name" resname="SL.official_name">
-				<source>Republic of Sierra Leone</source>
-			</trans-unit>
-			<trans-unit id="SM.name" resname="SM.name">
-				<source>San Marino</source>
-			</trans-unit>
-			<trans-unit id="SM.official_name" resname="SM.official_name">
-				<source>Republic of San Marino</source>
-			</trans-unit>
-			<trans-unit id="SN.name" resname="SN.name">
-				<source>Senegal</source>
-			</trans-unit>
-			<trans-unit id="SN.official_name" resname="SN.official_name">
-				<source>Republic of Senegal</source>
-			</trans-unit>
-			<trans-unit id="SO.name" resname="SO.name">
-				<source>Somalia</source>
-			</trans-unit>
-			<trans-unit id="SO.official_name" resname="SO.official_name">
-				<source>Federal Republic of Somalia</source>
-			</trans-unit>
-			<trans-unit id="SR.name" resname="SR.name">
-				<source>Suriname</source>
-			</trans-unit>
-			<trans-unit id="SR.official_name" resname="SR.official_name">
-				<source>Republic of Suriname</source>
-			</trans-unit>
-			<trans-unit id="SS.name" resname="SS.name">
-				<source>South Sudan</source>
-			</trans-unit>
-			<trans-unit id="SS.official_name" resname="SS.official_name">
-				<source>Republic of South Sudan</source>
-			</trans-unit>
-			<trans-unit id="ST.name" resname="ST.name">
-				<source>Sao Tome and Principe</source>
-			</trans-unit>
-			<trans-unit id="ST.official_name" resname="ST.official_name">
-				<source>Democratic Republic of Sao Tome and Principe</source>
-			</trans-unit>
-			<trans-unit id="SV.name" resname="SV.name">
-				<source>El Salvador</source>
-			</trans-unit>
-			<trans-unit id="SV.official_name" resname="SV.official_name">
-				<source>Republic of El Salvador</source>
-			</trans-unit>
-			<trans-unit id="SX.name" resname="SX.name">
-				<source>Sint Maarten (Dutch part)</source>
-			</trans-unit>
-			<trans-unit id="SX.official_name" resname="SX.official_name">
-				<source>Sint Maarten (Dutch part)</source>
-			</trans-unit>
-			<trans-unit id="SY.name" resname="SY.name">
-				<source>Syrian Arab Republic</source>
-			</trans-unit>
-			<trans-unit id="SZ.name" resname="SZ.name">
-				<source>Eswatini</source>
-			</trans-unit>
-			<trans-unit id="SZ.official_name" resname="SZ.official_name">
-				<source>Kingdom of Eswatini</source>
-			</trans-unit>
-			<trans-unit id="TC.name" resname="TC.name">
-				<source>Turks and Caicos Islands</source>
-			</trans-unit>
-			<trans-unit id="TD.name" resname="TD.name">
-				<source>Chad</source>
-			</trans-unit>
-			<trans-unit id="TD.official_name" resname="TD.official_name">
-				<source>Republic of Chad</source>
-			</trans-unit>
-			<trans-unit id="TF.name" resname="TF.name">
-				<source>French Southern Territories</source>
-			</trans-unit>
-			<trans-unit id="TG.name" resname="TG.name">
-				<source>Togo</source>
-			</trans-unit>
-			<trans-unit id="TG.official_name" resname="TG.official_name">
-				<source>Togolese Republic</source>
-			</trans-unit>
-			<trans-unit id="TH.name" resname="TH.name">
-				<source>Thailand</source>
-			</trans-unit>
-			<trans-unit id="TH.official_name" resname="TH.official_name">
-				<source>Kingdom of Thailand</source>
-			</trans-unit>
-			<trans-unit id="TJ.name" resname="TJ.name">
-				<source>Tajikistan</source>
-			</trans-unit>
-			<trans-unit id="TJ.official_name" resname="TJ.official_name">
-				<source>Republic of Tajikistan</source>
-			</trans-unit>
-			<trans-unit id="TK.name" resname="TK.name">
-				<source>Tokelau</source>
-			</trans-unit>
-			<trans-unit id="TL.name" resname="TL.name">
-				<source>Timor-Leste</source>
-			</trans-unit>
-			<trans-unit id="TL.official_name" resname="TL.official_name">
-				<source>Democratic Republic of Timor-Leste</source>
-			</trans-unit>
-			<trans-unit id="TM.name" resname="TM.name">
-				<source>Turkmenistan</source>
-			</trans-unit>
-			<trans-unit id="TN.name" resname="TN.name">
-				<source>Tunisia</source>
-			</trans-unit>
-			<trans-unit id="TN.official_name" resname="TN.official_name">
-				<source>Republic of Tunisia</source>
-			</trans-unit>
-			<trans-unit id="TO.name" resname="TO.name">
-				<source>Tonga</source>
-			</trans-unit>
-			<trans-unit id="TO.official_name" resname="TO.official_name">
-				<source>Kingdom of Tonga</source>
-			</trans-unit>
-			<trans-unit id="TR.name" resname="TR.name">
-				<source>Türkiye</source>
-			</trans-unit>
-			<trans-unit id="TR.official_name" resname="TR.official_name">
-				<source>Republic of Türkiye</source>
-			</trans-unit>
-			<trans-unit id="TT.name" resname="TT.name">
-				<source>Trinidad and Tobago</source>
-			</trans-unit>
-			<trans-unit id="TT.official_name" resname="TT.official_name">
-				<source>Republic of Trinidad and Tobago</source>
-			</trans-unit>
-			<trans-unit id="TV.name" resname="TV.name">
-				<source>Tuvalu</source>
-			</trans-unit>
-			<trans-unit id="TW.name" resname="TW.name">
-				<source>Taiwan, Province of China</source>
-			</trans-unit>
-			<trans-unit id="TW.official_name" resname="TW.official_name">
-				<source>Taiwan, Province of China</source>
-			</trans-unit>
-			<trans-unit id="TZ.name" resname="TZ.name">
-				<source>Tanzania, United Republic of</source>
-			</trans-unit>
-			<trans-unit id="TZ.official_name" resname="TZ.official_name">
-				<source>United Republic of Tanzania</source>
-			</trans-unit>
-			<trans-unit id="UA.name" resname="UA.name">
-				<source>Ukraine</source>
-			</trans-unit>
-			<trans-unit id="UG.name" resname="UG.name">
-				<source>Uganda</source>
-			</trans-unit>
-			<trans-unit id="UG.official_name" resname="UG.official_name">
-				<source>Republic of Uganda</source>
-			</trans-unit>
-			<trans-unit id="UM.name" resname="UM.name">
-				<source>United States Minor Outlying Islands</source>
-			</trans-unit>
-			<trans-unit id="US.name" resname="US.name">
-				<source>United States</source>
-			</trans-unit>
-			<trans-unit id="US.official_name" resname="US.official_name">
-				<source>United States of America</source>
-			</trans-unit>
-			<trans-unit id="UY.name" resname="UY.name">
-				<source>Uruguay</source>
-			</trans-unit>
-			<trans-unit id="UY.official_name" resname="UY.official_name">
-				<source>Eastern Republic of Uruguay</source>
-			</trans-unit>
-			<trans-unit id="UZ.name" resname="UZ.name">
-				<source>Uzbekistan</source>
-			</trans-unit>
-			<trans-unit id="UZ.official_name" resname="UZ.official_name">
-				<source>Republic of Uzbekistan</source>
-			</trans-unit>
-			<trans-unit id="VA.name" resname="VA.name">
-				<source>Holy See (Vatican City State)</source>
-			</trans-unit>
-			<trans-unit id="VC.name" resname="VC.name">
-				<source>Saint Vincent and the Grenadines</source>
-			</trans-unit>
-			<trans-unit id="VE.name" resname="VE.name">
-				<source>Venezuela, Bolivarian Republic of</source>
-			</trans-unit>
-			<trans-unit id="VE.official_name" resname="VE.official_name">
-				<source>Bolivarian Republic of Venezuela</source>
-			</trans-unit>
-			<trans-unit id="VG.name" resname="VG.name">
-				<source>Virgin Islands, British</source>
-			</trans-unit>
-			<trans-unit id="VG.official_name" resname="VG.official_name">
-				<source>British Virgin Islands</source>
-			</trans-unit>
-			<trans-unit id="VI.name" resname="VI.name">
-				<source>Virgin Islands, U.S.</source>
-			</trans-unit>
-			<trans-unit id="VI.official_name" resname="VI.official_name">
-				<source>Virgin Islands of the United States</source>
-			</trans-unit>
-			<trans-unit id="VN.name" resname="VN.name">
-				<source>Viet Nam</source>
-			</trans-unit>
-			<trans-unit id="VN.official_name" resname="VN.official_name">
-				<source>Socialist Republic of Viet Nam</source>
-			</trans-unit>
-			<trans-unit id="VU.name" resname="VU.name">
-				<source>Vanuatu</source>
-			</trans-unit>
-			<trans-unit id="VU.official_name" resname="VU.official_name">
-				<source>Republic of Vanuatu</source>
-			</trans-unit>
-			<trans-unit id="WF.name" resname="WF.name">
-				<source>Wallis and Futuna</source>
-			</trans-unit>
-			<trans-unit id="WS.name" resname="WS.name">
-				<source>Samoa</source>
-			</trans-unit>
-			<trans-unit id="WS.official_name" resname="WS.official_name">
-				<source>Independent State of Samoa</source>
-			</trans-unit>
-			<trans-unit id="YE.name" resname="YE.name">
-				<source>Yemen</source>
-			</trans-unit>
-			<trans-unit id="YE.official_name" resname="YE.official_name">
-				<source>Republic of Yemen</source>
-			</trans-unit>
-			<trans-unit id="YT.name" resname="YT.name">
-				<source>Mayotte</source>
-			</trans-unit>
-			<trans-unit id="ZA.name" resname="ZA.name">
-				<source>South Africa</source>
-			</trans-unit>
-			<trans-unit id="ZA.official_name" resname="ZA.official_name">
-				<source>Republic of South Africa</source>
-			</trans-unit>
-			<trans-unit id="ZM.name" resname="ZM.name">
-				<source>Zambia</source>
-			</trans-unit>
-			<trans-unit id="ZM.official_name" resname="ZM.official_name">
-				<source>Republic of Zambia</source>
-			</trans-unit>
-			<trans-unit id="ZW.name" resname="ZW.name">
-				<source>Zimbabwe</source>
-			</trans-unit>
-			<trans-unit id="ZW.official_name" resname="ZW.official_name">
-				<source>Republic of Zimbabwe</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/Iso/countries.xlf"
+    product-name="academic-partners"
+  >
+    <body>
+      <trans-unit id="AD.name" resname="AD.name">
+        <source>Andorra</source>
+      </trans-unit>
+      <trans-unit id="AD.official_name" resname="AD.official_name">
+        <source>Principality of Andorra</source>
+      </trans-unit>
+      <trans-unit id="AE.name" resname="AE.name">
+        <source>United Arab Emirates</source>
+      </trans-unit>
+      <trans-unit id="AF.name" resname="AF.name">
+        <source>Afghanistan</source>
+      </trans-unit>
+      <trans-unit id="AF.official_name" resname="AF.official_name">
+        <source>Islamic Republic of Afghanistan</source>
+      </trans-unit>
+      <trans-unit id="AG.name" resname="AG.name">
+        <source>Antigua and Barbuda</source>
+      </trans-unit>
+      <trans-unit id="AI.name" resname="AI.name">
+        <source>Anguilla</source>
+      </trans-unit>
+      <trans-unit id="AL.name" resname="AL.name">
+        <source>Albania</source>
+      </trans-unit>
+      <trans-unit id="AL.official_name" resname="AL.official_name">
+        <source>Republic of Albania</source>
+      </trans-unit>
+      <trans-unit id="AM.name" resname="AM.name">
+        <source>Armenia</source>
+      </trans-unit>
+      <trans-unit id="AM.official_name" resname="AM.official_name">
+        <source>Republic of Armenia</source>
+      </trans-unit>
+      <trans-unit id="AO.name" resname="AO.name">
+        <source>Angola</source>
+      </trans-unit>
+      <trans-unit id="AO.official_name" resname="AO.official_name">
+        <source>Republic of Angola</source>
+      </trans-unit>
+      <trans-unit id="AQ.name" resname="AQ.name">
+        <source>Antarctica</source>
+      </trans-unit>
+      <trans-unit id="AR.name" resname="AR.name">
+        <source>Argentina</source>
+      </trans-unit>
+      <trans-unit id="AR.official_name" resname="AR.official_name">
+        <source>Argentine Republic</source>
+      </trans-unit>
+      <trans-unit id="AS.name" resname="AS.name">
+        <source>American Samoa</source>
+      </trans-unit>
+      <trans-unit id="AT.name" resname="AT.name">
+        <source>Austria</source>
+      </trans-unit>
+      <trans-unit id="AT.official_name" resname="AT.official_name">
+        <source>Republic of Austria</source>
+      </trans-unit>
+      <trans-unit id="AU.name" resname="AU.name">
+        <source>Australia</source>
+      </trans-unit>
+      <trans-unit id="AW.name" resname="AW.name">
+        <source>Aruba</source>
+      </trans-unit>
+      <trans-unit id="AX.name" resname="AX.name">
+        <source>Åland Islands</source>
+      </trans-unit>
+      <trans-unit id="AZ.name" resname="AZ.name">
+        <source>Azerbaijan</source>
+      </trans-unit>
+      <trans-unit id="AZ.official_name" resname="AZ.official_name">
+        <source>Republic of Azerbaijan</source>
+      </trans-unit>
+      <trans-unit id="BA.name" resname="BA.name">
+        <source>Bosnia and Herzegovina</source>
+      </trans-unit>
+      <trans-unit id="BA.official_name" resname="BA.official_name">
+        <source>Republic of Bosnia and Herzegovina</source>
+      </trans-unit>
+      <trans-unit id="BB.name" resname="BB.name">
+        <source>Barbados</source>
+      </trans-unit>
+      <trans-unit id="BD.name" resname="BD.name">
+        <source>Bangladesh</source>
+      </trans-unit>
+      <trans-unit id="BD.official_name" resname="BD.official_name">
+        <source>People's Republic of Bangladesh</source>
+      </trans-unit>
+      <trans-unit id="BE.name" resname="BE.name">
+        <source>Belgium</source>
+      </trans-unit>
+      <trans-unit id="BE.official_name" resname="BE.official_name">
+        <source>Kingdom of Belgium</source>
+      </trans-unit>
+      <trans-unit id="BF.name" resname="BF.name">
+        <source>Burkina Faso</source>
+      </trans-unit>
+      <trans-unit id="BG.name" resname="BG.name">
+        <source>Bulgaria</source>
+      </trans-unit>
+      <trans-unit id="BG.official_name" resname="BG.official_name">
+        <source>Republic of Bulgaria</source>
+      </trans-unit>
+      <trans-unit id="BH.name" resname="BH.name">
+        <source>Bahrain</source>
+      </trans-unit>
+      <trans-unit id="BH.official_name" resname="BH.official_name">
+        <source>Kingdom of Bahrain</source>
+      </trans-unit>
+      <trans-unit id="BI.name" resname="BI.name">
+        <source>Burundi</source>
+      </trans-unit>
+      <trans-unit id="BI.official_name" resname="BI.official_name">
+        <source>Republic of Burundi</source>
+      </trans-unit>
+      <trans-unit id="BJ.name" resname="BJ.name">
+        <source>Benin</source>
+      </trans-unit>
+      <trans-unit id="BJ.official_name" resname="BJ.official_name">
+        <source>Republic of Benin</source>
+      </trans-unit>
+      <trans-unit id="BL.name" resname="BL.name">
+        <source>Saint Barthélemy</source>
+      </trans-unit>
+      <trans-unit id="BM.name" resname="BM.name">
+        <source>Bermuda</source>
+      </trans-unit>
+      <trans-unit id="BN.name" resname="BN.name">
+        <source>Brunei Darussalam</source>
+      </trans-unit>
+      <trans-unit id="BO.name" resname="BO.name">
+        <source>Bolivia, Plurinational State of</source>
+      </trans-unit>
+      <trans-unit id="BO.official_name" resname="BO.official_name">
+        <source>Plurinational State of Bolivia</source>
+      </trans-unit>
+      <trans-unit id="BQ.name" resname="BQ.name">
+        <source>Bonaire, Sint Eustatius and Saba</source>
+      </trans-unit>
+      <trans-unit id="BQ.official_name" resname="BQ.official_name">
+        <source>Bonaire, Sint Eustatius and Saba</source>
+      </trans-unit>
+      <trans-unit id="BR.name" resname="BR.name">
+        <source>Brazil</source>
+      </trans-unit>
+      <trans-unit id="BR.official_name" resname="BR.official_name">
+        <source>Federative Republic of Brazil</source>
+      </trans-unit>
+      <trans-unit id="BS.name" resname="BS.name">
+        <source>Bahamas</source>
+      </trans-unit>
+      <trans-unit id="BS.official_name" resname="BS.official_name">
+        <source>Commonwealth of the Bahamas</source>
+      </trans-unit>
+      <trans-unit id="BT.name" resname="BT.name">
+        <source>Bhutan</source>
+      </trans-unit>
+      <trans-unit id="BT.official_name" resname="BT.official_name">
+        <source>Kingdom of Bhutan</source>
+      </trans-unit>
+      <trans-unit id="BV.name" resname="BV.name">
+        <source>Bouvet Island</source>
+      </trans-unit>
+      <trans-unit id="BW.name" resname="BW.name">
+        <source>Botswana</source>
+      </trans-unit>
+      <trans-unit id="BW.official_name" resname="BW.official_name">
+        <source>Republic of Botswana</source>
+      </trans-unit>
+      <trans-unit id="BY.name" resname="BY.name">
+        <source>Belarus</source>
+      </trans-unit>
+      <trans-unit id="BY.official_name" resname="BY.official_name">
+        <source>Republic of Belarus</source>
+      </trans-unit>
+      <trans-unit id="BZ.name" resname="BZ.name">
+        <source>Belize</source>
+      </trans-unit>
+      <trans-unit id="CA.name" resname="CA.name">
+        <source>Canada</source>
+      </trans-unit>
+      <trans-unit id="CC.name" resname="CC.name">
+        <source>Cocos (Keeling) Islands</source>
+      </trans-unit>
+      <trans-unit id="CD.name" resname="CD.name">
+        <source>Congo, The Democratic Republic of the</source>
+      </trans-unit>
+      <trans-unit id="CF.name" resname="CF.name">
+        <source>Central African Republic</source>
+      </trans-unit>
+      <trans-unit id="CG.name" resname="CG.name">
+        <source>Congo</source>
+      </trans-unit>
+      <trans-unit id="CG.official_name" resname="CG.official_name">
+        <source>Republic of the Congo</source>
+      </trans-unit>
+      <trans-unit id="CH.name" resname="CH.name">
+        <source>Switzerland</source>
+      </trans-unit>
+      <trans-unit id="CH.official_name" resname="CH.official_name">
+        <source>Swiss Confederation</source>
+      </trans-unit>
+      <trans-unit id="CI.name" resname="CI.name">
+        <source>Côte d'Ivoire</source>
+      </trans-unit>
+      <trans-unit id="CI.official_name" resname="CI.official_name">
+        <source>Republic of Côte d'Ivoire</source>
+      </trans-unit>
+      <trans-unit id="CK.name" resname="CK.name">
+        <source>Cook Islands</source>
+      </trans-unit>
+      <trans-unit id="CL.name" resname="CL.name">
+        <source>Chile</source>
+      </trans-unit>
+      <trans-unit id="CL.official_name" resname="CL.official_name">
+        <source>Republic of Chile</source>
+      </trans-unit>
+      <trans-unit id="CM.name" resname="CM.name">
+        <source>Cameroon</source>
+      </trans-unit>
+      <trans-unit id="CM.official_name" resname="CM.official_name">
+        <source>Republic of Cameroon</source>
+      </trans-unit>
+      <trans-unit id="CN.name" resname="CN.name">
+        <source>China</source>
+      </trans-unit>
+      <trans-unit id="CN.official_name" resname="CN.official_name">
+        <source>People's Republic of China</source>
+      </trans-unit>
+      <trans-unit id="CO.name" resname="CO.name">
+        <source>Colombia</source>
+      </trans-unit>
+      <trans-unit id="CO.official_name" resname="CO.official_name">
+        <source>Republic of Colombia</source>
+      </trans-unit>
+      <trans-unit id="CR.name" resname="CR.name">
+        <source>Costa Rica</source>
+      </trans-unit>
+      <trans-unit id="CR.official_name" resname="CR.official_name">
+        <source>Republic of Costa Rica</source>
+      </trans-unit>
+      <trans-unit id="CU.name" resname="CU.name">
+        <source>Cuba</source>
+      </trans-unit>
+      <trans-unit id="CU.official_name" resname="CU.official_name">
+        <source>Republic of Cuba</source>
+      </trans-unit>
+      <trans-unit id="CV.name" resname="CV.name">
+        <source>Cabo Verde</source>
+      </trans-unit>
+      <trans-unit id="CV.official_name" resname="CV.official_name">
+        <source>Republic of Cabo Verde</source>
+      </trans-unit>
+      <trans-unit id="CW.name" resname="CW.name">
+        <source>Curaçao</source>
+      </trans-unit>
+      <trans-unit id="CW.official_name" resname="CW.official_name">
+        <source>Curaçao</source>
+      </trans-unit>
+      <trans-unit id="CX.name" resname="CX.name">
+        <source>Christmas Island</source>
+      </trans-unit>
+      <trans-unit id="CY.name" resname="CY.name">
+        <source>Cyprus</source>
+      </trans-unit>
+      <trans-unit id="CY.official_name" resname="CY.official_name">
+        <source>Republic of Cyprus</source>
+      </trans-unit>
+      <trans-unit id="CZ.name" resname="CZ.name">
+        <source>Czechia</source>
+      </trans-unit>
+      <trans-unit id="CZ.official_name" resname="CZ.official_name">
+        <source>Czech Republic</source>
+      </trans-unit>
+      <trans-unit id="DE.name" resname="DE.name">
+        <source>Germany</source>
+      </trans-unit>
+      <trans-unit id="DE.official_name" resname="DE.official_name">
+        <source>Federal Republic of Germany</source>
+      </trans-unit>
+      <trans-unit id="DJ.name" resname="DJ.name">
+        <source>Djibouti</source>
+      </trans-unit>
+      <trans-unit id="DJ.official_name" resname="DJ.official_name">
+        <source>Republic of Djibouti</source>
+      </trans-unit>
+      <trans-unit id="DK.name" resname="DK.name">
+        <source>Denmark</source>
+      </trans-unit>
+      <trans-unit id="DK.official_name" resname="DK.official_name">
+        <source>Kingdom of Denmark</source>
+      </trans-unit>
+      <trans-unit id="DM.name" resname="DM.name">
+        <source>Dominica</source>
+      </trans-unit>
+      <trans-unit id="DM.official_name" resname="DM.official_name">
+        <source>Commonwealth of Dominica</source>
+      </trans-unit>
+      <trans-unit id="DO.name" resname="DO.name">
+        <source>Dominican Republic</source>
+      </trans-unit>
+      <trans-unit id="DZ.name" resname="DZ.name">
+        <source>Algeria</source>
+      </trans-unit>
+      <trans-unit id="DZ.official_name" resname="DZ.official_name">
+        <source>People's Democratic Republic of Algeria</source>
+      </trans-unit>
+      <trans-unit id="EC.name" resname="EC.name">
+        <source>Ecuador</source>
+      </trans-unit>
+      <trans-unit id="EC.official_name" resname="EC.official_name">
+        <source>Republic of Ecuador</source>
+      </trans-unit>
+      <trans-unit id="EE.name" resname="EE.name">
+        <source>Estonia</source>
+      </trans-unit>
+      <trans-unit id="EE.official_name" resname="EE.official_name">
+        <source>Republic of Estonia</source>
+      </trans-unit>
+      <trans-unit id="EG.name" resname="EG.name">
+        <source>Egypt</source>
+      </trans-unit>
+      <trans-unit id="EG.official_name" resname="EG.official_name">
+        <source>Arab Republic of Egypt</source>
+      </trans-unit>
+      <trans-unit id="EH.name" resname="EH.name">
+        <source>Western Sahara</source>
+      </trans-unit>
+      <trans-unit id="ER.name" resname="ER.name">
+        <source>Eritrea</source>
+      </trans-unit>
+      <trans-unit id="ER.official_name" resname="ER.official_name">
+        <source>the State of Eritrea</source>
+      </trans-unit>
+      <trans-unit id="ES.name" resname="ES.name">
+        <source>Spain</source>
+      </trans-unit>
+      <trans-unit id="ES.official_name" resname="ES.official_name">
+        <source>Kingdom of Spain</source>
+      </trans-unit>
+      <trans-unit id="ET.name" resname="ET.name">
+        <source>Ethiopia</source>
+      </trans-unit>
+      <trans-unit id="ET.official_name" resname="ET.official_name">
+        <source>Federal Democratic Republic of Ethiopia</source>
+      </trans-unit>
+      <trans-unit id="FI.name" resname="FI.name">
+        <source>Finland</source>
+      </trans-unit>
+      <trans-unit id="FI.official_name" resname="FI.official_name">
+        <source>Republic of Finland</source>
+      </trans-unit>
+      <trans-unit id="FJ.name" resname="FJ.name">
+        <source>Fiji</source>
+      </trans-unit>
+      <trans-unit id="FJ.official_name" resname="FJ.official_name">
+        <source>Republic of Fiji</source>
+      </trans-unit>
+      <trans-unit id="FK.name" resname="FK.name">
+        <source>Falkland Islands (Malvinas)</source>
+      </trans-unit>
+      <trans-unit id="FM.name" resname="FM.name">
+        <source>Micronesia, Federated States of</source>
+      </trans-unit>
+      <trans-unit id="FM.official_name" resname="FM.official_name">
+        <source>Federated States of Micronesia</source>
+      </trans-unit>
+      <trans-unit id="FO.name" resname="FO.name">
+        <source>Faroe Islands</source>
+      </trans-unit>
+      <trans-unit id="FR.name" resname="FR.name">
+        <source>France</source>
+      </trans-unit>
+      <trans-unit id="FR.official_name" resname="FR.official_name">
+        <source>French Republic</source>
+      </trans-unit>
+      <trans-unit id="GA.name" resname="GA.name">
+        <source>Gabon</source>
+      </trans-unit>
+      <trans-unit id="GA.official_name" resname="GA.official_name">
+        <source>Gabonese Republic</source>
+      </trans-unit>
+      <trans-unit id="GB.name" resname="GB.name">
+        <source>United Kingdom</source>
+      </trans-unit>
+      <trans-unit id="GB.official_name" resname="GB.official_name">
+        <source>United Kingdom of Great Britain and Northern Ireland</source>
+      </trans-unit>
+      <trans-unit id="GD.name" resname="GD.name">
+        <source>Grenada</source>
+      </trans-unit>
+      <trans-unit id="GE.name" resname="GE.name">
+        <source>Georgia</source>
+      </trans-unit>
+      <trans-unit id="GF.name" resname="GF.name">
+        <source>French Guiana</source>
+      </trans-unit>
+      <trans-unit id="GG.name" resname="GG.name">
+        <source>Guernsey</source>
+      </trans-unit>
+      <trans-unit id="GH.name" resname="GH.name">
+        <source>Ghana</source>
+      </trans-unit>
+      <trans-unit id="GH.official_name" resname="GH.official_name">
+        <source>Republic of Ghana</source>
+      </trans-unit>
+      <trans-unit id="GI.name" resname="GI.name">
+        <source>Gibraltar</source>
+      </trans-unit>
+      <trans-unit id="GL.name" resname="GL.name">
+        <source>Greenland</source>
+      </trans-unit>
+      <trans-unit id="GM.name" resname="GM.name">
+        <source>Gambia</source>
+      </trans-unit>
+      <trans-unit id="GM.official_name" resname="GM.official_name">
+        <source>Republic of the Gambia</source>
+      </trans-unit>
+      <trans-unit id="GN.name" resname="GN.name">
+        <source>Guinea</source>
+      </trans-unit>
+      <trans-unit id="GN.official_name" resname="GN.official_name">
+        <source>Republic of Guinea</source>
+      </trans-unit>
+      <trans-unit id="GP.name" resname="GP.name">
+        <source>Guadeloupe</source>
+      </trans-unit>
+      <trans-unit id="GQ.name" resname="GQ.name">
+        <source>Equatorial Guinea</source>
+      </trans-unit>
+      <trans-unit id="GQ.official_name" resname="GQ.official_name">
+        <source>Republic of Equatorial Guinea</source>
+      </trans-unit>
+      <trans-unit id="GR.name" resname="GR.name">
+        <source>Greece</source>
+      </trans-unit>
+      <trans-unit id="GR.official_name" resname="GR.official_name">
+        <source>Hellenic Republic</source>
+      </trans-unit>
+      <trans-unit id="GS.name" resname="GS.name">
+        <source>South Georgia and the South Sandwich Islands</source>
+      </trans-unit>
+      <trans-unit id="GT.name" resname="GT.name">
+        <source>Guatemala</source>
+      </trans-unit>
+      <trans-unit id="GT.official_name" resname="GT.official_name">
+        <source>Republic of Guatemala</source>
+      </trans-unit>
+      <trans-unit id="GU.name" resname="GU.name">
+        <source>Guam</source>
+      </trans-unit>
+      <trans-unit id="GW.name" resname="GW.name">
+        <source>Guinea-Bissau</source>
+      </trans-unit>
+      <trans-unit id="GW.official_name" resname="GW.official_name">
+        <source>Republic of Guinea-Bissau</source>
+      </trans-unit>
+      <trans-unit id="GY.name" resname="GY.name">
+        <source>Guyana</source>
+      </trans-unit>
+      <trans-unit id="GY.official_name" resname="GY.official_name">
+        <source>Republic of Guyana</source>
+      </trans-unit>
+      <trans-unit id="HK.name" resname="HK.name">
+        <source>Hong Kong</source>
+      </trans-unit>
+      <trans-unit id="HK.official_name" resname="HK.official_name">
+        <source>Hong Kong Special Administrative Region of China</source>
+      </trans-unit>
+      <trans-unit id="HM.name" resname="HM.name">
+        <source>Heard Island and McDonald Islands</source>
+      </trans-unit>
+      <trans-unit id="HN.name" resname="HN.name">
+        <source>Honduras</source>
+      </trans-unit>
+      <trans-unit id="HN.official_name" resname="HN.official_name">
+        <source>Republic of Honduras</source>
+      </trans-unit>
+      <trans-unit id="HR.name" resname="HR.name">
+        <source>Croatia</source>
+      </trans-unit>
+      <trans-unit id="HR.official_name" resname="HR.official_name">
+        <source>Republic of Croatia</source>
+      </trans-unit>
+      <trans-unit id="HT.name" resname="HT.name">
+        <source>Haiti</source>
+      </trans-unit>
+      <trans-unit id="HT.official_name" resname="HT.official_name">
+        <source>Republic of Haiti</source>
+      </trans-unit>
+      <trans-unit id="HU.name" resname="HU.name">
+        <source>Hungary</source>
+      </trans-unit>
+      <trans-unit id="HU.official_name" resname="HU.official_name">
+        <source>Hungary</source>
+      </trans-unit>
+      <trans-unit id="ID.name" resname="ID.name">
+        <source>Indonesia</source>
+      </trans-unit>
+      <trans-unit id="ID.official_name" resname="ID.official_name">
+        <source>Republic of Indonesia</source>
+      </trans-unit>
+      <trans-unit id="IE.name" resname="IE.name">
+        <source>Ireland</source>
+      </trans-unit>
+      <trans-unit id="IL.name" resname="IL.name">
+        <source>Israel</source>
+      </trans-unit>
+      <trans-unit id="IL.official_name" resname="IL.official_name">
+        <source>State of Israel</source>
+      </trans-unit>
+      <trans-unit id="IM.name" resname="IM.name">
+        <source>Isle of Man</source>
+      </trans-unit>
+      <trans-unit id="IN.name" resname="IN.name">
+        <source>India</source>
+      </trans-unit>
+      <trans-unit id="IN.official_name" resname="IN.official_name">
+        <source>Republic of India</source>
+      </trans-unit>
+      <trans-unit id="IO.name" resname="IO.name">
+        <source>British Indian Ocean Territory</source>
+      </trans-unit>
+      <trans-unit id="IQ.name" resname="IQ.name">
+        <source>Iraq</source>
+      </trans-unit>
+      <trans-unit id="IQ.official_name" resname="IQ.official_name">
+        <source>Republic of Iraq</source>
+      </trans-unit>
+      <trans-unit id="IR.name" resname="IR.name">
+        <source>Iran, Islamic Republic of</source>
+      </trans-unit>
+      <trans-unit id="IR.official_name" resname="IR.official_name">
+        <source>Islamic Republic of Iran</source>
+      </trans-unit>
+      <trans-unit id="IS.name" resname="IS.name">
+        <source>Iceland</source>
+      </trans-unit>
+      <trans-unit id="IS.official_name" resname="IS.official_name">
+        <source>Republic of Iceland</source>
+      </trans-unit>
+      <trans-unit id="IT.name" resname="IT.name">
+        <source>Italy</source>
+      </trans-unit>
+      <trans-unit id="IT.official_name" resname="IT.official_name">
+        <source>Italian Republic</source>
+      </trans-unit>
+      <trans-unit id="JE.name" resname="JE.name">
+        <source>Jersey</source>
+      </trans-unit>
+      <trans-unit id="JM.name" resname="JM.name">
+        <source>Jamaica</source>
+      </trans-unit>
+      <trans-unit id="JO.name" resname="JO.name">
+        <source>Jordan</source>
+      </trans-unit>
+      <trans-unit id="JO.official_name" resname="JO.official_name">
+        <source>Hashemite Kingdom of Jordan</source>
+      </trans-unit>
+      <trans-unit id="JP.name" resname="JP.name">
+        <source>Japan</source>
+      </trans-unit>
+      <trans-unit id="KE.name" resname="KE.name">
+        <source>Kenya</source>
+      </trans-unit>
+      <trans-unit id="KE.official_name" resname="KE.official_name">
+        <source>Republic of Kenya</source>
+      </trans-unit>
+      <trans-unit id="KG.name" resname="KG.name">
+        <source>Kyrgyzstan</source>
+      </trans-unit>
+      <trans-unit id="KG.official_name" resname="KG.official_name">
+        <source>Kyrgyz Republic</source>
+      </trans-unit>
+      <trans-unit id="KH.name" resname="KH.name">
+        <source>Cambodia</source>
+      </trans-unit>
+      <trans-unit id="KH.official_name" resname="KH.official_name">
+        <source>Kingdom of Cambodia</source>
+      </trans-unit>
+      <trans-unit id="KI.name" resname="KI.name">
+        <source>Kiribati</source>
+      </trans-unit>
+      <trans-unit id="KI.official_name" resname="KI.official_name">
+        <source>Republic of Kiribati</source>
+      </trans-unit>
+      <trans-unit id="KM.name" resname="KM.name">
+        <source>Comoros</source>
+      </trans-unit>
+      <trans-unit id="KM.official_name" resname="KM.official_name">
+        <source>Union of the Comoros</source>
+      </trans-unit>
+      <trans-unit id="KN.name" resname="KN.name">
+        <source>Saint Kitts and Nevis</source>
+      </trans-unit>
+      <trans-unit id="KP.name" resname="KP.name">
+        <source>Korea, Democratic People's Republic of</source>
+      </trans-unit>
+      <trans-unit id="KP.official_name" resname="KP.official_name">
+        <source>Democratic People's Republic of Korea</source>
+      </trans-unit>
+      <trans-unit id="KR.name" resname="KR.name">
+        <source>Korea, Republic of</source>
+      </trans-unit>
+      <trans-unit id="KW.name" resname="KW.name">
+        <source>Kuwait</source>
+      </trans-unit>
+      <trans-unit id="KW.official_name" resname="KW.official_name">
+        <source>State of Kuwait</source>
+      </trans-unit>
+      <trans-unit id="KY.name" resname="KY.name">
+        <source>Cayman Islands</source>
+      </trans-unit>
+      <trans-unit id="KZ.name" resname="KZ.name">
+        <source>Kazakhstan</source>
+      </trans-unit>
+      <trans-unit id="KZ.official_name" resname="KZ.official_name">
+        <source>Republic of Kazakhstan</source>
+      </trans-unit>
+      <trans-unit id="LA.name" resname="LA.name">
+        <source>Lao People's Democratic Republic</source>
+      </trans-unit>
+      <trans-unit id="LB.name" resname="LB.name">
+        <source>Lebanon</source>
+      </trans-unit>
+      <trans-unit id="LB.official_name" resname="LB.official_name">
+        <source>Lebanese Republic</source>
+      </trans-unit>
+      <trans-unit id="LC.name" resname="LC.name">
+        <source>Saint Lucia</source>
+      </trans-unit>
+      <trans-unit id="LI.name" resname="LI.name">
+        <source>Liechtenstein</source>
+      </trans-unit>
+      <trans-unit id="LI.official_name" resname="LI.official_name">
+        <source>Principality of Liechtenstein</source>
+      </trans-unit>
+      <trans-unit id="LK.name" resname="LK.name">
+        <source>Sri Lanka</source>
+      </trans-unit>
+      <trans-unit id="LK.official_name" resname="LK.official_name">
+        <source>Democratic Socialist Republic of Sri Lanka</source>
+      </trans-unit>
+      <trans-unit id="LR.name" resname="LR.name">
+        <source>Liberia</source>
+      </trans-unit>
+      <trans-unit id="LR.official_name" resname="LR.official_name">
+        <source>Republic of Liberia</source>
+      </trans-unit>
+      <trans-unit id="LS.name" resname="LS.name">
+        <source>Lesotho</source>
+      </trans-unit>
+      <trans-unit id="LS.official_name" resname="LS.official_name">
+        <source>Kingdom of Lesotho</source>
+      </trans-unit>
+      <trans-unit id="LT.name" resname="LT.name">
+        <source>Lithuania</source>
+      </trans-unit>
+      <trans-unit id="LT.official_name" resname="LT.official_name">
+        <source>Republic of Lithuania</source>
+      </trans-unit>
+      <trans-unit id="LU.name" resname="LU.name">
+        <source>Luxembourg</source>
+      </trans-unit>
+      <trans-unit id="LU.official_name" resname="LU.official_name">
+        <source>Grand Duchy of Luxembourg</source>
+      </trans-unit>
+      <trans-unit id="LV.name" resname="LV.name">
+        <source>Latvia</source>
+      </trans-unit>
+      <trans-unit id="LV.official_name" resname="LV.official_name">
+        <source>Republic of Latvia</source>
+      </trans-unit>
+      <trans-unit id="LY.name" resname="LY.name">
+        <source>Libya</source>
+      </trans-unit>
+      <trans-unit id="LY.official_name" resname="LY.official_name">
+        <source>Libya</source>
+      </trans-unit>
+      <trans-unit id="MA.name" resname="MA.name">
+        <source>Morocco</source>
+      </trans-unit>
+      <trans-unit id="MA.official_name" resname="MA.official_name">
+        <source>Kingdom of Morocco</source>
+      </trans-unit>
+      <trans-unit id="MC.name" resname="MC.name">
+        <source>Monaco</source>
+      </trans-unit>
+      <trans-unit id="MC.official_name" resname="MC.official_name">
+        <source>Principality of Monaco</source>
+      </trans-unit>
+      <trans-unit id="MD.name" resname="MD.name">
+        <source>Moldova, Republic of</source>
+      </trans-unit>
+      <trans-unit id="MD.official_name" resname="MD.official_name">
+        <source>Republic of Moldova</source>
+      </trans-unit>
+      <trans-unit id="ME.name" resname="ME.name">
+        <source>Montenegro</source>
+      </trans-unit>
+      <trans-unit id="ME.official_name" resname="ME.official_name">
+        <source>Montenegro</source>
+      </trans-unit>
+      <trans-unit id="MF.name" resname="MF.name">
+        <source>Saint Martin (French part)</source>
+      </trans-unit>
+      <trans-unit id="MG.name" resname="MG.name">
+        <source>Madagascar</source>
+      </trans-unit>
+      <trans-unit id="MG.official_name" resname="MG.official_name">
+        <source>Republic of Madagascar</source>
+      </trans-unit>
+      <trans-unit id="MH.name" resname="MH.name">
+        <source>Marshall Islands</source>
+      </trans-unit>
+      <trans-unit id="MH.official_name" resname="MH.official_name">
+        <source>Republic of the Marshall Islands</source>
+      </trans-unit>
+      <trans-unit id="MK.name" resname="MK.name">
+        <source>North Macedonia</source>
+      </trans-unit>
+      <trans-unit id="MK.official_name" resname="MK.official_name">
+        <source>Republic of North Macedonia</source>
+      </trans-unit>
+      <trans-unit id="ML.name" resname="ML.name">
+        <source>Mali</source>
+      </trans-unit>
+      <trans-unit id="ML.official_name" resname="ML.official_name">
+        <source>Republic of Mali</source>
+      </trans-unit>
+      <trans-unit id="MM.name" resname="MM.name">
+        <source>Myanmar</source>
+      </trans-unit>
+      <trans-unit id="MM.official_name" resname="MM.official_name">
+        <source>Republic of Myanmar</source>
+      </trans-unit>
+      <trans-unit id="MN.name" resname="MN.name">
+        <source>Mongolia</source>
+      </trans-unit>
+      <trans-unit id="MO.name" resname="MO.name">
+        <source>Macao</source>
+      </trans-unit>
+      <trans-unit id="MO.official_name" resname="MO.official_name">
+        <source>Macao Special Administrative Region of China</source>
+      </trans-unit>
+      <trans-unit id="MP.name" resname="MP.name">
+        <source>Northern Mariana Islands</source>
+      </trans-unit>
+      <trans-unit id="MP.official_name" resname="MP.official_name">
+        <source>Commonwealth of the Northern Mariana Islands</source>
+      </trans-unit>
+      <trans-unit id="MQ.name" resname="MQ.name">
+        <source>Martinique</source>
+      </trans-unit>
+      <trans-unit id="MR.name" resname="MR.name">
+        <source>Mauritania</source>
+      </trans-unit>
+      <trans-unit id="MR.official_name" resname="MR.official_name">
+        <source>Islamic Republic of Mauritania</source>
+      </trans-unit>
+      <trans-unit id="MS.name" resname="MS.name">
+        <source>Montserrat</source>
+      </trans-unit>
+      <trans-unit id="MT.name" resname="MT.name">
+        <source>Malta</source>
+      </trans-unit>
+      <trans-unit id="MT.official_name" resname="MT.official_name">
+        <source>Republic of Malta</source>
+      </trans-unit>
+      <trans-unit id="MU.name" resname="MU.name">
+        <source>Mauritius</source>
+      </trans-unit>
+      <trans-unit id="MU.official_name" resname="MU.official_name">
+        <source>Republic of Mauritius</source>
+      </trans-unit>
+      <trans-unit id="MV.name" resname="MV.name">
+        <source>Maldives</source>
+      </trans-unit>
+      <trans-unit id="MV.official_name" resname="MV.official_name">
+        <source>Republic of Maldives</source>
+      </trans-unit>
+      <trans-unit id="MW.name" resname="MW.name">
+        <source>Malawi</source>
+      </trans-unit>
+      <trans-unit id="MW.official_name" resname="MW.official_name">
+        <source>Republic of Malawi</source>
+      </trans-unit>
+      <trans-unit id="MX.name" resname="MX.name">
+        <source>Mexico</source>
+      </trans-unit>
+      <trans-unit id="MX.official_name" resname="MX.official_name">
+        <source>United Mexican States</source>
+      </trans-unit>
+      <trans-unit id="MY.name" resname="MY.name">
+        <source>Malaysia</source>
+      </trans-unit>
+      <trans-unit id="MZ.name" resname="MZ.name">
+        <source>Mozambique</source>
+      </trans-unit>
+      <trans-unit id="MZ.official_name" resname="MZ.official_name">
+        <source>Republic of Mozambique</source>
+      </trans-unit>
+      <trans-unit id="NA.name" resname="NA.name">
+        <source>Namibia</source>
+      </trans-unit>
+      <trans-unit id="NA.official_name" resname="NA.official_name">
+        <source>Republic of Namibia</source>
+      </trans-unit>
+      <trans-unit id="NC.name" resname="NC.name">
+        <source>New Caledonia</source>
+      </trans-unit>
+      <trans-unit id="NE.name" resname="NE.name">
+        <source>Niger</source>
+      </trans-unit>
+      <trans-unit id="NE.official_name" resname="NE.official_name">
+        <source>Republic of the Niger</source>
+      </trans-unit>
+      <trans-unit id="NF.name" resname="NF.name">
+        <source>Norfolk Island</source>
+      </trans-unit>
+      <trans-unit id="NG.name" resname="NG.name">
+        <source>Nigeria</source>
+      </trans-unit>
+      <trans-unit id="NG.official_name" resname="NG.official_name">
+        <source>Federal Republic of Nigeria</source>
+      </trans-unit>
+      <trans-unit id="NI.name" resname="NI.name">
+        <source>Nicaragua</source>
+      </trans-unit>
+      <trans-unit id="NI.official_name" resname="NI.official_name">
+        <source>Republic of Nicaragua</source>
+      </trans-unit>
+      <trans-unit id="NL.name" resname="NL.name">
+        <source>Netherlands</source>
+      </trans-unit>
+      <trans-unit id="NL.official_name" resname="NL.official_name">
+        <source>Kingdom of the Netherlands</source>
+      </trans-unit>
+      <trans-unit id="NO.name" resname="NO.name">
+        <source>Norway</source>
+      </trans-unit>
+      <trans-unit id="NO.official_name" resname="NO.official_name">
+        <source>Kingdom of Norway</source>
+      </trans-unit>
+      <trans-unit id="NP.name" resname="NP.name">
+        <source>Nepal</source>
+      </trans-unit>
+      <trans-unit id="NP.official_name" resname="NP.official_name">
+        <source>Federal Democratic Republic of Nepal</source>
+      </trans-unit>
+      <trans-unit id="NR.name" resname="NR.name">
+        <source>Nauru</source>
+      </trans-unit>
+      <trans-unit id="NR.official_name" resname="NR.official_name">
+        <source>Republic of Nauru</source>
+      </trans-unit>
+      <trans-unit id="NU.name" resname="NU.name">
+        <source>Niue</source>
+      </trans-unit>
+      <trans-unit id="NU.official_name" resname="NU.official_name">
+        <source>Niue</source>
+      </trans-unit>
+      <trans-unit id="NZ.name" resname="NZ.name">
+        <source>New Zealand</source>
+      </trans-unit>
+      <trans-unit id="OM.name" resname="OM.name">
+        <source>Oman</source>
+      </trans-unit>
+      <trans-unit id="OM.official_name" resname="OM.official_name">
+        <source>Sultanate of Oman</source>
+      </trans-unit>
+      <trans-unit id="PA.name" resname="PA.name">
+        <source>Panama</source>
+      </trans-unit>
+      <trans-unit id="PA.official_name" resname="PA.official_name">
+        <source>Republic of Panama</source>
+      </trans-unit>
+      <trans-unit id="PE.name" resname="PE.name">
+        <source>Peru</source>
+      </trans-unit>
+      <trans-unit id="PE.official_name" resname="PE.official_name">
+        <source>Republic of Peru</source>
+      </trans-unit>
+      <trans-unit id="PF.name" resname="PF.name">
+        <source>French Polynesia</source>
+      </trans-unit>
+      <trans-unit id="PG.name" resname="PG.name">
+        <source>Papua New Guinea</source>
+      </trans-unit>
+      <trans-unit id="PG.official_name" resname="PG.official_name">
+        <source>Independent State of Papua New Guinea</source>
+      </trans-unit>
+      <trans-unit id="PH.name" resname="PH.name">
+        <source>Philippines</source>
+      </trans-unit>
+      <trans-unit id="PH.official_name" resname="PH.official_name">
+        <source>Republic of the Philippines</source>
+      </trans-unit>
+      <trans-unit id="PK.name" resname="PK.name">
+        <source>Pakistan</source>
+      </trans-unit>
+      <trans-unit id="PK.official_name" resname="PK.official_name">
+        <source>Islamic Republic of Pakistan</source>
+      </trans-unit>
+      <trans-unit id="PL.name" resname="PL.name">
+        <source>Poland</source>
+      </trans-unit>
+      <trans-unit id="PL.official_name" resname="PL.official_name">
+        <source>Republic of Poland</source>
+      </trans-unit>
+      <trans-unit id="PM.name" resname="PM.name">
+        <source>Saint Pierre and Miquelon</source>
+      </trans-unit>
+      <trans-unit id="PN.name" resname="PN.name">
+        <source>Pitcairn</source>
+      </trans-unit>
+      <trans-unit id="PR.name" resname="PR.name">
+        <source>Puerto Rico</source>
+      </trans-unit>
+      <trans-unit id="PS.name" resname="PS.name">
+        <source>Palestine, State of</source>
+      </trans-unit>
+      <trans-unit id="PS.official_name" resname="PS.official_name">
+        <source>the State of Palestine</source>
+      </trans-unit>
+      <trans-unit id="PT.name" resname="PT.name">
+        <source>Portugal</source>
+      </trans-unit>
+      <trans-unit id="PT.official_name" resname="PT.official_name">
+        <source>Portuguese Republic</source>
+      </trans-unit>
+      <trans-unit id="PW.name" resname="PW.name">
+        <source>Palau</source>
+      </trans-unit>
+      <trans-unit id="PW.official_name" resname="PW.official_name">
+        <source>Republic of Palau</source>
+      </trans-unit>
+      <trans-unit id="PY.name" resname="PY.name">
+        <source>Paraguay</source>
+      </trans-unit>
+      <trans-unit id="PY.official_name" resname="PY.official_name">
+        <source>Republic of Paraguay</source>
+      </trans-unit>
+      <trans-unit id="QA.name" resname="QA.name">
+        <source>Qatar</source>
+      </trans-unit>
+      <trans-unit id="QA.official_name" resname="QA.official_name">
+        <source>State of Qatar</source>
+      </trans-unit>
+      <trans-unit id="RE.name" resname="RE.name">
+        <source>Réunion</source>
+      </trans-unit>
+      <trans-unit id="RO.name" resname="RO.name">
+        <source>Romania</source>
+      </trans-unit>
+      <trans-unit id="RS.name" resname="RS.name">
+        <source>Serbia</source>
+      </trans-unit>
+      <trans-unit id="RS.official_name" resname="RS.official_name">
+        <source>Republic of Serbia</source>
+      </trans-unit>
+      <trans-unit id="RU.name" resname="RU.name">
+        <source>Russian Federation</source>
+      </trans-unit>
+      <trans-unit id="RW.name" resname="RW.name">
+        <source>Rwanda</source>
+      </trans-unit>
+      <trans-unit id="RW.official_name" resname="RW.official_name">
+        <source>Rwandese Republic</source>
+      </trans-unit>
+      <trans-unit id="SA.name" resname="SA.name">
+        <source>Saudi Arabia</source>
+      </trans-unit>
+      <trans-unit id="SA.official_name" resname="SA.official_name">
+        <source>Kingdom of Saudi Arabia</source>
+      </trans-unit>
+      <trans-unit id="SB.name" resname="SB.name">
+        <source>Solomon Islands</source>
+      </trans-unit>
+      <trans-unit id="SC.name" resname="SC.name">
+        <source>Seychelles</source>
+      </trans-unit>
+      <trans-unit id="SC.official_name" resname="SC.official_name">
+        <source>Republic of Seychelles</source>
+      </trans-unit>
+      <trans-unit id="SD.name" resname="SD.name">
+        <source>Sudan</source>
+      </trans-unit>
+      <trans-unit id="SD.official_name" resname="SD.official_name">
+        <source>Republic of the Sudan</source>
+      </trans-unit>
+      <trans-unit id="SE.name" resname="SE.name">
+        <source>Sweden</source>
+      </trans-unit>
+      <trans-unit id="SE.official_name" resname="SE.official_name">
+        <source>Kingdom of Sweden</source>
+      </trans-unit>
+      <trans-unit id="SG.name" resname="SG.name">
+        <source>Singapore</source>
+      </trans-unit>
+      <trans-unit id="SG.official_name" resname="SG.official_name">
+        <source>Republic of Singapore</source>
+      </trans-unit>
+      <trans-unit id="SH.name" resname="SH.name">
+        <source>Saint Helena, Ascension and Tristan da Cunha</source>
+      </trans-unit>
+      <trans-unit id="SI.name" resname="SI.name">
+        <source>Slovenia</source>
+      </trans-unit>
+      <trans-unit id="SI.official_name" resname="SI.official_name">
+        <source>Republic of Slovenia</source>
+      </trans-unit>
+      <trans-unit id="SJ.name" resname="SJ.name">
+        <source>Svalbard and Jan Mayen</source>
+      </trans-unit>
+      <trans-unit id="SK.name" resname="SK.name">
+        <source>Slovakia</source>
+      </trans-unit>
+      <trans-unit id="SK.official_name" resname="SK.official_name">
+        <source>Slovak Republic</source>
+      </trans-unit>
+      <trans-unit id="SL.name" resname="SL.name">
+        <source>Sierra Leone</source>
+      </trans-unit>
+      <trans-unit id="SL.official_name" resname="SL.official_name">
+        <source>Republic of Sierra Leone</source>
+      </trans-unit>
+      <trans-unit id="SM.name" resname="SM.name">
+        <source>San Marino</source>
+      </trans-unit>
+      <trans-unit id="SM.official_name" resname="SM.official_name">
+        <source>Republic of San Marino</source>
+      </trans-unit>
+      <trans-unit id="SN.name" resname="SN.name">
+        <source>Senegal</source>
+      </trans-unit>
+      <trans-unit id="SN.official_name" resname="SN.official_name">
+        <source>Republic of Senegal</source>
+      </trans-unit>
+      <trans-unit id="SO.name" resname="SO.name">
+        <source>Somalia</source>
+      </trans-unit>
+      <trans-unit id="SO.official_name" resname="SO.official_name">
+        <source>Federal Republic of Somalia</source>
+      </trans-unit>
+      <trans-unit id="SR.name" resname="SR.name">
+        <source>Suriname</source>
+      </trans-unit>
+      <trans-unit id="SR.official_name" resname="SR.official_name">
+        <source>Republic of Suriname</source>
+      </trans-unit>
+      <trans-unit id="SS.name" resname="SS.name">
+        <source>South Sudan</source>
+      </trans-unit>
+      <trans-unit id="SS.official_name" resname="SS.official_name">
+        <source>Republic of South Sudan</source>
+      </trans-unit>
+      <trans-unit id="ST.name" resname="ST.name">
+        <source>Sao Tome and Principe</source>
+      </trans-unit>
+      <trans-unit id="ST.official_name" resname="ST.official_name">
+        <source>Democratic Republic of Sao Tome and Principe</source>
+      </trans-unit>
+      <trans-unit id="SV.name" resname="SV.name">
+        <source>El Salvador</source>
+      </trans-unit>
+      <trans-unit id="SV.official_name" resname="SV.official_name">
+        <source>Republic of El Salvador</source>
+      </trans-unit>
+      <trans-unit id="SX.name" resname="SX.name">
+        <source>Sint Maarten (Dutch part)</source>
+      </trans-unit>
+      <trans-unit id="SX.official_name" resname="SX.official_name">
+        <source>Sint Maarten (Dutch part)</source>
+      </trans-unit>
+      <trans-unit id="SY.name" resname="SY.name">
+        <source>Syrian Arab Republic</source>
+      </trans-unit>
+      <trans-unit id="SZ.name" resname="SZ.name">
+        <source>Eswatini</source>
+      </trans-unit>
+      <trans-unit id="SZ.official_name" resname="SZ.official_name">
+        <source>Kingdom of Eswatini</source>
+      </trans-unit>
+      <trans-unit id="TC.name" resname="TC.name">
+        <source>Turks and Caicos Islands</source>
+      </trans-unit>
+      <trans-unit id="TD.name" resname="TD.name">
+        <source>Chad</source>
+      </trans-unit>
+      <trans-unit id="TD.official_name" resname="TD.official_name">
+        <source>Republic of Chad</source>
+      </trans-unit>
+      <trans-unit id="TF.name" resname="TF.name">
+        <source>French Southern Territories</source>
+      </trans-unit>
+      <trans-unit id="TG.name" resname="TG.name">
+        <source>Togo</source>
+      </trans-unit>
+      <trans-unit id="TG.official_name" resname="TG.official_name">
+        <source>Togolese Republic</source>
+      </trans-unit>
+      <trans-unit id="TH.name" resname="TH.name">
+        <source>Thailand</source>
+      </trans-unit>
+      <trans-unit id="TH.official_name" resname="TH.official_name">
+        <source>Kingdom of Thailand</source>
+      </trans-unit>
+      <trans-unit id="TJ.name" resname="TJ.name">
+        <source>Tajikistan</source>
+      </trans-unit>
+      <trans-unit id="TJ.official_name" resname="TJ.official_name">
+        <source>Republic of Tajikistan</source>
+      </trans-unit>
+      <trans-unit id="TK.name" resname="TK.name">
+        <source>Tokelau</source>
+      </trans-unit>
+      <trans-unit id="TL.name" resname="TL.name">
+        <source>Timor-Leste</source>
+      </trans-unit>
+      <trans-unit id="TL.official_name" resname="TL.official_name">
+        <source>Democratic Republic of Timor-Leste</source>
+      </trans-unit>
+      <trans-unit id="TM.name" resname="TM.name">
+        <source>Turkmenistan</source>
+      </trans-unit>
+      <trans-unit id="TN.name" resname="TN.name">
+        <source>Tunisia</source>
+      </trans-unit>
+      <trans-unit id="TN.official_name" resname="TN.official_name">
+        <source>Republic of Tunisia</source>
+      </trans-unit>
+      <trans-unit id="TO.name" resname="TO.name">
+        <source>Tonga</source>
+      </trans-unit>
+      <trans-unit id="TO.official_name" resname="TO.official_name">
+        <source>Kingdom of Tonga</source>
+      </trans-unit>
+      <trans-unit id="TR.name" resname="TR.name">
+        <source>Türkiye</source>
+      </trans-unit>
+      <trans-unit id="TR.official_name" resname="TR.official_name">
+        <source>Republic of Türkiye</source>
+      </trans-unit>
+      <trans-unit id="TT.name" resname="TT.name">
+        <source>Trinidad and Tobago</source>
+      </trans-unit>
+      <trans-unit id="TT.official_name" resname="TT.official_name">
+        <source>Republic of Trinidad and Tobago</source>
+      </trans-unit>
+      <trans-unit id="TV.name" resname="TV.name">
+        <source>Tuvalu</source>
+      </trans-unit>
+      <trans-unit id="TW.name" resname="TW.name">
+        <source>Taiwan, Province of China</source>
+      </trans-unit>
+      <trans-unit id="TW.official_name" resname="TW.official_name">
+        <source>Taiwan, Province of China</source>
+      </trans-unit>
+      <trans-unit id="TZ.name" resname="TZ.name">
+        <source>Tanzania, United Republic of</source>
+      </trans-unit>
+      <trans-unit id="TZ.official_name" resname="TZ.official_name">
+        <source>United Republic of Tanzania</source>
+      </trans-unit>
+      <trans-unit id="UA.name" resname="UA.name">
+        <source>Ukraine</source>
+      </trans-unit>
+      <trans-unit id="UG.name" resname="UG.name">
+        <source>Uganda</source>
+      </trans-unit>
+      <trans-unit id="UG.official_name" resname="UG.official_name">
+        <source>Republic of Uganda</source>
+      </trans-unit>
+      <trans-unit id="UM.name" resname="UM.name">
+        <source>United States Minor Outlying Islands</source>
+      </trans-unit>
+      <trans-unit id="US.name" resname="US.name">
+        <source>United States</source>
+      </trans-unit>
+      <trans-unit id="US.official_name" resname="US.official_name">
+        <source>United States of America</source>
+      </trans-unit>
+      <trans-unit id="UY.name" resname="UY.name">
+        <source>Uruguay</source>
+      </trans-unit>
+      <trans-unit id="UY.official_name" resname="UY.official_name">
+        <source>Eastern Republic of Uruguay</source>
+      </trans-unit>
+      <trans-unit id="UZ.name" resname="UZ.name">
+        <source>Uzbekistan</source>
+      </trans-unit>
+      <trans-unit id="UZ.official_name" resname="UZ.official_name">
+        <source>Republic of Uzbekistan</source>
+      </trans-unit>
+      <trans-unit id="VA.name" resname="VA.name">
+        <source>Holy See (Vatican City State)</source>
+      </trans-unit>
+      <trans-unit id="VC.name" resname="VC.name">
+        <source>Saint Vincent and the Grenadines</source>
+      </trans-unit>
+      <trans-unit id="VE.name" resname="VE.name">
+        <source>Venezuela, Bolivarian Republic of</source>
+      </trans-unit>
+      <trans-unit id="VE.official_name" resname="VE.official_name">
+        <source>Bolivarian Republic of Venezuela</source>
+      </trans-unit>
+      <trans-unit id="VG.name" resname="VG.name">
+        <source>Virgin Islands, British</source>
+      </trans-unit>
+      <trans-unit id="VG.official_name" resname="VG.official_name">
+        <source>British Virgin Islands</source>
+      </trans-unit>
+      <trans-unit id="VI.name" resname="VI.name">
+        <source>Virgin Islands, U.S.</source>
+      </trans-unit>
+      <trans-unit id="VI.official_name" resname="VI.official_name">
+        <source>Virgin Islands of the United States</source>
+      </trans-unit>
+      <trans-unit id="VN.name" resname="VN.name">
+        <source>Viet Nam</source>
+      </trans-unit>
+      <trans-unit id="VN.official_name" resname="VN.official_name">
+        <source>Socialist Republic of Viet Nam</source>
+      </trans-unit>
+      <trans-unit id="VU.name" resname="VU.name">
+        <source>Vanuatu</source>
+      </trans-unit>
+      <trans-unit id="VU.official_name" resname="VU.official_name">
+        <source>Republic of Vanuatu</source>
+      </trans-unit>
+      <trans-unit id="WF.name" resname="WF.name">
+        <source>Wallis and Futuna</source>
+      </trans-unit>
+      <trans-unit id="WS.name" resname="WS.name">
+        <source>Samoa</source>
+      </trans-unit>
+      <trans-unit id="WS.official_name" resname="WS.official_name">
+        <source>Independent State of Samoa</source>
+      </trans-unit>
+      <trans-unit id="YE.name" resname="YE.name">
+        <source>Yemen</source>
+      </trans-unit>
+      <trans-unit id="YE.official_name" resname="YE.official_name">
+        <source>Republic of Yemen</source>
+      </trans-unit>
+      <trans-unit id="YT.name" resname="YT.name">
+        <source>Mayotte</source>
+      </trans-unit>
+      <trans-unit id="ZA.name" resname="ZA.name">
+        <source>South Africa</source>
+      </trans-unit>
+      <trans-unit id="ZA.official_name" resname="ZA.official_name">
+        <source>Republic of South Africa</source>
+      </trans-unit>
+      <trans-unit id="ZM.name" resname="ZM.name">
+        <source>Zambia</source>
+      </trans-unit>
+      <trans-unit id="ZM.official_name" resname="ZM.official_name">
+        <source>Republic of Zambia</source>
+      </trans-unit>
+      <trans-unit id="ZW.name" resname="ZW.name">
+        <source>Zimbabwe</source>
+      </trans-unit>
+      <trans-unit id="ZW.official_name" resname="ZW.official_name">
+        <source>Republic of Zimbabwe</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/Iso/de.countries.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/Iso/de.countries.xlf
@@ -1,1701 +1,1701 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/Iso/countries.xlf"
-		product-name="academic-partners"
-	>
-		<body>
-			<trans-unit id="AD.name" resname="AD.name" approved="yes">
-				<source>Andorra</source>
-				<target>Andorra</target>
-			</trans-unit>
-			<trans-unit id="AD.official_name" resname="AD.official_name" approved="yes">
-				<source>Principality of Andorra</source>
-				<target>Fürstentum Andorra</target>
-			</trans-unit>
-			<trans-unit id="AE.name" resname="AE.name" approved="yes">
-				<source>United Arab Emirates</source>
-				<target>Vereinigte Arabische Emirate</target>
-			</trans-unit>
-			<trans-unit id="AF.name" resname="AF.name" approved="yes">
-				<source>Afghanistan</source>
-				<target>Afghanistan</target>
-			</trans-unit>
-			<trans-unit id="AF.official_name" resname="AF.official_name" approved="yes">
-				<source>Islamic Republic of Afghanistan</source>
-				<target>Islamische Republik Afghanistan</target>
-			</trans-unit>
-			<trans-unit id="AG.name" resname="AG.name" approved="yes">
-				<source>Antigua and Barbuda</source>
-				<target>Antigua und Barbuda</target>
-			</trans-unit>
-			<trans-unit id="AI.name" resname="AI.name" approved="yes">
-				<source>Anguilla</source>
-				<target>Anguilla</target>
-			</trans-unit>
-			<trans-unit id="AL.name" resname="AL.name" approved="yes">
-				<source>Albania</source>
-				<target>Albanien</target>
-			</trans-unit>
-			<trans-unit id="AL.official_name" resname="AL.official_name" approved="yes">
-				<source>Republic of Albania</source>
-				<target>Republik Albanien</target>
-			</trans-unit>
-			<trans-unit id="AM.name" resname="AM.name" approved="yes">
-				<source>Armenia</source>
-				<target>Armenien</target>
-			</trans-unit>
-			<trans-unit id="AM.official_name" resname="AM.official_name" approved="yes">
-				<source>Republic of Armenia</source>
-				<target>Republik Armenien</target>
-			</trans-unit>
-			<trans-unit id="AO.name" resname="AO.name" approved="yes">
-				<source>Angola</source>
-				<target>Angola</target>
-			</trans-unit>
-			<trans-unit id="AO.official_name" resname="AO.official_name" approved="yes">
-				<source>Republic of Angola</source>
-				<target>Republik Angola</target>
-			</trans-unit>
-			<trans-unit id="AQ.name" resname="AQ.name" approved="yes">
-				<source>Antarctica</source>
-				<target>Antarktis</target>
-			</trans-unit>
-			<trans-unit id="AR.name" resname="AR.name" approved="yes">
-				<source>Argentina</source>
-				<target>Argentinien</target>
-			</trans-unit>
-			<trans-unit id="AR.official_name" resname="AR.official_name" approved="yes">
-				<source>Argentine Republic</source>
-				<target>Argentinische Republik</target>
-			</trans-unit>
-			<trans-unit id="AS.name" resname="AS.name" approved="yes">
-				<source>American Samoa</source>
-				<target>Amerikanisch-Samoa</target>
-			</trans-unit>
-			<trans-unit id="AT.name" resname="AT.name" approved="yes">
-				<source>Austria</source>
-				<target>Österreich</target>
-			</trans-unit>
-			<trans-unit id="AT.official_name" resname="AT.official_name" approved="yes">
-				<source>Republic of Austria</source>
-				<target>Republik Österreich</target>
-			</trans-unit>
-			<trans-unit id="AU.name" resname="AU.name" approved="yes">
-				<source>Australia</source>
-				<target>Australien</target>
-			</trans-unit>
-			<trans-unit id="AW.name" resname="AW.name" approved="yes">
-				<source>Aruba</source>
-				<target>Aruba</target>
-			</trans-unit>
-			<trans-unit id="AX.name" resname="AX.name" approved="yes">
-				<source>Åland Islands</source>
-				<target>Åland-Inseln</target>
-			</trans-unit>
-			<trans-unit id="AZ.name" resname="AZ.name" approved="yes">
-				<source>Azerbaijan</source>
-				<target>Aserbaidschan</target>
-			</trans-unit>
-			<trans-unit id="AZ.official_name" resname="AZ.official_name" approved="yes">
-				<source>Republic of Azerbaijan</source>
-				<target>Republik Aserbaidschan</target>
-			</trans-unit>
-			<trans-unit id="BA.name" resname="BA.name" approved="yes">
-				<source>Bosnia and Herzegovina</source>
-				<target>Bosnien und Herzegowina</target>
-			</trans-unit>
-			<trans-unit id="BA.official_name" resname="BA.official_name" approved="yes">
-				<source>Republic of Bosnia and Herzegovina</source>
-				<target>Bosnien und Herzegowina</target>
-			</trans-unit>
-			<trans-unit id="BB.name" resname="BB.name" approved="yes">
-				<source>Barbados</source>
-				<target>Barbados</target>
-			</trans-unit>
-			<trans-unit id="BD.name" resname="BD.name" approved="yes">
-				<source>Bangladesh</source>
-				<target>Bangladesch</target>
-			</trans-unit>
-			<trans-unit id="BD.official_name" resname="BD.official_name" approved="yes">
-				<source>People's Republic of Bangladesh</source>
-				<target>Volksrepublik Bangladesh</target>
-			</trans-unit>
-			<trans-unit id="BE.name" resname="BE.name" approved="yes">
-				<source>Belgium</source>
-				<target>Belgien</target>
-			</trans-unit>
-			<trans-unit id="BE.official_name" resname="BE.official_name" approved="yes">
-				<source>Kingdom of Belgium</source>
-				<target>Königreich Belgien</target>
-			</trans-unit>
-			<trans-unit id="BF.name" resname="BF.name" approved="yes">
-				<source>Burkina Faso</source>
-				<target>Burkina Faso</target>
-			</trans-unit>
-			<trans-unit id="BG.name" resname="BG.name" approved="yes">
-				<source>Bulgaria</source>
-				<target>Bulgarien</target>
-			</trans-unit>
-			<trans-unit id="BG.official_name" resname="BG.official_name" approved="yes">
-				<source>Republic of Bulgaria</source>
-				<target>Republik Bulgarien</target>
-			</trans-unit>
-			<trans-unit id="BH.name" resname="BH.name" approved="yes">
-				<source>Bahrain</source>
-				<target>Bahrain</target>
-			</trans-unit>
-			<trans-unit id="BH.official_name" resname="BH.official_name" approved="yes">
-				<source>Kingdom of Bahrain</source>
-				<target>Königreich Bahrain</target>
-			</trans-unit>
-			<trans-unit id="BI.name" resname="BI.name" approved="yes">
-				<source>Burundi</source>
-				<target>Burundi</target>
-			</trans-unit>
-			<trans-unit id="BI.official_name" resname="BI.official_name" approved="yes">
-				<source>Republic of Burundi</source>
-				<target>Republik Burundi</target>
-			</trans-unit>
-			<trans-unit id="BJ.name" resname="BJ.name" approved="yes">
-				<source>Benin</source>
-				<target>Benin</target>
-			</trans-unit>
-			<trans-unit id="BJ.official_name" resname="BJ.official_name" approved="yes">
-				<source>Republic of Benin</source>
-				<target>Republik Benin</target>
-			</trans-unit>
-			<trans-unit id="BL.name" resname="BL.name" approved="yes">
-				<source>Saint Barthélemy</source>
-				<target>Saint-Barthélemy</target>
-			</trans-unit>
-			<trans-unit id="BM.name" resname="BM.name" approved="yes">
-				<source>Bermuda</source>
-				<target>Bermuda</target>
-			</trans-unit>
-			<trans-unit id="BN.name" resname="BN.name" approved="yes">
-				<source>Brunei Darussalam</source>
-				<target>Brunei Darussalam</target>
-			</trans-unit>
-			<trans-unit id="BO.name" resname="BO.name" approved="yes">
-				<source>Bolivia, Plurinational State of</source>
-				<target>Bolivien, Plurinationaler Staat</target>
-			</trans-unit>
-			<trans-unit id="BO.official_name" resname="BO.official_name" approved="yes">
-				<source>Plurinational State of Bolivia</source>
-				<target>Plurinationaler Staat Bolivien</target>
-			</trans-unit>
-			<trans-unit id="BQ.name" resname="BQ.name" approved="yes">
-				<source>Bonaire, Sint Eustatius and Saba</source>
-				<target>Bonaire, Sint Eustatius und Saba</target>
-			</trans-unit>
-			<trans-unit id="BQ.official_name" resname="BQ.official_name" approved="yes">
-				<source>Bonaire, Sint Eustatius and Saba</source>
-				<target>Bonaire, Sint Eustatius und Saba</target>
-			</trans-unit>
-			<trans-unit id="BR.name" resname="BR.name" approved="yes">
-				<source>Brazil</source>
-				<target>Brasilien</target>
-			</trans-unit>
-			<trans-unit id="BR.official_name" resname="BR.official_name" approved="yes">
-				<source>Federative Republic of Brazil</source>
-				<target>Föderative Republik Brasilien</target>
-			</trans-unit>
-			<trans-unit id="BS.name" resname="BS.name" approved="yes">
-				<source>Bahamas</source>
-				<target>Bahamas</target>
-			</trans-unit>
-			<trans-unit id="BS.official_name" resname="BS.official_name" approved="yes">
-				<source>Commonwealth of the Bahamas</source>
-				<target>Commonwealth der Bahamas</target>
-			</trans-unit>
-			<trans-unit id="BT.name" resname="BT.name" approved="yes">
-				<source>Bhutan</source>
-				<target>Bhutan</target>
-			</trans-unit>
-			<trans-unit id="BT.official_name" resname="BT.official_name" approved="yes">
-				<source>Kingdom of Bhutan</source>
-				<target>Königreich Bhutan</target>
-			</trans-unit>
-			<trans-unit id="BV.name" resname="BV.name" approved="yes">
-				<source>Bouvet Island</source>
-				<target>Bouvet-Insel</target>
-			</trans-unit>
-			<trans-unit id="BW.name" resname="BW.name" approved="yes">
-				<source>Botswana</source>
-				<target>Botsuana</target>
-			</trans-unit>
-			<trans-unit id="BW.official_name" resname="BW.official_name" approved="yes">
-				<source>Republic of Botswana</source>
-				<target>Republik Botsuana</target>
-			</trans-unit>
-			<trans-unit id="BY.name" resname="BY.name" approved="yes">
-				<source>Belarus</source>
-				<target>Belarus</target>
-			</trans-unit>
-			<trans-unit id="BY.official_name" resname="BY.official_name" approved="yes">
-				<source>Republic of Belarus</source>
-				<target>Republik Belarus</target>
-			</trans-unit>
-			<trans-unit id="BZ.name" resname="BZ.name" approved="yes">
-				<source>Belize</source>
-				<target>Belize</target>
-			</trans-unit>
-			<trans-unit id="CA.name" resname="CA.name" approved="yes">
-				<source>Canada</source>
-				<target>Kanada</target>
-			</trans-unit>
-			<trans-unit id="CC.name" resname="CC.name" approved="yes">
-				<source>Cocos (Keeling) Islands</source>
-				<target>Kokos-(Keeling-)Inseln</target>
-			</trans-unit>
-			<trans-unit id="CD.name" resname="CD.name" approved="yes">
-				<source>Congo, The Democratic Republic of the</source>
-				<target>Demokratische Republik Kongo</target>
-			</trans-unit>
-			<trans-unit id="CF.name" resname="CF.name" approved="yes">
-				<source>Central African Republic</source>
-				<target>Zentralafrikanische Republik</target>
-			</trans-unit>
-			<trans-unit id="CG.name" resname="CG.name" approved="yes">
-				<source>Congo</source>
-				<target>Kongo</target>
-			</trans-unit>
-			<trans-unit id="CG.official_name" resname="CG.official_name" approved="yes">
-				<source>Republic of the Congo</source>
-				<target>Republik Kongo</target>
-			</trans-unit>
-			<trans-unit id="CH.name" resname="CH.name" approved="yes">
-				<source>Switzerland</source>
-				<target>Schweiz</target>
-			</trans-unit>
-			<trans-unit id="CH.official_name" resname="CH.official_name" approved="yes">
-				<source>Swiss Confederation</source>
-				<target>Schweizerische Eidgenossenschaft</target>
-			</trans-unit>
-			<trans-unit id="CI.name" resname="CI.name" approved="yes">
-				<source>Côte d'Ivoire</source>
-				<target>Côte d'Ivoire</target>
-			</trans-unit>
-			<trans-unit id="CI.official_name" resname="CI.official_name" approved="yes">
-				<source>Republic of Côte d'Ivoire</source>
-				<target>Republik Côte d'Ivoire</target>
-			</trans-unit>
-			<trans-unit id="CK.name" resname="CK.name" approved="yes">
-				<source>Cook Islands</source>
-				<target>Cookinseln</target>
-			</trans-unit>
-			<trans-unit id="CL.name" resname="CL.name" approved="yes">
-				<source>Chile</source>
-				<target>Chile</target>
-			</trans-unit>
-			<trans-unit id="CL.official_name" resname="CL.official_name" approved="yes">
-				<source>Republic of Chile</source>
-				<target>Republik Chile</target>
-			</trans-unit>
-			<trans-unit id="CM.name" resname="CM.name" approved="yes">
-				<source>Cameroon</source>
-				<target>Kamerun</target>
-			</trans-unit>
-			<trans-unit id="CM.official_name" resname="CM.official_name" approved="yes">
-				<source>Republic of Cameroon</source>
-				<target>Republik Kamerun</target>
-			</trans-unit>
-			<trans-unit id="CN.name" resname="CN.name" approved="yes">
-				<source>China</source>
-				<target>China</target>
-			</trans-unit>
-			<trans-unit id="CN.official_name" resname="CN.official_name" approved="yes">
-				<source>People's Republic of China</source>
-				<target>Volksrepublik China</target>
-			</trans-unit>
-			<trans-unit id="CO.name" resname="CO.name" approved="yes">
-				<source>Colombia</source>
-				<target>Kolumbien</target>
-			</trans-unit>
-			<trans-unit id="CO.official_name" resname="CO.official_name" approved="yes">
-				<source>Republic of Colombia</source>
-				<target>Republik Kolumbien</target>
-			</trans-unit>
-			<trans-unit id="CR.name" resname="CR.name" approved="yes">
-				<source>Costa Rica</source>
-				<target>Costa Rica</target>
-			</trans-unit>
-			<trans-unit id="CR.official_name" resname="CR.official_name" approved="yes">
-				<source>Republic of Costa Rica</source>
-				<target>Republik Costa Rica</target>
-			</trans-unit>
-			<trans-unit id="CU.name" resname="CU.name" approved="yes">
-				<source>Cuba</source>
-				<target>Kuba</target>
-			</trans-unit>
-			<trans-unit id="CU.official_name" resname="CU.official_name" approved="yes">
-				<source>Republic of Cuba</source>
-				<target>Republik Kuba</target>
-			</trans-unit>
-			<trans-unit id="CV.name" resname="CV.name" approved="yes">
-				<source>Cabo Verde</source>
-				<target>Kap Verde</target>
-			</trans-unit>
-			<trans-unit id="CV.official_name" resname="CV.official_name" approved="yes">
-				<source>Republic of Cabo Verde</source>
-				<target>Republik Kap Verde</target>
-			</trans-unit>
-			<trans-unit id="CW.name" resname="CW.name" approved="yes">
-				<source>Curaçao</source>
-				<target>Curaçao</target>
-			</trans-unit>
-			<trans-unit id="CW.official_name" resname="CW.official_name" approved="yes">
-				<source>Curaçao</source>
-				<target>Curaçao</target>
-			</trans-unit>
-			<trans-unit id="CX.name" resname="CX.name" approved="yes">
-				<source>Christmas Island</source>
-				<target>Weihnachtsinseln</target>
-			</trans-unit>
-			<trans-unit id="CY.name" resname="CY.name" approved="yes">
-				<source>Cyprus</source>
-				<target>Zypern</target>
-			</trans-unit>
-			<trans-unit id="CY.official_name" resname="CY.official_name" approved="yes">
-				<source>Republic of Cyprus</source>
-				<target>Republik Zypern</target>
-			</trans-unit>
-			<trans-unit id="CZ.name" resname="CZ.name" approved="yes">
-				<source>Czechia</source>
-				<target>Tschechien</target>
-			</trans-unit>
-			<trans-unit id="CZ.official_name" resname="CZ.official_name" approved="yes">
-				<source>Czech Republic</source>
-				<target>Tschechische Republik</target>
-			</trans-unit>
-			<trans-unit id="DE.name" resname="DE.name" approved="yes">
-				<source>Germany</source>
-				<target>Deutschland</target>
-			</trans-unit>
-			<trans-unit id="DE.official_name" resname="DE.official_name" approved="yes">
-				<source>Federal Republic of Germany</source>
-				<target>Bundesrepublik Deutschland</target>
-			</trans-unit>
-			<trans-unit id="DJ.name" resname="DJ.name" approved="yes">
-				<source>Djibouti</source>
-				<target>Dschibuti</target>
-			</trans-unit>
-			<trans-unit id="DJ.official_name" resname="DJ.official_name" approved="yes">
-				<source>Republic of Djibouti</source>
-				<target>Republik Dschibuti</target>
-			</trans-unit>
-			<trans-unit id="DK.name" resname="DK.name" approved="yes">
-				<source>Denmark</source>
-				<target>Dänemark</target>
-			</trans-unit>
-			<trans-unit id="DK.official_name" resname="DK.official_name" approved="yes">
-				<source>Kingdom of Denmark</source>
-				<target>Königreich Dänemark</target>
-			</trans-unit>
-			<trans-unit id="DM.name" resname="DM.name" approved="yes">
-				<source>Dominica</source>
-				<target>Dominica</target>
-			</trans-unit>
-			<trans-unit id="DM.official_name" resname="DM.official_name" approved="yes">
-				<source>Commonwealth of Dominica</source>
-				<target>Commonwealth Dominica</target>
-			</trans-unit>
-			<trans-unit id="DO.name" resname="DO.name" approved="yes">
-				<source>Dominican Republic</source>
-				<target>Dominikanische Republik</target>
-			</trans-unit>
-			<trans-unit id="DZ.name" resname="DZ.name" approved="yes">
-				<source>Algeria</source>
-				<target>Algerien</target>
-			</trans-unit>
-			<trans-unit id="DZ.official_name" resname="DZ.official_name" approved="yes">
-				<source>People's Democratic Republic of Algeria</source>
-				<target>Demokratische Volksrepublik Algerien</target>
-			</trans-unit>
-			<trans-unit id="EC.name" resname="EC.name" approved="yes">
-				<source>Ecuador</source>
-				<target>Ecuador</target>
-			</trans-unit>
-			<trans-unit id="EC.official_name" resname="EC.official_name" approved="yes">
-				<source>Republic of Ecuador</source>
-				<target>Republik Ecuador</target>
-			</trans-unit>
-			<trans-unit id="EE.name" resname="EE.name" approved="yes">
-				<source>Estonia</source>
-				<target>Estland</target>
-			</trans-unit>
-			<trans-unit id="EE.official_name" resname="EE.official_name" approved="yes">
-				<source>Republic of Estonia</source>
-				<target>Republik Estland</target>
-			</trans-unit>
-			<trans-unit id="EG.name" resname="EG.name" approved="yes">
-				<source>Egypt</source>
-				<target>Ägypten</target>
-			</trans-unit>
-			<trans-unit id="EG.official_name" resname="EG.official_name" approved="yes">
-				<source>Arab Republic of Egypt</source>
-				<target>Arabische Republik Ägypten</target>
-			</trans-unit>
-			<trans-unit id="EH.name" resname="EH.name" approved="yes">
-				<source>Western Sahara</source>
-				<target>Westsahara</target>
-			</trans-unit>
-			<trans-unit id="ER.name" resname="ER.name" approved="yes">
-				<source>Eritrea</source>
-				<target>Eritrea</target>
-			</trans-unit>
-			<trans-unit id="ER.official_name" resname="ER.official_name" approved="yes">
-				<source>the State of Eritrea</source>
-				<target>Staat Eritrea</target>
-			</trans-unit>
-			<trans-unit id="ES.name" resname="ES.name" approved="yes">
-				<source>Spain</source>
-				<target>Spanien</target>
-			</trans-unit>
-			<trans-unit id="ES.official_name" resname="ES.official_name" approved="yes">
-				<source>Kingdom of Spain</source>
-				<target>Königreich Spanien</target>
-			</trans-unit>
-			<trans-unit id="ET.name" resname="ET.name" approved="yes">
-				<source>Ethiopia</source>
-				<target>Äthiopien</target>
-			</trans-unit>
-			<trans-unit id="ET.official_name" resname="ET.official_name" approved="yes">
-				<source>Federal Democratic Republic of Ethiopia</source>
-				<target>Demokratische Bundesrepublik Äthiopien</target>
-			</trans-unit>
-			<trans-unit id="FI.name" resname="FI.name" approved="yes">
-				<source>Finland</source>
-				<target>Finnland</target>
-			</trans-unit>
-			<trans-unit id="FI.official_name" resname="FI.official_name" approved="yes">
-				<source>Republic of Finland</source>
-				<target>Republik Finnland</target>
-			</trans-unit>
-			<trans-unit id="FJ.name" resname="FJ.name" approved="yes">
-				<source>Fiji</source>
-				<target>Fidschi</target>
-			</trans-unit>
-			<trans-unit id="FJ.official_name" resname="FJ.official_name" approved="yes">
-				<source>Republic of Fiji</source>
-				<target>Republik Fidschi</target>
-			</trans-unit>
-			<trans-unit id="FK.name" resname="FK.name" approved="yes">
-				<source>Falkland Islands (Malvinas)</source>
-				<target>Falklandinseln (Malwinen)</target>
-			</trans-unit>
-			<trans-unit id="FM.name" resname="FM.name" approved="yes">
-				<source>Micronesia, Federated States of</source>
-				<target>Mikronesien, Föderierte Staaten von</target>
-			</trans-unit>
-			<trans-unit id="FM.official_name" resname="FM.official_name" approved="yes">
-				<source>Federated States of Micronesia</source>
-				<target>Föderierte Staaten von Mikronesien</target>
-			</trans-unit>
-			<trans-unit id="FO.name" resname="FO.name" approved="yes">
-				<source>Faroe Islands</source>
-				<target>Färöer-Inseln</target>
-			</trans-unit>
-			<trans-unit id="FR.name" resname="FR.name" approved="yes">
-				<source>France</source>
-				<target>Frankreich</target>
-			</trans-unit>
-			<trans-unit id="FR.official_name" resname="FR.official_name" approved="yes">
-				<source>French Republic</source>
-				<target>Französische Republik</target>
-			</trans-unit>
-			<trans-unit id="GA.name" resname="GA.name" approved="yes">
-				<source>Gabon</source>
-				<target>Gabun</target>
-			</trans-unit>
-			<trans-unit id="GA.official_name" resname="GA.official_name" approved="yes">
-				<source>Gabonese Republic</source>
-				<target>Gabunische Republik</target>
-			</trans-unit>
-			<trans-unit id="GB.name" resname="GB.name" approved="yes">
-				<source>United Kingdom</source>
-				<target>Vereinigtes Königreich</target>
-			</trans-unit>
-			<trans-unit id="GB.official_name" resname="GB.official_name" approved="yes">
-				<source>United Kingdom of Great Britain and Northern Ireland</source>
-				<target>Vereinigtes Königreich Großbritannien und Nordirland</target>
-			</trans-unit>
-			<trans-unit id="GD.name" resname="GD.name" approved="yes">
-				<source>Grenada</source>
-				<target>Grenada</target>
-			</trans-unit>
-			<trans-unit id="GE.name" resname="GE.name" approved="yes">
-				<source>Georgia</source>
-				<target>Georgien</target>
-			</trans-unit>
-			<trans-unit id="GF.name" resname="GF.name" approved="yes">
-				<source>French Guiana</source>
-				<target>Französisch-Guyana</target>
-			</trans-unit>
-			<trans-unit id="GG.name" resname="GG.name" approved="yes">
-				<source>Guernsey</source>
-				<target>Guernsey</target>
-			</trans-unit>
-			<trans-unit id="GH.name" resname="GH.name" approved="yes">
-				<source>Ghana</source>
-				<target>Ghana</target>
-			</trans-unit>
-			<trans-unit id="GH.official_name" resname="GH.official_name" approved="yes">
-				<source>Republic of Ghana</source>
-				<target>Republik Ghana</target>
-			</trans-unit>
-			<trans-unit id="GI.name" resname="GI.name" approved="yes">
-				<source>Gibraltar</source>
-				<target>Gibraltar</target>
-			</trans-unit>
-			<trans-unit id="GL.name" resname="GL.name" approved="yes">
-				<source>Greenland</source>
-				<target>Grönland</target>
-			</trans-unit>
-			<trans-unit id="GM.name" resname="GM.name" approved="yes">
-				<source>Gambia</source>
-				<target>Gambia</target>
-			</trans-unit>
-			<trans-unit id="GM.official_name" resname="GM.official_name" approved="yes">
-				<source>Republic of the Gambia</source>
-				<target>Republik Gambia</target>
-			</trans-unit>
-			<trans-unit id="GN.name" resname="GN.name" approved="yes">
-				<source>Guinea</source>
-				<target>Guinea</target>
-			</trans-unit>
-			<trans-unit id="GN.official_name" resname="GN.official_name" approved="yes">
-				<source>Republic of Guinea</source>
-				<target>Republik Guinea</target>
-			</trans-unit>
-			<trans-unit id="GP.name" resname="GP.name" approved="yes">
-				<source>Guadeloupe</source>
-				<target>Guadeloupe</target>
-			</trans-unit>
-			<trans-unit id="GQ.name" resname="GQ.name" approved="yes">
-				<source>Equatorial Guinea</source>
-				<target>Äquatorialguinea</target>
-			</trans-unit>
-			<trans-unit id="GQ.official_name" resname="GQ.official_name" approved="yes">
-				<source>Republic of Equatorial Guinea</source>
-				<target>Republik Äquatorialguinea</target>
-			</trans-unit>
-			<trans-unit id="GR.name" resname="GR.name" approved="yes">
-				<source>Greece</source>
-				<target>Griechenland</target>
-			</trans-unit>
-			<trans-unit id="GR.official_name" resname="GR.official_name" approved="yes">
-				<source>Hellenic Republic</source>
-				<target>Hellenische Republik</target>
-			</trans-unit>
-			<trans-unit id="GS.name" resname="GS.name" approved="yes">
-				<source>South Georgia and the South Sandwich Islands</source>
-				<target>South Georgia und die Südlichen Sandwichinseln</target>
-			</trans-unit>
-			<trans-unit id="GT.name" resname="GT.name" approved="yes">
-				<source>Guatemala</source>
-				<target>Guatemala</target>
-			</trans-unit>
-			<trans-unit id="GT.official_name" resname="GT.official_name" approved="yes">
-				<source>Republic of Guatemala</source>
-				<target>Republik Guatemala</target>
-			</trans-unit>
-			<trans-unit id="GU.name" resname="GU.name" approved="yes">
-				<source>Guam</source>
-				<target>Guam</target>
-			</trans-unit>
-			<trans-unit id="GW.name" resname="GW.name" approved="yes">
-				<source>Guinea-Bissau</source>
-				<target>Guinea-Bissau</target>
-			</trans-unit>
-			<trans-unit id="GW.official_name" resname="GW.official_name" approved="yes">
-				<source>Republic of Guinea-Bissau</source>
-				<target>Republik Guinea-Bissau</target>
-			</trans-unit>
-			<trans-unit id="GY.name" resname="GY.name" approved="yes">
-				<source>Guyana</source>
-				<target>Guyana</target>
-			</trans-unit>
-			<trans-unit id="GY.official_name" resname="GY.official_name" approved="yes">
-				<source>Republic of Guyana</source>
-				<target>Kooperative Republik Guyana</target>
-			</trans-unit>
-			<trans-unit id="HK.name" resname="HK.name" approved="yes">
-				<source>Hong Kong</source>
-				<target>Hongkong</target>
-			</trans-unit>
-			<trans-unit id="HK.official_name" resname="HK.official_name" approved="yes">
-				<source>Hong Kong Special Administrative Region of China</source>
-				<target>Sonderverwaltungsregion Hongkong</target>
-			</trans-unit>
-			<trans-unit id="HM.name" resname="HM.name" approved="yes">
-				<source>Heard Island and McDonald Islands</source>
-				<target>Heard und McDonaldinseln</target>
-			</trans-unit>
-			<trans-unit id="HN.name" resname="HN.name" approved="yes">
-				<source>Honduras</source>
-				<target>Honduras</target>
-			</trans-unit>
-			<trans-unit id="HN.official_name" resname="HN.official_name" approved="yes">
-				<source>Republic of Honduras</source>
-				<target>Republik Honduras</target>
-			</trans-unit>
-			<trans-unit id="HR.name" resname="HR.name" approved="yes">
-				<source>Croatia</source>
-				<target>Kroatien</target>
-			</trans-unit>
-			<trans-unit id="HR.official_name" resname="HR.official_name" approved="yes">
-				<source>Republic of Croatia</source>
-				<target>Republik Kroatien</target>
-			</trans-unit>
-			<trans-unit id="HT.name" resname="HT.name" approved="yes">
-				<source>Haiti</source>
-				<target>Haiti</target>
-			</trans-unit>
-			<trans-unit id="HT.official_name" resname="HT.official_name" approved="yes">
-				<source>Republic of Haiti</source>
-				<target>Republik Haiti</target>
-			</trans-unit>
-			<trans-unit id="HU.name" resname="HU.name" approved="yes">
-				<source>Hungary</source>
-				<target>Ungarn</target>
-			</trans-unit>
-			<trans-unit id="HU.official_name" resname="HU.official_name" approved="yes">
-				<source>Hungary</source>
-				<target>Ungarn</target>
-			</trans-unit>
-			<trans-unit id="ID.name" resname="ID.name" approved="yes">
-				<source>Indonesia</source>
-				<target>Indonesien</target>
-			</trans-unit>
-			<trans-unit id="ID.official_name" resname="ID.official_name" approved="yes">
-				<source>Republic of Indonesia</source>
-				<target>Republik Indonesien</target>
-			</trans-unit>
-			<trans-unit id="IE.name" resname="IE.name" approved="yes">
-				<source>Ireland</source>
-				<target>Irland</target>
-			</trans-unit>
-			<trans-unit id="IL.name" resname="IL.name" approved="yes">
-				<source>Israel</source>
-				<target>Israel</target>
-			</trans-unit>
-			<trans-unit id="IL.official_name" resname="IL.official_name" approved="yes">
-				<source>State of Israel</source>
-				<target>Staat Israel</target>
-			</trans-unit>
-			<trans-unit id="IM.name" resname="IM.name" approved="yes">
-				<source>Isle of Man</source>
-				<target>Insel Man</target>
-			</trans-unit>
-			<trans-unit id="IN.name" resname="IN.name" approved="yes">
-				<source>India</source>
-				<target>Indien</target>
-			</trans-unit>
-			<trans-unit id="IN.official_name" resname="IN.official_name" approved="yes">
-				<source>Republic of India</source>
-				<target>Republik Indien</target>
-			</trans-unit>
-			<trans-unit id="IO.name" resname="IO.name" approved="yes">
-				<source>British Indian Ocean Territory</source>
-				<target>Britisches Territorium im Indischen Ozean</target>
-			</trans-unit>
-			<trans-unit id="IQ.name" resname="IQ.name" approved="yes">
-				<source>Iraq</source>
-				<target>Irak</target>
-			</trans-unit>
-			<trans-unit id="IQ.official_name" resname="IQ.official_name" approved="yes">
-				<source>Republic of Iraq</source>
-				<target>Republik Irak</target>
-			</trans-unit>
-			<trans-unit id="IR.name" resname="IR.name" approved="yes">
-				<source>Iran, Islamic Republic of</source>
-				<target>Iran, Islamische Republik</target>
-			</trans-unit>
-			<trans-unit id="IR.official_name" resname="IR.official_name" approved="yes">
-				<source>Islamic Republic of Iran</source>
-				<target>Islamische Republik Iran</target>
-			</trans-unit>
-			<trans-unit id="IS.name" resname="IS.name" approved="yes">
-				<source>Iceland</source>
-				<target>Island</target>
-			</trans-unit>
-			<trans-unit id="IS.official_name" resname="IS.official_name" approved="yes">
-				<source>Republic of Iceland</source>
-				<target>Republik Island</target>
-			</trans-unit>
-			<trans-unit id="IT.name" resname="IT.name" approved="yes">
-				<source>Italy</source>
-				<target>Italien</target>
-			</trans-unit>
-			<trans-unit id="IT.official_name" resname="IT.official_name" approved="yes">
-				<source>Italian Republic</source>
-				<target>Italienische Republik</target>
-			</trans-unit>
-			<trans-unit id="JE.name" resname="JE.name" approved="yes">
-				<source>Jersey</source>
-				<target>Jersey</target>
-			</trans-unit>
-			<trans-unit id="JM.name" resname="JM.name" approved="yes">
-				<source>Jamaica</source>
-				<target>Jamaika</target>
-			</trans-unit>
-			<trans-unit id="JO.name" resname="JO.name" approved="yes">
-				<source>Jordan</source>
-				<target>Jordanien</target>
-			</trans-unit>
-			<trans-unit id="JO.official_name" resname="JO.official_name" approved="yes">
-				<source>Hashemite Kingdom of Jordan</source>
-				<target>Haschemitisches Königreich Jordanien</target>
-			</trans-unit>
-			<trans-unit id="JP.name" resname="JP.name" approved="yes">
-				<source>Japan</source>
-				<target>Japan</target>
-			</trans-unit>
-			<trans-unit id="KE.name" resname="KE.name" approved="yes">
-				<source>Kenya</source>
-				<target>Kenia</target>
-			</trans-unit>
-			<trans-unit id="KE.official_name" resname="KE.official_name" approved="yes">
-				<source>Republic of Kenya</source>
-				<target>Republik Kenia</target>
-			</trans-unit>
-			<trans-unit id="KG.name" resname="KG.name" approved="yes">
-				<source>Kyrgyzstan</source>
-				<target>Kirgisistan</target>
-			</trans-unit>
-			<trans-unit id="KG.official_name" resname="KG.official_name" approved="yes">
-				<source>Kyrgyz Republic</source>
-				<target>Kirgisische Republik</target>
-			</trans-unit>
-			<trans-unit id="KH.name" resname="KH.name" approved="yes">
-				<source>Cambodia</source>
-				<target>Kambodscha</target>
-			</trans-unit>
-			<trans-unit id="KH.official_name" resname="KH.official_name" approved="yes">
-				<source>Kingdom of Cambodia</source>
-				<target>Königreich Kambodscha</target>
-			</trans-unit>
-			<trans-unit id="KI.name" resname="KI.name" approved="yes">
-				<source>Kiribati</source>
-				<target>Kiribati</target>
-			</trans-unit>
-			<trans-unit id="KI.official_name" resname="KI.official_name" approved="yes">
-				<source>Republic of Kiribati</source>
-				<target>Republik Kiribati</target>
-			</trans-unit>
-			<trans-unit id="KM.name" resname="KM.name" approved="yes">
-				<source>Comoros</source>
-				<target>Komoren</target>
-			</trans-unit>
-			<trans-unit id="KM.official_name" resname="KM.official_name" approved="yes">
-				<source>Union of the Comoros</source>
-				<target>Vereinigung der Komoren</target>
-			</trans-unit>
-			<trans-unit id="KN.name" resname="KN.name" approved="yes">
-				<source>Saint Kitts and Nevis</source>
-				<target>St. Kitts und Nevis</target>
-			</trans-unit>
-			<trans-unit id="KP.name" resname="KP.name" approved="yes">
-				<source>Korea, Democratic People's Republic of</source>
-				<target>Korea, Demokratische Volksrepublik</target>
-			</trans-unit>
-			<trans-unit id="KP.official_name" resname="KP.official_name" approved="yes">
-				<source>Democratic People's Republic of Korea</source>
-				<target>Demokratische Volksrepublik Korea</target>
-			</trans-unit>
-			<trans-unit id="KR.name" resname="KR.name" approved="yes">
-				<source>Korea, Republic of</source>
-				<target>Korea, Republik</target>
-			</trans-unit>
-			<trans-unit id="KW.name" resname="KW.name" approved="yes">
-				<source>Kuwait</source>
-				<target>Kuwait</target>
-			</trans-unit>
-			<trans-unit id="KW.official_name" resname="KW.official_name" approved="yes">
-				<source>State of Kuwait</source>
-				<target>Staat Kuwait</target>
-			</trans-unit>
-			<trans-unit id="KY.name" resname="KY.name" approved="yes">
-				<source>Cayman Islands</source>
-				<target>Cayman-Inseln</target>
-			</trans-unit>
-			<trans-unit id="KZ.name" resname="KZ.name" approved="yes">
-				<source>Kazakhstan</source>
-				<target>Kasachstan</target>
-			</trans-unit>
-			<trans-unit id="KZ.official_name" resname="KZ.official_name" approved="yes">
-				<source>Republic of Kazakhstan</source>
-				<target>Republik Kasachstan</target>
-			</trans-unit>
-			<trans-unit id="LA.name" resname="LA.name" approved="yes">
-				<source>Lao People's Democratic Republic</source>
-				<target>Laos, Demokratische Volksrepublik</target>
-			</trans-unit>
-			<trans-unit id="LB.name" resname="LB.name" approved="yes">
-				<source>Lebanon</source>
-				<target>Libanon</target>
-			</trans-unit>
-			<trans-unit id="LB.official_name" resname="LB.official_name" approved="yes">
-				<source>Lebanese Republic</source>
-				<target>Libanesische Republik</target>
-			</trans-unit>
-			<trans-unit id="LC.name" resname="LC.name" approved="yes">
-				<source>Saint Lucia</source>
-				<target>St. Lucia</target>
-			</trans-unit>
-			<trans-unit id="LI.name" resname="LI.name" approved="yes">
-				<source>Liechtenstein</source>
-				<target>Liechtenstein</target>
-			</trans-unit>
-			<trans-unit id="LI.official_name" resname="LI.official_name" approved="yes">
-				<source>Principality of Liechtenstein</source>
-				<target>Fürstentum Liechtenstein</target>
-			</trans-unit>
-			<trans-unit id="LK.name" resname="LK.name" approved="yes">
-				<source>Sri Lanka</source>
-				<target>Sri Lanka</target>
-			</trans-unit>
-			<trans-unit id="LK.official_name" resname="LK.official_name" approved="yes">
-				<source>Democratic Socialist Republic of Sri Lanka</source>
-				<target>Demokratische sozialistische Republik Sri Lanka</target>
-			</trans-unit>
-			<trans-unit id="LR.name" resname="LR.name" approved="yes">
-				<source>Liberia</source>
-				<target>Liberia</target>
-			</trans-unit>
-			<trans-unit id="LR.official_name" resname="LR.official_name" approved="yes">
-				<source>Republic of Liberia</source>
-				<target>Republik Liberia</target>
-			</trans-unit>
-			<trans-unit id="LS.name" resname="LS.name" approved="yes">
-				<source>Lesotho</source>
-				<target>Lesotho</target>
-			</trans-unit>
-			<trans-unit id="LS.official_name" resname="LS.official_name" approved="yes">
-				<source>Kingdom of Lesotho</source>
-				<target>Königreich Lesotho</target>
-			</trans-unit>
-			<trans-unit id="LT.name" resname="LT.name" approved="yes">
-				<source>Lithuania</source>
-				<target>Litauen</target>
-			</trans-unit>
-			<trans-unit id="LT.official_name" resname="LT.official_name" approved="yes">
-				<source>Republic of Lithuania</source>
-				<target>Republik Litauen</target>
-			</trans-unit>
-			<trans-unit id="LU.name" resname="LU.name" approved="yes">
-				<source>Luxembourg</source>
-				<target>Luxemburg</target>
-			</trans-unit>
-			<trans-unit id="LU.official_name" resname="LU.official_name" approved="yes">
-				<source>Grand Duchy of Luxembourg</source>
-				<target>Großherzogtum Luxemburg</target>
-			</trans-unit>
-			<trans-unit id="LV.name" resname="LV.name" approved="yes">
-				<source>Latvia</source>
-				<target>Lettland</target>
-			</trans-unit>
-			<trans-unit id="LV.official_name" resname="LV.official_name" approved="yes">
-				<source>Republic of Latvia</source>
-				<target>Republik Lettland</target>
-			</trans-unit>
-			<trans-unit id="LY.name" resname="LY.name" approved="yes">
-				<source>Libya</source>
-				<target>Libyen</target>
-			</trans-unit>
-			<trans-unit id="LY.official_name" resname="LY.official_name" approved="yes">
-				<source>Libya</source>
-				<target>Libyen</target>
-			</trans-unit>
-			<trans-unit id="MA.name" resname="MA.name" approved="yes">
-				<source>Morocco</source>
-				<target>Marokko</target>
-			</trans-unit>
-			<trans-unit id="MA.official_name" resname="MA.official_name" approved="yes">
-				<source>Kingdom of Morocco</source>
-				<target>Königreich Marokko</target>
-			</trans-unit>
-			<trans-unit id="MC.name" resname="MC.name" approved="yes">
-				<source>Monaco</source>
-				<target>Monaco</target>
-			</trans-unit>
-			<trans-unit id="MC.official_name" resname="MC.official_name" approved="yes">
-				<source>Principality of Monaco</source>
-				<target>Fürstentum Monaco</target>
-			</trans-unit>
-			<trans-unit id="MD.name" resname="MD.name" approved="yes">
-				<source>Moldova, Republic of</source>
-				<target>Moldau, Republik</target>
-			</trans-unit>
-			<trans-unit id="MD.official_name" resname="MD.official_name" approved="yes">
-				<source>Republic of Moldova</source>
-				<target>Republik Moldau</target>
-			</trans-unit>
-			<trans-unit id="ME.name" resname="ME.name" approved="yes">
-				<source>Montenegro</source>
-				<target>Montenegro</target>
-			</trans-unit>
-			<trans-unit id="ME.official_name" resname="ME.official_name" approved="yes">
-				<source>Montenegro</source>
-				<target>Montenegro</target>
-			</trans-unit>
-			<trans-unit id="MF.name" resname="MF.name" approved="yes">
-				<source>Saint Martin (French part)</source>
-				<target>Saint Martin (Französischer Teil)</target>
-			</trans-unit>
-			<trans-unit id="MG.name" resname="MG.name" approved="yes">
-				<source>Madagascar</source>
-				<target>Madagaskar</target>
-			</trans-unit>
-			<trans-unit id="MG.official_name" resname="MG.official_name" approved="yes">
-				<source>Republic of Madagascar</source>
-				<target>Republik Madagaskar</target>
-			</trans-unit>
-			<trans-unit id="MH.name" resname="MH.name" approved="yes">
-				<source>Marshall Islands</source>
-				<target>Marshallinseln</target>
-			</trans-unit>
-			<trans-unit id="MH.official_name" resname="MH.official_name" approved="yes">
-				<source>Republic of the Marshall Islands</source>
-				<target>Republik Marshallinseln</target>
-			</trans-unit>
-			<trans-unit id="MK.name" resname="MK.name" approved="yes">
-				<source>North Macedonia</source>
-				<target>Nordmazedonien</target>
-			</trans-unit>
-			<trans-unit id="MK.official_name" resname="MK.official_name" approved="yes">
-				<source>Republic of North Macedonia</source>
-				<target>Republik Nordmazedonien</target>
-			</trans-unit>
-			<trans-unit id="ML.name" resname="ML.name" approved="yes">
-				<source>Mali</source>
-				<target>Mali</target>
-			</trans-unit>
-			<trans-unit id="ML.official_name" resname="ML.official_name" approved="yes">
-				<source>Republic of Mali</source>
-				<target>Republik Mali</target>
-			</trans-unit>
-			<trans-unit id="MM.name" resname="MM.name" approved="yes">
-				<source>Myanmar</source>
-				<target>Myanmar</target>
-			</trans-unit>
-			<trans-unit id="MM.official_name" resname="MM.official_name" approved="yes">
-				<source>Republic of Myanmar</source>
-				<target>Republik Myanmar</target>
-			</trans-unit>
-			<trans-unit id="MN.name" resname="MN.name" approved="yes">
-				<source>Mongolia</source>
-				<target>Mongolei</target>
-			</trans-unit>
-			<trans-unit id="MO.name" resname="MO.name" approved="yes">
-				<source>Macao</source>
-				<target>Macao</target>
-			</trans-unit>
-			<trans-unit id="MO.official_name" resname="MO.official_name" approved="yes">
-				<source>Macao Special Administrative Region of China</source>
-				<target>Sonderverwaltungsregion Macao</target>
-			</trans-unit>
-			<trans-unit id="MP.name" resname="MP.name" approved="yes">
-				<source>Northern Mariana Islands</source>
-				<target>Nördliche Marianen</target>
-			</trans-unit>
-			<trans-unit id="MP.official_name" resname="MP.official_name" approved="yes">
-				<source>Commonwealth of the Northern Mariana Islands</source>
-				<target>Commonwealth Nördliche Mariana-Inseln</target>
-			</trans-unit>
-			<trans-unit id="MQ.name" resname="MQ.name" approved="yes">
-				<source>Martinique</source>
-				<target>Martinique</target>
-			</trans-unit>
-			<trans-unit id="MR.name" resname="MR.name" approved="yes">
-				<source>Mauritania</source>
-				<target>Mauretanien</target>
-			</trans-unit>
-			<trans-unit id="MR.official_name" resname="MR.official_name" approved="yes">
-				<source>Islamic Republic of Mauritania</source>
-				<target>Islamische Republik Mauretanien</target>
-			</trans-unit>
-			<trans-unit id="MS.name" resname="MS.name" approved="yes">
-				<source>Montserrat</source>
-				<target>Montserrat</target>
-			</trans-unit>
-			<trans-unit id="MT.name" resname="MT.name" approved="yes">
-				<source>Malta</source>
-				<target>Malta</target>
-			</trans-unit>
-			<trans-unit id="MT.official_name" resname="MT.official_name" approved="yes">
-				<source>Republic of Malta</source>
-				<target>Republik Malta</target>
-			</trans-unit>
-			<trans-unit id="MU.name" resname="MU.name" approved="yes">
-				<source>Mauritius</source>
-				<target>Mauritius</target>
-			</trans-unit>
-			<trans-unit id="MU.official_name" resname="MU.official_name" approved="yes">
-				<source>Republic of Mauritius</source>
-				<target>Republik Mauritius</target>
-			</trans-unit>
-			<trans-unit id="MV.name" resname="MV.name" approved="yes">
-				<source>Maldives</source>
-				<target>Malediven</target>
-			</trans-unit>
-			<trans-unit id="MV.official_name" resname="MV.official_name" approved="yes">
-				<source>Republic of Maldives</source>
-				<target>Republik Malediven</target>
-			</trans-unit>
-			<trans-unit id="MW.name" resname="MW.name" approved="yes">
-				<source>Malawi</source>
-				<target>Malawi</target>
-			</trans-unit>
-			<trans-unit id="MW.official_name" resname="MW.official_name" approved="yes">
-				<source>Republic of Malawi</source>
-				<target>Republik Malawi</target>
-			</trans-unit>
-			<trans-unit id="MX.name" resname="MX.name" approved="yes">
-				<source>Mexico</source>
-				<target>Mexiko</target>
-			</trans-unit>
-			<trans-unit id="MX.official_name" resname="MX.official_name" approved="yes">
-				<source>United Mexican States</source>
-				<target>Vereinigte Mexikanische Staaten</target>
-			</trans-unit>
-			<trans-unit id="MY.name" resname="MY.name" approved="yes">
-				<source>Malaysia</source>
-				<target>Malaysia</target>
-			</trans-unit>
-			<trans-unit id="MZ.name" resname="MZ.name" approved="yes">
-				<source>Mozambique</source>
-				<target>Mosambik</target>
-			</trans-unit>
-			<trans-unit id="MZ.official_name" resname="MZ.official_name" approved="yes">
-				<source>Republic of Mozambique</source>
-				<target>Republik Mosambik</target>
-			</trans-unit>
-			<trans-unit id="NA.name" resname="NA.name" approved="yes">
-				<source>Namibia</source>
-				<target>Namibia</target>
-			</trans-unit>
-			<trans-unit id="NA.official_name" resname="NA.official_name" approved="yes">
-				<source>Republic of Namibia</source>
-				<target>Republik Namibia</target>
-			</trans-unit>
-			<trans-unit id="NC.name" resname="NC.name" approved="yes">
-				<source>New Caledonia</source>
-				<target>Neukaledonien</target>
-			</trans-unit>
-			<trans-unit id="NE.name" resname="NE.name" approved="yes">
-				<source>Niger</source>
-				<target>Niger</target>
-			</trans-unit>
-			<trans-unit id="NE.official_name" resname="NE.official_name" approved="yes">
-				<source>Republic of the Niger</source>
-				<target>Republik Niger</target>
-			</trans-unit>
-			<trans-unit id="NF.name" resname="NF.name" approved="yes">
-				<source>Norfolk Island</source>
-				<target>Norfolkinsel</target>
-			</trans-unit>
-			<trans-unit id="NG.name" resname="NG.name" approved="yes">
-				<source>Nigeria</source>
-				<target>Nigeria</target>
-			</trans-unit>
-			<trans-unit id="NG.official_name" resname="NG.official_name" approved="yes">
-				<source>Federal Republic of Nigeria</source>
-				<target>Bundesrepublik Nigeria</target>
-			</trans-unit>
-			<trans-unit id="NI.name" resname="NI.name" approved="yes">
-				<source>Nicaragua</source>
-				<target>Nicaragua</target>
-			</trans-unit>
-			<trans-unit id="NI.official_name" resname="NI.official_name" approved="yes">
-				<source>Republic of Nicaragua</source>
-				<target>Republik Nicaragua</target>
-			</trans-unit>
-			<trans-unit id="NL.name" resname="NL.name" approved="yes">
-				<source>Netherlands</source>
-				<target>Niederlande</target>
-			</trans-unit>
-			<trans-unit id="NL.official_name" resname="NL.official_name" approved="yes">
-				<source>Kingdom of the Netherlands</source>
-				<target>Königreich der Niederlande</target>
-			</trans-unit>
-			<trans-unit id="NO.name" resname="NO.name" approved="yes">
-				<source>Norway</source>
-				<target>Norwegen</target>
-			</trans-unit>
-			<trans-unit id="NO.official_name" resname="NO.official_name" approved="yes">
-				<source>Kingdom of Norway</source>
-				<target>Königreich Norwegen</target>
-			</trans-unit>
-			<trans-unit id="NP.name" resname="NP.name" approved="yes">
-				<source>Nepal</source>
-				<target>Nepal</target>
-			</trans-unit>
-			<trans-unit id="NP.official_name" resname="NP.official_name" approved="yes">
-				<source>Federal Democratic Republic of Nepal</source>
-				<target>Demokratische Bundesrepublik Nepal</target>
-			</trans-unit>
-			<trans-unit id="NR.name" resname="NR.name" approved="yes">
-				<source>Nauru</source>
-				<target>Nauru</target>
-			</trans-unit>
-			<trans-unit id="NR.official_name" resname="NR.official_name" approved="yes">
-				<source>Republic of Nauru</source>
-				<target>Republik Nauru</target>
-			</trans-unit>
-			<trans-unit id="NU.name" resname="NU.name" approved="yes">
-				<source>Niue</source>
-				<target>Niue</target>
-			</trans-unit>
-			<trans-unit id="NU.official_name" resname="NU.official_name" approved="yes">
-				<source>Niue</source>
-				<target>Niue</target>
-			</trans-unit>
-			<trans-unit id="NZ.name" resname="NZ.name" approved="yes">
-				<source>New Zealand</source>
-				<target>Neuseeland</target>
-			</trans-unit>
-			<trans-unit id="OM.name" resname="OM.name" approved="yes">
-				<source>Oman</source>
-				<target>Oman</target>
-			</trans-unit>
-			<trans-unit id="OM.official_name" resname="OM.official_name" approved="yes">
-				<source>Sultanate of Oman</source>
-				<target>Sultanat Oman</target>
-			</trans-unit>
-			<trans-unit id="PA.name" resname="PA.name" approved="yes">
-				<source>Panama</source>
-				<target>Panama</target>
-			</trans-unit>
-			<trans-unit id="PA.official_name" resname="PA.official_name" approved="yes">
-				<source>Republic of Panama</source>
-				<target>Republik Panama</target>
-			</trans-unit>
-			<trans-unit id="PE.name" resname="PE.name" approved="yes">
-				<source>Peru</source>
-				<target>Peru</target>
-			</trans-unit>
-			<trans-unit id="PE.official_name" resname="PE.official_name" approved="yes">
-				<source>Republic of Peru</source>
-				<target>Republik Peru</target>
-			</trans-unit>
-			<trans-unit id="PF.name" resname="PF.name" approved="yes">
-				<source>French Polynesia</source>
-				<target>Französisch-Polynesien</target>
-			</trans-unit>
-			<trans-unit id="PG.name" resname="PG.name" approved="yes">
-				<source>Papua New Guinea</source>
-				<target>Papua-Neuguinea</target>
-			</trans-unit>
-			<trans-unit id="PG.official_name" resname="PG.official_name" approved="yes">
-				<source>Independent State of Papua New Guinea</source>
-				<target>Unabhängiger Staat Papua-Neuguinea</target>
-			</trans-unit>
-			<trans-unit id="PH.name" resname="PH.name" approved="yes">
-				<source>Philippines</source>
-				<target>Philippinen</target>
-			</trans-unit>
-			<trans-unit id="PH.official_name" resname="PH.official_name" approved="yes">
-				<source>Republic of the Philippines</source>
-				<target>Republik der Philippinen</target>
-			</trans-unit>
-			<trans-unit id="PK.name" resname="PK.name" approved="yes">
-				<source>Pakistan</source>
-				<target>Pakistan</target>
-			</trans-unit>
-			<trans-unit id="PK.official_name" resname="PK.official_name" approved="yes">
-				<source>Islamic Republic of Pakistan</source>
-				<target>Islamische Republik Pakistan</target>
-			</trans-unit>
-			<trans-unit id="PL.name" resname="PL.name" approved="yes">
-				<source>Poland</source>
-				<target>Polen</target>
-			</trans-unit>
-			<trans-unit id="PL.official_name" resname="PL.official_name" approved="yes">
-				<source>Republic of Poland</source>
-				<target>Republik Polen</target>
-			</trans-unit>
-			<trans-unit id="PM.name" resname="PM.name" approved="yes">
-				<source>Saint Pierre and Miquelon</source>
-				<target>St. Pierre und Miquelon</target>
-			</trans-unit>
-			<trans-unit id="PN.name" resname="PN.name" approved="yes">
-				<source>Pitcairn</source>
-				<target>Pitcairn</target>
-			</trans-unit>
-			<trans-unit id="PR.name" resname="PR.name" approved="yes">
-				<source>Puerto Rico</source>
-				<target>Puerto Rico</target>
-			</trans-unit>
-			<trans-unit id="PS.name" resname="PS.name" approved="yes">
-				<source>Palestine, State of</source>
-				<target>Palästina, Staat</target>
-			</trans-unit>
-			<trans-unit id="PS.official_name" resname="PS.official_name" approved="yes">
-				<source>the State of Palestine</source>
-				<target>Staat Palästina</target>
-			</trans-unit>
-			<trans-unit id="PT.name" resname="PT.name" approved="yes">
-				<source>Portugal</source>
-				<target>Portugal</target>
-			</trans-unit>
-			<trans-unit id="PT.official_name" resname="PT.official_name" approved="yes">
-				<source>Portuguese Republic</source>
-				<target>Portugiesische Republik</target>
-			</trans-unit>
-			<trans-unit id="PW.name" resname="PW.name" approved="yes">
-				<source>Palau</source>
-				<target>Palau</target>
-			</trans-unit>
-			<trans-unit id="PW.official_name" resname="PW.official_name" approved="yes">
-				<source>Republic of Palau</source>
-				<target>Republik Palau</target>
-			</trans-unit>
-			<trans-unit id="PY.name" resname="PY.name" approved="yes">
-				<source>Paraguay</source>
-				<target>Paraguay</target>
-			</trans-unit>
-			<trans-unit id="PY.official_name" resname="PY.official_name" approved="yes">
-				<source>Republic of Paraguay</source>
-				<target>Republik Paraguay</target>
-			</trans-unit>
-			<trans-unit id="QA.name" resname="QA.name" approved="yes">
-				<source>Qatar</source>
-				<target>Katar</target>
-			</trans-unit>
-			<trans-unit id="QA.official_name" resname="QA.official_name" approved="yes">
-				<source>State of Qatar</source>
-				<target>Staat Katar</target>
-			</trans-unit>
-			<trans-unit id="RE.name" resname="RE.name" approved="yes">
-				<source>Réunion</source>
-				<target>Réunion</target>
-			</trans-unit>
-			<trans-unit id="RO.name" resname="RO.name" approved="yes">
-				<source>Romania</source>
-				<target>Rumänien</target>
-			</trans-unit>
-			<trans-unit id="RS.name" resname="RS.name" approved="yes">
-				<source>Serbia</source>
-				<target>Serbien</target>
-			</trans-unit>
-			<trans-unit id="RS.official_name" resname="RS.official_name" approved="yes">
-				<source>Republic of Serbia</source>
-				<target>Republik Serbien</target>
-			</trans-unit>
-			<trans-unit id="RU.name" resname="RU.name" approved="yes">
-				<source>Russian Federation</source>
-				<target>Russische Föderation</target>
-			</trans-unit>
-			<trans-unit id="RW.name" resname="RW.name" approved="yes">
-				<source>Rwanda</source>
-				<target>Ruanda</target>
-			</trans-unit>
-			<trans-unit id="RW.official_name" resname="RW.official_name" approved="yes">
-				<source>Rwandese Republic</source>
-				<target>Republik Ruanda</target>
-			</trans-unit>
-			<trans-unit id="SA.name" resname="SA.name" approved="yes">
-				<source>Saudi Arabia</source>
-				<target>Saudi-Arabien</target>
-			</trans-unit>
-			<trans-unit id="SA.official_name" resname="SA.official_name" approved="yes">
-				<source>Kingdom of Saudi Arabia</source>
-				<target>Königreich Saudi-Arabien</target>
-			</trans-unit>
-			<trans-unit id="SB.name" resname="SB.name" approved="yes">
-				<source>Solomon Islands</source>
-				<target>Salomoninseln</target>
-			</trans-unit>
-			<trans-unit id="SC.name" resname="SC.name" approved="yes">
-				<source>Seychelles</source>
-				<target>Seychellen</target>
-			</trans-unit>
-			<trans-unit id="SC.official_name" resname="SC.official_name" approved="yes">
-				<source>Republic of Seychelles</source>
-				<target>Republik Seychellen</target>
-			</trans-unit>
-			<trans-unit id="SD.name" resname="SD.name" approved="yes">
-				<source>Sudan</source>
-				<target>Sudan</target>
-			</trans-unit>
-			<trans-unit id="SD.official_name" resname="SD.official_name" approved="yes">
-				<source>Republic of the Sudan</source>
-				<target>Republik Sudan</target>
-			</trans-unit>
-			<trans-unit id="SE.name" resname="SE.name" approved="yes">
-				<source>Sweden</source>
-				<target>Schweden</target>
-			</trans-unit>
-			<trans-unit id="SE.official_name" resname="SE.official_name" approved="yes">
-				<source>Kingdom of Sweden</source>
-				<target>Königreich Schweden</target>
-			</trans-unit>
-			<trans-unit id="SG.name" resname="SG.name" approved="yes">
-				<source>Singapore</source>
-				<target>Singapur</target>
-			</trans-unit>
-			<trans-unit id="SG.official_name" resname="SG.official_name" approved="yes">
-				<source>Republic of Singapore</source>
-				<target>Republik Singapur</target>
-			</trans-unit>
-			<trans-unit id="SH.name" resname="SH.name" approved="yes">
-				<source>Saint Helena, Ascension and Tristan da Cunha</source>
-				<target>St. Helena, Ascension und Tristan da Cunha</target>
-			</trans-unit>
-			<trans-unit id="SI.name" resname="SI.name" approved="yes">
-				<source>Slovenia</source>
-				<target>Slowenien</target>
-			</trans-unit>
-			<trans-unit id="SI.official_name" resname="SI.official_name" approved="yes">
-				<source>Republic of Slovenia</source>
-				<target>Republik Slowenien</target>
-			</trans-unit>
-			<trans-unit id="SJ.name" resname="SJ.name" approved="yes">
-				<source>Svalbard and Jan Mayen</source>
-				<target>Svalbard und Jan Mayen</target>
-			</trans-unit>
-			<trans-unit id="SK.name" resname="SK.name" approved="yes">
-				<source>Slovakia</source>
-				<target>Slowakei</target>
-			</trans-unit>
-			<trans-unit id="SK.official_name" resname="SK.official_name" approved="yes">
-				<source>Slovak Republic</source>
-				<target>Slowakische Republik</target>
-			</trans-unit>
-			<trans-unit id="SL.name" resname="SL.name" approved="yes">
-				<source>Sierra Leone</source>
-				<target>Sierra Leone</target>
-			</trans-unit>
-			<trans-unit id="SL.official_name" resname="SL.official_name" approved="yes">
-				<source>Republic of Sierra Leone</source>
-				<target>Republik Sierra Leone</target>
-			</trans-unit>
-			<trans-unit id="SM.name" resname="SM.name" approved="yes">
-				<source>San Marino</source>
-				<target>San Marino</target>
-			</trans-unit>
-			<trans-unit id="SM.official_name" resname="SM.official_name" approved="yes">
-				<source>Republic of San Marino</source>
-				<target>Republik San Marino</target>
-			</trans-unit>
-			<trans-unit id="SN.name" resname="SN.name" approved="yes">
-				<source>Senegal</source>
-				<target>Senegal</target>
-			</trans-unit>
-			<trans-unit id="SN.official_name" resname="SN.official_name" approved="yes">
-				<source>Republic of Senegal</source>
-				<target>Republik Senegal</target>
-			</trans-unit>
-			<trans-unit id="SO.name" resname="SO.name" approved="yes">
-				<source>Somalia</source>
-				<target>Somalia</target>
-			</trans-unit>
-			<trans-unit id="SO.official_name" resname="SO.official_name" approved="yes">
-				<source>Federal Republic of Somalia</source>
-				<target>Bundesrepublik Somalia</target>
-			</trans-unit>
-			<trans-unit id="SR.name" resname="SR.name" approved="yes">
-				<source>Suriname</source>
-				<target>Suriname</target>
-			</trans-unit>
-			<trans-unit id="SR.official_name" resname="SR.official_name" approved="yes">
-				<source>Republic of Suriname</source>
-				<target>Republik Suriname</target>
-			</trans-unit>
-			<trans-unit id="SS.name" resname="SS.name" approved="yes">
-				<source>South Sudan</source>
-				<target>Südsudan</target>
-			</trans-unit>
-			<trans-unit id="SS.official_name" resname="SS.official_name" approved="yes">
-				<source>Republic of South Sudan</source>
-				<target>Republik Südsudan</target>
-			</trans-unit>
-			<trans-unit id="ST.name" resname="ST.name" approved="yes">
-				<source>Sao Tome and Principe</source>
-				<target>São Tomé und Príncipe</target>
-			</trans-unit>
-			<trans-unit id="ST.official_name" resname="ST.official_name" approved="yes">
-				<source>Democratic Republic of Sao Tome and Principe</source>
-				<target>Demokratische Republik São Tomé und Príncipe</target>
-			</trans-unit>
-			<trans-unit id="SV.name" resname="SV.name" approved="yes">
-				<source>El Salvador</source>
-				<target>El Salvador</target>
-			</trans-unit>
-			<trans-unit id="SV.official_name" resname="SV.official_name" approved="yes">
-				<source>Republic of El Salvador</source>
-				<target>Republik El Salvador</target>
-			</trans-unit>
-			<trans-unit id="SX.name" resname="SX.name" approved="yes">
-				<source>Sint Maarten (Dutch part)</source>
-				<target>Saint-Martin (Niederländischer Teil)</target>
-			</trans-unit>
-			<trans-unit id="SX.official_name" resname="SX.official_name" approved="yes">
-				<source>Sint Maarten (Dutch part)</source>
-				<target>Saint-Martin (Niederländischer Teil)</target>
-			</trans-unit>
-			<trans-unit id="SY.name" resname="SY.name" approved="yes">
-				<source>Syrian Arab Republic</source>
-				<target>Syrien, Arabische Republik</target>
-			</trans-unit>
-			<trans-unit id="SZ.name" resname="SZ.name" approved="yes">
-				<source>Eswatini</source>
-				<target>Eswatini</target>
-			</trans-unit>
-			<trans-unit id="SZ.official_name" resname="SZ.official_name" approved="yes">
-				<source>Kingdom of Eswatini</source>
-				<target>Königreich Eswatini</target>
-			</trans-unit>
-			<trans-unit id="TC.name" resname="TC.name" approved="yes">
-				<source>Turks and Caicos Islands</source>
-				<target>Turks- und Caicosinseln</target>
-			</trans-unit>
-			<trans-unit id="TD.name" resname="TD.name" approved="yes">
-				<source>Chad</source>
-				<target>Tschad</target>
-			</trans-unit>
-			<trans-unit id="TD.official_name" resname="TD.official_name" approved="yes">
-				<source>Republic of Chad</source>
-				<target>Republik Tschad</target>
-			</trans-unit>
-			<trans-unit id="TF.name" resname="TF.name" approved="yes">
-				<source>French Southern Territories</source>
-				<target>Französische Süd- und Antarktisgebiete</target>
-			</trans-unit>
-			<trans-unit id="TG.name" resname="TG.name" approved="yes">
-				<source>Togo</source>
-				<target>Togo</target>
-			</trans-unit>
-			<trans-unit id="TG.official_name" resname="TG.official_name" approved="yes">
-				<source>Togolese Republic</source>
-				<target>Republik Togo</target>
-			</trans-unit>
-			<trans-unit id="TH.name" resname="TH.name" approved="yes">
-				<source>Thailand</source>
-				<target>Thailand</target>
-			</trans-unit>
-			<trans-unit id="TH.official_name" resname="TH.official_name" approved="yes">
-				<source>Kingdom of Thailand</source>
-				<target>Königreich Thailand</target>
-			</trans-unit>
-			<trans-unit id="TJ.name" resname="TJ.name" approved="yes">
-				<source>Tajikistan</source>
-				<target>Tadschikistan</target>
-			</trans-unit>
-			<trans-unit id="TJ.official_name" resname="TJ.official_name" approved="yes">
-				<source>Republic of Tajikistan</source>
-				<target>Republik Tadschikistan</target>
-			</trans-unit>
-			<trans-unit id="TK.name" resname="TK.name" approved="yes">
-				<source>Tokelau</source>
-				<target>Tokelau</target>
-			</trans-unit>
-			<trans-unit id="TL.name" resname="TL.name" approved="yes">
-				<source>Timor-Leste</source>
-				<target>Timor-Leste</target>
-			</trans-unit>
-			<trans-unit id="TL.official_name" resname="TL.official_name" approved="yes">
-				<source>Democratic Republic of Timor-Leste</source>
-				<target>Demokratische Republik Timor-Leste</target>
-			</trans-unit>
-			<trans-unit id="TM.name" resname="TM.name" approved="yes">
-				<source>Turkmenistan</source>
-				<target>Turkmenistan</target>
-			</trans-unit>
-			<trans-unit id="TN.name" resname="TN.name" approved="yes">
-				<source>Tunisia</source>
-				<target>Tunesien</target>
-			</trans-unit>
-			<trans-unit id="TN.official_name" resname="TN.official_name" approved="yes">
-				<source>Republic of Tunisia</source>
-				<target>Tunesische Republik</target>
-			</trans-unit>
-			<trans-unit id="TO.name" resname="TO.name" approved="yes">
-				<source>Tonga</source>
-				<target>Tonga</target>
-			</trans-unit>
-			<trans-unit id="TO.official_name" resname="TO.official_name" approved="yes">
-				<source>Kingdom of Tonga</source>
-				<target>Königreich Tonga</target>
-			</trans-unit>
-			<trans-unit id="TR.name" resname="TR.name" approved="yes">
-				<source>Türkiye</source>
-				<target>Türkei</target>
-			</trans-unit>
-			<trans-unit id="TR.official_name" resname="TR.official_name" approved="yes">
-				<source>Republic of Türkiye</source>
-				<target>Republik Türkei</target>
-			</trans-unit>
-			<trans-unit id="TT.name" resname="TT.name" approved="yes">
-				<source>Trinidad and Tobago</source>
-				<target>Trinidad und Tobago</target>
-			</trans-unit>
-			<trans-unit id="TT.official_name" resname="TT.official_name" approved="yes">
-				<source>Republic of Trinidad and Tobago</source>
-				<target>Republik Trinidad und Tobago</target>
-			</trans-unit>
-			<trans-unit id="TV.name" resname="TV.name" approved="yes">
-				<source>Tuvalu</source>
-				<target>Tuvalu</target>
-			</trans-unit>
-			<trans-unit id="TW.name" resname="TW.name" approved="yes">
-				<source>Taiwan, Province of China</source>
-				<target>Taiwan, Chinesische Provinz</target>
-			</trans-unit>
-			<trans-unit id="TW.official_name" resname="TW.official_name" approved="yes">
-				<source>Taiwan, Province of China</source>
-				<target>Taiwan, Chinesische Provinz</target>
-			</trans-unit>
-			<trans-unit id="TZ.name" resname="TZ.name" approved="yes">
-				<source>Tanzania, United Republic of</source>
-				<target>Tansania, Vereinigte Republik</target>
-			</trans-unit>
-			<trans-unit id="TZ.official_name" resname="TZ.official_name" approved="yes">
-				<source>United Republic of Tanzania</source>
-				<target>Vereinigte Republik Tansania</target>
-			</trans-unit>
-			<trans-unit id="UA.name" resname="UA.name" approved="yes">
-				<source>Ukraine</source>
-				<target>Ukraine</target>
-			</trans-unit>
-			<trans-unit id="UG.name" resname="UG.name" approved="yes">
-				<source>Uganda</source>
-				<target>Uganda</target>
-			</trans-unit>
-			<trans-unit id="UG.official_name" resname="UG.official_name" approved="yes">
-				<source>Republic of Uganda</source>
-				<target>Republik Uganda</target>
-			</trans-unit>
-			<trans-unit id="UM.name" resname="UM.name" approved="yes">
-				<source>United States Minor Outlying Islands</source>
-				<target>United States Minor Outlying Islands</target>
-			</trans-unit>
-			<trans-unit id="US.name" resname="US.name" approved="yes">
-				<source>United States</source>
-				<target>Vereinigte Staaten</target>
-			</trans-unit>
-			<trans-unit id="US.official_name" resname="US.official_name" approved="yes">
-				<source>United States of America</source>
-				<target>Vereinigte Staaten von Amerika</target>
-			</trans-unit>
-			<trans-unit id="UY.name" resname="UY.name" approved="yes">
-				<source>Uruguay</source>
-				<target>Uruguay</target>
-			</trans-unit>
-			<trans-unit id="UY.official_name" resname="UY.official_name" approved="yes">
-				<source>Eastern Republic of Uruguay</source>
-				<target>Republik Östlich des Uruguay</target>
-			</trans-unit>
-			<trans-unit id="UZ.name" resname="UZ.name" approved="yes">
-				<source>Uzbekistan</source>
-				<target>Usbekistan</target>
-			</trans-unit>
-			<trans-unit id="UZ.official_name" resname="UZ.official_name" approved="yes">
-				<source>Republic of Uzbekistan</source>
-				<target>Republik Usbekistan</target>
-			</trans-unit>
-			<trans-unit id="VA.name" resname="VA.name" approved="yes">
-				<source>Holy See (Vatican City State)</source>
-				<target>Heiliger Stuhl (Staat Vatikanstadt)</target>
-			</trans-unit>
-			<trans-unit id="VC.name" resname="VC.name" approved="yes">
-				<source>Saint Vincent and the Grenadines</source>
-				<target>St. Vincent und die Grenadinen</target>
-			</trans-unit>
-			<trans-unit id="VE.name" resname="VE.name" approved="yes">
-				<source>Venezuela, Bolivarian Republic of</source>
-				<target>Venezuela, Bolivarische Republik</target>
-			</trans-unit>
-			<trans-unit id="VE.official_name" resname="VE.official_name" approved="yes">
-				<source>Bolivarian Republic of Venezuela</source>
-				<target>Bolivarische Republik Venezuela</target>
-			</trans-unit>
-			<trans-unit id="VG.name" resname="VG.name" approved="yes">
-				<source>Virgin Islands, British</source>
-				<target>Britische Jungferninseln</target>
-			</trans-unit>
-			<trans-unit id="VG.official_name" resname="VG.official_name" approved="yes">
-				<source>British Virgin Islands</source>
-				<target>Britische Jungferninseln</target>
-			</trans-unit>
-			<trans-unit id="VI.name" resname="VI.name" approved="yes">
-				<source>Virgin Islands, U.S.</source>
-				<target>Amerikanische Jungferninseln</target>
-			</trans-unit>
-			<trans-unit id="VI.official_name" resname="VI.official_name" approved="yes">
-				<source>Virgin Islands of the United States</source>
-				<target>Amerikanische Jungferninseln</target>
-			</trans-unit>
-			<trans-unit id="VN.name" resname="VN.name" approved="yes">
-				<source>Viet Nam</source>
-				<target>Vietnam</target>
-			</trans-unit>
-			<trans-unit id="VN.official_name" resname="VN.official_name" approved="yes">
-				<source>Socialist Republic of Viet Nam</source>
-				<target>Sozialistische Republik Vietnam</target>
-			</trans-unit>
-			<trans-unit id="VU.name" resname="VU.name" approved="yes">
-				<source>Vanuatu</source>
-				<target>Vanuatu</target>
-			</trans-unit>
-			<trans-unit id="VU.official_name" resname="VU.official_name" approved="yes">
-				<source>Republic of Vanuatu</source>
-				<target>Republik Vanuatu</target>
-			</trans-unit>
-			<trans-unit id="WF.name" resname="WF.name" approved="yes">
-				<source>Wallis and Futuna</source>
-				<target>Wallis und Futuna</target>
-			</trans-unit>
-			<trans-unit id="WS.name" resname="WS.name" approved="yes">
-				<source>Samoa</source>
-				<target>Samoa</target>
-			</trans-unit>
-			<trans-unit id="WS.official_name" resname="WS.official_name" approved="yes">
-				<source>Independent State of Samoa</source>
-				<target>Unabhängiger Staat Samoa</target>
-			</trans-unit>
-			<trans-unit id="YE.name" resname="YE.name" approved="yes">
-				<source>Yemen</source>
-				<target>Jemen</target>
-			</trans-unit>
-			<trans-unit id="YE.official_name" resname="YE.official_name" approved="yes">
-				<source>Republic of Yemen</source>
-				<target>Republik Jemen</target>
-			</trans-unit>
-			<trans-unit id="YT.name" resname="YT.name" approved="yes">
-				<source>Mayotte</source>
-				<target>Mayotte</target>
-			</trans-unit>
-			<trans-unit id="ZA.name" resname="ZA.name" approved="yes">
-				<source>South Africa</source>
-				<target>Südafrika</target>
-			</trans-unit>
-			<trans-unit id="ZA.official_name" resname="ZA.official_name" approved="yes">
-				<source>Republic of South Africa</source>
-				<target>Republik Südafrika</target>
-			</trans-unit>
-			<trans-unit id="ZM.name" resname="ZM.name" approved="yes">
-				<source>Zambia</source>
-				<target>Sambia</target>
-			</trans-unit>
-			<trans-unit id="ZM.official_name" resname="ZM.official_name" approved="yes">
-				<source>Republic of Zambia</source>
-				<target>Republik Sambia</target>
-			</trans-unit>
-			<trans-unit id="ZW.name" resname="ZW.name" approved="yes">
-				<source>Zimbabwe</source>
-				<target>Simbabwe</target>
-			</trans-unit>
-			<trans-unit id="ZW.official_name" resname="ZW.official_name" approved="yes">
-				<source>Republic of Zimbabwe</source>
-				<target>Republik Simbabwe</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/Iso/countries.xlf"
+    product-name="academic-partners"
+  >
+    <body>
+      <trans-unit id="AD.name" resname="AD.name" approved="yes">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="AD.official_name" resname="AD.official_name" approved="yes">
+        <source>Principality of Andorra</source>
+        <target>Fürstentum Andorra</target>
+      </trans-unit>
+      <trans-unit id="AE.name" resname="AE.name" approved="yes">
+        <source>United Arab Emirates</source>
+        <target>Vereinigte Arabische Emirate</target>
+      </trans-unit>
+      <trans-unit id="AF.name" resname="AF.name" approved="yes">
+        <source>Afghanistan</source>
+        <target>Afghanistan</target>
+      </trans-unit>
+      <trans-unit id="AF.official_name" resname="AF.official_name" approved="yes">
+        <source>Islamic Republic of Afghanistan</source>
+        <target>Islamische Republik Afghanistan</target>
+      </trans-unit>
+      <trans-unit id="AG.name" resname="AG.name" approved="yes">
+        <source>Antigua and Barbuda</source>
+        <target>Antigua und Barbuda</target>
+      </trans-unit>
+      <trans-unit id="AI.name" resname="AI.name" approved="yes">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="AL.name" resname="AL.name" approved="yes">
+        <source>Albania</source>
+        <target>Albanien</target>
+      </trans-unit>
+      <trans-unit id="AL.official_name" resname="AL.official_name" approved="yes">
+        <source>Republic of Albania</source>
+        <target>Republik Albanien</target>
+      </trans-unit>
+      <trans-unit id="AM.name" resname="AM.name" approved="yes">
+        <source>Armenia</source>
+        <target>Armenien</target>
+      </trans-unit>
+      <trans-unit id="AM.official_name" resname="AM.official_name" approved="yes">
+        <source>Republic of Armenia</source>
+        <target>Republik Armenien</target>
+      </trans-unit>
+      <trans-unit id="AO.name" resname="AO.name" approved="yes">
+        <source>Angola</source>
+        <target>Angola</target>
+      </trans-unit>
+      <trans-unit id="AO.official_name" resname="AO.official_name" approved="yes">
+        <source>Republic of Angola</source>
+        <target>Republik Angola</target>
+      </trans-unit>
+      <trans-unit id="AQ.name" resname="AQ.name" approved="yes">
+        <source>Antarctica</source>
+        <target>Antarktis</target>
+      </trans-unit>
+      <trans-unit id="AR.name" resname="AR.name" approved="yes">
+        <source>Argentina</source>
+        <target>Argentinien</target>
+      </trans-unit>
+      <trans-unit id="AR.official_name" resname="AR.official_name" approved="yes">
+        <source>Argentine Republic</source>
+        <target>Argentinische Republik</target>
+      </trans-unit>
+      <trans-unit id="AS.name" resname="AS.name" approved="yes">
+        <source>American Samoa</source>
+        <target>Amerikanisch-Samoa</target>
+      </trans-unit>
+      <trans-unit id="AT.name" resname="AT.name" approved="yes">
+        <source>Austria</source>
+        <target>Österreich</target>
+      </trans-unit>
+      <trans-unit id="AT.official_name" resname="AT.official_name" approved="yes">
+        <source>Republic of Austria</source>
+        <target>Republik Österreich</target>
+      </trans-unit>
+      <trans-unit id="AU.name" resname="AU.name" approved="yes">
+        <source>Australia</source>
+        <target>Australien</target>
+      </trans-unit>
+      <trans-unit id="AW.name" resname="AW.name" approved="yes">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="AX.name" resname="AX.name" approved="yes">
+        <source>Åland Islands</source>
+        <target>Åland-Inseln</target>
+      </trans-unit>
+      <trans-unit id="AZ.name" resname="AZ.name" approved="yes">
+        <source>Azerbaijan</source>
+        <target>Aserbaidschan</target>
+      </trans-unit>
+      <trans-unit id="AZ.official_name" resname="AZ.official_name" approved="yes">
+        <source>Republic of Azerbaijan</source>
+        <target>Republik Aserbaidschan</target>
+      </trans-unit>
+      <trans-unit id="BA.name" resname="BA.name" approved="yes">
+        <source>Bosnia and Herzegovina</source>
+        <target>Bosnien und Herzegowina</target>
+      </trans-unit>
+      <trans-unit id="BA.official_name" resname="BA.official_name" approved="yes">
+        <source>Republic of Bosnia and Herzegovina</source>
+        <target>Bosnien und Herzegowina</target>
+      </trans-unit>
+      <trans-unit id="BB.name" resname="BB.name" approved="yes">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="BD.name" resname="BD.name" approved="yes">
+        <source>Bangladesh</source>
+        <target>Bangladesch</target>
+      </trans-unit>
+      <trans-unit id="BD.official_name" resname="BD.official_name" approved="yes">
+        <source>People's Republic of Bangladesh</source>
+        <target>Volksrepublik Bangladesh</target>
+      </trans-unit>
+      <trans-unit id="BE.name" resname="BE.name" approved="yes">
+        <source>Belgium</source>
+        <target>Belgien</target>
+      </trans-unit>
+      <trans-unit id="BE.official_name" resname="BE.official_name" approved="yes">
+        <source>Kingdom of Belgium</source>
+        <target>Königreich Belgien</target>
+      </trans-unit>
+      <trans-unit id="BF.name" resname="BF.name" approved="yes">
+        <source>Burkina Faso</source>
+        <target>Burkina Faso</target>
+      </trans-unit>
+      <trans-unit id="BG.name" resname="BG.name" approved="yes">
+        <source>Bulgaria</source>
+        <target>Bulgarien</target>
+      </trans-unit>
+      <trans-unit id="BG.official_name" resname="BG.official_name" approved="yes">
+        <source>Republic of Bulgaria</source>
+        <target>Republik Bulgarien</target>
+      </trans-unit>
+      <trans-unit id="BH.name" resname="BH.name" approved="yes">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="BH.official_name" resname="BH.official_name" approved="yes">
+        <source>Kingdom of Bahrain</source>
+        <target>Königreich Bahrain</target>
+      </trans-unit>
+      <trans-unit id="BI.name" resname="BI.name" approved="yes">
+        <source>Burundi</source>
+        <target>Burundi</target>
+      </trans-unit>
+      <trans-unit id="BI.official_name" resname="BI.official_name" approved="yes">
+        <source>Republic of Burundi</source>
+        <target>Republik Burundi</target>
+      </trans-unit>
+      <trans-unit id="BJ.name" resname="BJ.name" approved="yes">
+        <source>Benin</source>
+        <target>Benin</target>
+      </trans-unit>
+      <trans-unit id="BJ.official_name" resname="BJ.official_name" approved="yes">
+        <source>Republic of Benin</source>
+        <target>Republik Benin</target>
+      </trans-unit>
+      <trans-unit id="BL.name" resname="BL.name" approved="yes">
+        <source>Saint Barthélemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="BM.name" resname="BM.name" approved="yes">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="BN.name" resname="BN.name" approved="yes">
+        <source>Brunei Darussalam</source>
+        <target>Brunei Darussalam</target>
+      </trans-unit>
+      <trans-unit id="BO.name" resname="BO.name" approved="yes">
+        <source>Bolivia, Plurinational State of</source>
+        <target>Bolivien, Plurinationaler Staat</target>
+      </trans-unit>
+      <trans-unit id="BO.official_name" resname="BO.official_name" approved="yes">
+        <source>Plurinational State of Bolivia</source>
+        <target>Plurinationaler Staat Bolivien</target>
+      </trans-unit>
+      <trans-unit id="BQ.name" resname="BQ.name" approved="yes">
+        <source>Bonaire, Sint Eustatius and Saba</source>
+        <target>Bonaire, Sint Eustatius und Saba</target>
+      </trans-unit>
+      <trans-unit id="BQ.official_name" resname="BQ.official_name" approved="yes">
+        <source>Bonaire, Sint Eustatius and Saba</source>
+        <target>Bonaire, Sint Eustatius und Saba</target>
+      </trans-unit>
+      <trans-unit id="BR.name" resname="BR.name" approved="yes">
+        <source>Brazil</source>
+        <target>Brasilien</target>
+      </trans-unit>
+      <trans-unit id="BR.official_name" resname="BR.official_name" approved="yes">
+        <source>Federative Republic of Brazil</source>
+        <target>Föderative Republik Brasilien</target>
+      </trans-unit>
+      <trans-unit id="BS.name" resname="BS.name" approved="yes">
+        <source>Bahamas</source>
+        <target>Bahamas</target>
+      </trans-unit>
+      <trans-unit id="BS.official_name" resname="BS.official_name" approved="yes">
+        <source>Commonwealth of the Bahamas</source>
+        <target>Commonwealth der Bahamas</target>
+      </trans-unit>
+      <trans-unit id="BT.name" resname="BT.name" approved="yes">
+        <source>Bhutan</source>
+        <target>Bhutan</target>
+      </trans-unit>
+      <trans-unit id="BT.official_name" resname="BT.official_name" approved="yes">
+        <source>Kingdom of Bhutan</source>
+        <target>Königreich Bhutan</target>
+      </trans-unit>
+      <trans-unit id="BV.name" resname="BV.name" approved="yes">
+        <source>Bouvet Island</source>
+        <target>Bouvet-Insel</target>
+      </trans-unit>
+      <trans-unit id="BW.name" resname="BW.name" approved="yes">
+        <source>Botswana</source>
+        <target>Botsuana</target>
+      </trans-unit>
+      <trans-unit id="BW.official_name" resname="BW.official_name" approved="yes">
+        <source>Republic of Botswana</source>
+        <target>Republik Botsuana</target>
+      </trans-unit>
+      <trans-unit id="BY.name" resname="BY.name" approved="yes">
+        <source>Belarus</source>
+        <target>Belarus</target>
+      </trans-unit>
+      <trans-unit id="BY.official_name" resname="BY.official_name" approved="yes">
+        <source>Republic of Belarus</source>
+        <target>Republik Belarus</target>
+      </trans-unit>
+      <trans-unit id="BZ.name" resname="BZ.name" approved="yes">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="CA.name" resname="CA.name" approved="yes">
+        <source>Canada</source>
+        <target>Kanada</target>
+      </trans-unit>
+      <trans-unit id="CC.name" resname="CC.name" approved="yes">
+        <source>Cocos (Keeling) Islands</source>
+        <target>Kokos-(Keeling-)Inseln</target>
+      </trans-unit>
+      <trans-unit id="CD.name" resname="CD.name" approved="yes">
+        <source>Congo, The Democratic Republic of the</source>
+        <target>Demokratische Republik Kongo</target>
+      </trans-unit>
+      <trans-unit id="CF.name" resname="CF.name" approved="yes">
+        <source>Central African Republic</source>
+        <target>Zentralafrikanische Republik</target>
+      </trans-unit>
+      <trans-unit id="CG.name" resname="CG.name" approved="yes">
+        <source>Congo</source>
+        <target>Kongo</target>
+      </trans-unit>
+      <trans-unit id="CG.official_name" resname="CG.official_name" approved="yes">
+        <source>Republic of the Congo</source>
+        <target>Republik Kongo</target>
+      </trans-unit>
+      <trans-unit id="CH.name" resname="CH.name" approved="yes">
+        <source>Switzerland</source>
+        <target>Schweiz</target>
+      </trans-unit>
+      <trans-unit id="CH.official_name" resname="CH.official_name" approved="yes">
+        <source>Swiss Confederation</source>
+        <target>Schweizerische Eidgenossenschaft</target>
+      </trans-unit>
+      <trans-unit id="CI.name" resname="CI.name" approved="yes">
+        <source>Côte d'Ivoire</source>
+        <target>Côte d'Ivoire</target>
+      </trans-unit>
+      <trans-unit id="CI.official_name" resname="CI.official_name" approved="yes">
+        <source>Republic of Côte d'Ivoire</source>
+        <target>Republik Côte d'Ivoire</target>
+      </trans-unit>
+      <trans-unit id="CK.name" resname="CK.name" approved="yes">
+        <source>Cook Islands</source>
+        <target>Cookinseln</target>
+      </trans-unit>
+      <trans-unit id="CL.name" resname="CL.name" approved="yes">
+        <source>Chile</source>
+        <target>Chile</target>
+      </trans-unit>
+      <trans-unit id="CL.official_name" resname="CL.official_name" approved="yes">
+        <source>Republic of Chile</source>
+        <target>Republik Chile</target>
+      </trans-unit>
+      <trans-unit id="CM.name" resname="CM.name" approved="yes">
+        <source>Cameroon</source>
+        <target>Kamerun</target>
+      </trans-unit>
+      <trans-unit id="CM.official_name" resname="CM.official_name" approved="yes">
+        <source>Republic of Cameroon</source>
+        <target>Republik Kamerun</target>
+      </trans-unit>
+      <trans-unit id="CN.name" resname="CN.name" approved="yes">
+        <source>China</source>
+        <target>China</target>
+      </trans-unit>
+      <trans-unit id="CN.official_name" resname="CN.official_name" approved="yes">
+        <source>People's Republic of China</source>
+        <target>Volksrepublik China</target>
+      </trans-unit>
+      <trans-unit id="CO.name" resname="CO.name" approved="yes">
+        <source>Colombia</source>
+        <target>Kolumbien</target>
+      </trans-unit>
+      <trans-unit id="CO.official_name" resname="CO.official_name" approved="yes">
+        <source>Republic of Colombia</source>
+        <target>Republik Kolumbien</target>
+      </trans-unit>
+      <trans-unit id="CR.name" resname="CR.name" approved="yes">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="CR.official_name" resname="CR.official_name" approved="yes">
+        <source>Republic of Costa Rica</source>
+        <target>Republik Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="CU.name" resname="CU.name" approved="yes">
+        <source>Cuba</source>
+        <target>Kuba</target>
+      </trans-unit>
+      <trans-unit id="CU.official_name" resname="CU.official_name" approved="yes">
+        <source>Republic of Cuba</source>
+        <target>Republik Kuba</target>
+      </trans-unit>
+      <trans-unit id="CV.name" resname="CV.name" approved="yes">
+        <source>Cabo Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="CV.official_name" resname="CV.official_name" approved="yes">
+        <source>Republic of Cabo Verde</source>
+        <target>Republik Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="CW.name" resname="CW.name" approved="yes">
+        <source>Curaçao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="CW.official_name" resname="CW.official_name" approved="yes">
+        <source>Curaçao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="CX.name" resname="CX.name" approved="yes">
+        <source>Christmas Island</source>
+        <target>Weihnachtsinseln</target>
+      </trans-unit>
+      <trans-unit id="CY.name" resname="CY.name" approved="yes">
+        <source>Cyprus</source>
+        <target>Zypern</target>
+      </trans-unit>
+      <trans-unit id="CY.official_name" resname="CY.official_name" approved="yes">
+        <source>Republic of Cyprus</source>
+        <target>Republik Zypern</target>
+      </trans-unit>
+      <trans-unit id="CZ.name" resname="CZ.name" approved="yes">
+        <source>Czechia</source>
+        <target>Tschechien</target>
+      </trans-unit>
+      <trans-unit id="CZ.official_name" resname="CZ.official_name" approved="yes">
+        <source>Czech Republic</source>
+        <target>Tschechische Republik</target>
+      </trans-unit>
+      <trans-unit id="DE.name" resname="DE.name" approved="yes">
+        <source>Germany</source>
+        <target>Deutschland</target>
+      </trans-unit>
+      <trans-unit id="DE.official_name" resname="DE.official_name" approved="yes">
+        <source>Federal Republic of Germany</source>
+        <target>Bundesrepublik Deutschland</target>
+      </trans-unit>
+      <trans-unit id="DJ.name" resname="DJ.name" approved="yes">
+        <source>Djibouti</source>
+        <target>Dschibuti</target>
+      </trans-unit>
+      <trans-unit id="DJ.official_name" resname="DJ.official_name" approved="yes">
+        <source>Republic of Djibouti</source>
+        <target>Republik Dschibuti</target>
+      </trans-unit>
+      <trans-unit id="DK.name" resname="DK.name" approved="yes">
+        <source>Denmark</source>
+        <target>Dänemark</target>
+      </trans-unit>
+      <trans-unit id="DK.official_name" resname="DK.official_name" approved="yes">
+        <source>Kingdom of Denmark</source>
+        <target>Königreich Dänemark</target>
+      </trans-unit>
+      <trans-unit id="DM.name" resname="DM.name" approved="yes">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="DM.official_name" resname="DM.official_name" approved="yes">
+        <source>Commonwealth of Dominica</source>
+        <target>Commonwealth Dominica</target>
+      </trans-unit>
+      <trans-unit id="DO.name" resname="DO.name" approved="yes">
+        <source>Dominican Republic</source>
+        <target>Dominikanische Republik</target>
+      </trans-unit>
+      <trans-unit id="DZ.name" resname="DZ.name" approved="yes">
+        <source>Algeria</source>
+        <target>Algerien</target>
+      </trans-unit>
+      <trans-unit id="DZ.official_name" resname="DZ.official_name" approved="yes">
+        <source>People's Democratic Republic of Algeria</source>
+        <target>Demokratische Volksrepublik Algerien</target>
+      </trans-unit>
+      <trans-unit id="EC.name" resname="EC.name" approved="yes">
+        <source>Ecuador</source>
+        <target>Ecuador</target>
+      </trans-unit>
+      <trans-unit id="EC.official_name" resname="EC.official_name" approved="yes">
+        <source>Republic of Ecuador</source>
+        <target>Republik Ecuador</target>
+      </trans-unit>
+      <trans-unit id="EE.name" resname="EE.name" approved="yes">
+        <source>Estonia</source>
+        <target>Estland</target>
+      </trans-unit>
+      <trans-unit id="EE.official_name" resname="EE.official_name" approved="yes">
+        <source>Republic of Estonia</source>
+        <target>Republik Estland</target>
+      </trans-unit>
+      <trans-unit id="EG.name" resname="EG.name" approved="yes">
+        <source>Egypt</source>
+        <target>Ägypten</target>
+      </trans-unit>
+      <trans-unit id="EG.official_name" resname="EG.official_name" approved="yes">
+        <source>Arab Republic of Egypt</source>
+        <target>Arabische Republik Ägypten</target>
+      </trans-unit>
+      <trans-unit id="EH.name" resname="EH.name" approved="yes">
+        <source>Western Sahara</source>
+        <target>Westsahara</target>
+      </trans-unit>
+      <trans-unit id="ER.name" resname="ER.name" approved="yes">
+        <source>Eritrea</source>
+        <target>Eritrea</target>
+      </trans-unit>
+      <trans-unit id="ER.official_name" resname="ER.official_name" approved="yes">
+        <source>the State of Eritrea</source>
+        <target>Staat Eritrea</target>
+      </trans-unit>
+      <trans-unit id="ES.name" resname="ES.name" approved="yes">
+        <source>Spain</source>
+        <target>Spanien</target>
+      </trans-unit>
+      <trans-unit id="ES.official_name" resname="ES.official_name" approved="yes">
+        <source>Kingdom of Spain</source>
+        <target>Königreich Spanien</target>
+      </trans-unit>
+      <trans-unit id="ET.name" resname="ET.name" approved="yes">
+        <source>Ethiopia</source>
+        <target>Äthiopien</target>
+      </trans-unit>
+      <trans-unit id="ET.official_name" resname="ET.official_name" approved="yes">
+        <source>Federal Democratic Republic of Ethiopia</source>
+        <target>Demokratische Bundesrepublik Äthiopien</target>
+      </trans-unit>
+      <trans-unit id="FI.name" resname="FI.name" approved="yes">
+        <source>Finland</source>
+        <target>Finnland</target>
+      </trans-unit>
+      <trans-unit id="FI.official_name" resname="FI.official_name" approved="yes">
+        <source>Republic of Finland</source>
+        <target>Republik Finnland</target>
+      </trans-unit>
+      <trans-unit id="FJ.name" resname="FJ.name" approved="yes">
+        <source>Fiji</source>
+        <target>Fidschi</target>
+      </trans-unit>
+      <trans-unit id="FJ.official_name" resname="FJ.official_name" approved="yes">
+        <source>Republic of Fiji</source>
+        <target>Republik Fidschi</target>
+      </trans-unit>
+      <trans-unit id="FK.name" resname="FK.name" approved="yes">
+        <source>Falkland Islands (Malvinas)</source>
+        <target>Falklandinseln (Malwinen)</target>
+      </trans-unit>
+      <trans-unit id="FM.name" resname="FM.name" approved="yes">
+        <source>Micronesia, Federated States of</source>
+        <target>Mikronesien, Föderierte Staaten von</target>
+      </trans-unit>
+      <trans-unit id="FM.official_name" resname="FM.official_name" approved="yes">
+        <source>Federated States of Micronesia</source>
+        <target>Föderierte Staaten von Mikronesien</target>
+      </trans-unit>
+      <trans-unit id="FO.name" resname="FO.name" approved="yes">
+        <source>Faroe Islands</source>
+        <target>Färöer-Inseln</target>
+      </trans-unit>
+      <trans-unit id="FR.name" resname="FR.name" approved="yes">
+        <source>France</source>
+        <target>Frankreich</target>
+      </trans-unit>
+      <trans-unit id="FR.official_name" resname="FR.official_name" approved="yes">
+        <source>French Republic</source>
+        <target>Französische Republik</target>
+      </trans-unit>
+      <trans-unit id="GA.name" resname="GA.name" approved="yes">
+        <source>Gabon</source>
+        <target>Gabun</target>
+      </trans-unit>
+      <trans-unit id="GA.official_name" resname="GA.official_name" approved="yes">
+        <source>Gabonese Republic</source>
+        <target>Gabunische Republik</target>
+      </trans-unit>
+      <trans-unit id="GB.name" resname="GB.name" approved="yes">
+        <source>United Kingdom</source>
+        <target>Vereinigtes Königreich</target>
+      </trans-unit>
+      <trans-unit id="GB.official_name" resname="GB.official_name" approved="yes">
+        <source>United Kingdom of Great Britain and Northern Ireland</source>
+        <target>Vereinigtes Königreich Großbritannien und Nordirland</target>
+      </trans-unit>
+      <trans-unit id="GD.name" resname="GD.name" approved="yes">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="GE.name" resname="GE.name" approved="yes">
+        <source>Georgia</source>
+        <target>Georgien</target>
+      </trans-unit>
+      <trans-unit id="GF.name" resname="GF.name" approved="yes">
+        <source>French Guiana</source>
+        <target>Französisch-Guyana</target>
+      </trans-unit>
+      <trans-unit id="GG.name" resname="GG.name" approved="yes">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="GH.name" resname="GH.name" approved="yes">
+        <source>Ghana</source>
+        <target>Ghana</target>
+      </trans-unit>
+      <trans-unit id="GH.official_name" resname="GH.official_name" approved="yes">
+        <source>Republic of Ghana</source>
+        <target>Republik Ghana</target>
+      </trans-unit>
+      <trans-unit id="GI.name" resname="GI.name" approved="yes">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="GL.name" resname="GL.name" approved="yes">
+        <source>Greenland</source>
+        <target>Grönland</target>
+      </trans-unit>
+      <trans-unit id="GM.name" resname="GM.name" approved="yes">
+        <source>Gambia</source>
+        <target>Gambia</target>
+      </trans-unit>
+      <trans-unit id="GM.official_name" resname="GM.official_name" approved="yes">
+        <source>Republic of the Gambia</source>
+        <target>Republik Gambia</target>
+      </trans-unit>
+      <trans-unit id="GN.name" resname="GN.name" approved="yes">
+        <source>Guinea</source>
+        <target>Guinea</target>
+      </trans-unit>
+      <trans-unit id="GN.official_name" resname="GN.official_name" approved="yes">
+        <source>Republic of Guinea</source>
+        <target>Republik Guinea</target>
+      </trans-unit>
+      <trans-unit id="GP.name" resname="GP.name" approved="yes">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="GQ.name" resname="GQ.name" approved="yes">
+        <source>Equatorial Guinea</source>
+        <target>Äquatorialguinea</target>
+      </trans-unit>
+      <trans-unit id="GQ.official_name" resname="GQ.official_name" approved="yes">
+        <source>Republic of Equatorial Guinea</source>
+        <target>Republik Äquatorialguinea</target>
+      </trans-unit>
+      <trans-unit id="GR.name" resname="GR.name" approved="yes">
+        <source>Greece</source>
+        <target>Griechenland</target>
+      </trans-unit>
+      <trans-unit id="GR.official_name" resname="GR.official_name" approved="yes">
+        <source>Hellenic Republic</source>
+        <target>Hellenische Republik</target>
+      </trans-unit>
+      <trans-unit id="GS.name" resname="GS.name" approved="yes">
+        <source>South Georgia and the South Sandwich Islands</source>
+        <target>South Georgia und die Südlichen Sandwichinseln</target>
+      </trans-unit>
+      <trans-unit id="GT.name" resname="GT.name" approved="yes">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="GT.official_name" resname="GT.official_name" approved="yes">
+        <source>Republic of Guatemala</source>
+        <target>Republik Guatemala</target>
+      </trans-unit>
+      <trans-unit id="GU.name" resname="GU.name" approved="yes">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="GW.name" resname="GW.name" approved="yes">
+        <source>Guinea-Bissau</source>
+        <target>Guinea-Bissau</target>
+      </trans-unit>
+      <trans-unit id="GW.official_name" resname="GW.official_name" approved="yes">
+        <source>Republic of Guinea-Bissau</source>
+        <target>Republik Guinea-Bissau</target>
+      </trans-unit>
+      <trans-unit id="GY.name" resname="GY.name" approved="yes">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="GY.official_name" resname="GY.official_name" approved="yes">
+        <source>Republic of Guyana</source>
+        <target>Kooperative Republik Guyana</target>
+      </trans-unit>
+      <trans-unit id="HK.name" resname="HK.name" approved="yes">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="HK.official_name" resname="HK.official_name" approved="yes">
+        <source>Hong Kong Special Administrative Region of China</source>
+        <target>Sonderverwaltungsregion Hongkong</target>
+      </trans-unit>
+      <trans-unit id="HM.name" resname="HM.name" approved="yes">
+        <source>Heard Island and McDonald Islands</source>
+        <target>Heard und McDonaldinseln</target>
+      </trans-unit>
+      <trans-unit id="HN.name" resname="HN.name" approved="yes">
+        <source>Honduras</source>
+        <target>Honduras</target>
+      </trans-unit>
+      <trans-unit id="HN.official_name" resname="HN.official_name" approved="yes">
+        <source>Republic of Honduras</source>
+        <target>Republik Honduras</target>
+      </trans-unit>
+      <trans-unit id="HR.name" resname="HR.name" approved="yes">
+        <source>Croatia</source>
+        <target>Kroatien</target>
+      </trans-unit>
+      <trans-unit id="HR.official_name" resname="HR.official_name" approved="yes">
+        <source>Republic of Croatia</source>
+        <target>Republik Kroatien</target>
+      </trans-unit>
+      <trans-unit id="HT.name" resname="HT.name" approved="yes">
+        <source>Haiti</source>
+        <target>Haiti</target>
+      </trans-unit>
+      <trans-unit id="HT.official_name" resname="HT.official_name" approved="yes">
+        <source>Republic of Haiti</source>
+        <target>Republik Haiti</target>
+      </trans-unit>
+      <trans-unit id="HU.name" resname="HU.name" approved="yes">
+        <source>Hungary</source>
+        <target>Ungarn</target>
+      </trans-unit>
+      <trans-unit id="HU.official_name" resname="HU.official_name" approved="yes">
+        <source>Hungary</source>
+        <target>Ungarn</target>
+      </trans-unit>
+      <trans-unit id="ID.name" resname="ID.name" approved="yes">
+        <source>Indonesia</source>
+        <target>Indonesien</target>
+      </trans-unit>
+      <trans-unit id="ID.official_name" resname="ID.official_name" approved="yes">
+        <source>Republic of Indonesia</source>
+        <target>Republik Indonesien</target>
+      </trans-unit>
+      <trans-unit id="IE.name" resname="IE.name" approved="yes">
+        <source>Ireland</source>
+        <target>Irland</target>
+      </trans-unit>
+      <trans-unit id="IL.name" resname="IL.name" approved="yes">
+        <source>Israel</source>
+        <target>Israel</target>
+      </trans-unit>
+      <trans-unit id="IL.official_name" resname="IL.official_name" approved="yes">
+        <source>State of Israel</source>
+        <target>Staat Israel</target>
+      </trans-unit>
+      <trans-unit id="IM.name" resname="IM.name" approved="yes">
+        <source>Isle of Man</source>
+        <target>Insel Man</target>
+      </trans-unit>
+      <trans-unit id="IN.name" resname="IN.name" approved="yes">
+        <source>India</source>
+        <target>Indien</target>
+      </trans-unit>
+      <trans-unit id="IN.official_name" resname="IN.official_name" approved="yes">
+        <source>Republic of India</source>
+        <target>Republik Indien</target>
+      </trans-unit>
+      <trans-unit id="IO.name" resname="IO.name" approved="yes">
+        <source>British Indian Ocean Territory</source>
+        <target>Britisches Territorium im Indischen Ozean</target>
+      </trans-unit>
+      <trans-unit id="IQ.name" resname="IQ.name" approved="yes">
+        <source>Iraq</source>
+        <target>Irak</target>
+      </trans-unit>
+      <trans-unit id="IQ.official_name" resname="IQ.official_name" approved="yes">
+        <source>Republic of Iraq</source>
+        <target>Republik Irak</target>
+      </trans-unit>
+      <trans-unit id="IR.name" resname="IR.name" approved="yes">
+        <source>Iran, Islamic Republic of</source>
+        <target>Iran, Islamische Republik</target>
+      </trans-unit>
+      <trans-unit id="IR.official_name" resname="IR.official_name" approved="yes">
+        <source>Islamic Republic of Iran</source>
+        <target>Islamische Republik Iran</target>
+      </trans-unit>
+      <trans-unit id="IS.name" resname="IS.name" approved="yes">
+        <source>Iceland</source>
+        <target>Island</target>
+      </trans-unit>
+      <trans-unit id="IS.official_name" resname="IS.official_name" approved="yes">
+        <source>Republic of Iceland</source>
+        <target>Republik Island</target>
+      </trans-unit>
+      <trans-unit id="IT.name" resname="IT.name" approved="yes">
+        <source>Italy</source>
+        <target>Italien</target>
+      </trans-unit>
+      <trans-unit id="IT.official_name" resname="IT.official_name" approved="yes">
+        <source>Italian Republic</source>
+        <target>Italienische Republik</target>
+      </trans-unit>
+      <trans-unit id="JE.name" resname="JE.name" approved="yes">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="JM.name" resname="JM.name" approved="yes">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="JO.name" resname="JO.name" approved="yes">
+        <source>Jordan</source>
+        <target>Jordanien</target>
+      </trans-unit>
+      <trans-unit id="JO.official_name" resname="JO.official_name" approved="yes">
+        <source>Hashemite Kingdom of Jordan</source>
+        <target>Haschemitisches Königreich Jordanien</target>
+      </trans-unit>
+      <trans-unit id="JP.name" resname="JP.name" approved="yes">
+        <source>Japan</source>
+        <target>Japan</target>
+      </trans-unit>
+      <trans-unit id="KE.name" resname="KE.name" approved="yes">
+        <source>Kenya</source>
+        <target>Kenia</target>
+      </trans-unit>
+      <trans-unit id="KE.official_name" resname="KE.official_name" approved="yes">
+        <source>Republic of Kenya</source>
+        <target>Republik Kenia</target>
+      </trans-unit>
+      <trans-unit id="KG.name" resname="KG.name" approved="yes">
+        <source>Kyrgyzstan</source>
+        <target>Kirgisistan</target>
+      </trans-unit>
+      <trans-unit id="KG.official_name" resname="KG.official_name" approved="yes">
+        <source>Kyrgyz Republic</source>
+        <target>Kirgisische Republik</target>
+      </trans-unit>
+      <trans-unit id="KH.name" resname="KH.name" approved="yes">
+        <source>Cambodia</source>
+        <target>Kambodscha</target>
+      </trans-unit>
+      <trans-unit id="KH.official_name" resname="KH.official_name" approved="yes">
+        <source>Kingdom of Cambodia</source>
+        <target>Königreich Kambodscha</target>
+      </trans-unit>
+      <trans-unit id="KI.name" resname="KI.name" approved="yes">
+        <source>Kiribati</source>
+        <target>Kiribati</target>
+      </trans-unit>
+      <trans-unit id="KI.official_name" resname="KI.official_name" approved="yes">
+        <source>Republic of Kiribati</source>
+        <target>Republik Kiribati</target>
+      </trans-unit>
+      <trans-unit id="KM.name" resname="KM.name" approved="yes">
+        <source>Comoros</source>
+        <target>Komoren</target>
+      </trans-unit>
+      <trans-unit id="KM.official_name" resname="KM.official_name" approved="yes">
+        <source>Union of the Comoros</source>
+        <target>Vereinigung der Komoren</target>
+      </trans-unit>
+      <trans-unit id="KN.name" resname="KN.name" approved="yes">
+        <source>Saint Kitts and Nevis</source>
+        <target>St. Kitts und Nevis</target>
+      </trans-unit>
+      <trans-unit id="KP.name" resname="KP.name" approved="yes">
+        <source>Korea, Democratic People's Republic of</source>
+        <target>Korea, Demokratische Volksrepublik</target>
+      </trans-unit>
+      <trans-unit id="KP.official_name" resname="KP.official_name" approved="yes">
+        <source>Democratic People's Republic of Korea</source>
+        <target>Demokratische Volksrepublik Korea</target>
+      </trans-unit>
+      <trans-unit id="KR.name" resname="KR.name" approved="yes">
+        <source>Korea, Republic of</source>
+        <target>Korea, Republik</target>
+      </trans-unit>
+      <trans-unit id="KW.name" resname="KW.name" approved="yes">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="KW.official_name" resname="KW.official_name" approved="yes">
+        <source>State of Kuwait</source>
+        <target>Staat Kuwait</target>
+      </trans-unit>
+      <trans-unit id="KY.name" resname="KY.name" approved="yes">
+        <source>Cayman Islands</source>
+        <target>Cayman-Inseln</target>
+      </trans-unit>
+      <trans-unit id="KZ.name" resname="KZ.name" approved="yes">
+        <source>Kazakhstan</source>
+        <target>Kasachstan</target>
+      </trans-unit>
+      <trans-unit id="KZ.official_name" resname="KZ.official_name" approved="yes">
+        <source>Republic of Kazakhstan</source>
+        <target>Republik Kasachstan</target>
+      </trans-unit>
+      <trans-unit id="LA.name" resname="LA.name" approved="yes">
+        <source>Lao People's Democratic Republic</source>
+        <target>Laos, Demokratische Volksrepublik</target>
+      </trans-unit>
+      <trans-unit id="LB.name" resname="LB.name" approved="yes">
+        <source>Lebanon</source>
+        <target>Libanon</target>
+      </trans-unit>
+      <trans-unit id="LB.official_name" resname="LB.official_name" approved="yes">
+        <source>Lebanese Republic</source>
+        <target>Libanesische Republik</target>
+      </trans-unit>
+      <trans-unit id="LC.name" resname="LC.name" approved="yes">
+        <source>Saint Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="LI.name" resname="LI.name" approved="yes">
+        <source>Liechtenstein</source>
+        <target>Liechtenstein</target>
+      </trans-unit>
+      <trans-unit id="LI.official_name" resname="LI.official_name" approved="yes">
+        <source>Principality of Liechtenstein</source>
+        <target>Fürstentum Liechtenstein</target>
+      </trans-unit>
+      <trans-unit id="LK.name" resname="LK.name" approved="yes">
+        <source>Sri Lanka</source>
+        <target>Sri Lanka</target>
+      </trans-unit>
+      <trans-unit id="LK.official_name" resname="LK.official_name" approved="yes">
+        <source>Democratic Socialist Republic of Sri Lanka</source>
+        <target>Demokratische sozialistische Republik Sri Lanka</target>
+      </trans-unit>
+      <trans-unit id="LR.name" resname="LR.name" approved="yes">
+        <source>Liberia</source>
+        <target>Liberia</target>
+      </trans-unit>
+      <trans-unit id="LR.official_name" resname="LR.official_name" approved="yes">
+        <source>Republic of Liberia</source>
+        <target>Republik Liberia</target>
+      </trans-unit>
+      <trans-unit id="LS.name" resname="LS.name" approved="yes">
+        <source>Lesotho</source>
+        <target>Lesotho</target>
+      </trans-unit>
+      <trans-unit id="LS.official_name" resname="LS.official_name" approved="yes">
+        <source>Kingdom of Lesotho</source>
+        <target>Königreich Lesotho</target>
+      </trans-unit>
+      <trans-unit id="LT.name" resname="LT.name" approved="yes">
+        <source>Lithuania</source>
+        <target>Litauen</target>
+      </trans-unit>
+      <trans-unit id="LT.official_name" resname="LT.official_name" approved="yes">
+        <source>Republic of Lithuania</source>
+        <target>Republik Litauen</target>
+      </trans-unit>
+      <trans-unit id="LU.name" resname="LU.name" approved="yes">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="LU.official_name" resname="LU.official_name" approved="yes">
+        <source>Grand Duchy of Luxembourg</source>
+        <target>Großherzogtum Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="LV.name" resname="LV.name" approved="yes">
+        <source>Latvia</source>
+        <target>Lettland</target>
+      </trans-unit>
+      <trans-unit id="LV.official_name" resname="LV.official_name" approved="yes">
+        <source>Republic of Latvia</source>
+        <target>Republik Lettland</target>
+      </trans-unit>
+      <trans-unit id="LY.name" resname="LY.name" approved="yes">
+        <source>Libya</source>
+        <target>Libyen</target>
+      </trans-unit>
+      <trans-unit id="LY.official_name" resname="LY.official_name" approved="yes">
+        <source>Libya</source>
+        <target>Libyen</target>
+      </trans-unit>
+      <trans-unit id="MA.name" resname="MA.name" approved="yes">
+        <source>Morocco</source>
+        <target>Marokko</target>
+      </trans-unit>
+      <trans-unit id="MA.official_name" resname="MA.official_name" approved="yes">
+        <source>Kingdom of Morocco</source>
+        <target>Königreich Marokko</target>
+      </trans-unit>
+      <trans-unit id="MC.name" resname="MC.name" approved="yes">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="MC.official_name" resname="MC.official_name" approved="yes">
+        <source>Principality of Monaco</source>
+        <target>Fürstentum Monaco</target>
+      </trans-unit>
+      <trans-unit id="MD.name" resname="MD.name" approved="yes">
+        <source>Moldova, Republic of</source>
+        <target>Moldau, Republik</target>
+      </trans-unit>
+      <trans-unit id="MD.official_name" resname="MD.official_name" approved="yes">
+        <source>Republic of Moldova</source>
+        <target>Republik Moldau</target>
+      </trans-unit>
+      <trans-unit id="ME.name" resname="ME.name" approved="yes">
+        <source>Montenegro</source>
+        <target>Montenegro</target>
+      </trans-unit>
+      <trans-unit id="ME.official_name" resname="ME.official_name" approved="yes">
+        <source>Montenegro</source>
+        <target>Montenegro</target>
+      </trans-unit>
+      <trans-unit id="MF.name" resname="MF.name" approved="yes">
+        <source>Saint Martin (French part)</source>
+        <target>Saint Martin (Französischer Teil)</target>
+      </trans-unit>
+      <trans-unit id="MG.name" resname="MG.name" approved="yes">
+        <source>Madagascar</source>
+        <target>Madagaskar</target>
+      </trans-unit>
+      <trans-unit id="MG.official_name" resname="MG.official_name" approved="yes">
+        <source>Republic of Madagascar</source>
+        <target>Republik Madagaskar</target>
+      </trans-unit>
+      <trans-unit id="MH.name" resname="MH.name" approved="yes">
+        <source>Marshall Islands</source>
+        <target>Marshallinseln</target>
+      </trans-unit>
+      <trans-unit id="MH.official_name" resname="MH.official_name" approved="yes">
+        <source>Republic of the Marshall Islands</source>
+        <target>Republik Marshallinseln</target>
+      </trans-unit>
+      <trans-unit id="MK.name" resname="MK.name" approved="yes">
+        <source>North Macedonia</source>
+        <target>Nordmazedonien</target>
+      </trans-unit>
+      <trans-unit id="MK.official_name" resname="MK.official_name" approved="yes">
+        <source>Republic of North Macedonia</source>
+        <target>Republik Nordmazedonien</target>
+      </trans-unit>
+      <trans-unit id="ML.name" resname="ML.name" approved="yes">
+        <source>Mali</source>
+        <target>Mali</target>
+      </trans-unit>
+      <trans-unit id="ML.official_name" resname="ML.official_name" approved="yes">
+        <source>Republic of Mali</source>
+        <target>Republik Mali</target>
+      </trans-unit>
+      <trans-unit id="MM.name" resname="MM.name" approved="yes">
+        <source>Myanmar</source>
+        <target>Myanmar</target>
+      </trans-unit>
+      <trans-unit id="MM.official_name" resname="MM.official_name" approved="yes">
+        <source>Republic of Myanmar</source>
+        <target>Republik Myanmar</target>
+      </trans-unit>
+      <trans-unit id="MN.name" resname="MN.name" approved="yes">
+        <source>Mongolia</source>
+        <target>Mongolei</target>
+      </trans-unit>
+      <trans-unit id="MO.name" resname="MO.name" approved="yes">
+        <source>Macao</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="MO.official_name" resname="MO.official_name" approved="yes">
+        <source>Macao Special Administrative Region of China</source>
+        <target>Sonderverwaltungsregion Macao</target>
+      </trans-unit>
+      <trans-unit id="MP.name" resname="MP.name" approved="yes">
+        <source>Northern Mariana Islands</source>
+        <target>Nördliche Marianen</target>
+      </trans-unit>
+      <trans-unit id="MP.official_name" resname="MP.official_name" approved="yes">
+        <source>Commonwealth of the Northern Mariana Islands</source>
+        <target>Commonwealth Nördliche Mariana-Inseln</target>
+      </trans-unit>
+      <trans-unit id="MQ.name" resname="MQ.name" approved="yes">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="MR.name" resname="MR.name" approved="yes">
+        <source>Mauritania</source>
+        <target>Mauretanien</target>
+      </trans-unit>
+      <trans-unit id="MR.official_name" resname="MR.official_name" approved="yes">
+        <source>Islamic Republic of Mauritania</source>
+        <target>Islamische Republik Mauretanien</target>
+      </trans-unit>
+      <trans-unit id="MS.name" resname="MS.name" approved="yes">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="MT.name" resname="MT.name" approved="yes">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="MT.official_name" resname="MT.official_name" approved="yes">
+        <source>Republic of Malta</source>
+        <target>Republik Malta</target>
+      </trans-unit>
+      <trans-unit id="MU.name" resname="MU.name" approved="yes">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="MU.official_name" resname="MU.official_name" approved="yes">
+        <source>Republic of Mauritius</source>
+        <target>Republik Mauritius</target>
+      </trans-unit>
+      <trans-unit id="MV.name" resname="MV.name" approved="yes">
+        <source>Maldives</source>
+        <target>Malediven</target>
+      </trans-unit>
+      <trans-unit id="MV.official_name" resname="MV.official_name" approved="yes">
+        <source>Republic of Maldives</source>
+        <target>Republik Malediven</target>
+      </trans-unit>
+      <trans-unit id="MW.name" resname="MW.name" approved="yes">
+        <source>Malawi</source>
+        <target>Malawi</target>
+      </trans-unit>
+      <trans-unit id="MW.official_name" resname="MW.official_name" approved="yes">
+        <source>Republic of Malawi</source>
+        <target>Republik Malawi</target>
+      </trans-unit>
+      <trans-unit id="MX.name" resname="MX.name" approved="yes">
+        <source>Mexico</source>
+        <target>Mexiko</target>
+      </trans-unit>
+      <trans-unit id="MX.official_name" resname="MX.official_name" approved="yes">
+        <source>United Mexican States</source>
+        <target>Vereinigte Mexikanische Staaten</target>
+      </trans-unit>
+      <trans-unit id="MY.name" resname="MY.name" approved="yes">
+        <source>Malaysia</source>
+        <target>Malaysia</target>
+      </trans-unit>
+      <trans-unit id="MZ.name" resname="MZ.name" approved="yes">
+        <source>Mozambique</source>
+        <target>Mosambik</target>
+      </trans-unit>
+      <trans-unit id="MZ.official_name" resname="MZ.official_name" approved="yes">
+        <source>Republic of Mozambique</source>
+        <target>Republik Mosambik</target>
+      </trans-unit>
+      <trans-unit id="NA.name" resname="NA.name" approved="yes">
+        <source>Namibia</source>
+        <target>Namibia</target>
+      </trans-unit>
+      <trans-unit id="NA.official_name" resname="NA.official_name" approved="yes">
+        <source>Republic of Namibia</source>
+        <target>Republik Namibia</target>
+      </trans-unit>
+      <trans-unit id="NC.name" resname="NC.name" approved="yes">
+        <source>New Caledonia</source>
+        <target>Neukaledonien</target>
+      </trans-unit>
+      <trans-unit id="NE.name" resname="NE.name" approved="yes">
+        <source>Niger</source>
+        <target>Niger</target>
+      </trans-unit>
+      <trans-unit id="NE.official_name" resname="NE.official_name" approved="yes">
+        <source>Republic of the Niger</source>
+        <target>Republik Niger</target>
+      </trans-unit>
+      <trans-unit id="NF.name" resname="NF.name" approved="yes">
+        <source>Norfolk Island</source>
+        <target>Norfolkinsel</target>
+      </trans-unit>
+      <trans-unit id="NG.name" resname="NG.name" approved="yes">
+        <source>Nigeria</source>
+        <target>Nigeria</target>
+      </trans-unit>
+      <trans-unit id="NG.official_name" resname="NG.official_name" approved="yes">
+        <source>Federal Republic of Nigeria</source>
+        <target>Bundesrepublik Nigeria</target>
+      </trans-unit>
+      <trans-unit id="NI.name" resname="NI.name" approved="yes">
+        <source>Nicaragua</source>
+        <target>Nicaragua</target>
+      </trans-unit>
+      <trans-unit id="NI.official_name" resname="NI.official_name" approved="yes">
+        <source>Republic of Nicaragua</source>
+        <target>Republik Nicaragua</target>
+      </trans-unit>
+      <trans-unit id="NL.name" resname="NL.name" approved="yes">
+        <source>Netherlands</source>
+        <target>Niederlande</target>
+      </trans-unit>
+      <trans-unit id="NL.official_name" resname="NL.official_name" approved="yes">
+        <source>Kingdom of the Netherlands</source>
+        <target>Königreich der Niederlande</target>
+      </trans-unit>
+      <trans-unit id="NO.name" resname="NO.name" approved="yes">
+        <source>Norway</source>
+        <target>Norwegen</target>
+      </trans-unit>
+      <trans-unit id="NO.official_name" resname="NO.official_name" approved="yes">
+        <source>Kingdom of Norway</source>
+        <target>Königreich Norwegen</target>
+      </trans-unit>
+      <trans-unit id="NP.name" resname="NP.name" approved="yes">
+        <source>Nepal</source>
+        <target>Nepal</target>
+      </trans-unit>
+      <trans-unit id="NP.official_name" resname="NP.official_name" approved="yes">
+        <source>Federal Democratic Republic of Nepal</source>
+        <target>Demokratische Bundesrepublik Nepal</target>
+      </trans-unit>
+      <trans-unit id="NR.name" resname="NR.name" approved="yes">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="NR.official_name" resname="NR.official_name" approved="yes">
+        <source>Republic of Nauru</source>
+        <target>Republik Nauru</target>
+      </trans-unit>
+      <trans-unit id="NU.name" resname="NU.name" approved="yes">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="NU.official_name" resname="NU.official_name" approved="yes">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="NZ.name" resname="NZ.name" approved="yes">
+        <source>New Zealand</source>
+        <target>Neuseeland</target>
+      </trans-unit>
+      <trans-unit id="OM.name" resname="OM.name" approved="yes">
+        <source>Oman</source>
+        <target>Oman</target>
+      </trans-unit>
+      <trans-unit id="OM.official_name" resname="OM.official_name" approved="yes">
+        <source>Sultanate of Oman</source>
+        <target>Sultanat Oman</target>
+      </trans-unit>
+      <trans-unit id="PA.name" resname="PA.name" approved="yes">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="PA.official_name" resname="PA.official_name" approved="yes">
+        <source>Republic of Panama</source>
+        <target>Republik Panama</target>
+      </trans-unit>
+      <trans-unit id="PE.name" resname="PE.name" approved="yes">
+        <source>Peru</source>
+        <target>Peru</target>
+      </trans-unit>
+      <trans-unit id="PE.official_name" resname="PE.official_name" approved="yes">
+        <source>Republic of Peru</source>
+        <target>Republik Peru</target>
+      </trans-unit>
+      <trans-unit id="PF.name" resname="PF.name" approved="yes">
+        <source>French Polynesia</source>
+        <target>Französisch-Polynesien</target>
+      </trans-unit>
+      <trans-unit id="PG.name" resname="PG.name" approved="yes">
+        <source>Papua New Guinea</source>
+        <target>Papua-Neuguinea</target>
+      </trans-unit>
+      <trans-unit id="PG.official_name" resname="PG.official_name" approved="yes">
+        <source>Independent State of Papua New Guinea</source>
+        <target>Unabhängiger Staat Papua-Neuguinea</target>
+      </trans-unit>
+      <trans-unit id="PH.name" resname="PH.name" approved="yes">
+        <source>Philippines</source>
+        <target>Philippinen</target>
+      </trans-unit>
+      <trans-unit id="PH.official_name" resname="PH.official_name" approved="yes">
+        <source>Republic of the Philippines</source>
+        <target>Republik der Philippinen</target>
+      </trans-unit>
+      <trans-unit id="PK.name" resname="PK.name" approved="yes">
+        <source>Pakistan</source>
+        <target>Pakistan</target>
+      </trans-unit>
+      <trans-unit id="PK.official_name" resname="PK.official_name" approved="yes">
+        <source>Islamic Republic of Pakistan</source>
+        <target>Islamische Republik Pakistan</target>
+      </trans-unit>
+      <trans-unit id="PL.name" resname="PL.name" approved="yes">
+        <source>Poland</source>
+        <target>Polen</target>
+      </trans-unit>
+      <trans-unit id="PL.official_name" resname="PL.official_name" approved="yes">
+        <source>Republic of Poland</source>
+        <target>Republik Polen</target>
+      </trans-unit>
+      <trans-unit id="PM.name" resname="PM.name" approved="yes">
+        <source>Saint Pierre and Miquelon</source>
+        <target>St. Pierre und Miquelon</target>
+      </trans-unit>
+      <trans-unit id="PN.name" resname="PN.name" approved="yes">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="PR.name" resname="PR.name" approved="yes">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="PS.name" resname="PS.name" approved="yes">
+        <source>Palestine, State of</source>
+        <target>Palästina, Staat</target>
+      </trans-unit>
+      <trans-unit id="PS.official_name" resname="PS.official_name" approved="yes">
+        <source>the State of Palestine</source>
+        <target>Staat Palästina</target>
+      </trans-unit>
+      <trans-unit id="PT.name" resname="PT.name" approved="yes">
+        <source>Portugal</source>
+        <target>Portugal</target>
+      </trans-unit>
+      <trans-unit id="PT.official_name" resname="PT.official_name" approved="yes">
+        <source>Portuguese Republic</source>
+        <target>Portugiesische Republik</target>
+      </trans-unit>
+      <trans-unit id="PW.name" resname="PW.name" approved="yes">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="PW.official_name" resname="PW.official_name" approved="yes">
+        <source>Republic of Palau</source>
+        <target>Republik Palau</target>
+      </trans-unit>
+      <trans-unit id="PY.name" resname="PY.name" approved="yes">
+        <source>Paraguay</source>
+        <target>Paraguay</target>
+      </trans-unit>
+      <trans-unit id="PY.official_name" resname="PY.official_name" approved="yes">
+        <source>Republic of Paraguay</source>
+        <target>Republik Paraguay</target>
+      </trans-unit>
+      <trans-unit id="QA.name" resname="QA.name" approved="yes">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="QA.official_name" resname="QA.official_name" approved="yes">
+        <source>State of Qatar</source>
+        <target>Staat Katar</target>
+      </trans-unit>
+      <trans-unit id="RE.name" resname="RE.name" approved="yes">
+        <source>Réunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="RO.name" resname="RO.name" approved="yes">
+        <source>Romania</source>
+        <target>Rumänien</target>
+      </trans-unit>
+      <trans-unit id="RS.name" resname="RS.name" approved="yes">
+        <source>Serbia</source>
+        <target>Serbien</target>
+      </trans-unit>
+      <trans-unit id="RS.official_name" resname="RS.official_name" approved="yes">
+        <source>Republic of Serbia</source>
+        <target>Republik Serbien</target>
+      </trans-unit>
+      <trans-unit id="RU.name" resname="RU.name" approved="yes">
+        <source>Russian Federation</source>
+        <target>Russische Föderation</target>
+      </trans-unit>
+      <trans-unit id="RW.name" resname="RW.name" approved="yes">
+        <source>Rwanda</source>
+        <target>Ruanda</target>
+      </trans-unit>
+      <trans-unit id="RW.official_name" resname="RW.official_name" approved="yes">
+        <source>Rwandese Republic</source>
+        <target>Republik Ruanda</target>
+      </trans-unit>
+      <trans-unit id="SA.name" resname="SA.name" approved="yes">
+        <source>Saudi Arabia</source>
+        <target>Saudi-Arabien</target>
+      </trans-unit>
+      <trans-unit id="SA.official_name" resname="SA.official_name" approved="yes">
+        <source>Kingdom of Saudi Arabia</source>
+        <target>Königreich Saudi-Arabien</target>
+      </trans-unit>
+      <trans-unit id="SB.name" resname="SB.name" approved="yes">
+        <source>Solomon Islands</source>
+        <target>Salomoninseln</target>
+      </trans-unit>
+      <trans-unit id="SC.name" resname="SC.name" approved="yes">
+        <source>Seychelles</source>
+        <target>Seychellen</target>
+      </trans-unit>
+      <trans-unit id="SC.official_name" resname="SC.official_name" approved="yes">
+        <source>Republic of Seychelles</source>
+        <target>Republik Seychellen</target>
+      </trans-unit>
+      <trans-unit id="SD.name" resname="SD.name" approved="yes">
+        <source>Sudan</source>
+        <target>Sudan</target>
+      </trans-unit>
+      <trans-unit id="SD.official_name" resname="SD.official_name" approved="yes">
+        <source>Republic of the Sudan</source>
+        <target>Republik Sudan</target>
+      </trans-unit>
+      <trans-unit id="SE.name" resname="SE.name" approved="yes">
+        <source>Sweden</source>
+        <target>Schweden</target>
+      </trans-unit>
+      <trans-unit id="SE.official_name" resname="SE.official_name" approved="yes">
+        <source>Kingdom of Sweden</source>
+        <target>Königreich Schweden</target>
+      </trans-unit>
+      <trans-unit id="SG.name" resname="SG.name" approved="yes">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="SG.official_name" resname="SG.official_name" approved="yes">
+        <source>Republic of Singapore</source>
+        <target>Republik Singapur</target>
+      </trans-unit>
+      <trans-unit id="SH.name" resname="SH.name" approved="yes">
+        <source>Saint Helena, Ascension and Tristan da Cunha</source>
+        <target>St. Helena, Ascension und Tristan da Cunha</target>
+      </trans-unit>
+      <trans-unit id="SI.name" resname="SI.name" approved="yes">
+        <source>Slovenia</source>
+        <target>Slowenien</target>
+      </trans-unit>
+      <trans-unit id="SI.official_name" resname="SI.official_name" approved="yes">
+        <source>Republic of Slovenia</source>
+        <target>Republik Slowenien</target>
+      </trans-unit>
+      <trans-unit id="SJ.name" resname="SJ.name" approved="yes">
+        <source>Svalbard and Jan Mayen</source>
+        <target>Svalbard und Jan Mayen</target>
+      </trans-unit>
+      <trans-unit id="SK.name" resname="SK.name" approved="yes">
+        <source>Slovakia</source>
+        <target>Slowakei</target>
+      </trans-unit>
+      <trans-unit id="SK.official_name" resname="SK.official_name" approved="yes">
+        <source>Slovak Republic</source>
+        <target>Slowakische Republik</target>
+      </trans-unit>
+      <trans-unit id="SL.name" resname="SL.name" approved="yes">
+        <source>Sierra Leone</source>
+        <target>Sierra Leone</target>
+      </trans-unit>
+      <trans-unit id="SL.official_name" resname="SL.official_name" approved="yes">
+        <source>Republic of Sierra Leone</source>
+        <target>Republik Sierra Leone</target>
+      </trans-unit>
+      <trans-unit id="SM.name" resname="SM.name" approved="yes">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="SM.official_name" resname="SM.official_name" approved="yes">
+        <source>Republic of San Marino</source>
+        <target>Republik San Marino</target>
+      </trans-unit>
+      <trans-unit id="SN.name" resname="SN.name" approved="yes">
+        <source>Senegal</source>
+        <target>Senegal</target>
+      </trans-unit>
+      <trans-unit id="SN.official_name" resname="SN.official_name" approved="yes">
+        <source>Republic of Senegal</source>
+        <target>Republik Senegal</target>
+      </trans-unit>
+      <trans-unit id="SO.name" resname="SO.name" approved="yes">
+        <source>Somalia</source>
+        <target>Somalia</target>
+      </trans-unit>
+      <trans-unit id="SO.official_name" resname="SO.official_name" approved="yes">
+        <source>Federal Republic of Somalia</source>
+        <target>Bundesrepublik Somalia</target>
+      </trans-unit>
+      <trans-unit id="SR.name" resname="SR.name" approved="yes">
+        <source>Suriname</source>
+        <target>Suriname</target>
+      </trans-unit>
+      <trans-unit id="SR.official_name" resname="SR.official_name" approved="yes">
+        <source>Republic of Suriname</source>
+        <target>Republik Suriname</target>
+      </trans-unit>
+      <trans-unit id="SS.name" resname="SS.name" approved="yes">
+        <source>South Sudan</source>
+        <target>Südsudan</target>
+      </trans-unit>
+      <trans-unit id="SS.official_name" resname="SS.official_name" approved="yes">
+        <source>Republic of South Sudan</source>
+        <target>Republik Südsudan</target>
+      </trans-unit>
+      <trans-unit id="ST.name" resname="ST.name" approved="yes">
+        <source>Sao Tome and Principe</source>
+        <target>São Tomé und Príncipe</target>
+      </trans-unit>
+      <trans-unit id="ST.official_name" resname="ST.official_name" approved="yes">
+        <source>Democratic Republic of Sao Tome and Principe</source>
+        <target>Demokratische Republik São Tomé und Príncipe</target>
+      </trans-unit>
+      <trans-unit id="SV.name" resname="SV.name" approved="yes">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="SV.official_name" resname="SV.official_name" approved="yes">
+        <source>Republic of El Salvador</source>
+        <target>Republik El Salvador</target>
+      </trans-unit>
+      <trans-unit id="SX.name" resname="SX.name" approved="yes">
+        <source>Sint Maarten (Dutch part)</source>
+        <target>Saint-Martin (Niederländischer Teil)</target>
+      </trans-unit>
+      <trans-unit id="SX.official_name" resname="SX.official_name" approved="yes">
+        <source>Sint Maarten (Dutch part)</source>
+        <target>Saint-Martin (Niederländischer Teil)</target>
+      </trans-unit>
+      <trans-unit id="SY.name" resname="SY.name" approved="yes">
+        <source>Syrian Arab Republic</source>
+        <target>Syrien, Arabische Republik</target>
+      </trans-unit>
+      <trans-unit id="SZ.name" resname="SZ.name" approved="yes">
+        <source>Eswatini</source>
+        <target>Eswatini</target>
+      </trans-unit>
+      <trans-unit id="SZ.official_name" resname="SZ.official_name" approved="yes">
+        <source>Kingdom of Eswatini</source>
+        <target>Königreich Eswatini</target>
+      </trans-unit>
+      <trans-unit id="TC.name" resname="TC.name" approved="yes">
+        <source>Turks and Caicos Islands</source>
+        <target>Turks- und Caicosinseln</target>
+      </trans-unit>
+      <trans-unit id="TD.name" resname="TD.name" approved="yes">
+        <source>Chad</source>
+        <target>Tschad</target>
+      </trans-unit>
+      <trans-unit id="TD.official_name" resname="TD.official_name" approved="yes">
+        <source>Republic of Chad</source>
+        <target>Republik Tschad</target>
+      </trans-unit>
+      <trans-unit id="TF.name" resname="TF.name" approved="yes">
+        <source>French Southern Territories</source>
+        <target>Französische Süd- und Antarktisgebiete</target>
+      </trans-unit>
+      <trans-unit id="TG.name" resname="TG.name" approved="yes">
+        <source>Togo</source>
+        <target>Togo</target>
+      </trans-unit>
+      <trans-unit id="TG.official_name" resname="TG.official_name" approved="yes">
+        <source>Togolese Republic</source>
+        <target>Republik Togo</target>
+      </trans-unit>
+      <trans-unit id="TH.name" resname="TH.name" approved="yes">
+        <source>Thailand</source>
+        <target>Thailand</target>
+      </trans-unit>
+      <trans-unit id="TH.official_name" resname="TH.official_name" approved="yes">
+        <source>Kingdom of Thailand</source>
+        <target>Königreich Thailand</target>
+      </trans-unit>
+      <trans-unit id="TJ.name" resname="TJ.name" approved="yes">
+        <source>Tajikistan</source>
+        <target>Tadschikistan</target>
+      </trans-unit>
+      <trans-unit id="TJ.official_name" resname="TJ.official_name" approved="yes">
+        <source>Republic of Tajikistan</source>
+        <target>Republik Tadschikistan</target>
+      </trans-unit>
+      <trans-unit id="TK.name" resname="TK.name" approved="yes">
+        <source>Tokelau</source>
+        <target>Tokelau</target>
+      </trans-unit>
+      <trans-unit id="TL.name" resname="TL.name" approved="yes">
+        <source>Timor-Leste</source>
+        <target>Timor-Leste</target>
+      </trans-unit>
+      <trans-unit id="TL.official_name" resname="TL.official_name" approved="yes">
+        <source>Democratic Republic of Timor-Leste</source>
+        <target>Demokratische Republik Timor-Leste</target>
+      </trans-unit>
+      <trans-unit id="TM.name" resname="TM.name" approved="yes">
+        <source>Turkmenistan</source>
+        <target>Turkmenistan</target>
+      </trans-unit>
+      <trans-unit id="TN.name" resname="TN.name" approved="yes">
+        <source>Tunisia</source>
+        <target>Tunesien</target>
+      </trans-unit>
+      <trans-unit id="TN.official_name" resname="TN.official_name" approved="yes">
+        <source>Republic of Tunisia</source>
+        <target>Tunesische Republik</target>
+      </trans-unit>
+      <trans-unit id="TO.name" resname="TO.name" approved="yes">
+        <source>Tonga</source>
+        <target>Tonga</target>
+      </trans-unit>
+      <trans-unit id="TO.official_name" resname="TO.official_name" approved="yes">
+        <source>Kingdom of Tonga</source>
+        <target>Königreich Tonga</target>
+      </trans-unit>
+      <trans-unit id="TR.name" resname="TR.name" approved="yes">
+        <source>Türkiye</source>
+        <target>Türkei</target>
+      </trans-unit>
+      <trans-unit id="TR.official_name" resname="TR.official_name" approved="yes">
+        <source>Republic of Türkiye</source>
+        <target>Republik Türkei</target>
+      </trans-unit>
+      <trans-unit id="TT.name" resname="TT.name" approved="yes">
+        <source>Trinidad and Tobago</source>
+        <target>Trinidad und Tobago</target>
+      </trans-unit>
+      <trans-unit id="TT.official_name" resname="TT.official_name" approved="yes">
+        <source>Republic of Trinidad and Tobago</source>
+        <target>Republik Trinidad und Tobago</target>
+      </trans-unit>
+      <trans-unit id="TV.name" resname="TV.name" approved="yes">
+        <source>Tuvalu</source>
+        <target>Tuvalu</target>
+      </trans-unit>
+      <trans-unit id="TW.name" resname="TW.name" approved="yes">
+        <source>Taiwan, Province of China</source>
+        <target>Taiwan, Chinesische Provinz</target>
+      </trans-unit>
+      <trans-unit id="TW.official_name" resname="TW.official_name" approved="yes">
+        <source>Taiwan, Province of China</source>
+        <target>Taiwan, Chinesische Provinz</target>
+      </trans-unit>
+      <trans-unit id="TZ.name" resname="TZ.name" approved="yes">
+        <source>Tanzania, United Republic of</source>
+        <target>Tansania, Vereinigte Republik</target>
+      </trans-unit>
+      <trans-unit id="TZ.official_name" resname="TZ.official_name" approved="yes">
+        <source>United Republic of Tanzania</source>
+        <target>Vereinigte Republik Tansania</target>
+      </trans-unit>
+      <trans-unit id="UA.name" resname="UA.name" approved="yes">
+        <source>Ukraine</source>
+        <target>Ukraine</target>
+      </trans-unit>
+      <trans-unit id="UG.name" resname="UG.name" approved="yes">
+        <source>Uganda</source>
+        <target>Uganda</target>
+      </trans-unit>
+      <trans-unit id="UG.official_name" resname="UG.official_name" approved="yes">
+        <source>Republic of Uganda</source>
+        <target>Republik Uganda</target>
+      </trans-unit>
+      <trans-unit id="UM.name" resname="UM.name" approved="yes">
+        <source>United States Minor Outlying Islands</source>
+        <target>United States Minor Outlying Islands</target>
+      </trans-unit>
+      <trans-unit id="US.name" resname="US.name" approved="yes">
+        <source>United States</source>
+        <target>Vereinigte Staaten</target>
+      </trans-unit>
+      <trans-unit id="US.official_name" resname="US.official_name" approved="yes">
+        <source>United States of America</source>
+        <target>Vereinigte Staaten von Amerika</target>
+      </trans-unit>
+      <trans-unit id="UY.name" resname="UY.name" approved="yes">
+        <source>Uruguay</source>
+        <target>Uruguay</target>
+      </trans-unit>
+      <trans-unit id="UY.official_name" resname="UY.official_name" approved="yes">
+        <source>Eastern Republic of Uruguay</source>
+        <target>Republik Östlich des Uruguay</target>
+      </trans-unit>
+      <trans-unit id="UZ.name" resname="UZ.name" approved="yes">
+        <source>Uzbekistan</source>
+        <target>Usbekistan</target>
+      </trans-unit>
+      <trans-unit id="UZ.official_name" resname="UZ.official_name" approved="yes">
+        <source>Republic of Uzbekistan</source>
+        <target>Republik Usbekistan</target>
+      </trans-unit>
+      <trans-unit id="VA.name" resname="VA.name" approved="yes">
+        <source>Holy See (Vatican City State)</source>
+        <target>Heiliger Stuhl (Staat Vatikanstadt)</target>
+      </trans-unit>
+      <trans-unit id="VC.name" resname="VC.name" approved="yes">
+        <source>Saint Vincent and the Grenadines</source>
+        <target>St. Vincent und die Grenadinen</target>
+      </trans-unit>
+      <trans-unit id="VE.name" resname="VE.name" approved="yes">
+        <source>Venezuela, Bolivarian Republic of</source>
+        <target>Venezuela, Bolivarische Republik</target>
+      </trans-unit>
+      <trans-unit id="VE.official_name" resname="VE.official_name" approved="yes">
+        <source>Bolivarian Republic of Venezuela</source>
+        <target>Bolivarische Republik Venezuela</target>
+      </trans-unit>
+      <trans-unit id="VG.name" resname="VG.name" approved="yes">
+        <source>Virgin Islands, British</source>
+        <target>Britische Jungferninseln</target>
+      </trans-unit>
+      <trans-unit id="VG.official_name" resname="VG.official_name" approved="yes">
+        <source>British Virgin Islands</source>
+        <target>Britische Jungferninseln</target>
+      </trans-unit>
+      <trans-unit id="VI.name" resname="VI.name" approved="yes">
+        <source>Virgin Islands, U.S.</source>
+        <target>Amerikanische Jungferninseln</target>
+      </trans-unit>
+      <trans-unit id="VI.official_name" resname="VI.official_name" approved="yes">
+        <source>Virgin Islands of the United States</source>
+        <target>Amerikanische Jungferninseln</target>
+      </trans-unit>
+      <trans-unit id="VN.name" resname="VN.name" approved="yes">
+        <source>Viet Nam</source>
+        <target>Vietnam</target>
+      </trans-unit>
+      <trans-unit id="VN.official_name" resname="VN.official_name" approved="yes">
+        <source>Socialist Republic of Viet Nam</source>
+        <target>Sozialistische Republik Vietnam</target>
+      </trans-unit>
+      <trans-unit id="VU.name" resname="VU.name" approved="yes">
+        <source>Vanuatu</source>
+        <target>Vanuatu</target>
+      </trans-unit>
+      <trans-unit id="VU.official_name" resname="VU.official_name" approved="yes">
+        <source>Republic of Vanuatu</source>
+        <target>Republik Vanuatu</target>
+      </trans-unit>
+      <trans-unit id="WF.name" resname="WF.name" approved="yes">
+        <source>Wallis and Futuna</source>
+        <target>Wallis und Futuna</target>
+      </trans-unit>
+      <trans-unit id="WS.name" resname="WS.name" approved="yes">
+        <source>Samoa</source>
+        <target>Samoa</target>
+      </trans-unit>
+      <trans-unit id="WS.official_name" resname="WS.official_name" approved="yes">
+        <source>Independent State of Samoa</source>
+        <target>Unabhängiger Staat Samoa</target>
+      </trans-unit>
+      <trans-unit id="YE.name" resname="YE.name" approved="yes">
+        <source>Yemen</source>
+        <target>Jemen</target>
+      </trans-unit>
+      <trans-unit id="YE.official_name" resname="YE.official_name" approved="yes">
+        <source>Republic of Yemen</source>
+        <target>Republik Jemen</target>
+      </trans-unit>
+      <trans-unit id="YT.name" resname="YT.name" approved="yes">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="ZA.name" resname="ZA.name" approved="yes">
+        <source>South Africa</source>
+        <target>Südafrika</target>
+      </trans-unit>
+      <trans-unit id="ZA.official_name" resname="ZA.official_name" approved="yes">
+        <source>Republic of South Africa</source>
+        <target>Republik Südafrika</target>
+      </trans-unit>
+      <trans-unit id="ZM.name" resname="ZM.name" approved="yes">
+        <source>Zambia</source>
+        <target>Sambia</target>
+      </trans-unit>
+      <trans-unit id="ZM.official_name" resname="ZM.official_name" approved="yes">
+        <source>Republic of Zambia</source>
+        <target>Republik Sambia</target>
+      </trans-unit>
+      <trans-unit id="ZW.name" resname="ZW.name" approved="yes">
+        <source>Zimbabwe</source>
+        <target>Simbabwe</target>
+      </trans-unit>
+      <trans-unit id="ZW.official_name" resname="ZW.official_name" approved="yes">
+        <source>Republic of Zimbabwe</source>
+        <target>Republik Simbabwe</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang.xlf
@@ -1,108 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/locallang.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic_partners"
-	>
-		<header/>
-		<body>
-			<!-- System Categories -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/locallang.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic_partners"
+  >
+    <header/>
+    <body>
+      <!-- System Categories -->
 
-			<trans-unit id="sys_category.partners.collaboration_type">
-				<source>Collaboration Type</source>
-				<target>Kooperationsart</target>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.partner_type">
-				<source>Partner Type</source>
-				<target>Partnerart</target>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.region">
-				<source>Region</source>
-				<target>Region</target>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.sdg">
-				<source>SDG</source>
-				<target>SDG</target>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.allOptions">
-				<source>All options</source>
-				<target>Alle Optionen</target>
-			</trans-unit>
+      <trans-unit id="sys_category.partners.collaboration_type">
+        <source>Collaboration Type</source>
+        <target>Kooperationsart</target>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.partner_type">
+        <source>Partner Type</source>
+        <target>Partnerart</target>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.region">
+        <source>Region</source>
+        <target>Region</target>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.sdg">
+        <source>SDG</source>
+        <target>SDG</target>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.allOptions">
+        <source>All options</source>
+        <target>Alle Optionen</target>
+      </trans-unit>
 
-			<!-- Detail page labels -->
+      <!-- Detail page labels -->
 
-			<trans-unit id="academic_partners.address">
-				<source>Address</source>
-				<target>Adresse</target>
-			</trans-unit>
+      <trans-unit id="academic_partners.address">
+        <source>Address</source>
+        <target>Adresse</target>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-				<target>Sortierreihenfolge</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>ascending</source>
-				<target>aufsteigend</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>descending</source>
-				<target>absteigend</target>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+        <target>Sortierreihenfolge</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>ascending</source>
+        <target>aufsteigend</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>descending</source>
+        <target>absteigend</target>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-				<target>Sortierfeld</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-				<target>Zuletzt aktualisiert</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-				<target>Sortierung</target>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+        <target>Sortierfeld</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+        <target>Zuletzt aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+        <target>Sortierung</target>
+      </trans-unit>
 
-			<!-- Combined sorting options -->
+      <!-- Combined sorting options -->
 
-			<trans-unit id="sorting.title.asc">
-				<source>Title A-Z</source>
-				<target>Titel A-Z</target>
-			</trans-unit>
-			<trans-unit id="sorting.title.desc">
-				<source>Title Z-A</source>
-				<target>Titel Z-A</target>
-			</trans-unit>
-			<trans-unit id="sorting.lastUpdated.asc">
-				<source>Last updated (latest last)</source>
-				<target>Zuletzt aktualisiert (zuletzt zuletzt)</target>
-			</trans-unit>
-			<trans-unit id="sorting.lastUpdated.desc">
-				<source>Last updated (latest first)</source>
-				<target>Zuletzt aktualisiert (zuletzt zuerst)</target>
-			</trans-unit>
-			<trans-unit id="sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnisse sind möglicherweise unerwartet)</target>
-			</trans-unit>
+      <trans-unit id="sorting.title.asc">
+        <source>Title A-Z</source>
+        <target>Titel A-Z</target>
+      </trans-unit>
+      <trans-unit id="sorting.title.desc">
+        <source>Title Z-A</source>
+        <target>Titel Z-A</target>
+      </trans-unit>
+      <trans-unit id="sorting.lastUpdated.asc">
+        <source>Last updated (latest last)</source>
+        <target>Zuletzt aktualisiert (zuletzt zuletzt)</target>
+      </trans-unit>
+      <trans-unit id="sorting.lastUpdated.desc">
+        <source>Last updated (latest first)</source>
+        <target>Zuletzt aktualisiert (zuletzt zuerst)</target>
+      </trans-unit>
+      <trans-unit id="sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnisse sind möglicherweise unerwartet)</target>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noPartnersFound">
-				<source>No partners found.</source>
-				<target>Keine Partner gefunden.</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="list.noPartnersFound">
+        <source>No partners found.</source>
+        <target>Keine Partner gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/de.locallang_be.xlf
@@ -1,317 +1,317 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/locallang_be.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic_partners"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/locallang_be.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic_partners"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_partner">
-				<source>Academic Partner</source>
-				<target>Academic Partner</target>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_partner">
+        <source>Academic Partner</source>
+        <target>Academic Partner</target>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.groups.academic">
-				<source>Academic</source>
-				<target>Academic</target>
-			</trans-unit>
-			<trans-unit id="pages.doktype.items.academic_partner">
-				<source>Partners</source>
-				<target>Partner</target>
-			</trans-unit>
+      <trans-unit id="pages.doktype.groups.academic">
+        <source>Academic</source>
+        <target>Academic</target>
+      </trans-unit>
+      <trans-unit id="pages.doktype.items.academic_partner">
+        <source>Partners</source>
+        <target>Partner</target>
+      </trans-unit>
 
-			<!-- Labels	for pages -->
+      <!-- Labels	for pages -->
 
-			<trans-unit id="pages.academic_partners">
-				<source>Partner</source>
-				<target>Partnerseite</target>
-			</trans-unit>
-			<trans-unit id="pages.div.partner_information">
-				<source>Partner</source>
-				<target>Partner</target>
-			</trans-unit>
+      <trans-unit id="pages.academic_partners">
+        <source>Partner</source>
+        <target>Partnerseite</target>
+      </trans-unit>
+      <trans-unit id="pages.div.partner_information">
+        <source>Partner</source>
+        <target>Partner</target>
+      </trans-unit>
 
 
-			<!-- Plugins -->
+      <!-- Plugins -->
 
-			<trans-unit id="plugin.partner_list.title">
-				<source>Partners List</source>
-				<target>Partnerliste</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_list.description">
-				<source>Display a sortable and filterable list of partners.</source>
-				<target>Zeigt eine sortierbare und filterbare Liste von Partnern an.</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_list.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.title">
-				<source>Partners Map</source>
-				<target>Partnerkarte</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.description">
-				<source>Display a sortable and filterable list of partners with map</source>
-				<target>Zeigt eine sortierbare und filterbare Liste von Partnern mit Karte an.</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipslist.title">
-				<source>Partnerships List</source>
-				<target>Partnerschaften als Liste</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipslist.description">
-				<source>Display a list of partners assigned to this page.</source>
-				<target>Zeigt eine Liste von Partner an, die mit dieser Seite verbunden sind.</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipsteaser.title">
-				<source>Partnerships Teaser</source>
-				<target>Partnerschaften als Teaser</target>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipsteaser.description">
-				<source>Display teasers for partners assigned to this page.</source>
-				<target>Zeigt Teaser für Partner an, die mit dieser Seite verbunden sind.</target>
-			</trans-unit>
+      <trans-unit id="plugin.partner_list.title">
+        <source>Partners List</source>
+        <target>Partnerliste</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_list.description">
+        <source>Display a sortable and filterable list of partners.</source>
+        <target>Zeigt eine sortierbare und filterbare Liste von Partnern an.</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_list.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.title">
+        <source>Partners Map</source>
+        <target>Partnerkarte</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.description">
+        <source>Display a sortable and filterable list of partners with map</source>
+        <target>Zeigt eine sortierbare und filterbare Liste von Partnern mit Karte an.</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipslist.title">
+        <source>Partnerships List</source>
+        <target>Partnerschaften als Liste</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipslist.description">
+        <source>Display a list of partners assigned to this page.</source>
+        <target>Zeigt eine Liste von Partner an, die mit dieser Seite verbunden sind.</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipsteaser.title">
+        <source>Partnerships Teaser</source>
+        <target>Partnerschaften als Teaser</target>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipsteaser.description">
+        <source>Display teasers for partners assigned to this page.</source>
+        <target>Zeigt Teaser für Partner an, die mit dieser Seite verbunden sind.</target>
+      </trans-unit>
 
-			<!-- Flexform -->
+      <!-- Flexform -->
 
-			<trans-unit id="flexform.categories.label">
-				<source>Default categories</source>
-				<target>Standardkategorien</target>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
-				<target>Die ausgewählten Kategorien des gleichen Typs (z.B. „Abschluss“) werden als Alternativen (ODER) markiert. Wenn eine Kategorie Unterkategorien hat (z.B. „Master“ mit „Master of Arts“), werden diese automatisch zur Liste der Alternativen hinzugefügt. Darüber hinaus müssen die Seiten, die für jeden Kategorietyp gefunden wurden, auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.label">
-				<source>Hide category filtering</source>
-				<target>Kategorienfilter ausblenden</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.description">
-				<source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
-				<target>Wenn die Option aktiviert ist, werden die Optionen zum Filtern nach Kategorien im Frontend nicht angezeigt.</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.label">
-				<source>Hide sorting</source>
-				<target>Sortierung ausblenden</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.description">
-				<source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
-				<target>Wenn die Option aktiviert ist, werden die Optionen zum Sortieren im Frontend nicht angezeigt.</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Default sorting</source>
-				<target>Standard-Sortierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.description">
-				<source>Default sorting in frontend (can be changed by user if sorting options are visible in the frontend).</source>
-				<target>Standardsortierung im Frontend (kann durch den Beutzer geändert werden, wenn die Sortierung im Frontend aktiviert ist.</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-				<target>Titel A-Z</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-				<target>Titel Z-A</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update">
-				<source>Last updated (latest first)</source>
-				<target>Zuletzt aktualisiert (neueste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update.asc">
-				<source>Last updated (latest last)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnisse sind möglicherweise unerwartet)</target>
-			</trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Default categories</source>
+        <target>Standardkategorien</target>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+        <target>Die ausgewählten Kategorien des gleichen Typs (z.B. „Abschluss“) werden als Alternativen (ODER) markiert. Wenn eine Kategorie Unterkategorien hat (z.B. „Master“ mit „Master of Arts“), werden diese automatisch zur Liste der Alternativen hinzugefügt. Darüber hinaus müssen die Seiten, die für jeden Kategorietyp gefunden wurden, auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.label">
+        <source>Hide category filtering</source>
+        <target>Kategorienfilter ausblenden</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.description">
+        <source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
+        <target>Wenn die Option aktiviert ist, werden die Optionen zum Filtern nach Kategorien im Frontend nicht angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.label">
+        <source>Hide sorting</source>
+        <target>Sortierung ausblenden</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.description">
+        <source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
+        <target>Wenn die Option aktiviert ist, werden die Optionen zum Sortieren im Frontend nicht angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Default sorting</source>
+        <target>Standard-Sortierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.description">
+        <source>Default sorting in frontend (can be changed by user if sorting options are visible in the frontend).</source>
+        <target>Standardsortierung im Frontend (kann durch den Beutzer geändert werden, wenn die Sortierung im Frontend aktiviert ist.</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+        <target>Titel A-Z</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+        <target>Titel Z-A</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update">
+        <source>Last updated (latest first)</source>
+        <target>Zuletzt aktualisiert (neueste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update.asc">
+        <source>Last updated (latest last)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnisse sind möglicherweise unerwartet)</target>
+      </trans-unit>
 
-			<!-- TCA tabs and  palettes -->
+      <!-- TCA tabs and  palettes -->
 
-			<trans-unit id="pages.div.partner_information">
-				<source>Partner</source>
-				<target>Partner</target>
-			</trans-unit>
-			<trans-unit id="palettes.address.label">
-				<source>Address</source>
-				<target>Adresse</target>
-			</trans-unit>
-			<trans-unit id="palettes.geocode.label">
-				<source>Geodata</source>
-				<target>Geodata</target>
-			</trans-unit>
+      <trans-unit id="pages.div.partner_information">
+        <source>Partner</source>
+        <target>Partner</target>
+      </trans-unit>
+      <trans-unit id="palettes.address.label">
+        <source>Address</source>
+        <target>Adresse</target>
+      </trans-unit>
+      <trans-unit id="palettes.geocode.label">
+        <source>Geodata</source>
+        <target>Geodata</target>
+      </trans-unit>
 
-			<!-- TCA Columns -->
+      <!-- TCA Columns -->
 
-			<trans-unit id="columns.address_additional.label">
-				<source>Additional</source>
-				<target>Adresszusatz</target>
-			</trans-unit>
-			<trans-unit id="columns.address_city.label">
-				<source>City</source>
-				<target>Stadt</target>
-			</trans-unit>
-			<trans-unit id="columns.address_city.description">
-				<source>A valid city name is required for geocoding.</source>
-				<target>Ein gültiger Städtename ist für des Geocoding erforderlich.</target>
-			</trans-unit>
-			<trans-unit id="columns.address_country.label">
-				<source>Country</source>
-				<target>Land</target>
-			</trans-unit>
-			<trans-unit id="columns.address_country.description">
-				<source>A valid country is required for geocoding.</source>
-				<target>Ein gültiges Land ist für des Geocoding erforderlich.</target>
-			</trans-unit>
-			<trans-unit id="columns.address_street.label">
-				<source>Street</source>
-				<target>Straße</target>
-			</trans-unit>
-			<trans-unit id="columns.address_street.description">
-				<source>A valid street name is required for geocoding.</source>
-				<target>Ein gültiger Straßenname ist für des Geocoding erforderlich.</target>
-			</trans-unit>
-			<trans-unit id="columns.address_street_number.label">
-				<source>Street Number</source>
-				<target>Hausnummer</target>
-			</trans-unit>
-			<trans-unit id="columns.address_street_number.description">
-				<source>A valid street number is required for geocoding.</source>
-				<target>Eine gültige Hausnummer ist für des Geocoding erforderlich.</target>
-			</trans-unit>
-			<trans-unit id="columns.address_zip.label">
-				<source>Zip</source>
-				<target>Postleitzahl</target>
-			</trans-unit>
-			<trans-unit id="columns.address_zip.description">
-				<source>A valid zip code is required for geocoding.</source>
-				<target>Eine gültige Postleitzahl ist für des Geocoding erforderlich.</target>
-			</trans-unit>
-			<trans-unit id="columns.description.label">
-				<source>Description</source>
-				<target>Beschreibung</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_last_run.label">
-				<source>Geocoded on</source>
-				<target>Geocoded am</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_latitude.label">
-				<source>Latitude</source>
-				<target>Breitengrad</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_longitude.label">
-				<source>Longitude</source>
-				<target>Längengrad</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_message.label">
-				<source>Geocode Message</source>
-				<target>Geocode-Nachricht</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.label">
-				<source>Geocode Status</source>
-				<target>Geocode-Status</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.open.label">
-				<source>open</source>
-				<target>offen</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.successful.label">
-				<source>successful</source>
-				<target>erfolgreich</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.failed.label">
-				<source>failed</source>
-				<target>fehlgeschlagen</target>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.manually.label">
-				<source>manually</source>
-				<target>manuell</target>
-			</trans-unit>
-			<trans-unit id="columns.link.label">
-				<source>Link to Website</source>
-				<target>Link zur Webseite</target>
-			</trans-unit>
-			<trans-unit id="columns.name.label">
-				<source>Name</source>
-				<target>Name</target>
-			</trans-unit>
-			<trans-unit id="columns.abbreviation.label">
-				<source>Abbreviation</source>
-				<target>Abkürzung</target>
-			</trans-unit>
-			<trans-unit id="columns.show_on_map.label">
-				<source>Show on map</source>
-				<target>Auf Karte zeigen</target>
-			</trans-unit>
-			<trans-unit id="columns.tx_academicpartners_partnerships.label">
-				<source>Partnerships</source>
-				<target>Partnerschaften</target>
-			</trans-unit>
+      <trans-unit id="columns.address_additional.label">
+        <source>Additional</source>
+        <target>Adresszusatz</target>
+      </trans-unit>
+      <trans-unit id="columns.address_city.label">
+        <source>City</source>
+        <target>Stadt</target>
+      </trans-unit>
+      <trans-unit id="columns.address_city.description">
+        <source>A valid city name is required for geocoding.</source>
+        <target>Ein gültiger Städtename ist für des Geocoding erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="columns.address_country.label">
+        <source>Country</source>
+        <target>Land</target>
+      </trans-unit>
+      <trans-unit id="columns.address_country.description">
+        <source>A valid country is required for geocoding.</source>
+        <target>Ein gültiges Land ist für des Geocoding erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="columns.address_street.label">
+        <source>Street</source>
+        <target>Straße</target>
+      </trans-unit>
+      <trans-unit id="columns.address_street.description">
+        <source>A valid street name is required for geocoding.</source>
+        <target>Ein gültiger Straßenname ist für des Geocoding erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="columns.address_street_number.label">
+        <source>Street Number</source>
+        <target>Hausnummer</target>
+      </trans-unit>
+      <trans-unit id="columns.address_street_number.description">
+        <source>A valid street number is required for geocoding.</source>
+        <target>Eine gültige Hausnummer ist für des Geocoding erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="columns.address_zip.label">
+        <source>Zip</source>
+        <target>Postleitzahl</target>
+      </trans-unit>
+      <trans-unit id="columns.address_zip.description">
+        <source>A valid zip code is required for geocoding.</source>
+        <target>Eine gültige Postleitzahl ist für des Geocoding erforderlich.</target>
+      </trans-unit>
+      <trans-unit id="columns.description.label">
+        <source>Description</source>
+        <target>Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_last_run.label">
+        <source>Geocoded on</source>
+        <target>Geocoded am</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_latitude.label">
+        <source>Latitude</source>
+        <target>Breitengrad</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_longitude.label">
+        <source>Longitude</source>
+        <target>Längengrad</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_message.label">
+        <source>Geocode Message</source>
+        <target>Geocode-Nachricht</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.label">
+        <source>Geocode Status</source>
+        <target>Geocode-Status</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.open.label">
+        <source>open</source>
+        <target>offen</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.successful.label">
+        <source>successful</source>
+        <target>erfolgreich</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.failed.label">
+        <source>failed</source>
+        <target>fehlgeschlagen</target>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.manually.label">
+        <source>manually</source>
+        <target>manuell</target>
+      </trans-unit>
+      <trans-unit id="columns.link.label">
+        <source>Link to Website</source>
+        <target>Link zur Webseite</target>
+      </trans-unit>
+      <trans-unit id="columns.name.label">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="columns.abbreviation.label">
+        <source>Abbreviation</source>
+        <target>Abkürzung</target>
+      </trans-unit>
+      <trans-unit id="columns.show_on_map.label">
+        <source>Show on map</source>
+        <target>Auf Karte zeigen</target>
+      </trans-unit>
+      <trans-unit id="columns.tx_academicpartners_partnerships.label">
+        <source>Partnerships</source>
+        <target>Partnerschaften</target>
+      </trans-unit>
 
-			<!-- Partnership table: TCA columns -->
+      <!-- Partnership table: TCA columns -->
 
-			<trans-unit id="tx_academicpartners_domain_model_partnership">
-				<source>Partnership</source>
-				<target>Partnerschaft</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
-				<source>Create new linked page</source>
-				<target>Neue verlinkte Seite anlegen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.page">
-				<source>Page</source>
-				<target>Seite</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.partner">
-				<source>Partner</source>
-				<target>Partner</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.role">
-				<source>Role</source>
-				<target>Rolle</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership">
+        <source>Partnership</source>
+        <target>Partnerschaft</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
+        <source>Create new linked page</source>
+        <target>Neue verlinkte Seite anlegen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.page">
+        <source>Page</source>
+        <target>Seite</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.partner">
+        <source>Partner</source>
+        <target>Partner</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.role">
+        <source>Role</source>
+        <target>Rolle</target>
+      </trans-unit>
 
-			<!-- Role table: TCA columns -->
+      <!-- Role table: TCA columns -->
 
-			<trans-unit id="tx_academicpartners_domain_model_role">
-				<source>Role</source>
-				<target>Rolle</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.name">
-				<source>Name</source>
-				<target>Name</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.description">
-				<source>Description</source>
-				<target>Beschreibung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.doktypes">
-				<source>Page types</source>
-				<target>Seitentypen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.partnerships">
-				<source>Partnerships</source>
-				<target>Partnerschaften</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicpartners_domain_model_role">
+        <source>Role</source>
+        <target>Rolle</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.name">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.description">
+        <source>Description</source>
+        <target>Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.doktypes">
+        <source>Page types</source>
+        <target>Seitentypen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.partnerships">
+        <source>Partnerships</source>
+        <target>Partnerschaften</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/locallang.xlf
@@ -1,88 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/locallang.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic-partners"
-	>
-		<header/>
-		<body>
-			<!-- System Categories -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/locallang.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic-partners"
+  >
+    <header/>
+    <body>
+      <!-- System Categories -->
 
-			<trans-unit id="sys_category.partners.collaboration_type">
-				<source>Collaboration Type</source>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.partner_type">
-				<source>Partner Type</source>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.region">
-				<source>Region</source>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.sdg">
-				<source>SDG</source>
-			</trans-unit>
-			<trans-unit id="sys_category.partners.allOptions">
-				<source>All options</source>
-			</trans-unit>
+      <trans-unit id="sys_category.partners.collaboration_type">
+        <source>Collaboration Type</source>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.partner_type">
+        <source>Partner Type</source>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.region">
+        <source>Region</source>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.sdg">
+        <source>SDG</source>
+      </trans-unit>
+      <trans-unit id="sys_category.partners.allOptions">
+        <source>All options</source>
+      </trans-unit>
 
-			<!-- Detail page labels -->
+      <!-- Detail page labels -->
 
-			<trans-unit id="academic_partners.address">
-				<source>Address</source>
-			</trans-unit>
+      <trans-unit id="academic_partners.address">
+        <source>Address</source>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>ascending</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>descending</source>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>ascending</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>descending</source>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+      </trans-unit>
 
-			<!-- Combined sorting options -->
+      <!-- Combined sorting options -->
 
-			<trans-unit id="sorting.title.asc">
-				<source>Title A-Z</source>
-			</trans-unit>
-			<trans-unit id="sorting.title.desc">
-				<source>Title Z-A</source>
-			</trans-unit>
-			<trans-unit id="sorting.lastUpdated.asc">
-				<source>Last updated (latest last)</source>
-			</trans-unit>
-			<trans-unit id="sorting.lastUpdated.desc">
-				<source>Last updated (latest first)</source>
-			</trans-unit>
-			<trans-unit id="sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-			</trans-unit>
+      <trans-unit id="sorting.title.asc">
+        <source>Title A-Z</source>
+      </trans-unit>
+      <trans-unit id="sorting.title.desc">
+        <source>Title Z-A</source>
+      </trans-unit>
+      <trans-unit id="sorting.lastUpdated.asc">
+        <source>Last updated (latest last)</source>
+      </trans-unit>
+      <trans-unit id="sorting.lastUpdated.desc">
+        <source>Last updated (latest first)</source>
+      </trans-unit>
+      <trans-unit id="sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noPartnersFound">
-				<source>No partners found.</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="list.noPartnersFound">
+        <source>No partners found.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-partners/Resources/Private/Language/locallang_be.xlf
@@ -1,248 +1,248 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_partners/Resources/Private/Language/locallang_be.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic-partners"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_partners/Resources/Private/Language/locallang_be.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic-partners"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_partner">
-				<source>Academic Partner</source>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_partner">
+        <source>Academic Partner</source>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.groups.academic">
-				<source>Academic</source>
-			</trans-unit>
-			<trans-unit id="pages.doktype.items.academic_partner">
-				<source>Partner</source>
-			</trans-unit>
+      <trans-unit id="pages.doktype.groups.academic">
+        <source>Academic</source>
+      </trans-unit>
+      <trans-unit id="pages.doktype.items.academic_partner">
+        <source>Partner</source>
+      </trans-unit>
 
-			<!-- Labels	for pages -->
+      <!-- Labels	for pages -->
 
-			<trans-unit id="pages.academic_partners">
-				<source>Partner</source>
-			</trans-unit>
-			<trans-unit id="pages.div.partner_information">
-				<source>Partner</source>
-			</trans-unit>
+      <trans-unit id="pages.academic_partners">
+        <source>Partner</source>
+      </trans-unit>
+      <trans-unit id="pages.div.partner_information">
+        <source>Partner</source>
+      </trans-unit>
 
 
-			<!-- Plugins -->
+      <!-- Plugins -->
 
-			<trans-unit id="plugin.partner_list.title">
-				<source>Partners List</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_list.description">
-				<source>Display a sortable and filterable list of partners.</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_list.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.title">
-				<source>Partners Map</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.description">
-				<source>Display a sortable and filterable list of partners with map.</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_map.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipslist.title">
-				<source>Partnerships List</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipslist.description">
-				<source>Display a list of partners assigned to this page.</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipsteaser.title">
-				<source>Partnerships Teaser</source>
-			</trans-unit>
-			<trans-unit id="plugin.partner_partnershipsteaser.description">
-				<source>Display teasers for partners assigned to this page.</source>
-			</trans-unit>
+      <trans-unit id="plugin.partner_list.title">
+        <source>Partners List</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_list.description">
+        <source>Display a sortable and filterable list of partners.</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_list.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.title">
+        <source>Partners Map</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.description">
+        <source>Display a sortable and filterable list of partners with map.</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_map.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipslist.title">
+        <source>Partnerships List</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipslist.description">
+        <source>Display a list of partners assigned to this page.</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipsteaser.title">
+        <source>Partnerships Teaser</source>
+      </trans-unit>
+      <trans-unit id="plugin.partner_partnershipsteaser.description">
+        <source>Display teasers for partners assigned to this page.</source>
+      </trans-unit>
 
-			<!-- Flexform -->
+      <!-- Flexform -->
 
-			<trans-unit id="flexform.categories.label">
-				<source>Default categories</source>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.label">
-				<source>Hide category filtering</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.description">
-				<source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.label">
-				<source>Hide sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.description">
-				<source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Default sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.description">
-				<source>Default sorting in frontend (can be changed by user if sorting options are visible in the frontend).</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update">
-				<source>Last updated (latest first)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update.asc">
-				<source>Last updated (latest last)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (result may be unexpected)</source>
-			</trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Default categories</source>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.label">
+        <source>Hide category filtering</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.description">
+        <source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.label">
+        <source>Hide sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.description">
+        <source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Default sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.description">
+        <source>Default sorting in frontend (can be changed by user if sorting options are visible in the frontend).</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update">
+        <source>Last updated (latest first)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update.asc">
+        <source>Last updated (latest last)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (result may be unexpected)</source>
+      </trans-unit>
 
-			<!-- Pages table: TCA tabs and palettes -->
+      <!-- Pages table: TCA tabs and palettes -->
 
-			<trans-unit id="pages.div.partner_information">
-				<source>Partner</source>
-			</trans-unit>
-			<trans-unit id="palettes.address.label">
-				<source>Address</source>
-			</trans-unit>
-			<trans-unit id="palettes.geocode.label">
-				<source>Geodata</source>
-			</trans-unit>
+      <trans-unit id="pages.div.partner_information">
+        <source>Partner</source>
+      </trans-unit>
+      <trans-unit id="palettes.address.label">
+        <source>Address</source>
+      </trans-unit>
+      <trans-unit id="palettes.geocode.label">
+        <source>Geodata</source>
+      </trans-unit>
 
-			<!-- Pages table: TCA columns -->
+      <!-- Pages table: TCA columns -->
 
-			<trans-unit id="columns.address_additional.label">
-				<source>Additional</source>
-			</trans-unit>
-			<trans-unit id="columns.address_city.label">
-				<source>City</source>
-			</trans-unit>
-			<trans-unit id="columns.address_city.description">
-				<source>A valid city name is required for geocoding.</source>
-			</trans-unit>
-			<trans-unit id="columns.address_country.label">
-				<source>Country</source>
-			</trans-unit>
-			<trans-unit id="columns.address_country.description">
-				<source>A valid country is required for geocoding.</source>
-			</trans-unit>
-			<trans-unit id="columns.address_street.label">
-				<source>Street</source>
-			</trans-unit>
-			<trans-unit id="columns.address_street.description">
-				<source>A valid street name is required for geocoding.</source>
-			</trans-unit>
-			<trans-unit id="columns.address_street_number.label">
-				<source>Street Number</source>
-			</trans-unit>
-			<trans-unit id="columns.address_street_number.description">
-				<source>A valid street number is required for geocoding.</source>
-			</trans-unit>
-			<trans-unit id="columns.address_zip.label">
-				<source>Zip</source>
-			</trans-unit>
-			<trans-unit id="columns.address_zip.description">
-				<source>A valid zip code is required for geocoding.</source>
-			</trans-unit>
-			<trans-unit id="columns.description.label">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_last_run.label">
-				<source>Geocoded on</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_latitude.label">
-				<source>Latitude</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_longitude.label">
-				<source>Longitude</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_message.label">
-				<source>Geocode Message</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.label">
-				<source>Geocode Status</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.open.label">
-				<source>open</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.successful.label">
-				<source>successful</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.failed.label">
-				<source>failed</source>
-			</trans-unit>
-			<trans-unit id="columns.geocode_status.I.manually.label">
-				<source>manually</source>
-			</trans-unit>
-			<trans-unit id="columns.link.label">
-				<source>Link to Website</source>
-			</trans-unit>
-			<trans-unit id="columns.name.label">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="columns.abbreviation.label">
-				<source>Abbreviation</source>
-			</trans-unit>
-			<trans-unit id="columns.show_on_map.label">
-				<source>Show on map</source>
-			</trans-unit>
-			<trans-unit id="columns.tx_academicpartners_partnerships.label">
-				<source>Partnerships</source>
-			</trans-unit>
+      <trans-unit id="columns.address_additional.label">
+        <source>Additional</source>
+      </trans-unit>
+      <trans-unit id="columns.address_city.label">
+        <source>City</source>
+      </trans-unit>
+      <trans-unit id="columns.address_city.description">
+        <source>A valid city name is required for geocoding.</source>
+      </trans-unit>
+      <trans-unit id="columns.address_country.label">
+        <source>Country</source>
+      </trans-unit>
+      <trans-unit id="columns.address_country.description">
+        <source>A valid country is required for geocoding.</source>
+      </trans-unit>
+      <trans-unit id="columns.address_street.label">
+        <source>Street</source>
+      </trans-unit>
+      <trans-unit id="columns.address_street.description">
+        <source>A valid street name is required for geocoding.</source>
+      </trans-unit>
+      <trans-unit id="columns.address_street_number.label">
+        <source>Street Number</source>
+      </trans-unit>
+      <trans-unit id="columns.address_street_number.description">
+        <source>A valid street number is required for geocoding.</source>
+      </trans-unit>
+      <trans-unit id="columns.address_zip.label">
+        <source>Zip</source>
+      </trans-unit>
+      <trans-unit id="columns.address_zip.description">
+        <source>A valid zip code is required for geocoding.</source>
+      </trans-unit>
+      <trans-unit id="columns.description.label">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_last_run.label">
+        <source>Geocoded on</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_latitude.label">
+        <source>Latitude</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_longitude.label">
+        <source>Longitude</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_message.label">
+        <source>Geocode Message</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.label">
+        <source>Geocode Status</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.open.label">
+        <source>open</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.successful.label">
+        <source>successful</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.failed.label">
+        <source>failed</source>
+      </trans-unit>
+      <trans-unit id="columns.geocode_status.I.manually.label">
+        <source>manually</source>
+      </trans-unit>
+      <trans-unit id="columns.link.label">
+        <source>Link to Website</source>
+      </trans-unit>
+      <trans-unit id="columns.name.label">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="columns.abbreviation.label">
+        <source>Abbreviation</source>
+      </trans-unit>
+      <trans-unit id="columns.show_on_map.label">
+        <source>Show on map</source>
+      </trans-unit>
+      <trans-unit id="columns.tx_academicpartners_partnerships.label">
+        <source>Partnerships</source>
+      </trans-unit>
 
-			<!-- Partnership table: TCA columns -->
+      <!-- Partnership table: TCA columns -->
 
-			<trans-unit id="tx_academicpartners_domain_model_partnership">
-				<source>Partnership</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
-				<source>Create new linked page</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.page">
-				<source>Page</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.partner">
-				<source>Partner</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_partnership.role">
-				<source>Role</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership">
+        <source>Partnership</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.tx_academicpartners_domain_model_partnership.button">
+        <source>Create new linked page</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.page">
+        <source>Page</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.partner">
+        <source>Partner</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_partnership.role">
+        <source>Role</source>
+      </trans-unit>
 
-			<!-- Role table: TCA columns -->
+      <!-- Role table: TCA columns -->
 
-			<trans-unit id="tx_academicpartners_domain_model_role">
-				<source>Role</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.name">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.description">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.doktypes">
-				<source>Page types</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpartners_domain_model_role.partnerships">
-				<source>Partnerships</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicpartners_domain_model_role">
+        <source>Role</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.name">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.description">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.doktypes">
+        <source>Page types</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpartners_domain_model_role.partnerships">
+        <source>Partnerships</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-edit/.editorconfig
+++ b/packages/fgtclb/academic-persons-edit/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
@@ -1,888 +1,888 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons_edit/Resources/Private/Language/locallang.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_edit"
-	>
-		<header/>
-		<body>
-			<trans-unit id="back">
-				<source>back</source>
-				<target>zurück</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons_edit/Resources/Private/Language/locallang.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_edit"
+  >
+    <header/>
+    <body>
+      <trans-unit id="back">
+        <source>back</source>
+        <target>zurück</target>
+      </trans-unit>
 
-			<!-- Table headers -->
+      <!-- Table headers -->
 
-			<trans-unit id="list.profile.assigned">
-				<source>Assigned profiles</source>
-				<target>Zugewiesene Profile</target>
-			</trans-unit>
-			<trans-unit id="list.profile">
-				<source>Profile</source>
-				<target>Profil</target>
-			</trans-unit>
-			<trans-unit id="list.profileInformations.year">
-				<source>Year</source>
-				<target>Jahr</target>
-			</trans-unit>
-			<trans-unit id="list.profileInformations.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="list.contract.position">
-				<source>Position</source>
-				<target>Position</target>
-			</trans-unit>
-			<trans-unit id="list.actions">
-				<source>Actions</source>
-				<target>Aktionen</target>
-			</trans-unit>
-			<trans-unit id="list.hidden.badge">
-				<source>Hidden</source>
-				<target>Ausgeblendet</target>
-			</trans-unit>
+      <trans-unit id="list.profile.assigned">
+        <source>Assigned profiles</source>
+        <target>Zugewiesene Profile</target>
+      </trans-unit>
+      <trans-unit id="list.profile">
+        <source>Profile</source>
+        <target>Profil</target>
+      </trans-unit>
+      <trans-unit id="list.profileInformations.year">
+        <source>Year</source>
+        <target>Jahr</target>
+      </trans-unit>
+      <trans-unit id="list.profileInformations.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="list.contract.position">
+        <source>Position</source>
+        <target>Position</target>
+      </trans-unit>
+      <trans-unit id="list.actions">
+        <source>Actions</source>
+        <target>Aktionen</target>
+      </trans-unit>
+      <trans-unit id="list.hidden.badge">
+        <source>Hidden</source>
+        <target>Ausgeblendet</target>
+      </trans-unit>
 
-			<!-- No items found messages -->
+      <!-- No items found messages -->
 
-			<trans-unit id="list.noProfilesFound">
-				<source>No profiles found.</source>
-				<target>Keine Profile gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noContractsFound">
-				<source>No contracts found.</source>
-				<target>Keine Verträge gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.nolecturesFound">
-				<source>No lectures found.</source>
-				<target>Keine Vorlesungen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.nomembershipsFound">
-				<source>No memberships found.</source>
-				<target>Keine Mitgliedschaften gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.nopressMediaFound">
-				<source>No press media found.</source>
-				<target>Keine Pressemitteilungen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.nopublicationsFound">
-				<source>No publications found.</source>
-				<target>Keine Publikationen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noscientificResearchFound">
-				<source>No scientific research found.</source>
-				<target>Keine wissenschaftlichen Forschungen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.novitaFound">
-				<source>No vita found.</source>
-				<target>Keine Vita gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noPhysicalAddressesFound">
-				<source>No physical addresses found.</source>
-				<target>Keine physischen Adressen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noEmailAddressesFound">
-				<source>No email addresses found.</source>
-				<target>Keine E-Mail-Adressen gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noPhoneNumbersFound">
-				<source>No phone numbers found.</source>
-				<target>Keine Telefonnummern gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noTranslationFound">
-				<source>No translation found.</source>
-				<target>Keine Übersetzung gefunden.</target>
-			</trans-unit>
+      <trans-unit id="list.noProfilesFound">
+        <source>No profiles found.</source>
+        <target>Keine Profile gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noContractsFound">
+        <source>No contracts found.</source>
+        <target>Keine Verträge gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.nolecturesFound">
+        <source>No lectures found.</source>
+        <target>Keine Vorlesungen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.nomembershipsFound">
+        <source>No memberships found.</source>
+        <target>Keine Mitgliedschaften gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.nopressMediaFound">
+        <source>No press media found.</source>
+        <target>Keine Pressemitteilungen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.nopublicationsFound">
+        <source>No publications found.</source>
+        <target>Keine Publikationen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noscientificResearchFound">
+        <source>No scientific research found.</source>
+        <target>Keine wissenschaftlichen Forschungen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.novitaFound">
+        <source>No vita found.</source>
+        <target>Keine Vita gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noPhysicalAddressesFound">
+        <source>No physical addresses found.</source>
+        <target>Keine physischen Adressen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noEmailAddressesFound">
+        <source>No email addresses found.</source>
+        <target>Keine E-Mail-Adressen gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noPhoneNumbersFound">
+        <source>No phone numbers found.</source>
+        <target>Keine Telefonnummern gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noTranslationFound">
+        <source>No translation found.</source>
+        <target>Keine Übersetzung gefunden.</target>
+      </trans-unit>
 
-			<!-- Show profile headers -->
+      <!-- Show profile headers -->
 
-			<trans-unit id="profile.image">
-				<source>Image</source>
-				<target>Bild</target>
-			</trans-unit>
-			<trans-unit id="profile.personal">
-				<source>Personal data</source>
-				<target>Persönliche Daten</target>
-			</trans-unit>
-			<trans-unit id="profile.contracts">
-				<source>Contracts</source>
-				<target>Verträge</target>
-			</trans-unit>
-			<trans-unit id="profile.cooperation">
-				<source>Cooperations</source>
-				<target>Kooperationen</target>
-			</trans-unit>
-			<trans-unit id="profile.lectures">
-				<source>Lectures</source>
-				<target>Vorlesungen</target>
-			</trans-unit>
-			<trans-unit id="profile.memberships">
-				<source>Memberships</source>
-				<target>Mitgliedschaften</target>
-			</trans-unit>
-			<trans-unit id="profile.pressMedia">
-				<source>Press media</source>
-				<target>Pressemitteilungen</target>
-			</trans-unit>
-			<trans-unit id="profile.publications">
-				<source>Publications</source>
-				<target>Publikationen</target>
-			</trans-unit>
-			<trans-unit id="profile.scientificResearch">
-				<source>Scientific research</source>
-				<target>Wissenschaftliche Forschungen</target>
-			</trans-unit>
-			<trans-unit id="profile.vita">
-				<source>Vita</source>
-				<target>Vita</target>
-			</trans-unit>
+      <trans-unit id="profile.image">
+        <source>Image</source>
+        <target>Bild</target>
+      </trans-unit>
+      <trans-unit id="profile.personal">
+        <source>Personal data</source>
+        <target>Persönliche Daten</target>
+      </trans-unit>
+      <trans-unit id="profile.contracts">
+        <source>Contracts</source>
+        <target>Verträge</target>
+      </trans-unit>
+      <trans-unit id="profile.cooperation">
+        <source>Cooperations</source>
+        <target>Kooperationen</target>
+      </trans-unit>
+      <trans-unit id="profile.lectures">
+        <source>Lectures</source>
+        <target>Vorlesungen</target>
+      </trans-unit>
+      <trans-unit id="profile.memberships">
+        <source>Memberships</source>
+        <target>Mitgliedschaften</target>
+      </trans-unit>
+      <trans-unit id="profile.pressMedia">
+        <source>Press media</source>
+        <target>Pressemitteilungen</target>
+      </trans-unit>
+      <trans-unit id="profile.publications">
+        <source>Publications</source>
+        <target>Publikationen</target>
+      </trans-unit>
+      <trans-unit id="profile.scientificResearch">
+        <source>Scientific research</source>
+        <target>Wissenschaftliche Forschungen</target>
+      </trans-unit>
+      <trans-unit id="profile.vita">
+        <source>Vita</source>
+        <target>Vita</target>
+      </trans-unit>
 
-			<!-- Show profile information headers-->
+      <!-- Show profile information headers-->
 
-			<trans-unit id="profile.profileInformations.cooperation">
-				<source>Cooperation</source>
-				<target>Kooperation</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.lectures">
-				<source>Lecture</source>
-				<target>Vorlesung</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.memberships">
-				<source>Membership</source>
-				<target>Mitgliedschaft</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.pressMedia">
-				<source>Press media</source>
-				<target>Pressemitteilung</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.publications">
-				<source>Publication</source>
-				<target>Publikation</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.scientificResearch">
-				<source>Scientific research</source>
-				<target>Wissenschaftliche Forschung</target>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.vita">
-				<source>Vita</source>
-				<target>Vita</target>
-			</trans-unit>
+      <trans-unit id="profile.profileInformations.cooperation">
+        <source>Cooperation</source>
+        <target>Kooperation</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.lectures">
+        <source>Lecture</source>
+        <target>Vorlesung</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.memberships">
+        <source>Membership</source>
+        <target>Mitgliedschaft</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.pressMedia">
+        <source>Press media</source>
+        <target>Pressemitteilung</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.publications">
+        <source>Publication</source>
+        <target>Publikation</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.scientificResearch">
+        <source>Scientific research</source>
+        <target>Wissenschaftliche Forschung</target>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.vita">
+        <source>Vita</source>
+        <target>Vita</target>
+      </trans-unit>
 
-			<!-- Show contract headers -->
+      <!-- Show contract headers -->
 
-			<trans-unit id="contract.data">
-				<source>Contract data</source>
-				<target>Vertragsdaten</target>
-			</trans-unit>
-			<trans-unit id="contract.physicalAddresses">
-				<source>Physical addresses</source>
-				<target>Physische Adressen</target>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses">
-				<source>Email addresses</source>
-				<target>Email-Adressen</target>
-			</trans-unit>
-			<trans-unit id="contract.phoneNumbers">
-				<source>Phone numbers</source>
-				<target>Telefonnummern</target>
-			</trans-unit>
-			<trans-unit id="contract">
-				<source>Contract</source>
-				<target>Vertrag</target>
-			</trans-unit>
-			<trans-unit id="contract.physicalAddress">
-				<source>Physical address</source>
-				<target>Physische Adresse</target>
-			</trans-unit>
-			<trans-unit id="contract.emailAddress">
-				<source>Email address</source>
-				<target>Email-Adresse</target>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses.email">
-				<source>Email</source>
-				<target>E-Mail</target>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses.type">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="contract.phoneNumber">
-				<source>Phone number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
+      <trans-unit id="contract.data">
+        <source>Contract data</source>
+        <target>Vertragsdaten</target>
+      </trans-unit>
+      <trans-unit id="contract.physicalAddresses">
+        <source>Physical addresses</source>
+        <target>Physische Adressen</target>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses">
+        <source>Email addresses</source>
+        <target>Email-Adressen</target>
+      </trans-unit>
+      <trans-unit id="contract.phoneNumbers">
+        <source>Phone numbers</source>
+        <target>Telefonnummern</target>
+      </trans-unit>
+      <trans-unit id="contract">
+        <source>Contract</source>
+        <target>Vertrag</target>
+      </trans-unit>
+      <trans-unit id="contract.physicalAddress">
+        <source>Physical address</source>
+        <target>Physische Adresse</target>
+      </trans-unit>
+      <trans-unit id="contract.emailAddress">
+        <source>Email address</source>
+        <target>Email-Adresse</target>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses.email">
+        <source>Email</source>
+        <target>E-Mail</target>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses.type">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="contract.phoneNumber">
+        <source>Phone number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
 
-			<!-- Profile fields -->
+      <!-- Profile fields -->
 
-			<trans-unit id="profile.gender.label">
-				<source>Gender</source>
-				<target>Geschlecht</target>
-			</trans-unit>
-			<trans-unit id="profile.title.label">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="profile.title.placeholder">
-				<source>Prof.</source>
-				<target>Prof.</target>
-			</trans-unit>
-			<trans-unit id="profile.name.label">
-				<source>Name</source>
-				<target>Name</target>
-			</trans-unit>
-			<trans-unit id="profile.firstName.label">
-				<source>First name</source>
-				<target>Vorname</target>
-			</trans-unit>
-			<trans-unit id="profile.firstName.placeholder">
-				<source>John</source>
-				<target>Max</target>
-			</trans-unit>
-			<trans-unit id="profile.middleName.label">
-				<source>Middle name</source>
-				<target>Zweiter Vorname</target>
-			</trans-unit>
-			<trans-unit id="profile.middleName.placeholder">
-				<source>Paul</source>
-				<target>Moritz</target>
-			</trans-unit>
-			<trans-unit id="profile.lastName.label">
-				<source>Last name</source>
-				<target>Nachname</target>
-			</trans-unit>
-			<trans-unit id="profile.lastName.placeholder">
-				<source>Doe</source>
-				<target>Mustermann</target>
-			</trans-unit>
-			<trans-unit id="profile.website.label">
-				<source>Website</source>
-				<target>Webseite</target>
-			</trans-unit>
-			<trans-unit id="profile.website.placeholder">
-				<source>https://www.example.com</source>
-				<target>https://www.beispiel.de</target>
-			</trans-unit>
-			<trans-unit id="profile.websiteTitle.label">
-				<source>Website title</source>
-				<target>Webseitentitel</target>
-			</trans-unit>
-			<trans-unit id="profile.websiteTitle.placeholder">
-				<source>My personal website</source>
-				<target>Meine persönliche Webseite</target>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLink.label">
-				<source>Publications link</source>
-				<target>Publikationslink</target>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLink.placeholder">
-				<source>https://www.publications.com</source>
-				<target>https://www.publikationen.de</target>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLinkTitle.label">
-				<source>Publications link title</source>
-				<target>Publikationslink Titel</target>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLinkTitle.placeholder">
-				<source>My publications</source>
-				<target>Meine Publikationen</target>
-			</trans-unit>
-			<trans-unit id="profile.teachingArea.label">
-				<source>Teaching area</source>
-				<target>Lehrgebiet</target>
-			</trans-unit>
-			<trans-unit id="profile.teachingArea.placeholder">
-				<source>e.g. Computer Science</source>
-				<target>z.B. Informatik</target>
-			</trans-unit>
-			<trans-unit id="profile.coreCompetences.label">
-				<source>Core competences</source>
-				<target>Kernkompetenzen</target>
-			</trans-unit>
-			<trans-unit id="profile.coreCompetences.placeholder">
-				<source>e.g. Software Development, Data Science</source>
-				<target>z.B. Softwareentwicklung, Datenwissenschaft</target>
-			</trans-unit>
-			<trans-unit id="profile.supervisedThesis.label">
-				<source>Supervises thesis</source>
-				<target>Betreute Abschlussarbeiten</target>
-			</trans-unit>
-			<trans-unit id="profile.supervisedThesis.placeholder">
-				<source>e.g. Bachelor, Master</source>
-				<target>z.B. Bachelor, Master</target>
-			</trans-unit>
-			<trans-unit id="profile.supervisedDoctoralThesis.label">
-				<source>Supervises doctoral thesis</source>
-				<target>Betreute Doktorarbeiten</target>
-			</trans-unit>
-			<trans-unit id="profile.supervisedDoctoralThesis.placeholder">
-				<source>e.g. PhD, Doctorate</source>
-				<target>z.B. Doktorarbeit, Promotion</target>
-			</trans-unit>
-			<trans-unit id="profile.miscellaneous.label">
-				<source>Miscellaneous</source>
-				<target>Verschiedenes</target>
-			</trans-unit>
-			<trans-unit id="profile.miscellaneous.placeholder">
-				<source>e.g. Hobbies, Interests</source>
-				<target>z.B. Hobbys, Interessen</target>
-			</trans-unit>
-			<trans-unit id="profile.skipSync.label">
-				<source>Disable profile sync</source>
-				<target>Profil-Synchronisation deaktivieren</target>
-			</trans-unit>
-			<trans-unit id="profile.skipSync.description">
-				<source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
-				<target>Die Deaktivierung der Profil-Synchronisation verhindert automatische Aktualisierungen aus externen Quellen.</target>
-			</trans-unit>
+      <trans-unit id="profile.gender.label">
+        <source>Gender</source>
+        <target>Geschlecht</target>
+      </trans-unit>
+      <trans-unit id="profile.title.label">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="profile.title.placeholder">
+        <source>Prof.</source>
+        <target>Prof.</target>
+      </trans-unit>
+      <trans-unit id="profile.name.label">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="profile.firstName.label">
+        <source>First name</source>
+        <target>Vorname</target>
+      </trans-unit>
+      <trans-unit id="profile.firstName.placeholder">
+        <source>John</source>
+        <target>Max</target>
+      </trans-unit>
+      <trans-unit id="profile.middleName.label">
+        <source>Middle name</source>
+        <target>Zweiter Vorname</target>
+      </trans-unit>
+      <trans-unit id="profile.middleName.placeholder">
+        <source>Paul</source>
+        <target>Moritz</target>
+      </trans-unit>
+      <trans-unit id="profile.lastName.label">
+        <source>Last name</source>
+        <target>Nachname</target>
+      </trans-unit>
+      <trans-unit id="profile.lastName.placeholder">
+        <source>Doe</source>
+        <target>Mustermann</target>
+      </trans-unit>
+      <trans-unit id="profile.website.label">
+        <source>Website</source>
+        <target>Webseite</target>
+      </trans-unit>
+      <trans-unit id="profile.website.placeholder">
+        <source>https://www.example.com</source>
+        <target>https://www.beispiel.de</target>
+      </trans-unit>
+      <trans-unit id="profile.websiteTitle.label">
+        <source>Website title</source>
+        <target>Webseitentitel</target>
+      </trans-unit>
+      <trans-unit id="profile.websiteTitle.placeholder">
+        <source>My personal website</source>
+        <target>Meine persönliche Webseite</target>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLink.label">
+        <source>Publications link</source>
+        <target>Publikationslink</target>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLink.placeholder">
+        <source>https://www.publications.com</source>
+        <target>https://www.publikationen.de</target>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLinkTitle.label">
+        <source>Publications link title</source>
+        <target>Publikationslink Titel</target>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLinkTitle.placeholder">
+        <source>My publications</source>
+        <target>Meine Publikationen</target>
+      </trans-unit>
+      <trans-unit id="profile.teachingArea.label">
+        <source>Teaching area</source>
+        <target>Lehrgebiet</target>
+      </trans-unit>
+      <trans-unit id="profile.teachingArea.placeholder">
+        <source>e.g. Computer Science</source>
+        <target>z.B. Informatik</target>
+      </trans-unit>
+      <trans-unit id="profile.coreCompetences.label">
+        <source>Core competences</source>
+        <target>Kernkompetenzen</target>
+      </trans-unit>
+      <trans-unit id="profile.coreCompetences.placeholder">
+        <source>e.g. Software Development, Data Science</source>
+        <target>z.B. Softwareentwicklung, Datenwissenschaft</target>
+      </trans-unit>
+      <trans-unit id="profile.supervisedThesis.label">
+        <source>Supervises thesis</source>
+        <target>Betreute Abschlussarbeiten</target>
+      </trans-unit>
+      <trans-unit id="profile.supervisedThesis.placeholder">
+        <source>e.g. Bachelor, Master</source>
+        <target>z.B. Bachelor, Master</target>
+      </trans-unit>
+      <trans-unit id="profile.supervisedDoctoralThesis.label">
+        <source>Supervises doctoral thesis</source>
+        <target>Betreute Doktorarbeiten</target>
+      </trans-unit>
+      <trans-unit id="profile.supervisedDoctoralThesis.placeholder">
+        <source>e.g. PhD, Doctorate</source>
+        <target>z.B. Doktorarbeit, Promotion</target>
+      </trans-unit>
+      <trans-unit id="profile.miscellaneous.label">
+        <source>Miscellaneous</source>
+        <target>Verschiedenes</target>
+      </trans-unit>
+      <trans-unit id="profile.miscellaneous.placeholder">
+        <source>e.g. Hobbies, Interests</source>
+        <target>z.B. Hobbys, Interessen</target>
+      </trans-unit>
+      <trans-unit id="profile.skipSync.label">
+        <source>Disable profile sync</source>
+        <target>Profil-Synchronisation deaktivieren</target>
+      </trans-unit>
+      <trans-unit id="profile.skipSync.description">
+        <source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
+        <target>Die Deaktivierung der Profil-Synchronisation verhindert automatische Aktualisierungen aus externen Quellen.</target>
+      </trans-unit>
 
-			<!-- Profile information fields -->
+      <!-- Profile information fields -->
 
-			<trans-unit id="profileInformation.title.label">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.title.placeholder">
-				<source>My title</source>
-				<target>Mein Titel</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.link.label">
-				<source>Link</source>
-				<target>Link</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.link.placeholder">
-				<source>https://www.example.com</source>
-				<target>https://www.beispiel.de</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.year.label">
-				<source>Year</source>
-				<target>Jahr</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.year.placeholder">
-				<source>e.g. 2025</source>
-				<target>z.B. 2025</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearStart.label">
-				<source>Start year</source>
-				<target>Startjahr</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearStart.placeholder">
-				<source>e.g. 2020</source>
-				<target>z.B. 2020</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearEnd.label">
-				<source>End year</source>
-				<target>Endjahr</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearEnd.placeholder">
-				<source>e.g. 2025</source>
-				<target>z.B. 2025</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.bodytext.label">
-				<source>Text</source>
-				<target>Text</target>
-			</trans-unit>
-			<trans-unit id="profileInformation.bodytext.placeholder">
-				<source>Enter text here...</source>
-				<target>Text hier eingeben...</target>
-			</trans-unit>
+      <trans-unit id="profileInformation.title.label">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.title.placeholder">
+        <source>My title</source>
+        <target>Mein Titel</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.link.label">
+        <source>Link</source>
+        <target>Link</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.link.placeholder">
+        <source>https://www.example.com</source>
+        <target>https://www.beispiel.de</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.year.label">
+        <source>Year</source>
+        <target>Jahr</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.year.placeholder">
+        <source>e.g. 2025</source>
+        <target>z.B. 2025</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearStart.label">
+        <source>Start year</source>
+        <target>Startjahr</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearStart.placeholder">
+        <source>e.g. 2020</source>
+        <target>z.B. 2020</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearEnd.label">
+        <source>End year</source>
+        <target>Endjahr</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearEnd.placeholder">
+        <source>e.g. 2025</source>
+        <target>z.B. 2025</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.bodytext.label">
+        <source>Text</source>
+        <target>Text</target>
+      </trans-unit>
+      <trans-unit id="profileInformation.bodytext.placeholder">
+        <source>Enter text here...</source>
+        <target>Text hier eingeben...</target>
+      </trans-unit>
 
-			<!-- Contract fields -->
+      <!-- Contract fields -->
 
-			<trans-unit id="contract.position.label">
-				<source>Position</source>
-				<target>Position</target>
-			</trans-unit>
-			<trans-unit id="contract.position.placeholder">
-				<source>e.g. Professor, Lecturer</source>
-				<target>z.B. Professor, Dozent</target>
-			</trans-unit>
-			<trans-unit id="contract.organisationalUnit.label">
-				<source>Organisational unit</source>
-				<target>Organisatorische Einheit</target>
-			</trans-unit>
-			<trans-unit id="contract.functionType.label">
-				<source>Function type</source>
-				<target>Funktionstyp</target>
-			</trans-unit>
-			<trans-unit id="contract.validFrom.label">
-				<source>Valid from</source>
-				<target>Gültig ab</target>
-			</trans-unit>
-			<trans-unit id="contract.validTo.label">
-				<source>Valid to</source>
-				<target>Gültig bis</target>
-			</trans-unit>
-			<trans-unit id="contract.location.label">
-				<source>Location</source>
-				<target>Standort</target>
-			</trans-unit>
-			<trans-unit id="contract.location.placeholder">
-				<source>e.g. Main Campus</source>
-				<target>z.B. Hauptcampus</target>
-			</trans-unit>
-			<trans-unit id="contract.room.label">
-				<source>Room</source>
-				<target>Raum</target>
-			</trans-unit>
-			<trans-unit id="contract.room.placeholder">
-				<source>e.g. 101</source>
-				<target>z.B. 101</target>
-			</trans-unit>
-			<trans-unit id="contract.officeHours.label">
-				<source>Office hours</source>
-				<target>Sprechzeiten</target>
-			</trans-unit>
-			<trans-unit id="contract.officeHours.placeholder">
-				<source>e.g. Monday 10-12, Wednesday 14-16</source>
-				<target>z.B. Montag 10-12, Mittwoch 14-16</target>
-			</trans-unit>
-			<trans-unit id="contract.publish.label">
-				<source>Publish</source>
-				<target>Veröffentlichen</target>
-			</trans-unit>
-			<trans-unit id="contract.published.label">
-				<source>Published</source>
-				<target>Veröffentlicht</target>
-			</trans-unit>
+      <trans-unit id="contract.position.label">
+        <source>Position</source>
+        <target>Position</target>
+      </trans-unit>
+      <trans-unit id="contract.position.placeholder">
+        <source>e.g. Professor, Lecturer</source>
+        <target>z.B. Professor, Dozent</target>
+      </trans-unit>
+      <trans-unit id="contract.organisationalUnit.label">
+        <source>Organisational unit</source>
+        <target>Organisatorische Einheit</target>
+      </trans-unit>
+      <trans-unit id="contract.functionType.label">
+        <source>Function type</source>
+        <target>Funktionstyp</target>
+      </trans-unit>
+      <trans-unit id="contract.validFrom.label">
+        <source>Valid from</source>
+        <target>Gültig ab</target>
+      </trans-unit>
+      <trans-unit id="contract.validTo.label">
+        <source>Valid to</source>
+        <target>Gültig bis</target>
+      </trans-unit>
+      <trans-unit id="contract.location.label">
+        <source>Location</source>
+        <target>Standort</target>
+      </trans-unit>
+      <trans-unit id="contract.location.placeholder">
+        <source>e.g. Main Campus</source>
+        <target>z.B. Hauptcampus</target>
+      </trans-unit>
+      <trans-unit id="contract.room.label">
+        <source>Room</source>
+        <target>Raum</target>
+      </trans-unit>
+      <trans-unit id="contract.room.placeholder">
+        <source>e.g. 101</source>
+        <target>z.B. 101</target>
+      </trans-unit>
+      <trans-unit id="contract.officeHours.label">
+        <source>Office hours</source>
+        <target>Sprechzeiten</target>
+      </trans-unit>
+      <trans-unit id="contract.officeHours.placeholder">
+        <source>e.g. Monday 10-12, Wednesday 14-16</source>
+        <target>z.B. Montag 10-12, Mittwoch 14-16</target>
+      </trans-unit>
+      <trans-unit id="contract.publish.label">
+        <source>Publish</source>
+        <target>Veröffentlichen</target>
+      </trans-unit>
+      <trans-unit id="contract.published.label">
+        <source>Published</source>
+        <target>Veröffentlicht</target>
+      </trans-unit>
 
-			<!-- Physical address fields -->
+      <!-- Physical address fields -->
 
-			<trans-unit id="physicalAddress.street.label">
-				<source>Street</source>
-				<target>Straße</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.street.placeholder">
-				<source>Examplestreet</source>
-				<target>Musterstraße</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.streetNumber.label">
-				<source>Street number</source>
-				<target>Hausnummer</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.streetNumber.placeholder">
-				<source>123</source>
-				<target>123</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.additional.label">
-				<source>Additional</source>
-				<target>Addresszusatz</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.additional.placeholder">
-				<source>e.g. 2nd floor</source>
-				<target>z.B. 2. Etage</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.zip.label">
-				<source>Zip</source>
-				<target>Postleitzahl</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.zip.placeholder">
-				<source>12345</source>
-				<target>12345</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.city.label">
-				<source>City</source>
-				<target>Stadt</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.city.placeholder">
-				<source>Example City</source>
-				<target>Musterstadt</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.state.label">
-				<source>State</source>
-				<target>Bundesland</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.state.placeholder">
-				<source>Example State</source>
-				<target>Musterbundesland</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.country.label">
-				<source>Country</source>
-				<target>Land</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.country.placeholder">
-				<source>Exmplate Country</source>
-				<target>Musterland</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
+      <trans-unit id="physicalAddress.street.label">
+        <source>Street</source>
+        <target>Straße</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.street.placeholder">
+        <source>Examplestreet</source>
+        <target>Musterstraße</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.streetNumber.label">
+        <source>Street number</source>
+        <target>Hausnummer</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.streetNumber.placeholder">
+        <source>123</source>
+        <target>123</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.additional.label">
+        <source>Additional</source>
+        <target>Addresszusatz</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.additional.placeholder">
+        <source>e.g. 2nd floor</source>
+        <target>z.B. 2. Etage</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.zip.label">
+        <source>Zip</source>
+        <target>Postleitzahl</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.zip.placeholder">
+        <source>12345</source>
+        <target>12345</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.city.label">
+        <source>City</source>
+        <target>Stadt</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.city.placeholder">
+        <source>Example City</source>
+        <target>Musterstadt</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.state.label">
+        <source>State</source>
+        <target>Bundesland</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.state.placeholder">
+        <source>Example State</source>
+        <target>Musterbundesland</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.country.label">
+        <source>Country</source>
+        <target>Land</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.country.placeholder">
+        <source>Exmplate Country</source>
+        <target>Musterland</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
 
-			<!-- Phone number fields -->
+      <!-- Phone number fields -->
 
-			<trans-unit id="phoneNumber.phoneNumber.label">
-				<source>Phone number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.phoneNumber.placeholder">
-				<source>+49 123 4567890</source>
-				<target>+49 123 4567890</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
+      <trans-unit id="phoneNumber.phoneNumber.label">
+        <source>Phone number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.phoneNumber.placeholder">
+        <source>+49 123 4567890</source>
+        <target>+49 123 4567890</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
 
-			<!-- Email address fields -->
+      <!-- Email address fields -->
 
-			<trans-unit id="emailAddress.emailAddress.label">
-				<source>Email address</source>
-				<target>E-Mail-Adresse</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.emailAddress.placeholder">
-				<source>example@domain.com</source>
-				<target>beispiel@domain.de</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
+      <trans-unit id="emailAddress.emailAddress.label">
+        <source>Email address</source>
+        <target>E-Mail-Adresse</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.emailAddress.placeholder">
+        <source>example@domain.com</source>
+        <target>beispiel@domain.de</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
 
-			<!-- Action buttons -->
+      <!-- Action buttons -->
 
-			<trans-unit id="actions.view">
-				<source>View</source>
-				<target>Anzeigen</target>
-			</trans-unit>
-			<trans-unit id="actions.edit">
-				<source>Edit</source>
-				<target>Bearbeiten</target>
-			</trans-unit>
-			<trans-unit id="actions.add">
-				<source>Add</source>
-				<target>Hinzufügen</target>
-			</trans-unit>
-			<trans-unit id="actions.sortUp">
-				<source>Move upwards</source>
-				<target>Nach oben verschieben</target>
-			</trans-unit>
-			<trans-unit id="actions.sortDown">
-				<source>Move downwards</source>
-				<target>Nach unten verschieben</target>
-			</trans-unit>
-			<trans-unit id="actions.setToTop">
-				<source>Move to the top</source>
-				<target>An erste Stelle verschieben</target>
-			</trans-unit>
-			<trans-unit id="actions.setToBottom">
-				<source>Move to the bottom</source>
-				<target>An letzte Stelle verschieben</target>
-			</trans-unit>
-			<trans-unit id="actions.delete">
-				<source>Delete</source>
-				<target>Löschen</target>
-			</trans-unit>
-			<trans-unit id="actions.cancel">
-				<source>Cancel</source>
-				<target>Abbrechen</target>
-			</trans-unit>
-			<trans-unit id="actions.save">
-				<source>Save</source>
-				<target>Speichern</target>
-			</trans-unit>
-			<trans-unit id="actions.saveAndExit">
-				<source>Save and exit</source>
-				<target>Speichern und verlassen</target>
-			</trans-unit>
-			<trans-unit id="actions.translate">
-				<source>Translate</source>
-				<target>Übersetzen</target>
-			</trans-unit>
-			<trans-unit id="actions.hide">
-				<source>Hide in frontend</source>
-				<target>Im Frontend ausblenden</target>
-			</trans-unit>
-			<trans-unit id="actions.show">
-				<source>Show in frontend</source>
-				<target>Im Frontend einblenden</target>
-			</trans-unit>
+      <trans-unit id="actions.view">
+        <source>View</source>
+        <target>Anzeigen</target>
+      </trans-unit>
+      <trans-unit id="actions.edit">
+        <source>Edit</source>
+        <target>Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="actions.add">
+        <source>Add</source>
+        <target>Hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="actions.sortUp">
+        <source>Move upwards</source>
+        <target>Nach oben verschieben</target>
+      </trans-unit>
+      <trans-unit id="actions.sortDown">
+        <source>Move downwards</source>
+        <target>Nach unten verschieben</target>
+      </trans-unit>
+      <trans-unit id="actions.setToTop">
+        <source>Move to the top</source>
+        <target>An erste Stelle verschieben</target>
+      </trans-unit>
+      <trans-unit id="actions.setToBottom">
+        <source>Move to the bottom</source>
+        <target>An letzte Stelle verschieben</target>
+      </trans-unit>
+      <trans-unit id="actions.delete">
+        <source>Delete</source>
+        <target>Löschen</target>
+      </trans-unit>
+      <trans-unit id="actions.cancel">
+        <source>Cancel</source>
+        <target>Abbrechen</target>
+      </trans-unit>
+      <trans-unit id="actions.save">
+        <source>Save</source>
+        <target>Speichern</target>
+      </trans-unit>
+      <trans-unit id="actions.saveAndExit">
+        <source>Save and exit</source>
+        <target>Speichern und verlassen</target>
+      </trans-unit>
+      <trans-unit id="actions.translate">
+        <source>Translate</source>
+        <target>Übersetzen</target>
+      </trans-unit>
+      <trans-unit id="actions.hide">
+        <source>Hide in frontend</source>
+        <target>Im Frontend ausblenden</target>
+      </trans-unit>
+      <trans-unit id="actions.show">
+        <source>Show in frontend</source>
+        <target>Im Frontend einblenden</target>
+      </trans-unit>
 
-			<!-- Confirm deletion -->
+      <!-- Confirm deletion -->
 
-			<trans-unit id="contract.delete">
-				<source>Do you really want to delete this contract?</source>
-				<target>Wollen Sie diesen Vertrag wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="publications.delete">
-				<source>Do you really want to delete this publication?</source>
-				<target>Wollen Sie diese Publikation wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="cooperation.delete">
-				<source>Do you really want to delete this cooperation?</source>
-				<target>Wollen Sie diese Kooperation wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="memberships.delete">
-				<source>Do you really want to delete this membership?</source>
-				<target>Wollen Sie diese Mitgliedschaft wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="vita.delete">
-				<source>Do you really want to delete this vita?</source>
-				<target>Wollen Sie diese Vita wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="lectures.delete">
-				<source>Do you really want to delete this lecture?</source>
-				<target>Wollen Sie diese Vorlesung wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="pressMedia.delete">
-				<source>Do you really want to delete this press media?</source>
-				<target>Wollen Sie diese Pressemitteilung wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="scientificResearch.delete">
-				<source>Do you really want to delete this scientific research?</source>
-				<target>Wollen Sie diese wissenschaftliche Forschung wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.delete">
-				<source>Do you really want to delete this physical address?</source>
-				<target>Wollen Sie diese physische Adresse wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.delete">
-				<source>Do you really want to delete this email address?</source>
-				<target>Wollen Sie diese E-Mail-Adresse wirklich löschen?</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.delete">
-				<source>Do you really want to delete this phone number?</source>
-				<target>Wollen Sie diese Telefonnummer wirklich löschen?</target>
-			</trans-unit>
+      <trans-unit id="contract.delete">
+        <source>Do you really want to delete this contract?</source>
+        <target>Wollen Sie diesen Vertrag wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="publications.delete">
+        <source>Do you really want to delete this publication?</source>
+        <target>Wollen Sie diese Publikation wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="cooperation.delete">
+        <source>Do you really want to delete this cooperation?</source>
+        <target>Wollen Sie diese Kooperation wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="memberships.delete">
+        <source>Do you really want to delete this membership?</source>
+        <target>Wollen Sie diese Mitgliedschaft wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="vita.delete">
+        <source>Do you really want to delete this vita?</source>
+        <target>Wollen Sie diese Vita wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="lectures.delete">
+        <source>Do you really want to delete this lecture?</source>
+        <target>Wollen Sie diese Vorlesung wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="pressMedia.delete">
+        <source>Do you really want to delete this press media?</source>
+        <target>Wollen Sie diese Pressemitteilung wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="scientificResearch.delete">
+        <source>Do you really want to delete this scientific research?</source>
+        <target>Wollen Sie diese wissenschaftliche Forschung wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.delete">
+        <source>Do you really want to delete this physical address?</source>
+        <target>Wollen Sie diese physische Adresse wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.delete">
+        <source>Do you really want to delete this email address?</source>
+        <target>Wollen Sie diese E-Mail-Adresse wirklich löschen?</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.delete">
+        <source>Do you really want to delete this phone number?</source>
+        <target>Wollen Sie diese Telefonnummer wirklich löschen?</target>
+      </trans-unit>
 
-			<!-- Success messages -->
+      <!-- Success messages -->
 
-			<trans-unit id="profile.update.success">
-				<source>Profile updated successfully.</source>
-				<target>Profil erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="contract.create.success">
-				<source>Contract created successfully.</source>
-				<target>Vertrag erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="contract.update.success">
-				<source>Contract updated successfully.</source>
-				<target>Vertrag erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="contract.delete.success">
-				<source>Contract deleted successfully.</source>
-				<target>Vertrag erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="contract.sort.success">
-				<source>Contract sorted successfully.</source>
-				<target>Vertrag erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.create.success">
-				<source>Physical address created successfully.</source>
-				<target>Physische Adresse erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.update.success">
-				<source>Physical address updated successfully.</source>
-				<target>Physische Adresse erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.delete.success">
-				<source>Physical address deleted successfully.</source>
-				<target>Physische Adresse erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.sort.success">
-				<source>Physical address sorted successfully.</source>
-				<target>Physische Adresse erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.hidden.success">
-				<source>Physical address is now hidden in the frontend.</source>
-				<target>Physische Adresse ist jetzt im Frontend ausgeblendet.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.visible.success">
-				<source>Physical address is now visible in the frontend.</source>
-				<target>Physische Adresse ist jetzt im Frontend sichtbar.</target>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.error.notFound">
-				<source>Physical address could not be found.</source>
-				<target>Physische Adresse konnte nicht gefunden werden.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.create.success">
-				<source>Phone number created successfully.</source>
-				<target>Telefonnummer erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.update.success">
-				<source>Phone number updated successfully.</source>
-				<target>Telefonnummer erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.delete.success">
-				<source>Phone number deleted successfully.</source>
-				<target>Telefonnummer erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.sort.success">
-				<source>Phone number sorted successfully.</source>
-				<target>Telefonnummer erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.hidden.success">
-				<source>Phone number is now hidden in the frontend.</source>
-				<target>Telefonnummer ist jetzt im Frontend ausgeblendet.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.visible.success">
-				<source>Phone number is now visible in the frontend.</source>
-				<target>Telefonnummer ist jetzt im Frontend sichtbar.</target>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.error.notFound">
-				<source>Phone number could not be found.</source>
-				<target>Telefonnummer konnte nicht gefunden werden.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.create.success">
-				<source>Email address created successfully.</source>
-				<target>E-Mail-Adresse erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.update.success">
-				<source>Email address updated successfully.</source>
-				<target>E-Mail-Adresse erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.delete.success">
-				<source>Email address deleted successfully.</source>
-				<target>E-Mail-Adresse erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.sort.success">
-				<source>Email address sorted successfully.</source>
-				<target>E-Mail-Adresse erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.hidden.success">
-				<source>Email address is now hidden in the frontend.</source>
-				<target>E-Mail-Adresse ist jetzt im Frontend ausgeblendet.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.visible.success">
-				<source>Email address is now visible in the frontend.</source>
-				<target>E-Mail-Adresse ist jetzt im Frontend sichtbar.</target>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.error.notFound">
-				<source>Email address could not be found.</source>
-				<target>E-Mail-Adresse konnte nicht gefunden werden.</target>
-			</trans-unit>
-			<trans-unit id="scientific_research.create.success">
-				<source>Scientific research created successfully.</source>
-				<target>Wissenschaftliche Forschung erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="scientific_research.update.success">
-				<source>Scientific research updated successfully.</source>
-				<target>Wissenschaftliche Forschung erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="scientific_research.delete.success">
-				<source>Scientific research deleted successfully.</source>
-				<target>Wissenschaftliche Forschung erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="scientific_research.sort.success">
-				<source>Scientific research sorted successfully.</source>
-				<target>Wissenschaftliche Forschung erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="curriculum_vitae.create.success">
-				<source>Vita created successfully.</source>
-				<target>Vita erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="curriculum_vitae.update.success">
-				<source>Vita updated successfully.</source>
-				<target>Vita erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="curriculum_vitae.delete.success">
-				<source>Vita deleted successfully.</source>
-				<target>Vita erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="curriculum_vitae.sort.success">
-				<source>Vita sorted successfully.</source>
-				<target>Vita erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="membership.create.success">
-				<source>Membership created successfully.</source>
-				<target>Mitgliedschaft erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="membership.update.success">
-				<source>Membership updated successfully.</source>
-				<target>Mitgliedschaft erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="membership.delete.success">
-				<source>Membership deleted successfully.</source>
-				<target>Mitgliedschaft erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="membership.sort.success">
-				<source>Membership sorted successfully.</source>
-				<target>Mitgliedschaft erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="cooperation.create.success">
-				<source>Cooperation created successfully.</source>
-				<target>Kooperation erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="cooperation.update.success">
-				<source>Cooperation updated successfully.</source>
-				<target>Kooperation erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="cooperation.delete.success">
-				<source>Cooperation deleted successfully.</source>
-				<target>Kooperation erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="cooperation.sort.success">
-				<source>Cooperation sorted successfully.</source>
-				<target>Kooperation erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="publication.create.success">
-				<source>Publication created successfully.</source>
-				<target>Publikation erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="publication.update.success">
-				<source>Publication updated successfully.</source>
-				<target>Publikation erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="publication.delete.success">
-				<source>Publication deleted successfully.</source>
-				<target>Publikation erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="publication.sort.success">
-				<source>Publication sorted successfully.</source>
-				<target>Publikation erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="lecture.create.success">
-				<source>Lecture created successfully.</source>
-				<target>Vorlesung erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="lecture.update.success">
-				<source>Lecture updated successfully.</source>
-				<target>Vorlesung erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="lecture.delete.success">
-				<source>Lecture deleted successfully.</source>
-				<target>Vorlesung erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="lecture.sort.success">
-				<source>Lecture sorted successfully.</source>
-				<target>Vorlesung erfolgreich sortiert.</target>
-			</trans-unit>
-			<trans-unit id="press_media.create.success">
-				<source>Press media created successfully.</source>
-				<target>Pressemitteilung erfolgreich erstellt.</target>
-			</trans-unit>
-			<trans-unit id="press_media.update.success">
-				<source>Press media updated successfully.</source>
-				<target>Pressemitteilung erfolgreich aktualisiert.</target>
-			</trans-unit>
-			<trans-unit id="press_media.delete.success">
-				<source>Press media deleted successfully.</source>
-				<target>Pressemitteilung erfolgreich gelöscht.</target>
-			</trans-unit>
-			<trans-unit id="press_media.sort.success">
-				<source>Press media sorted successfully.</source>
-				<target>Pressemitteilung erfolgreich sortiert.</target>
-			</trans-unit>
+      <trans-unit id="profile.update.success">
+        <source>Profile updated successfully.</source>
+        <target>Profil erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="contract.create.success">
+        <source>Contract created successfully.</source>
+        <target>Vertrag erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="contract.update.success">
+        <source>Contract updated successfully.</source>
+        <target>Vertrag erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="contract.delete.success">
+        <source>Contract deleted successfully.</source>
+        <target>Vertrag erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="contract.sort.success">
+        <source>Contract sorted successfully.</source>
+        <target>Vertrag erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.create.success">
+        <source>Physical address created successfully.</source>
+        <target>Physische Adresse erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.update.success">
+        <source>Physical address updated successfully.</source>
+        <target>Physische Adresse erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.delete.success">
+        <source>Physical address deleted successfully.</source>
+        <target>Physische Adresse erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.sort.success">
+        <source>Physical address sorted successfully.</source>
+        <target>Physische Adresse erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.hidden.success">
+        <source>Physical address is now hidden in the frontend.</source>
+        <target>Physische Adresse ist jetzt im Frontend ausgeblendet.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.visible.success">
+        <source>Physical address is now visible in the frontend.</source>
+        <target>Physische Adresse ist jetzt im Frontend sichtbar.</target>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.error.notFound">
+        <source>Physical address could not be found.</source>
+        <target>Physische Adresse konnte nicht gefunden werden.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.create.success">
+        <source>Phone number created successfully.</source>
+        <target>Telefonnummer erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.update.success">
+        <source>Phone number updated successfully.</source>
+        <target>Telefonnummer erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.delete.success">
+        <source>Phone number deleted successfully.</source>
+        <target>Telefonnummer erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.sort.success">
+        <source>Phone number sorted successfully.</source>
+        <target>Telefonnummer erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.hidden.success">
+        <source>Phone number is now hidden in the frontend.</source>
+        <target>Telefonnummer ist jetzt im Frontend ausgeblendet.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.visible.success">
+        <source>Phone number is now visible in the frontend.</source>
+        <target>Telefonnummer ist jetzt im Frontend sichtbar.</target>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.error.notFound">
+        <source>Phone number could not be found.</source>
+        <target>Telefonnummer konnte nicht gefunden werden.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.create.success">
+        <source>Email address created successfully.</source>
+        <target>E-Mail-Adresse erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.update.success">
+        <source>Email address updated successfully.</source>
+        <target>E-Mail-Adresse erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.delete.success">
+        <source>Email address deleted successfully.</source>
+        <target>E-Mail-Adresse erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.sort.success">
+        <source>Email address sorted successfully.</source>
+        <target>E-Mail-Adresse erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.hidden.success">
+        <source>Email address is now hidden in the frontend.</source>
+        <target>E-Mail-Adresse ist jetzt im Frontend ausgeblendet.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.visible.success">
+        <source>Email address is now visible in the frontend.</source>
+        <target>E-Mail-Adresse ist jetzt im Frontend sichtbar.</target>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.error.notFound">
+        <source>Email address could not be found.</source>
+        <target>E-Mail-Adresse konnte nicht gefunden werden.</target>
+      </trans-unit>
+      <trans-unit id="scientific_research.create.success">
+        <source>Scientific research created successfully.</source>
+        <target>Wissenschaftliche Forschung erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="scientific_research.update.success">
+        <source>Scientific research updated successfully.</source>
+        <target>Wissenschaftliche Forschung erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="scientific_research.delete.success">
+        <source>Scientific research deleted successfully.</source>
+        <target>Wissenschaftliche Forschung erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="scientific_research.sort.success">
+        <source>Scientific research sorted successfully.</source>
+        <target>Wissenschaftliche Forschung erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="curriculum_vitae.create.success">
+        <source>Vita created successfully.</source>
+        <target>Vita erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="curriculum_vitae.update.success">
+        <source>Vita updated successfully.</source>
+        <target>Vita erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="curriculum_vitae.delete.success">
+        <source>Vita deleted successfully.</source>
+        <target>Vita erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="curriculum_vitae.sort.success">
+        <source>Vita sorted successfully.</source>
+        <target>Vita erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="membership.create.success">
+        <source>Membership created successfully.</source>
+        <target>Mitgliedschaft erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="membership.update.success">
+        <source>Membership updated successfully.</source>
+        <target>Mitgliedschaft erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="membership.delete.success">
+        <source>Membership deleted successfully.</source>
+        <target>Mitgliedschaft erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="membership.sort.success">
+        <source>Membership sorted successfully.</source>
+        <target>Mitgliedschaft erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="cooperation.create.success">
+        <source>Cooperation created successfully.</source>
+        <target>Kooperation erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="cooperation.update.success">
+        <source>Cooperation updated successfully.</source>
+        <target>Kooperation erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="cooperation.delete.success">
+        <source>Cooperation deleted successfully.</source>
+        <target>Kooperation erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="cooperation.sort.success">
+        <source>Cooperation sorted successfully.</source>
+        <target>Kooperation erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="publication.create.success">
+        <source>Publication created successfully.</source>
+        <target>Publikation erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="publication.update.success">
+        <source>Publication updated successfully.</source>
+        <target>Publikation erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="publication.delete.success">
+        <source>Publication deleted successfully.</source>
+        <target>Publikation erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="publication.sort.success">
+        <source>Publication sorted successfully.</source>
+        <target>Publikation erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="lecture.create.success">
+        <source>Lecture created successfully.</source>
+        <target>Vorlesung erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="lecture.update.success">
+        <source>Lecture updated successfully.</source>
+        <target>Vorlesung erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="lecture.delete.success">
+        <source>Lecture deleted successfully.</source>
+        <target>Vorlesung erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="lecture.sort.success">
+        <source>Lecture sorted successfully.</source>
+        <target>Vorlesung erfolgreich sortiert.</target>
+      </trans-unit>
+      <trans-unit id="press_media.create.success">
+        <source>Press media created successfully.</source>
+        <target>Pressemitteilung erfolgreich erstellt.</target>
+      </trans-unit>
+      <trans-unit id="press_media.update.success">
+        <source>Press media updated successfully.</source>
+        <target>Pressemitteilung erfolgreich aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="press_media.delete.success">
+        <source>Press media deleted successfully.</source>
+        <target>Pressemitteilung erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="press_media.sort.success">
+        <source>Press media sorted successfully.</source>
+        <target>Pressemitteilung erfolgreich sortiert.</target>
+      </trans-unit>
 
-			<!-- Error Messages -->
+      <!-- Error Messages -->
 
-			<trans-unit id="contractFormData.validTo.error.1307719788">
-				<source>"Valid to" must be a valid date. (Seperated by .)</source>
-				<target>"Gültig bis" muss ein gültiges Datum sein. (Getrennt durch .)</target>
-			</trans-unit>
-			<trans-unit id="contractFormData.validFrom.error.1307719788">
-				<source>"Valid from" must be a valid date. (Seperated by .)</source>
-				<target>"Gültig von" muss ein gültiges Datum sein. (Getrennt durch .)</target>
-			</trans-unit>
-			<trans-unit id="profileInformationFormData.yearStart.error.1332933658">
-				<source>"Year start" must be a number.</source>
-				<target>"Startjahr" muss eine Zahl sein.</target>
-			</trans-unit>
-			<trans-unit id="profileInformationFormData.yearEnd.error.1332933658">
-				<source>"Year end" must be a number.</source>
-				<target>"Endjahr" muss eine Zahl sein.</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="contractFormData.validTo.error.1307719788">
+        <source>"Valid to" must be a valid date. (Seperated by .)</source>
+        <target>"Gültig bis" muss ein gültiges Datum sein. (Getrennt durch .)</target>
+      </trans-unit>
+      <trans-unit id="contractFormData.validFrom.error.1307719788">
+        <source>"Valid from" must be a valid date. (Seperated by .)</source>
+        <target>"Gültig von" muss ein gültiges Datum sein. (Getrennt durch .)</target>
+      </trans-unit>
+      <trans-unit id="profileInformationFormData.yearStart.error.1332933658">
+        <source>"Year start" must be a number.</source>
+        <target>"Startjahr" muss eine Zahl sein.</target>
+      </trans-unit>
+      <trans-unit id="profileInformationFormData.yearEnd.error.1332933658">
+        <source>"Year end" must be a number.</source>
+        <target>"Endjahr" muss eine Zahl sein.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang_be.xlf
@@ -1,75 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_edit"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.profile_switcher.label">
-				<source>Profiles: Profile Switcher</source>
-				<target>Profile: Profil wechseln</target>
-			</trans-unit>
-			<trans-unit id="plugin.profile_editing.label">
-				<source>Profiles: Profile Editing</source>
-				<target>Profile: Profil Editor</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_edit"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.profile_switcher.label">
+        <source>Profiles: Profile Switcher</source>
+        <target>Profile: Profil wechseln</target>
+      </trans-unit>
+      <trans-unit id="plugin.profile_editing.label">
+        <source>Profiles: Profile Editing</source>
+        <target>Profile: Profil Editor</target>
+      </trans-unit>
 
-			<trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
-				<source>Deprecated and no effect. See EXT:academic_persons > autoCreateProfiles</source>
-				<target>Veraltet und hat kein Einfluss mehr. Siehe EXT:academic_persons > autoCreateProfiles</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
-				<source>Deprecated and no effect. See EXT:academic_persons > createProfileForUserGroups</source>
-				<target>Veraltet und hat kein Einfluss mehr. Siehe EXT:academic_persons > createProfileForUserGroups</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.allowedLanguages.label">
-				<source>Allowed languages: List of language IDs which a profile can be translated to.</source>
-				<target>Erlaubte Sprachen: Liste der Sprach-IDs in welche Profile übersetzt werden können</target>
-			</trans-unit>
+      <trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
+        <source>Deprecated and no effect. See EXT:academic_persons > autoCreateProfiles</source>
+        <target>Veraltet und hat kein Einfluss mehr. Siehe EXT:academic_persons > autoCreateProfiles</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
+        <source>Deprecated and no effect. See EXT:academic_persons > createProfileForUserGroups</source>
+        <target>Veraltet und hat kein Einfluss mehr. Siehe EXT:academic_persons > createProfileForUserGroups</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.allowedLanguages.label">
+        <source>Allowed languages: List of language IDs which a profile can be translated to.</source>
+        <target>Erlaubte Sprachen: Liste der Sprach-IDs in welche Profile übersetzt werden können</target>
+      </trans-unit>
 
-			<trans-unit id="fe_users.columns.tx_academicpersons_profiles.label">
-				<source>Assigned Profiles</source>
-				<target>Zugewiesene Profile</target>
-			</trans-unit>
-			<trans-unit id="fe_users.tabs.tx_academicpersons_profiles.label">
-				<source>Profiles</source>
-				<target>Profile</target>
-			</trans-unit>
-			<trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser">
-				<source>Academic Persons: User</source>
-				<target>Akademische Personen: Benutzer</target>
-			</trans-unit>
+      <trans-unit id="fe_users.columns.tx_academicpersons_profiles.label">
+        <source>Assigned Profiles</source>
+        <target>Zugewiesene Profile</target>
+      </trans-unit>
+      <trans-unit id="fe_users.tabs.tx_academicpersons_profiles.label">
+        <source>Profiles</source>
+        <target>Profile</target>
+      </trans-unit>
+      <trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser">
+        <source>Academic Persons: User</source>
+        <target>Akademische Personen: Benutzer</target>
+      </trans-unit>
 
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.frontend_users.label">
-				<source>Assigned Users</source>
-				<target>Zugewiesene Benutzer</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.tabs.frontend_users.label">
-				<source>Frontend Users</source>
-				<target>Frontend Benutzer</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.frontend_users.label">
+        <source>Assigned Users</source>
+        <target>Zugewiesene Benutzer</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.tabs.frontend_users.label">
+        <source>Frontend Users</source>
+        <target>Frontend Benutzer</target>
+      </trans-unit>
 
-			<trans-unit id="newContentElement.wizardItems.academic.profileEditing.title">
-				<source>Academic Persons Profile Editing</source>
-				<target>Akademische Personen Profil Bearbeitung</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileEditing.description">
-				<source>Plugin for editing profiles in the frontend</source>
-				<target>Plugin zur Bearbeitung von Profilen im Frontend</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.title">
-				<source>Academic Persons Edit Profile Switcher</source>
-				<target>Akademische Personen Profil wechseln</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.description">
-				<source>Plugin for switching profiles in the frontend</source>
-				<target>Plugin zum wechsel der Profile im Frontend</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="newContentElement.wizardItems.academic.profileEditing.title">
+        <source>Academic Persons Profile Editing</source>
+        <target>Akademische Personen Profil Bearbeitung</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileEditing.description">
+        <source>Plugin for editing profiles in the frontend</source>
+        <target>Plugin zur Bearbeitung von Profilen im Frontend</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.title">
+        <source>Academic Persons Edit Profile Switcher</source>
+        <target>Akademische Personen Profil wechseln</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.description">
+        <source>Plugin for switching profiles in the frontend</source>
+        <target>Plugin zum wechsel der Profile im Frontend</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
@@ -1,680 +1,680 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons_edit/Resources/Private/Language/locallang.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_edit"
-	>
-		<header/>
-		<body>
-			<trans-unit id="back">
-				<source>back</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons_edit/Resources/Private/Language/locallang.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_edit"
+  >
+    <header/>
+    <body>
+      <trans-unit id="back">
+        <source>back</source>
+      </trans-unit>
 
-			<!-- Table headers -->
+      <!-- Table headers -->
 
-			<trans-unit id="list.profile.assigned">
-				<source>Assigned profiles</source>
-			</trans-unit>
-			<trans-unit id="list.profile">
-				<source>Profile</source>
-			</trans-unit>
-			<trans-unit id="list.profileInformations.year">
-				<source>Year</source>
-			</trans-unit>
-			<trans-unit id="list.profileInformations.title">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="list.contract.position">
-				<source>Position</source>
-			</trans-unit>
-			<trans-unit id="list.actions">
-				<source>Actions</source>
-			</trans-unit>
-			<trans-unit id="list.hidden.badge">
-				<source>Hidden</source>
-			</trans-unit>
+      <trans-unit id="list.profile.assigned">
+        <source>Assigned profiles</source>
+      </trans-unit>
+      <trans-unit id="list.profile">
+        <source>Profile</source>
+      </trans-unit>
+      <trans-unit id="list.profileInformations.year">
+        <source>Year</source>
+      </trans-unit>
+      <trans-unit id="list.profileInformations.title">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="list.contract.position">
+        <source>Position</source>
+      </trans-unit>
+      <trans-unit id="list.actions">
+        <source>Actions</source>
+      </trans-unit>
+      <trans-unit id="list.hidden.badge">
+        <source>Hidden</source>
+      </trans-unit>
 
-			<!-- No items found messages -->
+      <!-- No items found messages -->
 
-			<trans-unit id="list.noProfilesFound">
-				<source>No profiles found.</source>
-			</trans-unit>
-			<trans-unit id="list.noContractsFound">
-				<source>No contracts found.</source>
-			</trans-unit>
-			<trans-unit id="list.nolecturesFound">
-				<source>No lectures found.</source>
-			</trans-unit>
-			<trans-unit id="list.nomembershipsFound">
-				<source>No memberships found.</source>
-			</trans-unit>
-			<trans-unit id="list.nopressMediaFound">
-				<source>No press media found.</source>
-			</trans-unit>
-			<trans-unit id="list.nopublicationsFound">
-				<source>No publications found.</source>
-			</trans-unit>
-			<trans-unit id="list.noscientificResearchFound">
-				<source>No scientific research found.</source>
-			</trans-unit>
-			<trans-unit id="list.novitaFound">
-				<source>No vita found.</source>
-			</trans-unit>
-			<trans-unit id="list.noPhysicalAddressesFound">
-				<source>No physical addresses found.</source>
-			</trans-unit>
-			<trans-unit id="list.noEmailAddressesFound">
-				<source>No email addresses found.</source>
-			</trans-unit>
-			<trans-unit id="list.noPhoneNumbersFound">
-				<source>No phone numbers found.</source>
-			</trans-unit>
-			<trans-unit id="list.noTranslationFound">
-				<source>No translation found.</source>
-			</trans-unit>
+      <trans-unit id="list.noProfilesFound">
+        <source>No profiles found.</source>
+      </trans-unit>
+      <trans-unit id="list.noContractsFound">
+        <source>No contracts found.</source>
+      </trans-unit>
+      <trans-unit id="list.nolecturesFound">
+        <source>No lectures found.</source>
+      </trans-unit>
+      <trans-unit id="list.nomembershipsFound">
+        <source>No memberships found.</source>
+      </trans-unit>
+      <trans-unit id="list.nopressMediaFound">
+        <source>No press media found.</source>
+      </trans-unit>
+      <trans-unit id="list.nopublicationsFound">
+        <source>No publications found.</source>
+      </trans-unit>
+      <trans-unit id="list.noscientificResearchFound">
+        <source>No scientific research found.</source>
+      </trans-unit>
+      <trans-unit id="list.novitaFound">
+        <source>No vita found.</source>
+      </trans-unit>
+      <trans-unit id="list.noPhysicalAddressesFound">
+        <source>No physical addresses found.</source>
+      </trans-unit>
+      <trans-unit id="list.noEmailAddressesFound">
+        <source>No email addresses found.</source>
+      </trans-unit>
+      <trans-unit id="list.noPhoneNumbersFound">
+        <source>No phone numbers found.</source>
+      </trans-unit>
+      <trans-unit id="list.noTranslationFound">
+        <source>No translation found.</source>
+      </trans-unit>
 
-			<!-- Show profile headers -->
+      <!-- Show profile headers -->
 
-			<trans-unit id="profile.image">
-				<source>Image</source>
-			</trans-unit>
-			<trans-unit id="profile.personal">
-				<source>Personal data</source>
-			</trans-unit>
-			<trans-unit id="profile.contracts">
-				<source>Contracts</source>
-			</trans-unit>
-			<trans-unit id="profile.cooperation">
-				<source>Cooperations</source>
-			</trans-unit>
-			<trans-unit id="profile.lectures">
-				<source>Lectures</source>
-			</trans-unit>
-			<trans-unit id="profile.memberships">
-				<source>Memberships</source>
-			</trans-unit>
-			<trans-unit id="profile.pressMedia">
-				<source>Press media</source>
-			</trans-unit>
-			<trans-unit id="profile.publications">
-				<source>Publications</source>
-			</trans-unit>
-			<trans-unit id="profile.scientificResearch">
-				<source>Scientific research</source>
-			</trans-unit>
-			<trans-unit id="profile.vita">
-				<source>Vita</source>
-			</trans-unit>
+      <trans-unit id="profile.image">
+        <source>Image</source>
+      </trans-unit>
+      <trans-unit id="profile.personal">
+        <source>Personal data</source>
+      </trans-unit>
+      <trans-unit id="profile.contracts">
+        <source>Contracts</source>
+      </trans-unit>
+      <trans-unit id="profile.cooperation">
+        <source>Cooperations</source>
+      </trans-unit>
+      <trans-unit id="profile.lectures">
+        <source>Lectures</source>
+      </trans-unit>
+      <trans-unit id="profile.memberships">
+        <source>Memberships</source>
+      </trans-unit>
+      <trans-unit id="profile.pressMedia">
+        <source>Press media</source>
+      </trans-unit>
+      <trans-unit id="profile.publications">
+        <source>Publications</source>
+      </trans-unit>
+      <trans-unit id="profile.scientificResearch">
+        <source>Scientific research</source>
+      </trans-unit>
+      <trans-unit id="profile.vita">
+        <source>Vita</source>
+      </trans-unit>
 
-			<!-- Show profile information headers-->
+      <!-- Show profile information headers-->
 
-			<trans-unit id="profile.profileInformations.cooperation">
-				<source>Cooperation</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.lectures">
-				<source>Lecture</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.memberships">
-				<source>Membership</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.pressMedia">
-				<source>Press media</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.publications">
-				<source>Publication</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.scientificResearch">
-				<source>Scientific research</source>
-			</trans-unit>
-			<trans-unit id="profile.profileInformations.vita">
-				<source>Vita</source>
-			</trans-unit>
+      <trans-unit id="profile.profileInformations.cooperation">
+        <source>Cooperation</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.lectures">
+        <source>Lecture</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.memberships">
+        <source>Membership</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.pressMedia">
+        <source>Press media</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.publications">
+        <source>Publication</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.scientificResearch">
+        <source>Scientific research</source>
+      </trans-unit>
+      <trans-unit id="profile.profileInformations.vita">
+        <source>Vita</source>
+      </trans-unit>
 
-			<!-- Show contract headers -->
+      <!-- Show contract headers -->
 
-			<trans-unit id="contract.data">
-				<source>Contract data</source>
-			</trans-unit>
-			<trans-unit id="contract.physicalAddresses">
-				<source>Physical addresses</source>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses">
-				<source>Email addresses</source>
-			</trans-unit>
-			<trans-unit id="contract.phoneNumbers">
-				<source>Phone numbers</source>
-			</trans-unit>
-			<trans-unit id="contract">
-				<source>Contract</source>
-			</trans-unit>
-			<trans-unit id="contract.physicalAddress">
-				<source>Physical address</source>
-			</trans-unit>
-			<trans-unit id="contract.emailAddress">
-				<source>Email address</source>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses.email">
-				<source>Email</source>
-			</trans-unit>
-			<trans-unit id="contract.emailAddresses.type">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="contract.phoneNumber">
-				<source>Phone number</source>
-			</trans-unit>
+      <trans-unit id="contract.data">
+        <source>Contract data</source>
+      </trans-unit>
+      <trans-unit id="contract.physicalAddresses">
+        <source>Physical addresses</source>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses">
+        <source>Email addresses</source>
+      </trans-unit>
+      <trans-unit id="contract.phoneNumbers">
+        <source>Phone numbers</source>
+      </trans-unit>
+      <trans-unit id="contract">
+        <source>Contract</source>
+      </trans-unit>
+      <trans-unit id="contract.physicalAddress">
+        <source>Physical address</source>
+      </trans-unit>
+      <trans-unit id="contract.emailAddress">
+        <source>Email address</source>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses.email">
+        <source>Email</source>
+      </trans-unit>
+      <trans-unit id="contract.emailAddresses.type">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="contract.phoneNumber">
+        <source>Phone number</source>
+      </trans-unit>
 
-			<!-- Profile fields -->
+      <!-- Profile fields -->
 
-			<trans-unit id="profile.gender.label">
-				<source>Gender</source>
-			</trans-unit>
-			<trans-unit id="profile.title.label">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="profile.title.placeholder">
-				<source>Prof.</source>
-			</trans-unit>
-			<trans-unit id="profile.name.label">
-				<source>Name</source>
-			</trans-unit>
-			<trans-unit id="profile.firstName.label">
-				<source>First name</source>
-			</trans-unit>
-			<trans-unit id="profile.firstName.placeholder">
-				<source>John</source>
-			</trans-unit>
-			<trans-unit id="profile.middleName.label">
-				<source>Middle name</source>
-			</trans-unit>
-			<trans-unit id="profile.middleName.placeholder">
-				<source>Paul</source>
-			</trans-unit>
-			<trans-unit id="profile.lastName.label">
-				<source>Last name</source>
-			</trans-unit>
-			<trans-unit id="profile.lastName.placeholder">
-				<source>Doe</source>
-			</trans-unit>
-			<trans-unit id="profile.website.label">
-				<source>Website</source>
-			</trans-unit>
-			<trans-unit id="profile.website.placeholder">
-				<source>https://www.example.com</source>
-			</trans-unit>
-			<trans-unit id="profile.websiteTitle.label">
-				<source>Website title</source>
-			</trans-unit>
-			<trans-unit id="profile.websiteTitle.placeholder">
-				<source>My personal website</source>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLink.label">
-				<source>Publications link</source>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLink.placeholder">
-				<source>https://www.publications.com</source>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLinkTitle.label">
-				<source>Publications link title</source>
-			</trans-unit>
-			<trans-unit id="profile.publicationsLinkTitle.placeholder">
-				<source>My publications</source>
-			</trans-unit>
-			<trans-unit id="profile.teachingArea.label">
-				<source>Teaching area</source>
-			</trans-unit>
-			<trans-unit id="profile.teachingArea.placeholder">
-				<source>e.g. Computer Science</source>
-			</trans-unit>
-			<trans-unit id="profile.coreCompetences.label">
-				<source>Core competences</source>
-			</trans-unit>
-			<trans-unit id="profile.coreCompetences.placeholder">
-				<source>e.g. Software Development, Data Science</source>
-			</trans-unit>
-			<trans-unit id="profile.supervisedThesis.label">
-				<source>Supervises thesis</source>
-			</trans-unit>
-			<trans-unit id="profile.supervisedThesis.placeholder">
-				<source>e.g. Bachelor, Master</source>
-			</trans-unit>
-			<trans-unit id="profile.supervisedDoctoralThesis.label">
-				<source>Supervises doctoral thesis</source>
-			</trans-unit>
-			<trans-unit id="profile.supervisedDoctoralThesis.placeholder">
-				<source>e.g. PhD, Doctorate</source>
-			</trans-unit>
-			<trans-unit id="profile.miscellaneous.label">
-				<source>Miscellaneous</source>
-			</trans-unit>
-			<trans-unit id="profile.miscellaneous.placeholder">
-				<source>e.g. Hobbies, Interests</source>
-			</trans-unit>
-			<trans-unit id="profile.skipSync.label">
-				<source>Disable profile sync</source>
-			</trans-unit>
-			<trans-unit id="profile.skipSync.description">
-				<source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
-			</trans-unit>
+      <trans-unit id="profile.gender.label">
+        <source>Gender</source>
+      </trans-unit>
+      <trans-unit id="profile.title.label">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="profile.title.placeholder">
+        <source>Prof.</source>
+      </trans-unit>
+      <trans-unit id="profile.name.label">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="profile.firstName.label">
+        <source>First name</source>
+      </trans-unit>
+      <trans-unit id="profile.firstName.placeholder">
+        <source>John</source>
+      </trans-unit>
+      <trans-unit id="profile.middleName.label">
+        <source>Middle name</source>
+      </trans-unit>
+      <trans-unit id="profile.middleName.placeholder">
+        <source>Paul</source>
+      </trans-unit>
+      <trans-unit id="profile.lastName.label">
+        <source>Last name</source>
+      </trans-unit>
+      <trans-unit id="profile.lastName.placeholder">
+        <source>Doe</source>
+      </trans-unit>
+      <trans-unit id="profile.website.label">
+        <source>Website</source>
+      </trans-unit>
+      <trans-unit id="profile.website.placeholder">
+        <source>https://www.example.com</source>
+      </trans-unit>
+      <trans-unit id="profile.websiteTitle.label">
+        <source>Website title</source>
+      </trans-unit>
+      <trans-unit id="profile.websiteTitle.placeholder">
+        <source>My personal website</source>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLink.label">
+        <source>Publications link</source>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLink.placeholder">
+        <source>https://www.publications.com</source>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLinkTitle.label">
+        <source>Publications link title</source>
+      </trans-unit>
+      <trans-unit id="profile.publicationsLinkTitle.placeholder">
+        <source>My publications</source>
+      </trans-unit>
+      <trans-unit id="profile.teachingArea.label">
+        <source>Teaching area</source>
+      </trans-unit>
+      <trans-unit id="profile.teachingArea.placeholder">
+        <source>e.g. Computer Science</source>
+      </trans-unit>
+      <trans-unit id="profile.coreCompetences.label">
+        <source>Core competences</source>
+      </trans-unit>
+      <trans-unit id="profile.coreCompetences.placeholder">
+        <source>e.g. Software Development, Data Science</source>
+      </trans-unit>
+      <trans-unit id="profile.supervisedThesis.label">
+        <source>Supervises thesis</source>
+      </trans-unit>
+      <trans-unit id="profile.supervisedThesis.placeholder">
+        <source>e.g. Bachelor, Master</source>
+      </trans-unit>
+      <trans-unit id="profile.supervisedDoctoralThesis.label">
+        <source>Supervises doctoral thesis</source>
+      </trans-unit>
+      <trans-unit id="profile.supervisedDoctoralThesis.placeholder">
+        <source>e.g. PhD, Doctorate</source>
+      </trans-unit>
+      <trans-unit id="profile.miscellaneous.label">
+        <source>Miscellaneous</source>
+      </trans-unit>
+      <trans-unit id="profile.miscellaneous.placeholder">
+        <source>e.g. Hobbies, Interests</source>
+      </trans-unit>
+      <trans-unit id="profile.skipSync.label">
+        <source>Disable profile sync</source>
+      </trans-unit>
+      <trans-unit id="profile.skipSync.description">
+        <source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
+      </trans-unit>
 
-			<!-- Profile information fields -->
+      <!-- Profile information fields -->
 
-			<trans-unit id="profileInformation.title.label">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.title.placeholder">
-				<source>My title</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.link.label">
-				<source>Link</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.link.placeholder">
-				<source>https://www.example.com</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.year.label">
-				<source>Year</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.year.placeholder">
-				<source>e.g. 2025</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearStart.label">
-				<source>Start year</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearStart.placeholder">
-				<source>e.g. 2020</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearEnd.label">
-				<source>End year</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.yearEnd.placeholder">
-				<source>e.g. 2025</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.bodytext.label">
-				<source>Text</source>
-			</trans-unit>
-			<trans-unit id="profileInformation.bodytext.placeholder">
-				<source>Enter text here...</source>
-			</trans-unit>
+      <trans-unit id="profileInformation.title.label">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.title.placeholder">
+        <source>My title</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.link.label">
+        <source>Link</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.link.placeholder">
+        <source>https://www.example.com</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.year.label">
+        <source>Year</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.year.placeholder">
+        <source>e.g. 2025</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearStart.label">
+        <source>Start year</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearStart.placeholder">
+        <source>e.g. 2020</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearEnd.label">
+        <source>End year</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.yearEnd.placeholder">
+        <source>e.g. 2025</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.bodytext.label">
+        <source>Text</source>
+      </trans-unit>
+      <trans-unit id="profileInformation.bodytext.placeholder">
+        <source>Enter text here...</source>
+      </trans-unit>
 
-			<!-- Contract fields -->
+      <!-- Contract fields -->
 
-			<trans-unit id="contract.position.label">
-				<source>Position</source>
-			</trans-unit>
-			<trans-unit id="contract.position.placeholder">
-				<source>e.g. Professor, Lecturer</source>
-			</trans-unit>
-			<trans-unit id="contract.organisationalUnit.label">
-				<source>Organisational unit</source>
-			</trans-unit>
-			<trans-unit id="contract.functionType.label">
-				<source>Function type</source>
-			</trans-unit>
-			<trans-unit id="contract.validFrom.label">
-				<source>Valid from</source>
-			</trans-unit>
-			<trans-unit id="contract.validTo.label">
-				<source>Valid to</source>
-			</trans-unit>
-			<trans-unit id="contract.location.label">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="contract.location.placeholder">
-				<source>e.g. Main Campus</source>
-			</trans-unit>
-			<trans-unit id="contract.room.label">
-				<source>Room</source>
-			</trans-unit>
-			<trans-unit id="contract.room.placeholder">
-				<source>e.g. 101</source>
-			</trans-unit>
-			<trans-unit id="contract.officeHours.label">
-				<source>Office hours</source>
-			</trans-unit>
-			<trans-unit id="contract.officeHours.placeholder">
-				<source>e.g. Monday 10-12, Wednesday 14-16</source>
-			</trans-unit>
-			<trans-unit id="contract.publish.label">
-				<source>Publish</source>
-			</trans-unit>
-			<trans-unit id="contract.published.label">
-				<source>Published</source>
-			</trans-unit>
+      <trans-unit id="contract.position.label">
+        <source>Position</source>
+      </trans-unit>
+      <trans-unit id="contract.position.placeholder">
+        <source>e.g. Professor, Lecturer</source>
+      </trans-unit>
+      <trans-unit id="contract.organisationalUnit.label">
+        <source>Organisational unit</source>
+      </trans-unit>
+      <trans-unit id="contract.functionType.label">
+        <source>Function type</source>
+      </trans-unit>
+      <trans-unit id="contract.validFrom.label">
+        <source>Valid from</source>
+      </trans-unit>
+      <trans-unit id="contract.validTo.label">
+        <source>Valid to</source>
+      </trans-unit>
+      <trans-unit id="contract.location.label">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="contract.location.placeholder">
+        <source>e.g. Main Campus</source>
+      </trans-unit>
+      <trans-unit id="contract.room.label">
+        <source>Room</source>
+      </trans-unit>
+      <trans-unit id="contract.room.placeholder">
+        <source>e.g. 101</source>
+      </trans-unit>
+      <trans-unit id="contract.officeHours.label">
+        <source>Office hours</source>
+      </trans-unit>
+      <trans-unit id="contract.officeHours.placeholder">
+        <source>e.g. Monday 10-12, Wednesday 14-16</source>
+      </trans-unit>
+      <trans-unit id="contract.publish.label">
+        <source>Publish</source>
+      </trans-unit>
+      <trans-unit id="contract.published.label">
+        <source>Published</source>
+      </trans-unit>
 
-			<!-- Physical address fields -->
+      <!-- Physical address fields -->
 
-			<trans-unit id="physicalAddress.street.label">
-				<source>Street</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.street.placeholder">
-				<source>Examplestreet</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.streetNumber.label">
-				<source>Street number</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.streetNumber.placeholder">
-				<source>123</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.additional.label">
-				<source>Additional</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.additional.placeholder">
-				<source>e.g. 2nd floor</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.zip.label">
-				<source>Zip</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.zip.placeholder">
-				<source>12345</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.city.label">
-				<source>City</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.city.placeholder">
-				<source>Example City</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.state.label">
-				<source>State</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.state.placeholder">
-				<source>Example State</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.country.label">
-				<source>Country</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.country.placeholder">
-				<source>Exmplate Country</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.type.label">
-				<source>Type</source>
-			</trans-unit>
+      <trans-unit id="physicalAddress.street.label">
+        <source>Street</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.street.placeholder">
+        <source>Examplestreet</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.streetNumber.label">
+        <source>Street number</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.streetNumber.placeholder">
+        <source>123</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.additional.label">
+        <source>Additional</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.additional.placeholder">
+        <source>e.g. 2nd floor</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.zip.label">
+        <source>Zip</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.zip.placeholder">
+        <source>12345</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.city.label">
+        <source>City</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.city.placeholder">
+        <source>Example City</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.state.label">
+        <source>State</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.state.placeholder">
+        <source>Example State</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.country.label">
+        <source>Country</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.country.placeholder">
+        <source>Exmplate Country</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.type.label">
+        <source>Type</source>
+      </trans-unit>
 
-			<!-- Phone number fields -->
+      <!-- Phone number fields -->
 
-			<trans-unit id="phoneNumber.phoneNumber.label">
-				<source>Phone number</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.phoneNumber.placeholder">
-				<source>+49 123 4567890</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.type.label">
-				<source>Type</source>
-			</trans-unit>
+      <trans-unit id="phoneNumber.phoneNumber.label">
+        <source>Phone number</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.phoneNumber.placeholder">
+        <source>+49 123 4567890</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.type.label">
+        <source>Type</source>
+      </trans-unit>
 
-			<!-- Email address fields -->
+      <!-- Email address fields -->
 
-			<trans-unit id="emailAddress.emailAddress.label">
-				<source>Email address</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.emailAddress.placeholder">
-				<source>example@domain.com</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.type.label">
-				<source>Type</source>
-			</trans-unit>
+      <trans-unit id="emailAddress.emailAddress.label">
+        <source>Email address</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.emailAddress.placeholder">
+        <source>example@domain.com</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.type.label">
+        <source>Type</source>
+      </trans-unit>
 
-			<!-- Action buttons -->
+      <!-- Action buttons -->
 
-			<trans-unit id="actions.view">
-				<source>View</source>
-			</trans-unit>
-			<trans-unit id="actions.edit">
-				<source>Edit</source>
-			</trans-unit>
-			<trans-unit id="actions.add">
-				<source>Add</source>
-			</trans-unit>
-			<trans-unit id="actions.sortUp">
-				<source>Move upwards</source>
-			</trans-unit>
-			<trans-unit id="actions.sortDown">
-				<source>Move downwards</source>
-			</trans-unit>
-			<trans-unit id="actions.setToTop">
-				<source>Move to the top</source>
-			</trans-unit>
-			<trans-unit id="actions.setToBottom">
-				<source>Move to the bottom</source>
-			</trans-unit>
-			<trans-unit id="actions.delete">
-				<source>Delete</source>
-			</trans-unit>
-			<trans-unit id="actions.cancel">
-				<source>Cancel</source>
-			</trans-unit>
-			<trans-unit id="actions.save">
-				<source>Save</source>
-			</trans-unit>
-			<trans-unit id="actions.saveAndExit">
-				<source>Save and exit</source>
-			</trans-unit>
-			<trans-unit id="actions.translate">
-				<source>Translate</source>
-			</trans-unit>
-			<trans-unit id="actions.hide">
-				<source>Hide in frontend</source>
-			</trans-unit>
-			<trans-unit id="actions.show">
-				<source>Show in frontend</source>
-			</trans-unit>
+      <trans-unit id="actions.view">
+        <source>View</source>
+      </trans-unit>
+      <trans-unit id="actions.edit">
+        <source>Edit</source>
+      </trans-unit>
+      <trans-unit id="actions.add">
+        <source>Add</source>
+      </trans-unit>
+      <trans-unit id="actions.sortUp">
+        <source>Move upwards</source>
+      </trans-unit>
+      <trans-unit id="actions.sortDown">
+        <source>Move downwards</source>
+      </trans-unit>
+      <trans-unit id="actions.setToTop">
+        <source>Move to the top</source>
+      </trans-unit>
+      <trans-unit id="actions.setToBottom">
+        <source>Move to the bottom</source>
+      </trans-unit>
+      <trans-unit id="actions.delete">
+        <source>Delete</source>
+      </trans-unit>
+      <trans-unit id="actions.cancel">
+        <source>Cancel</source>
+      </trans-unit>
+      <trans-unit id="actions.save">
+        <source>Save</source>
+      </trans-unit>
+      <trans-unit id="actions.saveAndExit">
+        <source>Save and exit</source>
+      </trans-unit>
+      <trans-unit id="actions.translate">
+        <source>Translate</source>
+      </trans-unit>
+      <trans-unit id="actions.hide">
+        <source>Hide in frontend</source>
+      </trans-unit>
+      <trans-unit id="actions.show">
+        <source>Show in frontend</source>
+      </trans-unit>
 
-			<!-- Confirm deletion -->
+      <!-- Confirm deletion -->
 
-			<trans-unit id="contract.delete">
-				<source>Do you really want to delete this contract?</source>
-			</trans-unit>
-			<trans-unit id="publications.delete">
-				<source>Do you really want to delete this publication?</source>
-			</trans-unit>
-			<trans-unit id="cooperation.delete">
-				<source>Do you really want to delete this cooperation?</source>
-			</trans-unit>
-			<trans-unit id="memberships.delete">
-				<source>Do you really want to delete this membership?</source>
-			</trans-unit>
-			<trans-unit id="vita.delete">
-				<source>Do you really want to delete this vita?</source>
-			</trans-unit>
-			<trans-unit id="lectures.delete">
-				<source>Do you really want to delete this lecture?</source>
-			</trans-unit>
-			<trans-unit id="pressMedia.delete">
-				<source>Do you really want to delete this press media?</source>
-			</trans-unit>
-			<trans-unit id="scientificResearch.delete">
-				<source>Do you really want to delete this scientific research?</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.delete">
-				<source>Do you really want to delete this physical address?</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.delete">
-				<source>Do you really want to delete this email address?</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.delete">
-				<source>Do you really want to delete this phone number?</source>
-			</trans-unit>
+      <trans-unit id="contract.delete">
+        <source>Do you really want to delete this contract?</source>
+      </trans-unit>
+      <trans-unit id="publications.delete">
+        <source>Do you really want to delete this publication?</source>
+      </trans-unit>
+      <trans-unit id="cooperation.delete">
+        <source>Do you really want to delete this cooperation?</source>
+      </trans-unit>
+      <trans-unit id="memberships.delete">
+        <source>Do you really want to delete this membership?</source>
+      </trans-unit>
+      <trans-unit id="vita.delete">
+        <source>Do you really want to delete this vita?</source>
+      </trans-unit>
+      <trans-unit id="lectures.delete">
+        <source>Do you really want to delete this lecture?</source>
+      </trans-unit>
+      <trans-unit id="pressMedia.delete">
+        <source>Do you really want to delete this press media?</source>
+      </trans-unit>
+      <trans-unit id="scientificResearch.delete">
+        <source>Do you really want to delete this scientific research?</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.delete">
+        <source>Do you really want to delete this physical address?</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.delete">
+        <source>Do you really want to delete this email address?</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.delete">
+        <source>Do you really want to delete this phone number?</source>
+      </trans-unit>
 
-			<!-- Success messages -->
+      <!-- Success messages -->
 
-			<trans-unit id="profile.update.success">
-				<source>Profile updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="contract.create.success">
-				<source>Contract created successfully.</source>
-			</trans-unit>
-			<trans-unit id="contract.update.success">
-				<source>Contract updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="contract.delete.success">
-				<source>Contract deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="contract.sort.success">
-				<source>Contract sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.create.success">
-				<source>Physical address created successfully.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.update.success">
-				<source>Physical address updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.delete.success">
-				<source>Physical address deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.sort.success">
-				<source>Physical address sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.hidden.success">
-				<source>Physical address is now hidden in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.visible.success">
-				<source>Physical address is now visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="physicalAddress.toggleVisibility.error.notFound">
-				<source>Physical address could not be found.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.create.success">
-				<source>Phone number created successfully.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.update.success">
-				<source>Phone number updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.delete.success">
-				<source>Phone number deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.sort.success">
-				<source>Phone number sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.hidden.success">
-				<source>Phone number is now hidden in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.visible.success">
-				<source>Phone number is now visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="phoneNumber.toggleVisibility.error.notFound">
-				<source>Phone number could not be found.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.create.success">
-				<source>Email address created successfully.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.update.success">
-				<source>Email address updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.delete.success">
-				<source>Email address deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.sort.success">
-				<source>Email address sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.hidden.success">
-				<source>Email address is now hidden in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.visible.success">
-				<source>Email address is now visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="emailAddress.toggleVisibility.error.notFound">
-				<source>Email address could not be found.</source>
-			</trans-unit>
-			<trans-unit id="scientific_research.create.success">
-				<source>Scientific research created successfully.</source>
-			</trans-unit>
-			<trans-unit id="scientific_research.update.success">
-				<source>Scientific research updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="scientific_research.delete.success">
-				<source>Scientific research deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="scientific_research.sort.success">
-				<source>Scientific research sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="vita.create.success">
-				<source>Vita created successfully.</source>
-			</trans-unit>
-			<trans-unit id="vita.update.success">
-				<source>Vita updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="vita.delete.success">
-				<source>Vita deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="vita.sort.success">
-				<source>Vita sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="membership.create.success">
-				<source>Membership created successfully.</source>
-			</trans-unit>
-			<trans-unit id="membership.update.success">
-				<source>Membership updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="membership.delete.success">
-				<source>Membership deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="membership.sort.success">
-				<source>Membership sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="cooperation.create.success">
-				<source>Cooperation created successfully.</source>
-			</trans-unit>
-			<trans-unit id="cooperation.update.success">
-				<source>Cooperation updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="cooperation.delete.success">
-				<source>Cooperation deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="cooperation.sort.success">
-				<source>Cooperation sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="publication.create.success">
-				<source>Publication created successfully.</source>
-			</trans-unit>
-			<trans-unit id="publication.update.success">
-				<source>Publication updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="publication.delete.success">
-				<source>Publication deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="publication.sort.success">
-				<source>Publication sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="lecture.create.success">
-				<source>Lecture created successfully.</source>
-			</trans-unit>
-			<trans-unit id="lecture.update.success">
-				<source>Lecture updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="lecture.delete.success">
-				<source>Lecture deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="lecture.sort.success">
-				<source>Lecture sorted successfully.</source>
-			</trans-unit>
-			<trans-unit id="press_media.create.success">
-				<source>Press media created successfully.</source>
-			</trans-unit>
-			<trans-unit id="press_media.update.success">
-				<source>Press media updated successfully.</source>
-			</trans-unit>
-			<trans-unit id="press_media.delete.success">
-				<source>Press media deleted successfully.</source>
-			</trans-unit>
-			<trans-unit id="press_media.sort.success">
-				<source>Press media sorted successfully.</source>
-			</trans-unit>
+      <trans-unit id="profile.update.success">
+        <source>Profile updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="contract.create.success">
+        <source>Contract created successfully.</source>
+      </trans-unit>
+      <trans-unit id="contract.update.success">
+        <source>Contract updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="contract.delete.success">
+        <source>Contract deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="contract.sort.success">
+        <source>Contract sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.create.success">
+        <source>Physical address created successfully.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.update.success">
+        <source>Physical address updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.delete.success">
+        <source>Physical address deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.sort.success">
+        <source>Physical address sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.hidden.success">
+        <source>Physical address is now hidden in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.visible.success">
+        <source>Physical address is now visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="physicalAddress.toggleVisibility.error.notFound">
+        <source>Physical address could not be found.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.create.success">
+        <source>Phone number created successfully.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.update.success">
+        <source>Phone number updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.delete.success">
+        <source>Phone number deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.sort.success">
+        <source>Phone number sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.hidden.success">
+        <source>Phone number is now hidden in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.visible.success">
+        <source>Phone number is now visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="phoneNumber.toggleVisibility.error.notFound">
+        <source>Phone number could not be found.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.create.success">
+        <source>Email address created successfully.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.update.success">
+        <source>Email address updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.delete.success">
+        <source>Email address deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.sort.success">
+        <source>Email address sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.hidden.success">
+        <source>Email address is now hidden in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.visible.success">
+        <source>Email address is now visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="emailAddress.toggleVisibility.error.notFound">
+        <source>Email address could not be found.</source>
+      </trans-unit>
+      <trans-unit id="scientific_research.create.success">
+        <source>Scientific research created successfully.</source>
+      </trans-unit>
+      <trans-unit id="scientific_research.update.success">
+        <source>Scientific research updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="scientific_research.delete.success">
+        <source>Scientific research deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="scientific_research.sort.success">
+        <source>Scientific research sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="vita.create.success">
+        <source>Vita created successfully.</source>
+      </trans-unit>
+      <trans-unit id="vita.update.success">
+        <source>Vita updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="vita.delete.success">
+        <source>Vita deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="vita.sort.success">
+        <source>Vita sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="membership.create.success">
+        <source>Membership created successfully.</source>
+      </trans-unit>
+      <trans-unit id="membership.update.success">
+        <source>Membership updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="membership.delete.success">
+        <source>Membership deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="membership.sort.success">
+        <source>Membership sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="cooperation.create.success">
+        <source>Cooperation created successfully.</source>
+      </trans-unit>
+      <trans-unit id="cooperation.update.success">
+        <source>Cooperation updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="cooperation.delete.success">
+        <source>Cooperation deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="cooperation.sort.success">
+        <source>Cooperation sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="publication.create.success">
+        <source>Publication created successfully.</source>
+      </trans-unit>
+      <trans-unit id="publication.update.success">
+        <source>Publication updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="publication.delete.success">
+        <source>Publication deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="publication.sort.success">
+        <source>Publication sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="lecture.create.success">
+        <source>Lecture created successfully.</source>
+      </trans-unit>
+      <trans-unit id="lecture.update.success">
+        <source>Lecture updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="lecture.delete.success">
+        <source>Lecture deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="lecture.sort.success">
+        <source>Lecture sorted successfully.</source>
+      </trans-unit>
+      <trans-unit id="press_media.create.success">
+        <source>Press media created successfully.</source>
+      </trans-unit>
+      <trans-unit id="press_media.update.success">
+        <source>Press media updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="press_media.delete.success">
+        <source>Press media deleted successfully.</source>
+      </trans-unit>
+      <trans-unit id="press_media.sort.success">
+        <source>Press media sorted successfully.</source>
+      </trans-unit>
 
-			<!-- Error Messages -->
+      <!-- Error Messages -->
 
-			<trans-unit id="contractFormData.validTo.error.1307719788">
-				<source>"Valid to" must be a valid date. (Seperated by .)</source>
-			</trans-unit>
-			<trans-unit id="contractFormData.validFrom.error.1307719788">
-				<source>"Valid from" must be a valid date. (Seperated by .)</source>
-			</trans-unit>
-			<trans-unit id="profileInformationFormData.yearStart.error.1332933658">
-				<source>"Year start" must be a number.</source>
-			</trans-unit>
-			<trans-unit id="profileInformationFormData.yearEnd.error.1332933658">
-				<source>"Year end" must be a number.</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="contractFormData.validTo.error.1307719788">
+        <source>"Valid to" must be a valid date. (Seperated by .)</source>
+      </trans-unit>
+      <trans-unit id="contractFormData.validFrom.error.1307719788">
+        <source>"Valid from" must be a valid date. (Seperated by .)</source>
+      </trans-unit>
+      <trans-unit id="profileInformationFormData.yearStart.error.1332933658">
+        <source>"Year start" must be a number.</source>
+      </trans-unit>
+      <trans-unit id="profileInformationFormData.yearEnd.error.1332933658">
+        <source>"Year end" must be a number.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang_be.xlf
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_edit"
-	>
-		<header/>
-		<body>
-			<trans-unit id="plugin.profile_switcher.label">
-				<source>Profiles: Profile Switcher</source>
-			</trans-unit>
-			<trans-unit id="plugin.profile_editing.label">
-				<source>Profiles: Profile Editing</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_edit"
+  >
+    <header/>
+    <body>
+      <trans-unit id="plugin.profile_switcher.label">
+        <source>Profiles: Profile Switcher</source>
+      </trans-unit>
+      <trans-unit id="plugin.profile_editing.label">
+        <source>Profiles: Profile Editing</source>
+      </trans-unit>
 
-			<trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
-				<source>Deprecated and no effect. See EXT:academic_persons > autoCreateProfiles</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
-				<source>Deprecated and no effect. See EXT:academic_persons > createProfileForUserGroups</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.allowedLanguages.label">
-				<source>Allowed languages: List of language IDs which a profile can be translated to.</source>
-			</trans-unit>
+      <trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
+        <source>Deprecated and no effect. See EXT:academic_persons > autoCreateProfiles</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
+        <source>Deprecated and no effect. See EXT:academic_persons > createProfileForUserGroups</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.allowedLanguages.label">
+        <source>Allowed languages: List of language IDs which a profile can be translated to.</source>
+      </trans-unit>
 
-			<trans-unit id="fe_users.columns.tx_academicpersons_profiles.label">
-				<source>Assigned Profiles</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tabs.tx_academicpersons_profiles.label">
-				<source>Profiles</source>
-			</trans-unit>
-			<trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser">
-				<source>Academic Persons: User</source>
-			</trans-unit>
+      <trans-unit id="fe_users.columns.tx_academicpersons_profiles.label">
+        <source>Assigned Profiles</source>
+      </trans-unit>
+      <trans-unit id="fe_users.tabs.tx_academicpersons_profiles.label">
+        <source>Profiles</source>
+      </trans-unit>
+      <trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_AcademicPersonsEdit_Domain_Model_FrontendUser">
+        <source>Academic Persons: User</source>
+      </trans-unit>
 
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.frontend_users.label">
-				<source>Assigned Users</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.tabs.frontend_users.label">
-				<source>Frontend Users</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.frontend_users.label">
+        <source>Assigned Users</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.tabs.frontend_users.label">
+        <source>Frontend Users</source>
+      </trans-unit>
 
-			<trans-unit id="newContentElement.wizardItems.academic.profileEditing.title">
-				<source>Academic Persons Profile Editing</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileEditing.description">
-				<source>Plugin for editing profiles in the frontend</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.title">
-				<source>Academic Persons Edit Profile Switcher</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.description">
-				<source>Plugin for switching profiles in the frontend</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="newContentElement.wizardItems.academic.profileEditing.title">
+        <source>Academic Persons Profile Editing</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileEditing.description">
+        <source>Plugin for editing profiles in the frontend</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.title">
+        <source>Academic Persons Edit Profile Switcher</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.profileSwitcher.description">
+        <source>Plugin for switching profiles in the frontend</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-sync/.editorconfig
+++ b/packages/fgtclb/academic-persons-sync/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-persons-sync/Resources/Private/Language/de.locallang_tca.xlf
+++ b/packages/fgtclb/academic-persons-sync/Resources/Private/Language/de.locallang_tca.xlf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons_sync/Resources/Private/Language/locallang.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_sync"
-	>
-		<header/>
-		<body>
-			<trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser">
-				<source>Academic Persons: External User</source>
-				<target>Academic Persons: Externer Benutzer</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons_sync/Resources/Private/Language/locallang.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_sync"
+  >
+    <header/>
+    <body>
+      <trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser">
+        <source>Academic Persons: External User</source>
+        <target>Academic Persons: Externer Benutzer</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons-sync/Resources/Private/Language/locallang_tca.xlf
+++ b/packages/fgtclb/academic-persons-sync/Resources/Private/Language/locallang_tca.xlf
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons_sync/Resources/Private/Language/locallang.xlf"
-		date="2015-11-10T06:53:10Z"
-		product-name="academic_persons_sync"
-	>
-		<header/>
-		<body>
-			<trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser">
-				<source>Academic Persons: External User</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons_sync/Resources/Private/Language/locallang.xlf"
+    date="2015-11-10T06:53:10Z"
+    product-name="academic_persons_sync"
+  >
+    <header/>
+    <body>
+      <trans-unit id="fe_users.columns.tx_extbase_type.items.Tx_Academicpersonssync_Domain_Model_FrontendUser">
+        <source>Academic Persons: External User</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/.editorconfig
+++ b/packages/fgtclb/academic-persons/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang.xlf
@@ -1,152 +1,152 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
 
-			<!-- Contracts -->
+      <!-- Contracts -->
 
-			<trans-unit id="contracts.room">
-				<source>Room</source>
-				<target>Raum</target>
-			</trans-unit>
-			<trans-unit id="contracts.position">
-				<source>Position</source>
-				<target>Position</target>
-			</trans-unit>
-			<trans-unit id="contracts.officeHours">
-				<source>Office Hours</source>
-				<target>Bürozeiten</target>
-			</trans-unit>
-			<trans-unit id="contracts.location">
-				<source>Location</source>
-				<target>Ort</target>
-			</trans-unit>
-			<trans-unit id="contracts.emailAddresses">
-				<source>E-Mail</source>
-				<target>E-Mail</target>
-			</trans-unit>
-			<trans-unit id="contracts.phoneNumbers">
-				<source>Phone</source>
-				<target>Telefon</target>
-			</trans-unit>
-			<trans-unit id="contracts.physicalAddresses">
-				<source>Addresses</source>
-				<target>Adressen</target>
-			</trans-unit>
+      <trans-unit id="contracts.room">
+        <source>Room</source>
+        <target>Raum</target>
+      </trans-unit>
+      <trans-unit id="contracts.position">
+        <source>Position</source>
+        <target>Position</target>
+      </trans-unit>
+      <trans-unit id="contracts.officeHours">
+        <source>Office Hours</source>
+        <target>Bürozeiten</target>
+      </trans-unit>
+      <trans-unit id="contracts.location">
+        <source>Location</source>
+        <target>Ort</target>
+      </trans-unit>
+      <trans-unit id="contracts.emailAddresses">
+        <source>E-Mail</source>
+        <target>E-Mail</target>
+      </trans-unit>
+      <trans-unit id="contracts.phoneNumbers">
+        <source>Phone</source>
+        <target>Telefon</target>
+      </trans-unit>
+      <trans-unit id="contracts.physicalAddresses">
+        <source>Addresses</source>
+        <target>Adressen</target>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProfilesFound" resname="list.noProfilesFound">
-				<source>No profiles found.</source>
-				<target>Keine Profile gefunden.</target>
-			</trans-unit>
-			<trans-unit id="list.noContractsFound" resname="list.noContractsFound">
-				<source>No contracts found.</source>
-				<target>Keine Verträge gefunden.</target>
-			</trans-unit>
+      <trans-unit id="list.noProfilesFound" resname="list.noProfilesFound">
+        <source>No profiles found.</source>
+        <target>Keine Profile gefunden.</target>
+      </trans-unit>
+      <trans-unit id="list.noContractsFound" resname="list.noContractsFound">
+        <source>No contracts found.</source>
+        <target>Keine Verträge gefunden.</target>
+      </trans-unit>
 
-			<!-- Detail -->
+      <!-- Detail -->
 
-			<trans-unit id="detail.contracts" resname="detail.contracts">
-				<source>Contracts</source>
-				<target>Verträge</target>
-			</trans-unit>
-			<trans-unit id="detail.room" resname="detail.room">
-				<source>Room</source>
-				<target>Raum</target>
-			</trans-unit>
-			<trans-unit id="detail.phoneNumbers" resname="detail.phoneNumbers">
-				<source>Phone number(s)</source>
-				<target>Telefonnummer(n)</target>
-			</trans-unit>
-			<trans-unit id="detail.emailAddresses" resname="detail.emailAddresses">
-				<source>Email address(es)</source>
-				<target>Email Adresse(n)</target>
-			</trans-unit>
-			<trans-unit id="detail.physicalAddress.private" resname="detail.physicalAddress.private">
-				<source>Private</source>
-				<target>Privat</target>
-			</trans-unit>
-			<trans-unit id="detail.physicalAddress.business" resname="detail.physicalAddress.business">
-				<source>Business</source>
-				<target>Geschäftlich</target>
-			</trans-unit>
-			<trans-unit id="detail.additionalInformation" resname="detail.additionalInformation">
-				<source>Additional information</source>
-				<target>Zusätzliche Informationen</target>
-			</trans-unit>
-			<trans-unit id="detail.website" resname="detail.website">
-				<source>Website</source>
-				<target>Website</target>
-			</trans-unit>
-			<trans-unit id="detail.teachingArea" resname="detail.teachingArea">
-				<source>Teaching areas</source>
-				<target>Lehrgebiete/Aufgabenbereiche</target>
-			</trans-unit>
-			<trans-unit id="detail.coreCompetences" resname="detail.coreCompetences">
-				<source>Core competences</source>
-				<target>Kernkompetenzen</target>
-			</trans-unit>
-			<trans-unit id="detail.supervisedThesis" resname="detail.supervisedThesis">
-				<source>Supervised thesis</source>
-				<target>Beaufsichtigte Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="detail.supervisedDoctoralThesis" resname="detail.supervisedDoctoralThesis">
-				<source>Supervised doctoral thesis</source>
-				<target>Beaufsichtigte Doktorarbeit</target>
-			</trans-unit>
-			<trans-unit id="detail.miscellaneous" resname="detail.miscellaneous">
-				<source>Miscellaneous information</source>
-				<target>Sonstige Informationen</target>
-			</trans-unit>
-			<trans-unit id="detail.scientificResearch" resname="detail.scientificResearch">
-				<source>Research projects</source>
-				<target>Forschungsprojekte</target>
-			</trans-unit>
-			<trans-unit id="detail.vita" resname="detail.vita">
-				<source>Academic career</source>
-				<target>Akademischer Werdegang</target>
-			</trans-unit>
-			<trans-unit id="detail.memberships" resname="detail.memberships">
-				<source>Memberships/Committee activities</source>
-				<target>Mitgliedschaften/Gremientätigkeiten</target>
-			</trans-unit>
-			<trans-unit id="detail.cooperation" resname="detail.cooperation">
-				<source>Network/cooperation</source>
-				<target>Netzwerk/Kooperation</target>
-			</trans-unit>
-			<trans-unit id="detail.publications" resname="detail.publications">
-				<source>Publications</source>
-				<target>Publikationen</target>
-			</trans-unit>
-			<trans-unit id="detail.lectures" resname="detail.lectures">
-				<source>Lectures</source>
-				<target>Vorträge</target>
-			</trans-unit>
-			<trans-unit id="detail.pressMedia" resname="detail.pressMedia">
-				<source>Press/Media</source>
-				<target>Presse/Medien</target>
-			</trans-unit>
-			<trans-unit id="detail.publicationsLink" resname="detail.publicationsLink">
-				<source>Link to publications</source>
-				<target>Link zu Publikationen</target>
-			</trans-unit>
-			<trans-unit id="detail.since" resname="detail.since">
-				<source>Since</source>
-				<target>Seit</target>
-			</trans-unit>
-			<trans-unit id="detail.till" resname="detail.till">
-				<source>Till</source>
-				<target>Bis</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="detail.contracts" resname="detail.contracts">
+        <source>Contracts</source>
+        <target>Verträge</target>
+      </trans-unit>
+      <trans-unit id="detail.room" resname="detail.room">
+        <source>Room</source>
+        <target>Raum</target>
+      </trans-unit>
+      <trans-unit id="detail.phoneNumbers" resname="detail.phoneNumbers">
+        <source>Phone number(s)</source>
+        <target>Telefonnummer(n)</target>
+      </trans-unit>
+      <trans-unit id="detail.emailAddresses" resname="detail.emailAddresses">
+        <source>Email address(es)</source>
+        <target>Email Adresse(n)</target>
+      </trans-unit>
+      <trans-unit id="detail.physicalAddress.private" resname="detail.physicalAddress.private">
+        <source>Private</source>
+        <target>Privat</target>
+      </trans-unit>
+      <trans-unit id="detail.physicalAddress.business" resname="detail.physicalAddress.business">
+        <source>Business</source>
+        <target>Geschäftlich</target>
+      </trans-unit>
+      <trans-unit id="detail.additionalInformation" resname="detail.additionalInformation">
+        <source>Additional information</source>
+        <target>Zusätzliche Informationen</target>
+      </trans-unit>
+      <trans-unit id="detail.website" resname="detail.website">
+        <source>Website</source>
+        <target>Website</target>
+      </trans-unit>
+      <trans-unit id="detail.teachingArea" resname="detail.teachingArea">
+        <source>Teaching areas</source>
+        <target>Lehrgebiete/Aufgabenbereiche</target>
+      </trans-unit>
+      <trans-unit id="detail.coreCompetences" resname="detail.coreCompetences">
+        <source>Core competences</source>
+        <target>Kernkompetenzen</target>
+      </trans-unit>
+      <trans-unit id="detail.supervisedThesis" resname="detail.supervisedThesis">
+        <source>Supervised thesis</source>
+        <target>Beaufsichtigte Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="detail.supervisedDoctoralThesis" resname="detail.supervisedDoctoralThesis">
+        <source>Supervised doctoral thesis</source>
+        <target>Beaufsichtigte Doktorarbeit</target>
+      </trans-unit>
+      <trans-unit id="detail.miscellaneous" resname="detail.miscellaneous">
+        <source>Miscellaneous information</source>
+        <target>Sonstige Informationen</target>
+      </trans-unit>
+      <trans-unit id="detail.scientificResearch" resname="detail.scientificResearch">
+        <source>Research projects</source>
+        <target>Forschungsprojekte</target>
+      </trans-unit>
+      <trans-unit id="detail.vita" resname="detail.vita">
+        <source>Academic career</source>
+        <target>Akademischer Werdegang</target>
+      </trans-unit>
+      <trans-unit id="detail.memberships" resname="detail.memberships">
+        <source>Memberships/Committee activities</source>
+        <target>Mitgliedschaften/Gremientätigkeiten</target>
+      </trans-unit>
+      <trans-unit id="detail.cooperation" resname="detail.cooperation">
+        <source>Network/cooperation</source>
+        <target>Netzwerk/Kooperation</target>
+      </trans-unit>
+      <trans-unit id="detail.publications" resname="detail.publications">
+        <source>Publications</source>
+        <target>Publikationen</target>
+      </trans-unit>
+      <trans-unit id="detail.lectures" resname="detail.lectures">
+        <source>Lectures</source>
+        <target>Vorträge</target>
+      </trans-unit>
+      <trans-unit id="detail.pressMedia" resname="detail.pressMedia">
+        <source>Press/Media</source>
+        <target>Presse/Medien</target>
+      </trans-unit>
+      <trans-unit id="detail.publicationsLink" resname="detail.publicationsLink">
+        <source>Link to publications</source>
+        <target>Link zu Publikationen</target>
+      </trans-unit>
+      <trans-unit id="detail.since" resname="detail.since">
+        <source>Since</source>
+        <target>Seit</target>
+      </trans-unit>
+      <trans-unit id="detail.till" resname="detail.till">
+        <source>Till</source>
+        <target>Bis</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_be.xlf
@@ -1,286 +1,286 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang_be.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
-			<trans-unit id="extension_configuration.types.profileTypes.label">
-				<source>Profile Types: Comma-separated list of profile types</source>
-				<target>Profiltypen: Kommagetrennte Liste von Profiltypen</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.physicalAddressTypes.label">
-				<source>Physical Address Types: Comma-separated list of physical address types</source>
-				<target>Physikalische Adresstypen: Kommagetrennte Liste von physischen Adresstypen</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.emailAddressTypes.label">
-				<source>Email Address Types: Comma-separated list of email address types</source>
-				<target>E-Mail Adresstypen: Kommagetrennte Liste von E-Mail-Adresstypen</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.phoneNumberTypes.label">
-				<source>Phone Number Types: Comma-separated list of phone number types</source>
-				<target>Rufnummertypen: Kommagetrennte Liste von Rufnummertypen</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
-				<source>Group By Values: Comma-separated list of allowed group by values</source>
-				<target>Nach Werten gruppieren: Kommagetrennte Liste von zulässigen Gruppierungswerten</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.demand.allowedSortByValues.label">
-				<source>Sort By Values: Comma-separated list of allowed sort by values</source>
-				<target>Nach Werten sortieren: Kommagetrennte Liste von zulässigen Sortierwerten</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
-				<source>Auto create profile: Automatically creates a new profile for FE users</source>
-				<target>Automatisch Profil erstellen: Legt automatisch ein neues Profil für FE Benutzer an</target>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
-				<source>Create for user groups: Create profiles only if current user is in one of these user group IDs.</source>
-				<target>Für Benutzergruppen erstellen: Legt Profile an, wenn der aktuelle Benutzer Teil dieser Gruppen-IDs ist</target>
-			</trans-unit>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang_be.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
+      <trans-unit id="extension_configuration.types.profileTypes.label">
+        <source>Profile Types: Comma-separated list of profile types</source>
+        <target>Profiltypen: Kommagetrennte Liste von Profiltypen</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.physicalAddressTypes.label">
+        <source>Physical Address Types: Comma-separated list of physical address types</source>
+        <target>Physikalische Adresstypen: Kommagetrennte Liste von physischen Adresstypen</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.emailAddressTypes.label">
+        <source>Email Address Types: Comma-separated list of email address types</source>
+        <target>E-Mail Adresstypen: Kommagetrennte Liste von E-Mail-Adresstypen</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.phoneNumberTypes.label">
+        <source>Phone Number Types: Comma-separated list of phone number types</source>
+        <target>Rufnummertypen: Kommagetrennte Liste von Rufnummertypen</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
+        <source>Group By Values: Comma-separated list of allowed group by values</source>
+        <target>Nach Werten gruppieren: Kommagetrennte Liste von zulässigen Gruppierungswerten</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.demand.allowedSortByValues.label">
+        <source>Sort By Values: Comma-separated list of allowed sort by values</source>
+        <target>Nach Werten sortieren: Kommagetrennte Liste von zulässigen Sortierwerten</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
+        <source>Auto create profile: Automatically creates a new profile for FE users</source>
+        <target>Automatisch Profil erstellen: Legt automatisch ein neues Profil für FE Benutzer an</target>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
+        <source>Create for user groups: Create profiles only if current user is in one of these user group IDs.</source>
+        <target>Für Benutzergruppen erstellen: Legt Profile an, wenn der aktuelle Benutzer Teil dieser Gruppen-IDs ist</target>
+      </trans-unit>
 
-			<trans-unit id="plugin.list.label">
-				<source>Persons List</source>
-				<target>Personen Liste</target>
-			</trans-unit>
-			<trans-unit id="plugin.detail.label">
-				<source>Persons Detail</source>
-				<target>Personen Detail</target>
-			</trans-unit>
-			<trans-unit id="plugin.listAndDetail.label">
-				<source>Persons List and Detail</source>
-				<target>Personen Liste and Detail</target>
-			</trans-unit>
-			<trans-unit id="plugin.selectedprofiles.label">
-				<source>Profiles: Selected Profiles</source>
-				<target>Profiles: Selected Profiles</target>
-			</trans-unit>
-			<trans-unit id="plugin.selectedprofiles.description">
-				<source>Plugin to list only selected profiles</source>
-				<target>Plugin to list only selected profiles</target>
-			</trans-unit>
-			<trans-unit id="plugin.selectedcontracts.label">
-				<source>Profiles: Selected Contracts</source>
-				<target>Profiles: Selected Contracts</target>
-			</trans-unit>
-			<trans-unit id="plugin.selectedcontracts.description">
-				<source>Plugin to list only selected contracts</source>
-				<target>Plugin to list only selected contracts</target>
-			</trans-unit>
+      <trans-unit id="plugin.list.label">
+        <source>Persons List</source>
+        <target>Personen Liste</target>
+      </trans-unit>
+      <trans-unit id="plugin.detail.label">
+        <source>Persons Detail</source>
+        <target>Personen Detail</target>
+      </trans-unit>
+      <trans-unit id="plugin.listAndDetail.label">
+        <source>Persons List and Detail</source>
+        <target>Personen Liste and Detail</target>
+      </trans-unit>
+      <trans-unit id="plugin.selectedprofiles.label">
+        <source>Profiles: Selected Profiles</source>
+        <target>Profiles: Selected Profiles</target>
+      </trans-unit>
+      <trans-unit id="plugin.selectedprofiles.description">
+        <source>Plugin to list only selected profiles</source>
+        <target>Plugin to list only selected profiles</target>
+      </trans-unit>
+      <trans-unit id="plugin.selectedcontracts.label">
+        <source>Profiles: Selected Contracts</source>
+        <target>Profiles: Selected Contracts</target>
+      </trans-unit>
+      <trans-unit id="plugin.selectedcontracts.description">
+        <source>Plugin to list only selected contracts</source>
+        <target>Plugin to list only selected contracts</target>
+      </trans-unit>
 
-			<trans-unit id="newContentElement.wizardItems.academic">
-				<source>Academic</source>
-				<target>Akademisch</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.title">
-				<source>Persons List</source>
-				<target>Personen Liste</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.description">
-				<source>Plugin for listing academic persons</source>
-				<target>Plugin zur Auflistung akademischer Personen</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.title">
-				<source>Persons Detail</source>
-				<target>Personen Detail</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.description">
-				<source>Plugin for viewing single academic persons</source>
-				<target>Plugin zur Ansicht einzelner akademischer Personen</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
-				<source>Persons List and Detail</source>
-				<target>Personen Liste und Detail</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
-				<source>Plugin for listing and viewing academic persons</source>
-				<target>Plugin zur Auflistung und Ansicht akademischer Personen</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.card.title">
-				<source>Contacts</source>
-				<target>Kontakte</target>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.card.description">
-				<source>Adds one or more contacts</source>
-				<target>Fügt ein oder mehrere Kontakte hinzu</target>
-			</trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic">
+        <source>Academic</source>
+        <target>Akademisch</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.title">
+        <source>Persons List</source>
+        <target>Personen Liste</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.description">
+        <source>Plugin for listing academic persons</source>
+        <target>Plugin zur Auflistung akademischer Personen</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+        <source>Persons Detail</source>
+        <target>Personen Detail</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+        <source>Plugin for viewing single academic persons</source>
+        <target>Plugin zur Ansicht einzelner akademischer Personen</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
+        <source>Persons List and Detail</source>
+        <target>Personen Liste und Detail</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
+        <source>Plugin for listing and viewing academic persons</source>
+        <target>Plugin zur Auflistung und Ansicht akademischer Personen</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.card.title">
+        <source>Contacts</source>
+        <target>Kontakte</target>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.card.description">
+        <source>Adds one or more contacts</source>
+        <target>Fügt ein oder mehrere Kontakte hinzu</target>
+      </trans-unit>
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="flexform.tab.settings">
-				<source>Settings</source>
-				<target>Einstellungen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.detailPid.label">
-				<source>Detail Page</source>
-				<target>Detail Seite</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.listPid.label">
-				<source>List Page</source>
-				<target>Listen Seite</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.functionTypes.label">
-				<source>Function Types</source>
-				<target>Funktionstypen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.label">
-				<source>Group By (is given priority in sorting if activ)</source>
-				<target>Gruppieren nach (wird vorrangig bei der Sortierung berücksichtigt)</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.none">
-				<source>No grouping</source>
-				<target>Keine Gruppierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.first_name">
-				<source>First Letter of First Name</source>
-				<target>Erster Buchstabe des Vornamens</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.last_name">
-				<source>First Letter of Last Name</source>
-				<target>Erster Buchstabe des Nachnamens</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.organisationalUnits.label">
-				<source>Organisational Units</source>
-				<target>Organisationseinheiten</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.label">
-				<source>Sort By (sorting of activated grouping has priority)</source>
-				<target>Sortieren nach (wird nachrangig bei aktivierter Gruppierung berücksichtigt)</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.selectedContracts.label">
-				<source>Selected Contracts</source>
-				<target>Ausgewählte Verträge</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.selectedProfiles.label">
-				<source>Selected Profiles</source>
-				<target>Ausgewählte Profile</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.label">
-				<source>Show only selected Fields</source>
-				<target>Nur ausgewählte Felder anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.groups.profile">
-				<source>Profile</source>
-				<target>Profil</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.groups.contracts">
-				<source>Contracts</source>
-				<target>Verträge</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.none">
-				<source>No sorting</source>
-				<target>Keine Sortierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.first_name">
-				<source>First Name</source>
-				<target>Vorname</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.last_name">
-				<source>Last Name</source>
-				<target>Nachname</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.label">
-				<source>Sort By Direction</source>
-				<target>Nach Richtung sortieren</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.asc">
-				<source>Ascending</source>
-				<target>Aufsteigend</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.desc">
-				<source>Descending</source>
-				<target>Absteigend</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.alphabetPaginationEnabled.label">
-				<source>Alphabetical Pagination</source>
-				<target>Alphabetische Paginierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
-				<source>Enabled</source>
-				<target>Aktiviert</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.paginationEnabled.label">
-				<source>Pagination</source>
-				<target>Paginierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.paginationEnabled.items.0.label">
-				<source>Enabled</source>
-				<target>Aktiviert</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.resultsPerPage.label">
-				<source>Results per Page</source>
-				<target>Ergebnisse pro Seite</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.numberOfLinks.label">
-				<source>Number of Links</source>
-				<target>Anzahl der Links</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.paginationEnabled.items.0.label">
-				<source>Enabled</source>
-				<target>Aktiviert</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.label">
-				<source>PageTitle display format</source>
-				<target>Seitentitel Anzeige Format</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
-				<source>for person detail page</source>
-				<target>für Person Detailansicht</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.none">
-				<source>Default page title</source>
-				<target>Standard Seitentitel</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
-				<source>Title Firstname Middlename Lastname</source>
-				<target>Titel Vorname Mittelname Nachname</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
-				<source>Lastname, Firstname Middlename</source>
-				<target>Nachname, Vorname Mittelname</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.profileList.label">
-				<source>List of profiles</source>
-				<target>Liste von Profilen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.fallbackForNonTranslated.label">
-				<source>Fallback to default language for non translated profiles</source>
-				<target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.enabled.label">
-				<source>View Mode Toggle</source>
-				<target>Ansichtsmodus-Umschalter</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.enabled.items.0.label">
-				<source>Enabled</source>
-				<target>Aktiviert</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.label">
-				<source>View Mode Default</source>
-				<target>Standard für Ansichtsmodus</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.I.list">
-				<source>List</source>
-				<target>Liste</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.I.table">
-				<source>Table</source>
-				<target>Tabelle</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.el.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="flexform.tab.settings">
+        <source>Settings</source>
+        <target>Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.detailPid.label">
+        <source>Detail Page</source>
+        <target>Detail Seite</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.listPid.label">
+        <source>List Page</source>
+        <target>Listen Seite</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.functionTypes.label">
+        <source>Function Types</source>
+        <target>Funktionstypen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.label">
+        <source>Group By (is given priority in sorting if activ)</source>
+        <target>Gruppieren nach (wird vorrangig bei der Sortierung berücksichtigt)</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.none">
+        <source>No grouping</source>
+        <target>Keine Gruppierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.first_name">
+        <source>First Letter of First Name</source>
+        <target>Erster Buchstabe des Vornamens</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.last_name">
+        <source>First Letter of Last Name</source>
+        <target>Erster Buchstabe des Nachnamens</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.organisationalUnits.label">
+        <source>Organisational Units</source>
+        <target>Organisationseinheiten</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.label">
+        <source>Sort By (sorting of activated grouping has priority)</source>
+        <target>Sortieren nach (wird nachrangig bei aktivierter Gruppierung berücksichtigt)</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.selectedContracts.label">
+        <source>Selected Contracts</source>
+        <target>Ausgewählte Verträge</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.selectedProfiles.label">
+        <source>Selected Profiles</source>
+        <target>Ausgewählte Profile</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.label">
+        <source>Show only selected Fields</source>
+        <target>Nur ausgewählte Felder anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.groups.profile">
+        <source>Profile</source>
+        <target>Profil</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.groups.contracts">
+        <source>Contracts</source>
+        <target>Verträge</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.none">
+        <source>No sorting</source>
+        <target>Keine Sortierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.first_name">
+        <source>First Name</source>
+        <target>Vorname</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.last_name">
+        <source>Last Name</source>
+        <target>Nachname</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.label">
+        <source>Sort By Direction</source>
+        <target>Nach Richtung sortieren</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.asc">
+        <source>Ascending</source>
+        <target>Aufsteigend</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.desc">
+        <source>Descending</source>
+        <target>Absteigend</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.alphabetPaginationEnabled.label">
+        <source>Alphabetical Pagination</source>
+        <target>Alphabetische Paginierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
+        <source>Enabled</source>
+        <target>Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.paginationEnabled.label">
+        <source>Pagination</source>
+        <target>Paginierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.paginationEnabled.items.0.label">
+        <source>Enabled</source>
+        <target>Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.resultsPerPage.label">
+        <source>Results per Page</source>
+        <target>Ergebnisse pro Seite</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.numberOfLinks.label">
+        <source>Number of Links</source>
+        <target>Anzahl der Links</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.paginationEnabled.items.0.label">
+        <source>Enabled</source>
+        <target>Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.label">
+        <source>PageTitle display format</source>
+        <target>Seitentitel Anzeige Format</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
+        <source>for person detail page</source>
+        <target>für Person Detailansicht</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.none">
+        <source>Default page title</source>
+        <target>Standard Seitentitel</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
+        <source>Title Firstname Middlename Lastname</source>
+        <target>Titel Vorname Mittelname Nachname</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
+        <source>Lastname, Firstname Middlename</source>
+        <target>Nachname, Vorname Mittelname</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.profileList.label">
+        <source>List of profiles</source>
+        <target>Liste von Profilen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.fallbackForNonTranslated.label">
+        <source>Fallback to default language for non translated profiles</source>
+        <target>Fallback auf die Standardsprache für nicht übersetzte Profile</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.enabled.label">
+        <source>View Mode Toggle</source>
+        <target>Ansichtsmodus-Umschalter</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.enabled.items.0.label">
+        <source>Enabled</source>
+        <target>Aktiviert</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.label">
+        <source>View Mode Default</source>
+        <target>Standard für Ansichtsmodus</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.I.list">
+        <source>List</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.I.table">
+        <source>Table</source>
+        <target>Tabelle</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.el.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_tca.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/de.locallang_tca.xlf
@@ -1,460 +1,460 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
-			<!-- Addresses -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
+      <!-- Addresses -->
 
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.additional.label">
-				<source>Additional</source>
-				<target>Zusätzlich</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.city.label">
-				<source>City</source>
-				<target>Stadt</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.country.label">
-				<source>Country</source>
-				<target>Land</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.employee_type.label">
-				<source>Employee Type</source>
-				<target>Mitarbeitertyp</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.state.label">
-				<source>State</source>
-				<target>Bundesland</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.street.label">
-				<source>Street</source>
-				<target>Straße</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.street_number.label">
-				<source>Street Number</source>
-				<target>Hausnummer</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.type.items.undefined.label">
-				<source>Undefined</source>
-				<target>Nicht definiert</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.zip.label">
-				<source>Zip</source>
-				<target>PLZ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.ctrl.label">
-				<source>Address</source>
-				<target>Anschrift</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.additional.label">
+        <source>Additional</source>
+        <target>Zusätzlich</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.city.label">
+        <source>City</source>
+        <target>Stadt</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.country.label">
+        <source>Country</source>
+        <target>Land</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.employee_type.label">
+        <source>Employee Type</source>
+        <target>Mitarbeitertyp</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.state.label">
+        <source>State</source>
+        <target>Bundesland</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.street.label">
+        <source>Street</source>
+        <target>Straße</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.street_number.label">
+        <source>Street Number</source>
+        <target>Hausnummer</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.type.items.undefined.label">
+        <source>Undefined</source>
+        <target>Nicht definiert</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.zip.label">
+        <source>Zip</source>
+        <target>PLZ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.ctrl.label">
+        <source>Address</source>
+        <target>Anschrift</target>
+      </trans-unit>
 
-			<!-- Contracts -->
+      <!-- Contracts -->
 
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.email_addresses.label">
-				<source>Email Addresses</source>
-				<target>E-Mail-Adressen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.employee_type.label">
-				<source>Employee Type</source>
-				<target>Mitarbeiter-Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.function_type.label">
-				<source>Function Type</source>
-				<target>Funktionsart</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.location.label">
-				<source>Location / Campus</source>
-				<target>Standort / Campus</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.office_hours.label">
-				<source>Office hours</source>
-				<target>Geschäftszeiten</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.phone_numbers.label">
-				<source>Phone Numbers</source>
-				<target>Telefonnummern</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses.label">
-				<source>Addresses</source>
-				<target>Anschriften</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses_chosen.label">
-				<source>Address</source>
-				<target>Anschrift</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.position.label">
-				<source>Position</source>
-				<target>Position</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.publish.label">
-				<source>Show this contract online?</source>
-				<target>Diesen Vertrag online anzeigen?</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.room.label">
-				<source>Room</source>
-				<target>Zimmer</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_from.label">
-				<source>Valid From</source>
-				<target>Gültig ab</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_to.label">
-				<source>Valid To</source>
-				<target>Gültig bis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.ctrl.label">
-				<source>Employee Contract</source>
-				<target>Mitarbeitervertrag</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.addresses.label">
-				<source>Addresses</source>
-				<target>Adressen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.employeeType.label">
-				<source>Employee Type</source>
-				<target>Mitarbeiter-Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.general.label">
-				<source>General</source>
-				<target>Stammdaten</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.please_select">
-				<source>Please select...</source>
-				<target>Bitte auswählen...</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.email_addresses.label">
+        <source>Email Addresses</source>
+        <target>E-Mail-Adressen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.employee_type.label">
+        <source>Employee Type</source>
+        <target>Mitarbeiter-Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.function_type.label">
+        <source>Function Type</source>
+        <target>Funktionsart</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.location.label">
+        <source>Location / Campus</source>
+        <target>Standort / Campus</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.office_hours.label">
+        <source>Office hours</source>
+        <target>Geschäftszeiten</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.phone_numbers.label">
+        <source>Phone Numbers</source>
+        <target>Telefonnummern</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses.label">
+        <source>Addresses</source>
+        <target>Anschriften</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses_chosen.label">
+        <source>Address</source>
+        <target>Anschrift</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.position.label">
+        <source>Position</source>
+        <target>Position</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.publish.label">
+        <source>Show this contract online?</source>
+        <target>Diesen Vertrag online anzeigen?</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.room.label">
+        <source>Room</source>
+        <target>Zimmer</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_from.label">
+        <source>Valid From</source>
+        <target>Gültig ab</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_to.label">
+        <source>Valid To</source>
+        <target>Gültig bis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.ctrl.label">
+        <source>Employee Contract</source>
+        <target>Mitarbeitervertrag</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.addresses.label">
+        <source>Addresses</source>
+        <target>Adressen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.employeeType.label">
+        <source>Employee Type</source>
+        <target>Mitarbeiter-Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.general.label">
+        <source>General</source>
+        <target>Stammdaten</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.please_select">
+        <source>Please select...</source>
+        <target>Bitte auswählen...</target>
+      </trans-unit>
 
-			<!-- Email Addresses -->
+      <!-- Email Addresses -->
 
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.contract.label">
-				<source>Contract</source>
-				<target>Vertrag</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.email.label">
-				<source>Email Address</source>
-				<target>E-Mail-Adresse</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.type.items.undefined.label">
-				<source>Undefined</source>
-				<target>Nicht definiert</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.ctrl.label">
-				<source>Email Address</source>
-				<target>E-Mail-Adresse</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.contract.label">
+        <source>Contract</source>
+        <target>Vertrag</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.email.label">
+        <source>Email Address</source>
+        <target>E-Mail-Adresse</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.type.items.undefined.label">
+        <source>Undefined</source>
+        <target>Nicht definiert</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.ctrl.label">
+        <source>Email Address</source>
+        <target>E-Mail-Adresse</target>
+      </trans-unit>
 
-			<!-- Function Types -->
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name.label">
-				<source>Function Name</source>
-				<target>Funktionsname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_female.label">
-				<source>Function Name Female</source>
-				<target>Funktionsname weiblich</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_male.label">
-				<source>Function Name Male</source>
-				<target>Funktionsname männlich</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.ctrl.label">
-				<source>Function Type</source>
-				<target>Funktionsart</target>
-			</trans-unit>
+      <!-- Function Types -->
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name.label">
+        <source>Function Name</source>
+        <target>Funktionsname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_female.label">
+        <source>Function Name Female</source>
+        <target>Funktionsname weiblich</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_male.label">
+        <source>Function Name Male</source>
+        <target>Funktionsname männlich</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.ctrl.label">
+        <source>Function Type</source>
+        <target>Funktionsart</target>
+      </trans-unit>
 
-			<!-- Locations -->
+      <!-- Locations -->
 
-			<trans-unit id="tx_academicpersons_domain_model_location.columns.title.label">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_location.ctrl.label">
-				<source>Location</source>
-				<target>Standort</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_location.columns.title.label">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_location.ctrl.label">
+        <source>Location</source>
+        <target>Standort</target>
+      </trans-unit>
 
-			<!-- Organisational Units -->
+      <!-- Organisational Units -->
 
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.display_text.label">
-				<source>Display Text</source>
-				<target>Anzeigetext</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.long_text.label">
-				<source>Long Text</source>
-				<target>Langer Text</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.label">
-				<source>Parent</source>
-				<target>Übergeordnete Einheit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.default.label">
-				<source>No parent</source>
-				<target>Keine übergeordnete Einheit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unique_name.label">
-				<source>Unique Name</source>
-				<target>Eindeutiger Name</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unit_name.label">
-				<source>Unit Name</source>
-				<target>Name der Einheit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_from.label">
-				<source>Valid From</source>
-				<target>Gültig ab</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_to.label">
-				<source>Valid To</source>
-				<target>Gültig bis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.ctrl.label">
-				<source>Organisational Unit</source>
-				<target>Organisationseinheit</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.display_text.label">
+        <source>Display Text</source>
+        <target>Anzeigetext</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.long_text.label">
+        <source>Long Text</source>
+        <target>Langer Text</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.label">
+        <source>Parent</source>
+        <target>Übergeordnete Einheit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.default.label">
+        <source>No parent</source>
+        <target>Keine übergeordnete Einheit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unique_name.label">
+        <source>Unique Name</source>
+        <target>Eindeutiger Name</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unit_name.label">
+        <source>Unit Name</source>
+        <target>Name der Einheit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_from.label">
+        <source>Valid From</source>
+        <target>Gültig ab</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_to.label">
+        <source>Valid To</source>
+        <target>Gültig bis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.ctrl.label">
+        <source>Organisational Unit</source>
+        <target>Organisationseinheit</target>
+      </trans-unit>
 
-			<!-- Phone Numbers -->
+      <!-- Phone Numbers -->
 
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.contract.label">
-				<source>Contract</source>
-				<target>Vertrag</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.phone_number.label">
-				<source>Phone Number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.items.undefined.label">
-				<source>Undefined</source>
-				<target>Nicht definiert</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.ctrl.label">
-				<source>Phone Number</source>
-				<target>Telefonnummer</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.contract.label">
+        <source>Contract</source>
+        <target>Vertrag</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.phone_number.label">
+        <source>Phone Number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.items.undefined.label">
+        <source>Undefined</source>
+        <target>Nicht definiert</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.ctrl.label">
+        <source>Phone Number</source>
+        <target>Telefonnummer</target>
+      </trans-unit>
 
-			<!-- Profiles -->
+      <!-- Profiles -->
 
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
-				<source>Employee Contracts</source>
-				<target>Mitarbeiterverträge</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
-				<source>Networks and Cooperations</source>
-				<target>Netzwerke/Kooperationen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
-				<source>Research areas</source>
-				<target>Forschungsgebiete</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name.label">
-				<source>First Name</source>
-				<target>Vorname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name_alpha.label">
-				<source>First Letter of First Name</source>
-				<target>Erster Buchstabe Vorname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.diverse">
-				<source>Diverse</source>
-				<target>Divers</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.mr">
-				<source>Mr.</source>
-				<target>Herr</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.ms">
-				<source>Ms.</source>
-				<target>Frau</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.none">
-				<source>Not given</source>
-				<target>Keine Angabe</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.label">
-				<source>Gender</source>
-				<target>Geschlecht</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
-				<source>Image</source>
-				<target>Bild</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name.label">
-				<source>Last Name</source>
-				<target>Nachname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name_alpha.label">
-				<source>First Letter of Last Name</source>
-				<target>Erster Buchstabe Nachname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
-				<source>Lectures</source>
-				<target>Vorträge</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
-				<source>Memberships/Committee activities</source>
-				<target>Mitgliedschaften/Gremientätigkeiten</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
-				<source>Middle Name</source>
-				<target>Zweitname</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
-				<source>Miscellaneous information</source>
-				<target>Sonstige Informationen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.press_media.label">
-				<source>Press/Media</source>
-				<target>Presse/Medien</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications.label">
-				<source>Publications</source>
-				<target>Publikationen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link.label">
-				<source>Link to publications</source>
-				<target>Link zu Publikationen</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link_title.label">
-				<source>Website link title (e.g. OPUS4)</source>
-				<target>Website Link-Titel (z.B. OPUS4)</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.scientific_research.label">
-				<source>Research projects</source>
-				<target>Forschungsprojekte</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
-				<source>URL Path</source>
-				<target>URL-Pfad</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
-				<source>Supervised doctoral theses</source>
-				<target>Beaufsichtigte Doktorarbeit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
-				<source>Supervised theses</source>
-				<target>Beaufsichtigte Abschlussarbeit</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
-				<source>Teaching areas/Fields of activity</source>
-				<target>Lehrgebiete/Aufgabenbereiche</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
-				<source>Academic career</source>
-				<target>Akademischer Werdegang</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
-				<source>Website</source>
-				<target>Website</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
-				<source>Website Link Title</source>
-				<target>Website Link-Titel</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.ctrl.label">
-				<source>Profile</source>
-				<target>Profil</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.contracts.label">
-				<source>Contracts</source>
-				<target>Beschäftigungsverhältnis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.general.label">
-				<source>General</source>
-				<target>Stammdaten</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.structuredInformation.label">
-				<source>Profile (Timeline)</source>
-				<target>Profil (Timeline)</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.unstructuredInformation.label">
-				<source>Profile (Text)</source>
-				<target>Profil (Text)</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.label">
-				<source>Disable profile sync</source>
-				<target>Profil-Synchronisation deaktivieren</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.description">
-				<source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
-				<target>Die Deaktivierung der Profil-Synchronisation verhindert automatische Aktualisierungen aus externen Quellen.</target>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
+        <source>Employee Contracts</source>
+        <target>Mitarbeiterverträge</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
+        <source>Networks and Cooperations</source>
+        <target>Netzwerke/Kooperationen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
+        <source>Research areas</source>
+        <target>Forschungsgebiete</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name.label">
+        <source>First Name</source>
+        <target>Vorname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name_alpha.label">
+        <source>First Letter of First Name</source>
+        <target>Erster Buchstabe Vorname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.diverse">
+        <source>Diverse</source>
+        <target>Divers</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.mr">
+        <source>Mr.</source>
+        <target>Herr</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.ms">
+        <source>Ms.</source>
+        <target>Frau</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.none">
+        <source>Not given</source>
+        <target>Keine Angabe</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.label">
+        <source>Gender</source>
+        <target>Geschlecht</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
+        <source>Image</source>
+        <target>Bild</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name.label">
+        <source>Last Name</source>
+        <target>Nachname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name_alpha.label">
+        <source>First Letter of Last Name</source>
+        <target>Erster Buchstabe Nachname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
+        <source>Lectures</source>
+        <target>Vorträge</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
+        <source>Memberships/Committee activities</source>
+        <target>Mitgliedschaften/Gremientätigkeiten</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
+        <source>Middle Name</source>
+        <target>Zweitname</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
+        <source>Miscellaneous information</source>
+        <target>Sonstige Informationen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.press_media.label">
+        <source>Press/Media</source>
+        <target>Presse/Medien</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications.label">
+        <source>Publications</source>
+        <target>Publikationen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link.label">
+        <source>Link to publications</source>
+        <target>Link zu Publikationen</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link_title.label">
+        <source>Website link title (e.g. OPUS4)</source>
+        <target>Website Link-Titel (z.B. OPUS4)</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.scientific_research.label">
+        <source>Research projects</source>
+        <target>Forschungsprojekte</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
+        <source>URL Path</source>
+        <target>URL-Pfad</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
+        <source>Supervised doctoral theses</source>
+        <target>Beaufsichtigte Doktorarbeit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
+        <source>Supervised theses</source>
+        <target>Beaufsichtigte Abschlussarbeit</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
+        <source>Teaching areas/Fields of activity</source>
+        <target>Lehrgebiete/Aufgabenbereiche</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
+        <source>Academic career</source>
+        <target>Akademischer Werdegang</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
+        <source>Website</source>
+        <target>Website</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
+        <source>Website Link Title</source>
+        <target>Website Link-Titel</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.ctrl.label">
+        <source>Profile</source>
+        <target>Profil</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.contracts.label">
+        <source>Contracts</source>
+        <target>Beschäftigungsverhältnis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.general.label">
+        <source>General</source>
+        <target>Stammdaten</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.structuredInformation.label">
+        <source>Profile (Timeline)</source>
+        <target>Profil (Timeline)</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.unstructuredInformation.label">
+        <source>Profile (Text)</source>
+        <target>Profil (Text)</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.label">
+        <source>Disable profile sync</source>
+        <target>Profil-Synchronisation deaktivieren</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.description">
+        <source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
+        <target>Die Deaktivierung der Profil-Synchronisation verhindert automatische Aktualisierungen aus externen Quellen.</target>
+      </trans-unit>
 
-			<!-- Profile Information -->
+      <!-- Profile Information -->
 
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.bodytext.label">
-				<source>Text</source>
-				<target>Text</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.link.label">
-				<source>Link</source>
-				<target>Link</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.profile.label">
-				<source>Profile</source>
-				<target>Profil</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.title.label">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.cooperation.label">
-				<source>Network / cooperation</source>
-				<target>Netzwerk/Kooperation</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.curriculum_vitae.label">
-				<source>Curriculum vitae</source>
-				<target>Lebenslauf</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.lecture.label">
-				<source>Lecture</source>
-				<target>Vorlesung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.membership.label">
-				<source>Membership / committee</source>
-				<target>Mitgliedschaft / Ausschuss</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.publication.label">
-				<source>Publication</source>
-				<target>Veröffentlichung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.label">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year.label">
-				<source>Year</source>
-				<target>Jahr</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_end.label">
-				<source>End Year</source>
-				<target>Endjahr</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_start.label">
-				<source>Start Year</source>
-				<target>Startjahr</target>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.ctrl.label">
-				<source>Profile information</source>
-				<target>Profil Informationen</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.bodytext.label">
+        <source>Text</source>
+        <target>Text</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.link.label">
+        <source>Link</source>
+        <target>Link</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.profile.label">
+        <source>Profile</source>
+        <target>Profil</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.title.label">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.cooperation.label">
+        <source>Network / cooperation</source>
+        <target>Netzwerk/Kooperation</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.curriculum_vitae.label">
+        <source>Curriculum vitae</source>
+        <target>Lebenslauf</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.lecture.label">
+        <source>Lecture</source>
+        <target>Vorlesung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.membership.label">
+        <source>Membership / committee</source>
+        <target>Mitgliedschaft / Ausschuss</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.publication.label">
+        <source>Publication</source>
+        <target>Veröffentlichung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.label">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year.label">
+        <source>Year</source>
+        <target>Jahr</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_end.label">
+        <source>End Year</source>
+        <target>Endjahr</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_start.label">
+        <source>Start Year</source>
+        <target>Startjahr</target>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.ctrl.label">
+        <source>Profile information</source>
+        <target>Profil Informationen</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang.xlf
@@ -1,119 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
 
-			<!-- Contracts -->
+      <!-- Contracts -->
 
-			<trans-unit id="contracts.room">
-				<source>Room</source>
-			</trans-unit>
-			<trans-unit id="contracts.position">
-				<source>Position</source>
-			</trans-unit>
-			<trans-unit id="contracts.officeHours">
-				<source>Office Hours</source>
-			</trans-unit>
-			<trans-unit id="contracts.location">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="contracts.emailAdresses">
-				<source>E-Mail</source>
-			</trans-unit>
-			<trans-unit id="contracts.phoneNumbers">
-				<source>Phone</source>
-			</trans-unit>
-			<trans-unit id="contracts.physicalAddresses">
-				<source>Addresses</source>
-			</trans-unit>
+      <trans-unit id="contracts.room">
+        <source>Room</source>
+      </trans-unit>
+      <trans-unit id="contracts.position">
+        <source>Position</source>
+      </trans-unit>
+      <trans-unit id="contracts.officeHours">
+        <source>Office Hours</source>
+      </trans-unit>
+      <trans-unit id="contracts.location">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="contracts.emailAdresses">
+        <source>E-Mail</source>
+      </trans-unit>
+      <trans-unit id="contracts.phoneNumbers">
+        <source>Phone</source>
+      </trans-unit>
+      <trans-unit id="contracts.physicalAddresses">
+        <source>Addresses</source>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProfilesFound" resname="list.noProfilesFound">
-				<source>No profiles found.</source>
-			</trans-unit>
-			<trans-unit id="list.noContractsFound" resname="list.noContractsFound">
-				<source>No contracts found.</source>
-			</trans-unit>
+      <trans-unit id="list.noProfilesFound" resname="list.noProfilesFound">
+        <source>No profiles found.</source>
+      </trans-unit>
+      <trans-unit id="list.noContractsFound" resname="list.noContractsFound">
+        <source>No contracts found.</source>
+      </trans-unit>
 
-			<!-- Detail -->
+      <!-- Detail -->
 
-			<trans-unit id="detail.contracts" resname="detail.contracts">
-				<source>Contracts</source>
-			</trans-unit>
-			<trans-unit id="detail.room" resname="detail.room">
-				<source>Room</source>
-			</trans-unit>
-			<trans-unit id="detail.phoneNumbers" resname="detail.phoneNumbers">
-				<source>Phone number(s)</source>
-			</trans-unit>
-			<trans-unit id="detail.emailAddresses" resname="detail.emailAddresses">
-				<source>Email address(es)</source>
-			</trans-unit>
-			<trans-unit id="detail.physicalAddress.private" resname="detail.physicalAddress.private">
-				<source>Private</source>
-			</trans-unit>
-			<trans-unit id="detail.physicalAddress.business" resname="detail.physicalAddress.business">
-				<source>Business</source>
-			</trans-unit>
-			<trans-unit id="detail.additionalInformation" resname="detail.additionalInformation">
-				<source>Additional information</source>
-			</trans-unit>
-			<trans-unit id="detail.website" resname="detail.website">
-				<source>Website</source>
-			</trans-unit>
-			<trans-unit id="detail.teachingArea" resname="detail.teachingArea">
-				<source>Teaching areas</source>
-			</trans-unit>
-			<trans-unit id="detail.coreCompetences" resname="detail.coreCompetences">
-				<source>Core competences</source>
-			</trans-unit>
-			<trans-unit id="detail.supervisedThesis" resname="detail.supervisedThesis">
-				<source>Supervised thesis</source>
-			</trans-unit>
-			<trans-unit id="detail.supervisedDoctoralThesis" resname="detail.supervisedDoctoralThesis">
-				<source>Supervised doctoral thesis</source>
-			</trans-unit>
-			<trans-unit id="detail.miscellaneous" resname="detail.miscellaneous">
-				<source>Miscellaneous information</source>
-			</trans-unit>
-			<trans-unit id="detail.scientificResearch" resname="detail.scientificResearch">
-				<source>Research projects</source>
-			</trans-unit>
-			<trans-unit id="detail.vita" resname="detail.vita">
-				<source>Academic career</source>
-			</trans-unit>
-			<trans-unit id="detail.memberships" resname="detail.memberships">
-				<source>Memberships/Committee activities</source>
-			</trans-unit>
-			<trans-unit id="detail.cooperation" resname="detail.cooperation">
-				<source>Network/cooperation</source>
-			</trans-unit>
-			<trans-unit id="detail.publications" resname="detail.publications">
-				<source>Publications</source>
-			</trans-unit>
-			<trans-unit id="detail.lectures" resname="detail.lectures">
-				<source>Lectures</source>
-			</trans-unit>
-			<trans-unit id="detail.pressMedia" resname="detail.pressMedia">
-				<source>Press/Media</source>
-			</trans-unit>
-			<trans-unit id="detail.publicationsLink" resname="detail.publicationsLink">
-				<source>Link to publications</source>
-			</trans-unit>
-			<trans-unit id="detail.since" resname="detail.since">
-				<source>Since</source>
-			</trans-unit>
-			<trans-unit id="detail.till" resname="detail.till">
-				<source>Till</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="detail.contracts" resname="detail.contracts">
+        <source>Contracts</source>
+      </trans-unit>
+      <trans-unit id="detail.room" resname="detail.room">
+        <source>Room</source>
+      </trans-unit>
+      <trans-unit id="detail.phoneNumbers" resname="detail.phoneNumbers">
+        <source>Phone number(s)</source>
+      </trans-unit>
+      <trans-unit id="detail.emailAddresses" resname="detail.emailAddresses">
+        <source>Email address(es)</source>
+      </trans-unit>
+      <trans-unit id="detail.physicalAddress.private" resname="detail.physicalAddress.private">
+        <source>Private</source>
+      </trans-unit>
+      <trans-unit id="detail.physicalAddress.business" resname="detail.physicalAddress.business">
+        <source>Business</source>
+      </trans-unit>
+      <trans-unit id="detail.additionalInformation" resname="detail.additionalInformation">
+        <source>Additional information</source>
+      </trans-unit>
+      <trans-unit id="detail.website" resname="detail.website">
+        <source>Website</source>
+      </trans-unit>
+      <trans-unit id="detail.teachingArea" resname="detail.teachingArea">
+        <source>Teaching areas</source>
+      </trans-unit>
+      <trans-unit id="detail.coreCompetences" resname="detail.coreCompetences">
+        <source>Core competences</source>
+      </trans-unit>
+      <trans-unit id="detail.supervisedThesis" resname="detail.supervisedThesis">
+        <source>Supervised thesis</source>
+      </trans-unit>
+      <trans-unit id="detail.supervisedDoctoralThesis" resname="detail.supervisedDoctoralThesis">
+        <source>Supervised doctoral thesis</source>
+      </trans-unit>
+      <trans-unit id="detail.miscellaneous" resname="detail.miscellaneous">
+        <source>Miscellaneous information</source>
+      </trans-unit>
+      <trans-unit id="detail.scientificResearch" resname="detail.scientificResearch">
+        <source>Research projects</source>
+      </trans-unit>
+      <trans-unit id="detail.vita" resname="detail.vita">
+        <source>Academic career</source>
+      </trans-unit>
+      <trans-unit id="detail.memberships" resname="detail.memberships">
+        <source>Memberships/Committee activities</source>
+      </trans-unit>
+      <trans-unit id="detail.cooperation" resname="detail.cooperation">
+        <source>Network/cooperation</source>
+      </trans-unit>
+      <trans-unit id="detail.publications" resname="detail.publications">
+        <source>Publications</source>
+      </trans-unit>
+      <trans-unit id="detail.lectures" resname="detail.lectures">
+        <source>Lectures</source>
+      </trans-unit>
+      <trans-unit id="detail.pressMedia" resname="detail.pressMedia">
+        <source>Press/Media</source>
+      </trans-unit>
+      <trans-unit id="detail.publicationsLink" resname="detail.publicationsLink">
+        <source>Link to publications</source>
+      </trans-unit>
+      <trans-unit id="detail.since" resname="detail.since">
+        <source>Since</source>
+      </trans-unit>
+      <trans-unit id="detail.till" resname="detail.till">
+        <source>Till</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_be.xlf
@@ -1,215 +1,215 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang_be.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
-			<trans-unit id="extension_configuration.types.profileTypes.label">
-				<source>Profile Types: Comma-separated list of profile types</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.physicalAddressTypes.label">
-				<source>Physical Address Types: Comma-separated list of physical address types</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.emailAddressTypes.label">
-				<source>Email Address Types: Comma-separated list of email address types</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.types.phoneNumberTypes.label">
-				<source>Phone Number Types: Comma-separated list of phone number types</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
-				<source>Group By Values: Comma-separated list of allowed group by values</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.demand.allowedSortByValues.label">
-				<source>Sort By Values: Comma-separated list of allowed sort by values</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
-				<source>Auto create profile: Automatically creates a new profile for FE users</source>
-			</trans-unit>
-			<trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
-				<source>Create for user groups: Create profiles only if current user is in one of these user group IDs.</source>
-			</trans-unit>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang_be.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
+      <trans-unit id="extension_configuration.types.profileTypes.label">
+        <source>Profile Types: Comma-separated list of profile types</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.physicalAddressTypes.label">
+        <source>Physical Address Types: Comma-separated list of physical address types</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.emailAddressTypes.label">
+        <source>Email Address Types: Comma-separated list of email address types</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.types.phoneNumberTypes.label">
+        <source>Phone Number Types: Comma-separated list of phone number types</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.demand.allowedGroupByValues.label">
+        <source>Group By Values: Comma-separated list of allowed group by values</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.demand.allowedSortByValues.label">
+        <source>Sort By Values: Comma-separated list of allowed sort by values</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.autoCreateProfiles.label">
+        <source>Auto create profile: Automatically creates a new profile for FE users</source>
+      </trans-unit>
+      <trans-unit id="extension_configuration.profile.createProfileForUserGroups.label">
+        <source>Create for user groups: Create profiles only if current user is in one of these user group IDs.</source>
+      </trans-unit>
 
-			<trans-unit id="plugin.list.label">
-				<source>Persons List</source>
-			</trans-unit>
-			<trans-unit id="plugin.detail.label">
-				<source>Persons Detail</source>
-			</trans-unit>
-			<trans-unit id="plugin.listAndDetail.label">
-				<source>Persons List and Detail</source>
-			</trans-unit>
-			<trans-unit id="plugin.selectedprofiles.label">
-				<source>Profiles: Selected Profiles</source>
-			</trans-unit>
-			<trans-unit id="plugin.selectedprofiles.description">
-				<source>Plugin to list only selected profiles</source>
-			</trans-unit>
-			<trans-unit id="plugin.selectedcontracts.label">
-				<source>Profiles: Selected Contracts</source>
-			</trans-unit>
-			<trans-unit id="plugin.selectedcontracts.description">
-				<source>Plugin to list only selected contracts</source>
-			</trans-unit>
+      <trans-unit id="plugin.list.label">
+        <source>Persons List</source>
+      </trans-unit>
+      <trans-unit id="plugin.detail.label">
+        <source>Persons Detail</source>
+      </trans-unit>
+      <trans-unit id="plugin.listAndDetail.label">
+        <source>Persons List and Detail</source>
+      </trans-unit>
+      <trans-unit id="plugin.selectedprofiles.label">
+        <source>Profiles: Selected Profiles</source>
+      </trans-unit>
+      <trans-unit id="plugin.selectedprofiles.description">
+        <source>Plugin to list only selected profiles</source>
+      </trans-unit>
+      <trans-unit id="plugin.selectedcontracts.label">
+        <source>Profiles: Selected Contracts</source>
+      </trans-unit>
+      <trans-unit id="plugin.selectedcontracts.description">
+        <source>Plugin to list only selected contracts</source>
+      </trans-unit>
 
-			<trans-unit id="newContentElement.wizardItems.academic">
-				<source>Academic</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.title">
-				<source>Persons List</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.list.description">
-				<source>Plugin for listing academic persons</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.title">
-				<source>Persons Detail</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.detail.description">
-				<source>Plugin for viewing single academic persons</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
-				<source>Persons List and Detail</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
-				<source>Plugin for listing and viewing academic persons</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.card.title">
-				<source>Contacts</source>
-			</trans-unit>
-			<trans-unit id="newContentElement.wizardItems.academic.card.description">
-				<source>Adds one or more contacts</source>
-			</trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic">
+        <source>Academic</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.title">
+        <source>Persons List</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.list.description">
+        <source>Plugin for listing academic persons</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.title">
+        <source>Persons Detail</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.detail.description">
+        <source>Plugin for viewing single academic persons</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.title">
+        <source>Persons List and Detail</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.listAndDetail.description">
+        <source>Plugin for listing and viewing academic persons</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.card.title">
+        <source>Contacts</source>
+      </trans-unit>
+      <trans-unit id="newContentElement.wizardItems.academic.card.description">
+        <source>Adds one or more contacts</source>
+      </trans-unit>
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="flexform.tab.settings">
-				<source>Settings</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.detailPid.label">
-				<source>Detail Page</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.listPid.label">
-				<source>List Page</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.functionTypes.label">
-				<source>Function Types</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.label">
-				<source>Group By (is given priority in sorting if activ)</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.none">
-				<source>No grouping</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.first_name">
-				<source>First Letter of First Name</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.groupBy.items.last_name">
-				<source>First Letter of Last Name</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.organisationalUnits.label">
-				<source>Organisational Units</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.selectedContracts.label">
-				<source>Selected Contracts</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.selectedProfiles.label">
-				<source>Selected Profiles</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.label">
-				<source>Show only selected Fields</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.groups.profile">
-				<source>Profile</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.showFields.groups.contracts">
-				<source>Contracts</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.label">
-				<source>Sort By (sorting of activated grouping has priority)</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.none">
-				<source>No sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.first_name">
-				<source>First Name</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortBy.items.last_name">
-				<source>Last Name</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.label">
-				<source>Sort By Direction</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.asc">
-				<source>Ascending</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.sortByDirection.items.desc">
-				<source>Descending</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.alphabetPaginationEnabled.label">
-				<source>Alphabetical Pagination</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
-				<source>Enabled</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.paginationEnabled.label">
-				<source>Pagination</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.paginationEnabled.items.0.label">
-				<source>Enabled</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.resultsPerPage.label">
-				<source>Results per Page</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.numberOfLinks.label">
-				<source>Number of Links</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.label">
-				<source>PageTitle display format</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
-				<source>for person detail page</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.none">
-				<source>Default page title</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
-				<source>Title Firstname Middlename Lastname</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
-				<source>Lastname, Firstname Middlename</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.profileList.label">
-				<source>List of profiles</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.fallbackForNonTranslated.label">
-				<source>Fallback to default language for non translated profiles</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.enabled.label">
-				<source>View Mode Toggle</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.enabled.items.0.label">
-				<source>Enabled</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.label">
-				<source>View Mode Default</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.I.list">
-				<source>List</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.viewMode.default.I.table">
-				<source>Table</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.el.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="flexform.tab.settings">
+        <source>Settings</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.detailPid.label">
+        <source>Detail Page</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.listPid.label">
+        <source>List Page</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.functionTypes.label">
+        <source>Function Types</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.label">
+        <source>Group By (is given priority in sorting if activ)</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.none">
+        <source>No grouping</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.first_name">
+        <source>First Letter of First Name</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.groupBy.items.last_name">
+        <source>First Letter of Last Name</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.organisationalUnits.label">
+        <source>Organisational Units</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.selectedContracts.label">
+        <source>Selected Contracts</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.selectedProfiles.label">
+        <source>Selected Profiles</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.label">
+        <source>Show only selected Fields</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.groups.profile">
+        <source>Profile</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.showFields.groups.contracts">
+        <source>Contracts</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.label">
+        <source>Sort By (sorting of activated grouping has priority)</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.none">
+        <source>No sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.first_name">
+        <source>First Name</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortBy.items.last_name">
+        <source>Last Name</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.label">
+        <source>Sort By Direction</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.asc">
+        <source>Ascending</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.sortByDirection.items.desc">
+        <source>Descending</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.alphabetPaginationEnabled.label">
+        <source>Alphabetical Pagination</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.alphabetPaginationEnabled.items.0.label">
+        <source>Enabled</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.paginationEnabled.label">
+        <source>Pagination</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.paginationEnabled.items.0.label">
+        <source>Enabled</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.resultsPerPage.label">
+        <source>Results per Page</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.numberOfLinks.label">
+        <source>Number of Links</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.label">
+        <source>PageTitle display format</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.listanddetail_description">
+        <source>for person detail page</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.none">
+        <source>Default page title</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.tiltefirstmiddlelastname">
+        <source>Title Firstname Middlename Lastname</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.pageTitleFormat.items.lastcommafirstmiddlename">
+        <source>Lastname, Firstname Middlename</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.profileList.label">
+        <source>List of profiles</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.fallbackForNonTranslated.label">
+        <source>Fallback to default language for non translated profiles</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.enabled.label">
+        <source>View Mode Toggle</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.enabled.items.0.label">
+        <source>Enabled</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.label">
+        <source>View Mode Default</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.I.list">
+        <source>List</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.viewMode.default.I.table">
+        <source>Table</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.el.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_tca.xlf
+++ b/packages/fgtclb/academic-persons/Resources/Private/Language/locallang_tca.xlf
@@ -1,369 +1,369 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf"
-		date="2025-02-24T11:41:07Z"
-		product-name="academic_persons"
-	>
-		<header/>
-		<body>
-			<!-- Addresses -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf"
+    date="2025-02-24T11:41:07Z"
+    product-name="academic_persons"
+  >
+    <header/>
+    <body>
+      <!-- Addresses -->
 
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.additional.label">
-				<source>Additional</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.city.label">
-				<source>City</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.country.label">
-				<source>Country</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.state.label">
-				<source>State</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.street.label">
-				<source>Street</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.street_number.label">
-				<source>Street Number</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.type.items.undefined.label">
-				<source>Undefined</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.type.label">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.columns.zip.label">
-				<source>Zip</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_address.ctrl.label">
-				<source>Address</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.additional.label">
+        <source>Additional</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.city.label">
+        <source>City</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.country.label">
+        <source>Country</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.state.label">
+        <source>State</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.street.label">
+        <source>Street</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.street_number.label">
+        <source>Street Number</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.type.items.undefined.label">
+        <source>Undefined</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.type.label">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.columns.zip.label">
+        <source>Zip</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_address.ctrl.label">
+        <source>Address</source>
+      </trans-unit>
 
-			<!-- Contracts -->
+      <!-- Contracts -->
 
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.email_addresses.label">
-				<source>Email Addresses</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.employee_type.label">
-				<source>Employee Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.function_type.label">
-				<source>Function Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.location.label">
-				<source>Location / Campus</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.office_hours.label">
-				<source>Office hours</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_1.label">
-				<source>Organisational Level 1</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_2.label">
-				<source>Organisational Level 2</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_3.label">
-				<source>Organisational Level 3</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_unit.label">
-				<source>Organisational Unit</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.phone_numbers.label">
-				<source>Phone Numbers</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses.label">
-				<source>Addresses</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses_chosen.label">
-				<source>Address</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.position.label">
-				<source>Position</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.publish.label">
-				<source>Show this contract online?</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.room.label">
-				<source>Room</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.sorting.label">
-				<source>Sorting</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_from.label">
-				<source>Valid From</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_to.label">
-				<source>Valid To</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.ctrl.label">
-				<source>Employee Contract</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.addresses.label">
-				<source>Addresses</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.employeeType.label">
-				<source>Employee Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.div.general.label">
-				<source>General</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_contract.please_select">
-				<source>Please select...</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.email_addresses.label">
+        <source>Email Addresses</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.employee_type.label">
+        <source>Employee Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.function_type.label">
+        <source>Function Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.location.label">
+        <source>Location / Campus</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.office_hours.label">
+        <source>Office hours</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_1.label">
+        <source>Organisational Level 1</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_2.label">
+        <source>Organisational Level 2</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_level_3.label">
+        <source>Organisational Level 3</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.organisational_unit.label">
+        <source>Organisational Unit</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.phone_numbers.label">
+        <source>Phone Numbers</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses.label">
+        <source>Addresses</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.physical_addresses_chosen.label">
+        <source>Address</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.position.label">
+        <source>Position</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.publish.label">
+        <source>Show this contract online?</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.room.label">
+        <source>Room</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.sorting.label">
+        <source>Sorting</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_from.label">
+        <source>Valid From</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.columns.valid_to.label">
+        <source>Valid To</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.ctrl.label">
+        <source>Employee Contract</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.addresses.label">
+        <source>Addresses</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.employeeType.label">
+        <source>Employee Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.div.general.label">
+        <source>General</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_contract.please_select">
+        <source>Please select...</source>
+      </trans-unit>
 
-			<!-- Email Addresses -->
+      <!-- Email Addresses -->
 
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.contract.label">
-				<source>Contract</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.email.label">
-				<source>Email Address</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.type.items.undefined.label">
-				<source>Undefined</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.columns.type.label">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_email.ctrl.label">
-				<source>Email Address</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.contract.label">
+        <source>Contract</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.email.label">
+        <source>Email Address</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.type.items.undefined.label">
+        <source>Undefined</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.columns.type.label">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_email.ctrl.label">
+        <source>Email Address</source>
+      </trans-unit>
 
-			<!-- Function Types -->
+      <!-- Function Types -->
 
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name.label">
-				<source>Function Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_female.label">
-				<source>Function Name Female</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_male.label">
-				<source>Function Name Male</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_function_type.ctrl.label">
-				<source>Function Type</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name.label">
+        <source>Function Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_female.label">
+        <source>Function Name Female</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.columns.function_name_male.label">
+        <source>Function Name Male</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_function_type.ctrl.label">
+        <source>Function Type</source>
+      </trans-unit>
 
-			<!-- Locations -->
+      <!-- Locations -->
 
-			<trans-unit id="tx_academicpersons_domain_model_location.columns.title.label">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_location.ctrl.label">
-				<source>Location</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_location.columns.title.label">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_location.ctrl.label">
+        <source>Location</source>
+      </trans-unit>
 
-			<!-- Organisational Units -->
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.display_text.label">
-				<source>Display Text</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.long_text.label">
-				<source>Long Text</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.label">
-				<source>Parent</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.default.label">
-				<source>No parent</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unique_name.label">
-				<source>Unique Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unit_name.label">
-				<source>Unit Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_from.label">
-				<source>Valid From</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_to.label">
-				<source>Valid To</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.ctrl.label">
-				<source>Organisational Unit</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.contracts.label">
-				<source>Employee Contracts</source>
-			</trans-unit>
+      <!-- Organisational Units -->
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.display_text.label">
+        <source>Display Text</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.long_text.label">
+        <source>Long Text</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.label">
+        <source>Parent</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.parent.default.label">
+        <source>No parent</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unique_name.label">
+        <source>Unique Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.unit_name.label">
+        <source>Unit Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_from.label">
+        <source>Valid From</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.valid_to.label">
+        <source>Valid To</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.ctrl.label">
+        <source>Organisational Unit</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_organisational_unit.columns.contracts.label">
+        <source>Employee Contracts</source>
+      </trans-unit>
 
-			<!-- Phone Numbers -->
+      <!-- Phone Numbers -->
 
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.contract.label">
-				<source>Contract</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.phone_number.label">
-				<source>Phone Number</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.items.undefined.label">
-				<source>Undefined</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.label">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_phone_number.ctrl.label">
-				<source>Phone Number</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.contract.label">
+        <source>Contract</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.phone_number.label">
+        <source>Phone Number</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.items.undefined.label">
+        <source>Undefined</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.columns.type.label">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_phone_number.ctrl.label">
+        <source>Phone Number</source>
+      </trans-unit>
 
-			<!-- Profiles -->
+      <!-- Profiles -->
 
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
-				<source>Employee Contracts</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
-				<source>Networks and Cooperations</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
-				<source>Research areas</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name.label">
-				<source>First Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name_alpha.label">
-				<source>First Letter of First Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.diverse">
-				<source>Diverse</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.mr">
-				<source>Mr.</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.ms">
-				<source>Ms.</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.none">
-				<source>Not given</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.label">
-				<source>Gender</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
-				<source>Image</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name.label">
-				<source>Last Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name_alpha.label">
-				<source>First Letter of Last Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
-				<source>Lectures</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
-				<source>Memberships/Committee activities</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
-				<source>Middle Name</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
-				<source>Miscellaneous information</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.press_media.label">
-				<source>Press/Media</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications.label">
-				<source>Publications</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link.label">
-				<source>Link to publications</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link_title.label">
-				<source>Website link title (e.g. OPUS4)</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.scientific_research.label">
-				<source>Research projects</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
-				<source>URL Path</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
-				<source>Supervised doctoral theses</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
-				<source>Supervised theses</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
-				<source>Teaching areas/Fields of activity</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
-				<source>Academic career</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
-				<source>Website</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
-				<source>Website Link Title</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.ctrl.label">
-				<source>Profile</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.contracts.label">
-				<source>Contracts</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.general.label">
-				<source>General</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.structuredInformation.label">
-				<source>Profile (Timeline)</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.div.unstructuredInformation.label">
-				<source>Profile (Text)</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.label">
-				<source>Disable profile sync</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.description">
-				<source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
-			</trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.contracts.label">
+        <source>Employee Contracts</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.cooperation.label">
+        <source>Networks and Cooperations</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.core_competences.label">
+        <source>Research areas</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name.label">
+        <source>First Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.first_name_alpha.label">
+        <source>First Letter of First Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.diverse">
+        <source>Diverse</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.mr">
+        <source>Mr.</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.ms">
+        <source>Ms.</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.items.none">
+        <source>Not given</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.gender.label">
+        <source>Gender</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.image.label">
+        <source>Image</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name.label">
+        <source>Last Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.last_name_alpha.label">
+        <source>First Letter of Last Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.lectures.label">
+        <source>Lectures</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.memberships.label">
+        <source>Memberships/Committee activities</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.middle_name.label">
+        <source>Middle Name</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.miscellaneous.label">
+        <source>Miscellaneous information</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.press_media.label">
+        <source>Press/Media</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications.label">
+        <source>Publications</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link.label">
+        <source>Link to publications</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.publications_link_title.label">
+        <source>Website link title (e.g. OPUS4)</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.scientific_research.label">
+        <source>Research projects</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.slug.label">
+        <source>URL Path</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_doctoral_thesis.label">
+        <source>Supervised doctoral theses</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.supervised_thesis.label">
+        <source>Supervised theses</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.teaching_area.label">
+        <source>Teaching areas/Fields of activity</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.title.label">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.vita.label">
+        <source>Academic career</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.website.label">
+        <source>Website</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.website_title.label">
+        <source>Website Link Title</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.ctrl.label">
+        <source>Profile</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.contracts.label">
+        <source>Contracts</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.general.label">
+        <source>General</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.structuredInformation.label">
+        <source>Profile (Timeline)</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.div.unstructuredInformation.label">
+        <source>Profile (Text)</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.label">
+        <source>Disable profile sync</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile.columns.skip_sync.description">
+        <source>Disabling the profile synchronization will prevent automatic updates from external sources.</source>
+      </trans-unit>
 
-			<!-- Profile Information -->
+      <!-- Profile Information -->
 
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.bodytext.label">
-				<source>Text</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.link.label">
-				<source>Link</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.profile.label">
-				<source>Profile</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.title.label">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.cooperation.label">
-				<source>Network / cooperation</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.curriculum_vitae.label">
-				<source>Curriculum vitae</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.lecture.label">
-				<source>Lecture</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.membership.label">
-				<source>Membership / committee</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.publication.label">
-				<source>Publication</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.label">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year.label">
-				<source>Year</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_end.label">
-				<source>End Year</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_start.label">
-				<source>Start Year</source>
-			</trans-unit>
-			<trans-unit id="tx_academicpersons_domain_model_profile_information.ctrl.label">
-				<source>Profile information</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.bodytext.label">
+        <source>Text</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.link.label">
+        <source>Link</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.profile.label">
+        <source>Profile</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.title.label">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.cooperation.label">
+        <source>Network / cooperation</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.curriculum_vitae.label">
+        <source>Curriculum vitae</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.lecture.label">
+        <source>Lecture</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.membership.label">
+        <source>Membership / committee</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.items.publication.label">
+        <source>Publication</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.type.label">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year.label">
+        <source>Year</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_end.label">
+        <source>End Year</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.columns.year_start.label">
+        <source>Start Year</source>
+      </trans-unit>
+      <trans-unit id="tx_academicpersons_domain_model_profile_information.ctrl.label">
+        <source>Profile information</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/de.locallang.xlf
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
-		<header/>
-		<body>
+     xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
+    <header/>
+    <body>
 
-			<!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
+      <!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
 
-			<trans-unit id="placeholder.with.dots">
-				<source>Placeholder with dots</source>
-				<target>Platzhalter mit Punkten</target>
-			</trans-unit>
-			<trans-unit id="placeholder-with-dashes">
-				<source>Placeholder with dashes</source>
-				<target>Platzhalter mit Bindestrichen</target>
-			</trans-unit>
-			<trans-unit id="placeholder_with_underscores">
-				<source>Placeholder with underscores</source>
-				<target>Platzhalter mit Unterstrichen</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="placeholder.with.dots">
+        <source>Placeholder with dots</source>
+        <target>Platzhalter mit Punkten</target>
+      </trans-unit>
+      <trans-unit id="placeholder-with-dashes">
+        <source>Placeholder with dashes</source>
+        <target>Platzhalter mit Bindestrichen</target>
+      </trans-unit>
+      <trans-unit id="placeholder_with_underscores">
+        <source>Placeholder with underscores</source>
+        <target>Platzhalter mit Unterstrichen</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_language_files/Resources/Private/Language/locallang.xlf
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	   xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
-		<header/>
-		<body>
+     xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="messages" date="2025-02-24T11:41:07Z" product-name="test_language_files">
+    <header/>
+    <body>
 
-			<!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
+      <!-- /* \FGTCLB\AcademicPersons\Tests\Functional\PageTitle\ProfileTitleProviderTest */ -->
 
-			<trans-unit id="placeholder.with.dots">
-				<source>Placeholder with dots</source>
-			</trans-unit>
-			<trans-unit id="placeholder-with-dashes">
-				<source>Placeholder with dashes</source>
-			</trans-unit>
-			<trans-unit id="placeholder_with_underscores">
-				<source>Placeholder with underscores</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="placeholder.with.dots">
+        <source>Placeholder with dots</source>
+      </trans-unit>
+      <trans-unit id="placeholder-with-dashes">
+        <source>Placeholder with dashes</source>
+      </trans-unit>
+      <trans-unit id="placeholder_with_underscores">
+        <source>Placeholder with underscores</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-programs/.editorconfig
+++ b/packages/fgtclb/academic-programs/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang.xlf
@@ -1,133 +1,133 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic_programs"
-	>
-		<header/>
-		<body>
-			<!-- Labels for SysCategories -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic_programs"
+  >
+    <header/>
+    <body>
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.programs.group">
-				<source>Academic Programs</source>
-				<target>Akademische Programme</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.admission_restriction">
-				<source>Admission restriction</source>
-				<target>Zulassungsbeschränkung</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.application_period">
-				<source>Application period</source>
-				<target>Bewerbungszeitraum</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.begin_program">
-				<source>Begin of program</source>
-				<target>Programmbeginn</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.costs">
-				<source>Costs</source>
-				<target>Kosten</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.degree">
-				<source>Degree</source>
-				<target>Abschluss</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.department">
-				<source>Department / Faculty</source>
-				<target>Abteilung / Fakultät</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.location">
-				<source>Location</source>
-				<target>Standort</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.paying">
-				<source>Paying?</source>
-				<target>Zahlungspflichtig?</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.program_type">
-				<source>Type of program</source>
-				<target>Art des Programms</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.standard_period">
-				<source>Standard period</source>
-				<target>Regelstudienzeit</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.teaching_language">
-				<source>Teaching language</source>
-				<target>Unterrichtssprache</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.topic">
-				<source>Topic</source>
-				<target>Thema</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.allOptions">
-				<source>All options</source>
-				<target>Alle Optionen</target>
-			</trans-unit>
+      <trans-unit id="sys_category.programs.group">
+        <source>Academic Programs</source>
+        <target>Akademische Programme</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.admission_restriction">
+        <source>Admission restriction</source>
+        <target>Zulassungsbeschränkung</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.application_period">
+        <source>Application period</source>
+        <target>Bewerbungszeitraum</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.begin_program">
+        <source>Begin of program</source>
+        <target>Programmbeginn</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.costs">
+        <source>Costs</source>
+        <target>Kosten</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.degree">
+        <source>Degree</source>
+        <target>Abschluss</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.department">
+        <source>Department / Faculty</source>
+        <target>Abteilung / Fakultät</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.location">
+        <source>Location</source>
+        <target>Standort</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.paying">
+        <source>Paying?</source>
+        <target>Zahlungspflichtig?</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.program_type">
+        <source>Type of program</source>
+        <target>Art des Programms</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.standard_period">
+        <source>Standard period</source>
+        <target>Regelstudienzeit</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.teaching_language">
+        <source>Teaching language</source>
+        <target>Unterrichtssprache</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.topic">
+        <source>Topic</source>
+        <target>Thema</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.allOptions">
+        <source>All options</source>
+        <target>Alle Optionen</target>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-				<target>Sortierungsrichtung</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>Ascending</source>
-				<target>Aufsteigend</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>Descending</source>
-				<target>Absteigend</target>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+        <target>Sortierungsrichtung</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>Ascending</source>
+        <target>Aufsteigend</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>Descending</source>
+        <target>Absteigend</target>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-				<target>Sortierungsfeld</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-				<target>Zuletzt aktualisiert</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-				<target>Sortierung</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+        <target>Sortierungsfeld</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+        <target>Zuletzt aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+        <target>Sortierung</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProgramsFound">
-				<source>No programs found.</source>
-				<target>Keine Studiengänge gefunden.</target>
-			</trans-unit>
+      <trans-unit id="list.noProgramsFound">
+        <source>No programs found.</source>
+        <target>Keine Studiengänge gefunden.</target>
+      </trans-unit>
 
-			<!-- Detail -->
+      <!-- Detail -->
 
-			<trans-unit id="program.prerequisites">
-				<source>Prerequisites</source>
-				<target>Voraussetzungen</target>
-			</trans-unit>
-			<trans-unit id="program.creditPoints">
-				<source>Credit points</source>
-				<target>Leistungspunkte</target>
-			</trans-unit>
-			<trans-unit id="program.jobProfile">
-				<source>Job profile</source>
-				<target>Berufsprofil</target>
-			</trans-unit>
-			<trans-unit id="program.performanceScope">
-				<source>Performance scope</source>
-				<target>Leistungsumfang</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="program.prerequisites">
+        <source>Prerequisites</source>
+        <target>Voraussetzungen</target>
+      </trans-unit>
+      <trans-unit id="program.creditPoints">
+        <source>Credit points</source>
+        <target>Leistungspunkte</target>
+      </trans-unit>
+      <trans-unit id="program.jobProfile">
+        <source>Job profile</source>
+        <target>Berufsprofil</target>
+      </trans-unit>
+      <trans-unit id="program.performanceScope">
+        <source>Performance scope</source>
+        <target>Leistungsumfang</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/de.locallang_be.xlf
@@ -1,216 +1,216 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_programs/Resources/Private/Language/locallang_be.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic_programs"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_programs/Resources/Private/Language/locallang_be.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic_programs"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_program">
-				<source>Academic Program</source>
-				<target>Akademisches Programm</target>
-			</trans-unit>
-			<trans-unit id="backend_layout.academic_program.column.content">
-				<source>Content</source>
-				<target>Inhalt</target>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_program">
+        <source>Academic Program</source>
+        <target>Akademisches Programm</target>
+      </trans-unit>
+      <trans-unit id="backend_layout.academic_program.column.content">
+        <source>Content</source>
+        <target>Inhalt</target>
+      </trans-unit>
 
-			<!-- Plugin configuration -->
+      <!-- Plugin configuration -->
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="flexform.categories.label">
-				<source>Default categories</source>
-				<target>Standard-Kategorien</target>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
-				<target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B. "Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.label">
-				<source>Hide category filtering</source>
-				<target>Kategorienfilter ausblenden</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.description">
-				<source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
-				<target>Wenn diese Option aktiviert ist, werden die Filteroptionen nach Kategorien im Frontend nicht sichtbar sein.</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.label">
-				<source>Hide sorting</source>
-				<target>Sortierung ausblenden</target>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.description">
-				<source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
-				<target>Wenn diese Option aktiviert ist, werden die Sortieroptionen im Frontend nicht sichtbar sein.</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Default sorting</source>
-				<target>Standard-Sortierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.description">
-				<source>Default sorting in frontend which can be changed by user if sorting options are visible.</source>
-				<target>Standard-Sortierung im Frontend, die vom Benutzer geändert werden kann, wenn die Sortieroptionen sichtbar sind.</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-				<target>Titel A-Z</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-				<target>Titel Z-A</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update">
-				<source>Last updated (latest first)</source>
-				<target>Zuletzt aktualisiert (neueste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update.asc">
-				<source>Last updated (latest last)</source>
-				<target>Zuletzt aktualisiert (älteste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
-			</trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Default categories</source>
+        <target>Standard-Kategorien</target>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+        <target>Ausgewählte Kategorien desselben Typs (z. B. "Abschluss") werden als Alternativen geprüft (ODER). Wenn eine Kategorie über Unterkategorien verfügt (z.B. "Master" mit "Master of Arts"), werden diese automatisch zur Liste der Alternativen hinzugefügt. Zusätzlich müssen die gefundenen Seiten für jeden Kategorietyp auch in allen anderen ausgewählten Kategorietypen gefunden werden können (UND).</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.label">
+        <source>Hide category filtering</source>
+        <target>Kategorienfilter ausblenden</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.description">
+        <source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
+        <target>Wenn diese Option aktiviert ist, werden die Filteroptionen nach Kategorien im Frontend nicht sichtbar sein.</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.label">
+        <source>Hide sorting</source>
+        <target>Sortierung ausblenden</target>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.description">
+        <source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
+        <target>Wenn diese Option aktiviert ist, werden die Sortieroptionen im Frontend nicht sichtbar sein.</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Default sorting</source>
+        <target>Standard-Sortierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.description">
+        <source>Default sorting in frontend which can be changed by user if sorting options are visible.</source>
+        <target>Standard-Sortierung im Frontend, die vom Benutzer geändert werden kann, wenn die Sortieroptionen sichtbar sind.</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+        <target>Titel A-Z</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+        <target>Titel Z-A</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update">
+        <source>Last updated (latest first)</source>
+        <target>Zuletzt aktualisiert (neueste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update.asc">
+        <source>Last updated (latest last)</source>
+        <target>Zuletzt aktualisiert (älteste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
+      </trans-unit>
 
-			<!-- Wizard -->
+      <!-- Wizard -->
 
-			<trans-unit id="wizard_items.academic">
-				<source>Academic</source>
-				<target>Akademisch</target>
-			</trans-unit>
-			<trans-unit id="plugin.program_list.title">
-				<source>Program List</source>
-				<target>Programmliste</target>
-			</trans-unit>
-			<trans-unit id="plugin.program_list.description">
-				<source>Display a sortable and filterable list of academic programs.</source>
-				<target>Zeigt eine sortierbare und filterbare Liste von akademischen Programmen an.</target>
-			</trans-unit>
-			<trans-unit id="plugin.program_details.title">
-				<source>Program Details</source>
-				<target>Programmdetails</target>
-			</trans-unit>
-			<trans-unit id="plugin.program_details.description">
-				<source>Displays the details of an academic program</source>
-				<target>Zeigt die Details eines akademischen Programms an.</target>
-			</trans-unit>
+      <trans-unit id="wizard_items.academic">
+        <source>Academic</source>
+        <target>Akademisch</target>
+      </trans-unit>
+      <trans-unit id="plugin.program_list.title">
+        <source>Program List</source>
+        <target>Programmliste</target>
+      </trans-unit>
+      <trans-unit id="plugin.program_list.description">
+        <source>Display a sortable and filterable list of academic programs.</source>
+        <target>Zeigt eine sortierbare und filterbare Liste von akademischen Programmen an.</target>
+      </trans-unit>
+      <trans-unit id="plugin.program_details.title">
+        <source>Program Details</source>
+        <target>Programmdetails</target>
+      </trans-unit>
+      <trans-unit id="plugin.program_details.description">
+        <source>Displays the details of an academic program</source>
+        <target>Zeigt die Details eines akademischen Programms an.</target>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.item_group.academic">
-				<source>Academic Pages</source>
-				<target>Akademische Seiten</target>
-			</trans-unit>
-			<trans-unit id="pages.doktype.item.academic_program">
-				<source>Program</source>
-				<target>Programm</target>
-			</trans-unit>
+      <trans-unit id="pages.doktype.item_group.academic">
+        <source>Academic Pages</source>
+        <target>Akademische Seiten</target>
+      </trans-unit>
+      <trans-unit id="pages.doktype.item.academic_program">
+        <source>Program</source>
+        <target>Programm</target>
+      </trans-unit>
 
-			<!-- Labels for SysCategories -->
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.programs.group">
-				<source>Academic Programs</source>
-				<target>Akademische Programme</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.admission_restriction">
-				<source>Admission restriction</source>
-				<target>Zulassungsbeschränkung</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.application_period">
-				<source>Application period</source>
-				<target>Bewerbungszeitraum</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.begin_program">
-				<source>Begin of program</source>
-				<target>Programmbeginn</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.costs">
-				<source>Costs</source>
-				<target>Kosten</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.degree">
-				<source>Degree</source>
-				<target>Abschluss</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.department">
-				<source>Department / Faculty</source>
-				<target>Abteilung / Fakultät</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.location">
-				<source>Location</source>
-				<target>Standort</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.paying">
-				<source>Paying?</source>
-				<target>Zahlungspflichtig?</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.program_type">
-				<source>Type of program</source>
-				<target>Art des Programms</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.standard_period">
-				<source>Standard period</source>
-				<target>Regelstudienzeit</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.teaching_language">
-				<source>Teaching language</source>
-				<target>Unterrichtssprache</target>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.topic">
-				<source>Topic</source>
-				<target>Thema</target>
-			</trans-unit>
+      <trans-unit id="sys_category.programs.group">
+        <source>Academic Programs</source>
+        <target>Akademische Programme</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.admission_restriction">
+        <source>Admission restriction</source>
+        <target>Zulassungsbeschränkung</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.application_period">
+        <source>Application period</source>
+        <target>Bewerbungszeitraum</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.begin_program">
+        <source>Begin of program</source>
+        <target>Programmbeginn</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.costs">
+        <source>Costs</source>
+        <target>Kosten</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.degree">
+        <source>Degree</source>
+        <target>Abschluss</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.department">
+        <source>Department / Faculty</source>
+        <target>Abteilung / Fakultät</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.location">
+        <source>Location</source>
+        <target>Standort</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.paying">
+        <source>Paying?</source>
+        <target>Zahlungspflichtig?</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.program_type">
+        <source>Type of program</source>
+        <target>Art des Programms</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.standard_period">
+        <source>Standard period</source>
+        <target>Regelstudienzeit</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.teaching_language">
+        <source>Teaching language</source>
+        <target>Unterrichtssprache</target>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.topic">
+        <source>Topic</source>
+        <target>Thema</target>
+      </trans-unit>
 
-			<!-- TCA -->
+      <!-- TCA -->
 
-			<trans-unit id="pages.div.program">
-				<source>Program</source>
-				<target>Programm</target>
-			</trans-unit>
-			<trans-unit id="pages.prerequisites">
-				<source>Prerequisites</source>
-				<target>Voraussetzungen</target>
-			</trans-unit>
-			<trans-unit id="pages.credit_points">
-				<source>Credit points</source>
-				<target>Leistungspunkte</target>
-			</trans-unit>
-			<trans-unit id="pages.job_profile">
-				<source>Job profile</source>
-				<target>Berufsprofil</target>
-			</trans-unit>
-			<trans-unit id="pages.performance_scope">
-				<source>Performance scope</source>
-				<target>Leistungsumfang</target>
-			</trans-unit>
-			<trans-unit id="pages.overview">
-				<source>Overview</source>
-				<target>Überblick</target>
-			</trans-unit>
-			<trans-unit id="pages.contents">
-				<source>Programm contents</source>
-				<target>Programminhalte</target>
-			</trans-unit>
-			<trans-unit id="pages.application">
-				<source>Application</source>
-				<target>Bewerbung</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="pages.div.program">
+        <source>Program</source>
+        <target>Programm</target>
+      </trans-unit>
+      <trans-unit id="pages.prerequisites">
+        <source>Prerequisites</source>
+        <target>Voraussetzungen</target>
+      </trans-unit>
+      <trans-unit id="pages.credit_points">
+        <source>Credit points</source>
+        <target>Leistungspunkte</target>
+      </trans-unit>
+      <trans-unit id="pages.job_profile">
+        <source>Job profile</source>
+        <target>Berufsprofil</target>
+      </trans-unit>
+      <trans-unit id="pages.performance_scope">
+        <source>Performance scope</source>
+        <target>Leistungsumfang</target>
+      </trans-unit>
+      <trans-unit id="pages.overview">
+        <source>Overview</source>
+        <target>Überblick</target>
+      </trans-unit>
+      <trans-unit id="pages.contents">
+        <source>Programm contents</source>
+        <target>Programminhalte</target>
+      </trans-unit>
+      <trans-unit id="pages.application">
+        <source>Application</source>
+        <target>Bewerbung</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/locallang.xlf
@@ -1,110 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic_programs"
-	>
-		<header/>
-		<body>
-			<!-- Labels for SysCategories -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic_programs"
+  >
+    <header/>
+    <body>
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.programs.group">
-				<source>Academic Programs</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.admission_restriction">
-				<source>Admission restriction</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.application_period">
-				<source>Application period</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.begin_program">
-				<source>Begin of program</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.costs">
-				<source>Costs</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.degree">
-				<source>Degree</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.department">
-				<source>Department / Faculty</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.location">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.paying">
-				<source>Paying?</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.program_type">
-				<source>Type of program</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.standard_period">
-				<source>Standard period</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.teaching_language">
-				<source>Teaching language</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.topic">
-				<source>Topic</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.allOptions">
-				<source>All options</source>
-			</trans-unit>
+      <trans-unit id="sys_category.programs.group">
+        <source>Academic Programs</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.admission_restriction">
+        <source>Admission restriction</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.application_period">
+        <source>Application period</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.begin_program">
+        <source>Begin of program</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.costs">
+        <source>Costs</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.degree">
+        <source>Degree</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.department">
+        <source>Department / Faculty</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.location">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.paying">
+        <source>Paying?</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.program_type">
+        <source>Type of program</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.standard_period">
+        <source>Standard period</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.teaching_language">
+        <source>Teaching language</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.topic">
+        <source>Topic</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.allOptions">
+        <source>All options</source>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>Ascending</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>Descending</source>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>Ascending</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>Descending</source>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProgramsFound">
-				<source>No programs found.</source>
-			</trans-unit>
+      <trans-unit id="list.noProgramsFound">
+        <source>No programs found.</source>
+      </trans-unit>
 
-			<!-- Detail -->
+      <!-- Detail -->
 
-			<trans-unit id="program.prerequisites">
-				<source>Prerequisites</source>
-				<target>Voraussetzungen</target>
-			</trans-unit>
-			<trans-unit id="program.creditPoints">
-				<source>Credit points</source>
-				<target>Leistungspunkte</target>
-			</trans-unit>
-			<trans-unit id="program.jobProfile">
-				<source>Job profile</source>
-				<target>Berufsprofil</target>
-			</trans-unit>
-			<trans-unit id="program.performanceScope">
-				<source>Performance scope</source>
-				<target>Leistungsumfang</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="program.prerequisites">
+        <source>Prerequisites</source>
+        <target>Voraussetzungen</target>
+      </trans-unit>
+      <trans-unit id="program.creditPoints">
+        <source>Credit points</source>
+        <target>Leistungspunkte</target>
+      </trans-unit>
+      <trans-unit id="program.jobProfile">
+        <source>Job profile</source>
+        <target>Berufsprofil</target>
+      </trans-unit>
+      <trans-unit id="program.performanceScope">
+        <source>Performance scope</source>
+        <target>Leistungsumfang</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-programs/Resources/Private/Language/locallang_be.xlf
@@ -1,169 +1,169 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic_programs"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_programs/Resources/Private/Language/locallang.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic_programs"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_program">
-				<source>Academic Program</source>
-			</trans-unit>
-			<trans-unit id="backend_layout.academic_program.column.content">
-				<source>Content</source>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_program">
+        <source>Academic Program</source>
+      </trans-unit>
+      <trans-unit id="backend_layout.academic_program.column.content">
+        <source>Content</source>
+      </trans-unit>
 
-			<!-- Plugin configuration -->
+      <!-- Plugin configuration -->
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="flexform.categories.label">
-				<source>Default categories</source>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.label">
-				<source>Hide category filtering</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_filtering.description">
-				<source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.label">
-				<source>Hide sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.hide_sorting.description">
-				<source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Default sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.description">
-				<source>Default sorting in frontend which can be changed by user if sorting options are visible.</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update">
-				<source>Last updated (latest first)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.update.asc">
-				<source>Last updated (latest last)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-			</trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Default categories</source>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Selected categories of the same type (e.g. ‘Degree’) are checked as alternatives (OR). If a category has subcategories (e.g. ‘Master’ with ‘Master of Arts’), these are automatically added to the list of alternatives. In addition, the pages found for each category type must also be able to be found in all other selected category types (AND).</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.label">
+        <source>Hide category filtering</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_filtering.description">
+        <source>If the option is enabled, options for filtering by categories will not be visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.label">
+        <source>Hide sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.hide_sorting.description">
+        <source>If the option is enabled, options for sorting will not be visible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Default sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.description">
+        <source>Default sorting in frontend which can be changed by user if sorting options are visible.</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update">
+        <source>Last updated (latest first)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.update.asc">
+        <source>Last updated (latest last)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+      </trans-unit>
 
-			<!-- Wizard -->
+      <!-- Wizard -->
 
-			<trans-unit id="wizard_items.academic">
-				<source>Academic</source>
-			</trans-unit>
-			<trans-unit id="plugin.program_list.title">
-				<source>Program List</source>
-			</trans-unit>
-			<trans-unit id="plugin.program_list.description">
-				<source>Display a sortable and filterable list of academic programs.</source>
-			</trans-unit>
-			<trans-unit id="plugin.program_details.title">
-				<source>Program Details</source>
-			</trans-unit>
-			<trans-unit id="plugin.program_details.description">
-				<source>Displays the details of an academic program</source>
-			</trans-unit>
+      <trans-unit id="wizard_items.academic">
+        <source>Academic</source>
+      </trans-unit>
+      <trans-unit id="plugin.program_list.title">
+        <source>Program List</source>
+      </trans-unit>
+      <trans-unit id="plugin.program_list.description">
+        <source>Display a sortable and filterable list of academic programs.</source>
+      </trans-unit>
+      <trans-unit id="plugin.program_details.title">
+        <source>Program Details</source>
+      </trans-unit>
+      <trans-unit id="plugin.program_details.description">
+        <source>Displays the details of an academic program</source>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.item_group.academic">
-				<source>Academic Pages</source>
-			</trans-unit>
-			<trans-unit id="pages.doktype.item.academic_program">
-				<source>Program</source>
-			</trans-unit>
+      <trans-unit id="pages.doktype.item_group.academic">
+        <source>Academic Pages</source>
+      </trans-unit>
+      <trans-unit id="pages.doktype.item.academic_program">
+        <source>Program</source>
+      </trans-unit>
 
-			<!-- Labels for SysCategories -->
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.programs.group">
-				<source>Academic Programs</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.admission_restriction">
-				<source>Admission restriction</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.application_period">
-				<source>Application period</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.begin_program">
-				<source>Begin of program</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.costs">
-				<source>Costs</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.degree">
-				<source>Degree</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.department">
-				<source>Department / Faculty</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.location">
-				<source>Location</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.paying">
-				<source>Paying?</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.program_type">
-				<source>Type of program</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.standard_period">
-				<source>Standard period</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.teaching_language">
-				<source>Teaching language</source>
-			</trans-unit>
-			<trans-unit id="sys_category.programs.topic">
-				<source>Topic</source>
-			</trans-unit>
+      <trans-unit id="sys_category.programs.group">
+        <source>Academic Programs</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.admission_restriction">
+        <source>Admission restriction</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.application_period">
+        <source>Application period</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.begin_program">
+        <source>Begin of program</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.costs">
+        <source>Costs</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.degree">
+        <source>Degree</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.department">
+        <source>Department / Faculty</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.location">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.paying">
+        <source>Paying?</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.program_type">
+        <source>Type of program</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.standard_period">
+        <source>Standard period</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.teaching_language">
+        <source>Teaching language</source>
+      </trans-unit>
+      <trans-unit id="sys_category.programs.topic">
+        <source>Topic</source>
+      </trans-unit>
 
-			<!-- TCA -->
+      <!-- TCA -->
 
-			<trans-unit id="pages.div.program">
-				<source>Program</source>
-			</trans-unit>
-			<trans-unit id="pages.prerequisites">
-				<source>Prerequisites</source>
-			</trans-unit>
-			<trans-unit id="pages.credit_points">
-				<source>Credit points</source>
-			</trans-unit>
-			<trans-unit id="pages.job_profile">
-				<source>Job profile</source>
-			</trans-unit>
-			<trans-unit id="pages.performance_scope">
-				<source>Performance scope</source>
-			</trans-unit>
-			<trans-unit id="pages.overview">
-				<source>Overview</source>
-			</trans-unit>
-			<trans-unit id="pages.contents">
-				<source>Programm contents</source>
-			</trans-unit>
-			<trans-unit id="pages.application">
-				<source>Application</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="pages.div.program">
+        <source>Program</source>
+      </trans-unit>
+      <trans-unit id="pages.prerequisites">
+        <source>Prerequisites</source>
+      </trans-unit>
+      <trans-unit id="pages.credit_points">
+        <source>Credit points</source>
+      </trans-unit>
+      <trans-unit id="pages.job_profile">
+        <source>Job profile</source>
+      </trans-unit>
+      <trans-unit id="pages.performance_scope">
+        <source>Performance scope</source>
+      </trans-unit>
+      <trans-unit id="pages.overview">
+        <source>Overview</source>
+      </trans-unit>
+      <trans-unit id="pages.contents">
+        <source>Programm contents</source>
+      </trans-unit>
+      <trans-unit id="pages.application">
+        <source>Application</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-projects/.editorconfig
+++ b/packages/fgtclb/academic-projects/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang.xlf
@@ -1,175 +1,175 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic_projects"
-	>
-		<header/>
-		<body>
-			<!-- Labels for SysCategories -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic_projects"
+  >
+    <header/>
+    <body>
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.projects.group">
-				<source>Academic Projects</source>
-				<target>Akademische Projekte</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.allOptions">
-				<source>All options</source>
-				<target>Alle Optionen</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.department">
-				<source>Department</source>
-				<target>Organisationseinheit</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.competence_field">
-				<source>Competence field</source>
-				<target>Kompetenzfeld</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.cooperation">
-				<source>Cooperation</source>
-				<target>Kooperation</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.funding_partner">
-				<source>Funding partner</source>
-				<target>Mittelgebende</target>
-			</trans-unit>
+      <trans-unit id="sys_category.projects.group">
+        <source>Academic Projects</source>
+        <target>Akademische Projekte</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.allOptions">
+        <source>All options</source>
+        <target>Alle Optionen</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.department">
+        <source>Department</source>
+        <target>Organisationseinheit</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.competence_field">
+        <source>Competence field</source>
+        <target>Kompetenzfeld</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.cooperation">
+        <source>Cooperation</source>
+        <target>Kooperation</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.funding_partner">
+        <source>Funding partner</source>
+        <target>Mittelgebende</target>
+      </trans-unit>
 
-			<!-- Detail page labels -->
+      <!-- Detail page labels -->
 
-			<trans-unit id="project.runtime">
-				<source>Runtime</source>
-				<target>Laufzeit</target>
-			</trans-unit>
-			<trans-unit id="project.until">
-				<source>Until</source>
-				<target>Bis</target>
-			</trans-unit>
-			<trans-unit id="project.since">
-				<source>Since</source>
-				<target>Seit</target>
-			</trans-unit>
-			<trans-unit id="project.budget">
-				<source>Budget</source>
-				<target>Budget</target>
-			</trans-unit>
-			<trans-unit id="project.funders">
-				<source>Funders</source>
-				<target>Förderer</target>
-			</trans-unit>
+      <trans-unit id="project.runtime">
+        <source>Runtime</source>
+        <target>Laufzeit</target>
+      </trans-unit>
+      <trans-unit id="project.until">
+        <source>Until</source>
+        <target>Bis</target>
+      </trans-unit>
+      <trans-unit id="project.since">
+        <source>Since</source>
+        <target>Seit</target>
+      </trans-unit>
+      <trans-unit id="project.budget">
+        <source>Budget</source>
+        <target>Budget</target>
+      </trans-unit>
+      <trans-unit id="project.funders">
+        <source>Funders</source>
+        <target>Förderer</target>
+      </trans-unit>
 
-			<!-- Active state -->
+      <!-- Active state -->
 
-			<trans-unit id="activeState.label">
-				<source>Active state</source>
-				<target>Aktivitätsstatus</target>
-			</trans-unit>
-			<trans-unit id="activeState.all">
-				<source>All</source>
-				<target>Alle</target>
-			</trans-unit>
-			<trans-unit id="activeState.active">
-				<source>Active</source>
-				<target>Aktiv</target>
-			</trans-unit>
-			<trans-unit id="activeState.completed">
-				<source>Completed</source>
-				<target>Abgeschlossen</target>
-			</trans-unit>
+      <trans-unit id="activeState.label">
+        <source>Active state</source>
+        <target>Aktivitätsstatus</target>
+      </trans-unit>
+      <trans-unit id="activeState.all">
+        <source>All</source>
+        <target>Alle</target>
+      </trans-unit>
+      <trans-unit id="activeState.active">
+        <source>Active</source>
+        <target>Aktiv</target>
+      </trans-unit>
+      <trans-unit id="activeState.completed">
+        <source>Completed</source>
+        <target>Abgeschlossen</target>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-				<target>Sortierungsrichtung</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>Ascending</source>
-				<target>Aufsteigend</target>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>Descending</source>
-				<target>Absteigend</target>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+        <target>Sortierungsrichtung</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>Ascending</source>
+        <target>Aufsteigend</target>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>Descending</source>
+        <target>Absteigend</target>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-				<target>Sortierungsfeld</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-				<target>Zuletzt aktualisiert</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-				<target>Sortierung</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-				<target>Titel</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.tx_academicprojects_budget">
-				<source>Budget</source>
-				<target>Budget</target>
-			</trans-unit>
-			<trans-unit id="sorting.field.tx_academicprojects_start_date">
-				<source>Start date</source>
-				<target>Startdatum</target>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+        <target>Sortierungsfeld</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+        <target>Zuletzt aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+        <target>Sortierung</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+        <target>Titel</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.tx_academicprojects_budget">
+        <source>Budget</source>
+        <target>Budget</target>
+      </trans-unit>
+      <trans-unit id="sorting.field.tx_academicprojects_start_date">
+        <source>Start date</source>
+        <target>Startdatum</target>
+      </trans-unit>
 
-			<!-- Combined sorting options -->
+      <!-- Combined sorting options -->
 
-			<trans-unit id="filter.sorting.lastUpdated.asc">
-				<source>Last updated (latest first)</source>
-				<target>Zuletzt aktualisiert (neueste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.lastUpdated.desc">
-				<source>Last updated (latest last)</source>
-				<target>Zuletzt aktualisiert (neueste zuletzt)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.sorting.desc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.title.asc">
-				<source>Title A-Z</source>
-				<target>Titel A-Z</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.title.desc">
-				<source>Title Z-A</source>
-				<target>Titel Z-A</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.tx_academicprojects_budget.asc">
-				<source>Budget (low to high)</source>
-				<target>Budget (niedrig bis hoch)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.tx_academicprojects_budget.desc">
-				<source>Budget (high to low)</source>
-				<target>Budget (hoch bis niedrig)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.tx_academicprojects_start_date.asc">
-				<source>Start date (oldest first)</source>
-				<target>Startdatum (älteste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="filter.sorting.tx_academicprojects_start_date.desc">
-				<source>Start date (newest first)</source>
-				<target>Startdatum (neueste zuerst)</target>
-			</trans-unit>
+      <trans-unit id="filter.sorting.lastUpdated.asc">
+        <source>Last updated (latest first)</source>
+        <target>Zuletzt aktualisiert (neueste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.lastUpdated.desc">
+        <source>Last updated (latest last)</source>
+        <target>Zuletzt aktualisiert (neueste zuletzt)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.sorting.desc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.title.asc">
+        <source>Title A-Z</source>
+        <target>Titel A-Z</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.title.desc">
+        <source>Title Z-A</source>
+        <target>Titel Z-A</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.tx_academicprojects_budget.asc">
+        <source>Budget (low to high)</source>
+        <target>Budget (niedrig bis hoch)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.tx_academicprojects_budget.desc">
+        <source>Budget (high to low)</source>
+        <target>Budget (hoch bis niedrig)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.tx_academicprojects_start_date.asc">
+        <source>Start date (oldest first)</source>
+        <target>Startdatum (älteste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="filter.sorting.tx_academicprojects_start_date.desc">
+        <source>Start date (newest first)</source>
+        <target>Startdatum (neueste zuerst)</target>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProjectsFound">
-				<source>No projects found.</source>
-				<target>Keine Projekte gefunden.</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="list.noProjectsFound">
+        <source>No projects found.</source>
+        <target>Keine Projekte gefunden.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/de.locallang_be.xlf
@@ -1,212 +1,212 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic_projects"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic_projects"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_project">
-				<source>Academic Project</source>
-				<target>Akademisches Projekt</target>
-			</trans-unit>
-			<trans-unit id="backend_layout.academic_project.column.content">
-				<source>Content</source>
-				<target>Inhalt</target>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_project">
+        <source>Academic Project</source>
+        <target>Akademisches Projekt</target>
+      </trans-unit>
+      <trans-unit id="backend_layout.academic_project.column.content">
+        <source>Content</source>
+        <target>Inhalt</target>
+      </trans-unit>
 
-			<!-- Plugin configuration -->
+      <!-- Plugin configuration -->
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-				<target>Konfiguration</target>
-			</trans-unit>
-			<trans-unit id="element.field.pages">
-				<source>Selected pages for startingpoints</source>
-				<target>Ausgewählte Seiten für Startpunkte</target>
-			</trans-unit>
-			<trans-unit id="element.field.pages.selected">
-				<source>Selected projects to display</source>
-				<target>Ausgewählte Projekte zum anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.hideActiveState.label">
-				<source>Show active state options</source>
-				<target>Aktivstatus-Optionen anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.label">
-				<source>Active state</source>
-				<target>Aktivstatus</target>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.all">
-				<source>All</source>
-				<target>Alle</target>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.active">
-				<source>Active</source>
-				<target>Aktiv</target>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.completed">
-				<source>Completed</source>
-				<target>Abgeschlossen</target>
-			</trans-unit>
-			<trans-unit id="flexform.categories.label">
-				<source>Categories</source>
-				<target>Kategorien</target>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Select categories. Main categories will select all subcategories by OR, multiple categories selects by AND</source>
-				<target>Wählen Sie Kategorien aus. Hauptkategorien wählen alle Unterkategorien durch ODER aus, mehrere Kategorien wählen durch UND aus</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-				<target>Versteckte Datensätze anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-				<target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
-			</trans-unit>
-			<trans-unit id="flexform.hideFilter.label">
-				<source>Show filter options</source>
-				<target>Filteroptionen anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.hideSorting.label">
-				<source>Show sorting options</source>
-				<target>Sortieroptionen anzeigen</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Sorting</source>
-				<target>Sortierung</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.lastUpdated.asc">
-				<source>Last updated (latest first)</source>
-				<target>Zuletzt aktualisiert (neueste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.lastUpdated.desc">
-				<source>Last updated (latest last)</source>
-				<target>Zuletzt aktualisiert (neueste zuletzt)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.desc">
-				<source>Page sorting (Result may be unexpected)</source>
-				<target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-				<target>Titel A-Z</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-				<target>Titel Z-A</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_budget.asc">
-				<source>Budget (low to high)</source>
-				<target>Budget (niedrig bis hoch)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_budget.desc">
-				<source>Budget (high to low)</source>
-				<target>Budget (hoch bis niedrig)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_start_date.asc">
-				<source>Start date (oldest first)</source>
-				<target>Startdatum (älteste zuerst)</target>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_start_date.desc">
-				<source>Start date (newest first)</source>
-				<target>Startdatum (neueste zuerst)</target>
-			</trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+        <target>Konfiguration</target>
+      </trans-unit>
+      <trans-unit id="element.field.pages">
+        <source>Selected pages for startingpoints</source>
+        <target>Ausgewählte Seiten für Startpunkte</target>
+      </trans-unit>
+      <trans-unit id="element.field.pages.selected">
+        <source>Selected projects to display</source>
+        <target>Ausgewählte Projekte zum anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.hideActiveState.label">
+        <source>Show active state options</source>
+        <target>Aktivstatus-Optionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.label">
+        <source>Active state</source>
+        <target>Aktivstatus</target>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.all">
+        <source>All</source>
+        <target>Alle</target>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.active">
+        <source>Active</source>
+        <target>Aktiv</target>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.completed">
+        <source>Completed</source>
+        <target>Abgeschlossen</target>
+      </trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Categories</source>
+        <target>Kategorien</target>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Select categories. Main categories will select all subcategories by OR, multiple categories selects by AND</source>
+        <target>Wählen Sie Kategorien aus. Hauptkategorien wählen alle Unterkategorien durch ODER aus, mehrere Kategorien wählen durch UND aus</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+        <target>Versteckte Datensätze anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+        <target>Wenn aktiviert, werden versteckte (deaktivierte) Datensätze unabhängig von den Backend-Vorschaueinstellungen im Frontend ausgegeben.</target>
+      </trans-unit>
+      <trans-unit id="flexform.hideFilter.label">
+        <source>Show filter options</source>
+        <target>Filteroptionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.hideSorting.label">
+        <source>Show sorting options</source>
+        <target>Sortieroptionen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Sorting</source>
+        <target>Sortierung</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.lastUpdated.asc">
+        <source>Last updated (latest first)</source>
+        <target>Zuletzt aktualisiert (neueste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.lastUpdated.desc">
+        <source>Last updated (latest last)</source>
+        <target>Zuletzt aktualisiert (neueste zuletzt)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.desc">
+        <source>Page sorting (Result may be unexpected)</source>
+        <target>Seitensortierung (Ergebnis kann unerwartet sein)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+        <target>Titel A-Z</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+        <target>Titel Z-A</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_budget.asc">
+        <source>Budget (low to high)</source>
+        <target>Budget (niedrig bis hoch)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_budget.desc">
+        <source>Budget (high to low)</source>
+        <target>Budget (hoch bis niedrig)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_start_date.asc">
+        <source>Start date (oldest first)</source>
+        <target>Startdatum (älteste zuerst)</target>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_start_date.desc">
+        <source>Start date (newest first)</source>
+        <target>Startdatum (neueste zuerst)</target>
+      </trans-unit>
 
-			<!-- Wizard -->
+      <!-- Wizard -->
 
-			<trans-unit id="plugin.project_list.name">
-				<source>Projects</source>
-				<target>Projekte</target>
-			</trans-unit>
-			<trans-unit id="plugin.project_list.description">
-				<source>List of academic projects with sorting and filtering</source>
-				<target>Liste akademischer Projekte mit Sortierung und Filterung</target>
-			</trans-unit>
-			<trans-unit id="plugin.project_selected.name">
-				<source>Projects (selected)</source>
-				<target>Projekte (ausgewählte)</target>
-			</trans-unit>
-			<trans-unit id="plugin.project_selected.description">
-				<source>List of selected academic projects with sorting and filtering</source>
-				<target>Liste ausgewählter akademischer Projekte mit Sortierung und Filterung</target>
-			</trans-unit>
+      <trans-unit id="plugin.project_list.name">
+        <source>Projects</source>
+        <target>Projekte</target>
+      </trans-unit>
+      <trans-unit id="plugin.project_list.description">
+        <source>List of academic projects with sorting and filtering</source>
+        <target>Liste akademischer Projekte mit Sortierung und Filterung</target>
+      </trans-unit>
+      <trans-unit id="plugin.project_selected.name">
+        <source>Projects (selected)</source>
+        <target>Projekte (ausgewählte)</target>
+      </trans-unit>
+      <trans-unit id="plugin.project_selected.description">
+        <source>List of selected academic projects with sorting and filtering</source>
+        <target>Liste ausgewählter akademischer Projekte mit Sortierung und Filterung</target>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.item_group.academic">
-				<source>Academic Pages</source>
-				<target>Akademische Seiten</target>
-			</trans-unit>
-			<trans-unit id="pages.doktype.item.academic_project">
-				<source>Project</source>
-				<target>Projekt</target>
-			</trans-unit>
+      <trans-unit id="pages.doktype.item_group.academic">
+        <source>Academic Pages</source>
+        <target>Akademische Seiten</target>
+      </trans-unit>
+      <trans-unit id="pages.doktype.item.academic_project">
+        <source>Project</source>
+        <target>Projekt</target>
+      </trans-unit>
 
-			<!-- Labels for SysCategories -->
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.projects.group">
-				<source>Academic Projects</source>
-				<target>Akademische Projekte</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.department">
-				<source>Department</source>
-				<target>Organisationseinheit</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.competence_field">
-				<source>Competence field</source>
-				<target>Kompetenzfeld</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.cooperation">
-				<source>Cooperation</source>
-				<target>Kooperation</target>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.funding_partner">
-				<source>Funding partner</source>
-				<target>Mittelgebende</target>
-			</trans-unit>
+      <trans-unit id="sys_category.projects.group">
+        <source>Academic Projects</source>
+        <target>Akademische Projekte</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.department">
+        <source>Department</source>
+        <target>Organisationseinheit</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.competence_field">
+        <source>Competence field</source>
+        <target>Kompetenzfeld</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.cooperation">
+        <source>Cooperation</source>
+        <target>Kooperation</target>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.funding_partner">
+        <source>Funding partner</source>
+        <target>Mittelgebende</target>
+      </trans-unit>
 
-			<!-- TCA -->
+      <!-- TCA -->
 
-			<trans-unit id="pages.div.project">
-				<source>Project</source>
-				<target>Projekt</target>
-			</trans-unit>
-			<trans-unit id="pages.budget">
-				<source>Project budget</source>
-				<target>Projektbudget</target>
-			</trans-unit>
-			<trans-unit id="pages.end_date">
-				<source>Project end</source>
-				<target>Projektende</target>
-			</trans-unit>
-			<trans-unit id="pages.funders">
-				<source>Project funders</source>
-				<target>Mittelgebende</target>
-			</trans-unit>
-			<trans-unit id="pages.project_title">
-				<source>Project title</source>
-				<target>Projekttitel</target>
-			</trans-unit>
-			<trans-unit id="pages.short_description">
-				<source>Project short description</source>
-				<target>Kurzbeschreibung des Projektes</target>
-			</trans-unit>
-			<trans-unit id="pages.start_date">
-				<source>Project start</source>
-				<target>Projektbeginn</target>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="pages.div.project">
+        <source>Project</source>
+        <target>Projekt</target>
+      </trans-unit>
+      <trans-unit id="pages.budget">
+        <source>Project budget</source>
+        <target>Projektbudget</target>
+      </trans-unit>
+      <trans-unit id="pages.end_date">
+        <source>Project end</source>
+        <target>Projektende</target>
+      </trans-unit>
+      <trans-unit id="pages.funders">
+        <source>Project funders</source>
+        <target>Mittelgebende</target>
+      </trans-unit>
+      <trans-unit id="pages.project_title">
+        <source>Project title</source>
+        <target>Projekttitel</target>
+      </trans-unit>
+      <trans-unit id="pages.short_description">
+        <source>Project short description</source>
+        <target>Kurzbeschreibung des Projektes</target>
+      </trans-unit>
+      <trans-unit id="pages.start_date">
+        <source>Project start</source>
+        <target>Projektbeginn</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/locallang.xlf
@@ -1,127 +1,127 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_projects/Resources/Private/Language/locallang.xlf"
-		date="2023-03-15T11:39:25Z"
-		product-name="academic_projects"
-	>
-		<header/>
-		<body>
-			<!-- Labels for SysCategories -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_projects/Resources/Private/Language/locallang.xlf"
+    date="2023-03-15T11:39:25Z"
+    product-name="academic_projects"
+  >
+    <header/>
+    <body>
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.projects.group">
-				<source>Academic Projects</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.allOptions">
-				<source>All options</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.department">
-				<source>Department</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.competence_field">
-				<source>Competence field</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.cooperation">
-				<source>Cooperation</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.funding_partner">
-				<source>Funding partner</source>
-			</trans-unit>
+      <trans-unit id="sys_category.projects.group">
+        <source>Academic Projects</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.allOptions">
+        <source>All options</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.department">
+        <source>Department</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.competence_field">
+        <source>Competence field</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.cooperation">
+        <source>Cooperation</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.funding_partner">
+        <source>Funding partner</source>
+      </trans-unit>
 
-			<!-- Detail page labels -->
+      <!-- Detail page labels -->
 
-			<trans-unit id="project.runtime">
-				<source>Runtime</source>
-			</trans-unit>
-			<trans-unit id="project.until">
-				<source>Until</source>
-			</trans-unit>
-			<trans-unit id="project.since">
-				<source>Since</source>
-			</trans-unit>
-			<trans-unit id="project.budget">
-				<source>Budget</source>
-			</trans-unit>
-			<trans-unit id="project.funders">
-				<source>Funders</source>
-			</trans-unit>
+      <trans-unit id="project.runtime">
+        <source>Runtime</source>
+      </trans-unit>
+      <trans-unit id="project.until">
+        <source>Until</source>
+      </trans-unit>
+      <trans-unit id="project.since">
+        <source>Since</source>
+      </trans-unit>
+      <trans-unit id="project.budget">
+        <source>Budget</source>
+      </trans-unit>
+      <trans-unit id="project.funders">
+        <source>Funders</source>
+      </trans-unit>
 
-			<!-- Active state -->
+      <!-- Active state -->
 
-			<trans-unit id="activeState.label">
-				<source>Active state</source>
-			</trans-unit>
-			<trans-unit id="activeState.all">
-				<source>All</source>
-			</trans-unit>
-			<trans-unit id="activeState.active">
-				<source>Active</source>
-			</trans-unit>
-			<trans-unit id="activeState.completed">
-				<source>Completed</source>
-			</trans-unit>
+      <trans-unit id="activeState.label">
+        <source>Active state</source>
+      </trans-unit>
+      <trans-unit id="activeState.all">
+        <source>All</source>
+      </trans-unit>
+      <trans-unit id="activeState.active">
+        <source>Active</source>
+      </trans-unit>
+      <trans-unit id="activeState.completed">
+        <source>Completed</source>
+      </trans-unit>
 
-			<!-- Sorting direction options -->
+      <!-- Sorting direction options -->
 
-			<trans-unit id="sorting.direction.label">
-				<source>Sorting direction</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.asc">
-				<source>Ascending</source>
-			</trans-unit>
-			<trans-unit id="sorting.direction.desc">
-				<source>Descending</source>
-			</trans-unit>
+      <trans-unit id="sorting.direction.label">
+        <source>Sorting direction</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.asc">
+        <source>Ascending</source>
+      </trans-unit>
+      <trans-unit id="sorting.direction.desc">
+        <source>Descending</source>
+      </trans-unit>
 
-			<!-- Sorting field options -->
+      <!-- Sorting field options -->
 
-			<trans-unit id="sorting.field.label">
-				<source>Sorting field</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.lastUpdated">
-				<source>Last updated</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.sorting">
-				<source>Sorting</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.title">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.tx_academicprojects_budget">
-				<source>Budget</source>
-			</trans-unit>
-			<trans-unit id="sorting.field.tx_academicprojects_start_date">
-				<source>Start date</source>
-			</trans-unit>
+      <trans-unit id="sorting.field.label">
+        <source>Sorting field</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.lastUpdated">
+        <source>Last updated</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.sorting">
+        <source>Sorting</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.title">
+        <source>Title</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.tx_academicprojects_budget">
+        <source>Budget</source>
+      </trans-unit>
+      <trans-unit id="sorting.field.tx_academicprojects_start_date">
+        <source>Start date</source>
+      </trans-unit>
 
-			<!-- Combined sorting options -->
+      <!-- Combined sorting options -->
 
-			<trans-unit id="sorting.title.asc">
-				<source>Title A-Z</source>
-			</trans-unit>
-			<trans-unit id="sorting.title.desc">
-				<source>Title Z-A</source>
-			</trans-unit>
-			<trans-unit id="sorting.tx_academicprojects_budget.asc">
-				<source>Budget (low to high)</source>
-			</trans-unit>
-			<trans-unit id="sorting.tx_academicprojects_budget.desc">
-				<source>Budget (high to low)</source>
-			</trans-unit>
-			<trans-unit id="sorting.tx_academicprojects_start_date.asc">
-				<source>Start date (oldest first)</source>
-			</trans-unit>
-			<trans-unit id="sorting.tx_academicprojects_start_date.desc">
-				<source>Start date (newest first)</source>
-			</trans-unit>
+      <trans-unit id="sorting.title.asc">
+        <source>Title A-Z</source>
+      </trans-unit>
+      <trans-unit id="sorting.title.desc">
+        <source>Title Z-A</source>
+      </trans-unit>
+      <trans-unit id="sorting.tx_academicprojects_budget.asc">
+        <source>Budget (low to high)</source>
+      </trans-unit>
+      <trans-unit id="sorting.tx_academicprojects_budget.desc">
+        <source>Budget (high to low)</source>
+      </trans-unit>
+      <trans-unit id="sorting.tx_academicprojects_start_date.asc">
+        <source>Start date (oldest first)</source>
+      </trans-unit>
+      <trans-unit id="sorting.tx_academicprojects_start_date.desc">
+        <source>Start date (newest first)</source>
+      </trans-unit>
 
-			<!-- List -->
+      <!-- List -->
 
-			<trans-unit id="list.noProjectsFound">
-				<source>No projects found.</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="list.noProjectsFound">
+        <source>No projects found.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-projects/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-projects/Resources/Private/Language/locallang_be.xlf
@@ -1,166 +1,166 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
-		date="2023-04-24T15:52:42Z"
-		product-name="academic_projects"
-	>
-		<header/>
-		<body>
-			<!-- Backend Layout -->
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_projects/Resources/Private/Language/locallang_be.xlf"
+    date="2023-04-24T15:52:42Z"
+    product-name="academic_projects"
+  >
+    <header/>
+    <body>
+      <!-- Backend Layout -->
 
-			<trans-unit id="backend_layout.academic_project">
-				<source>Academic Project</source>
-			</trans-unit>
-			<trans-unit id="backend_layout.academic_project.column.content">
-				<source>Content</source>
-			</trans-unit>
+      <trans-unit id="backend_layout.academic_project">
+        <source>Academic Project</source>
+      </trans-unit>
+      <trans-unit id="backend_layout.academic_project.column.content">
+        <source>Content</source>
+      </trans-unit>
 
-			<!-- Plugin configuration -->
+      <!-- Plugin configuration -->
 
-			<trans-unit id="element.tab.configuration">
-				<source>Configuration</source>
-			</trans-unit>
-			<trans-unit id="element.field.pages">
-				<source>Selected pages for startingpoints</source>
-			</trans-unit>
-			<trans-unit id="element.field.pages.selected">
-				<source>Selected projects to display</source>
-			</trans-unit>
-			<trans-unit id="flexform.hideActiveState.label">
-				<source>Show active state options</source>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.label">
-				<source>Active state</source>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.all">
-				<source>All</source>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.active">
-				<source>Active</source>
-			</trans-unit>
-			<trans-unit id="flexform.activeState.completed">
-				<source>Completed</source>
-			</trans-unit>
-			<trans-unit id="flexform.categories.label">
-				<source>Categories</source>
-			</trans-unit>
-			<trans-unit id="flexform.categories.description">
-				<source>Select categories. Main categories will select all subcategories by OR, multiple categories selects by AND</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.label">
-				<source>Show hidden records</source>
-			</trans-unit>
-			<trans-unit id="flexform.showHiddenRecords.description">
-				<source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
-			</trans-unit>
-			<trans-unit id="flexform.hideFilter.label">
-				<source>Show filter options</source>
-			</trans-unit>
-			<trans-unit id="flexform.hideSorting.label">
-				<source>Show sorting options</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.label">
-				<source>Sorting</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.lastUpdated.asc">
-				<source>Last updated (latest first)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.lastUpdated.desc">
-				<source>Last updated (latest last)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.asc">
-				<source>Page sorting (Result may be unexpected)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.sorting.desc">
-				<source>Page sorting (Result may be unexpected)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.asc">
-				<source>Title A-Z</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.title.desc">
-				<source>Title Z-A</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_budget.asc">
-				<source>Budget (low to high)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_budget.desc">
-				<source>Budget (high to low)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_start_date.asc">
-				<source>Start date (oldest first)</source>
-			</trans-unit>
-			<trans-unit id="flexform.sorting.tx_academicprojects_start_date.desc">
-				<source>Start date (newest first)</source>
-			</trans-unit>
+      <trans-unit id="element.tab.configuration">
+        <source>Configuration</source>
+      </trans-unit>
+      <trans-unit id="element.field.pages">
+        <source>Selected pages for startingpoints</source>
+      </trans-unit>
+      <trans-unit id="element.field.pages.selected">
+        <source>Selected projects to display</source>
+      </trans-unit>
+      <trans-unit id="flexform.hideActiveState.label">
+        <source>Show active state options</source>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.label">
+        <source>Active state</source>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.all">
+        <source>All</source>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.active">
+        <source>Active</source>
+      </trans-unit>
+      <trans-unit id="flexform.activeState.completed">
+        <source>Completed</source>
+      </trans-unit>
+      <trans-unit id="flexform.categories.label">
+        <source>Categories</source>
+      </trans-unit>
+      <trans-unit id="flexform.categories.description">
+        <source>Select categories. Main categories will select all subcategories by OR, multiple categories selects by AND</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.label">
+        <source>Show hidden records</source>
+      </trans-unit>
+      <trans-unit id="flexform.showHiddenRecords.description">
+        <source>If enabled, hidden (disabled) records are shown in the frontend, independent of the backend preview settings.</source>
+      </trans-unit>
+      <trans-unit id="flexform.hideFilter.label">
+        <source>Show filter options</source>
+      </trans-unit>
+      <trans-unit id="flexform.hideSorting.label">
+        <source>Show sorting options</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.label">
+        <source>Sorting</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.lastUpdated.asc">
+        <source>Last updated (latest first)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.lastUpdated.desc">
+        <source>Last updated (latest last)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.asc">
+        <source>Page sorting (Result may be unexpected)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.sorting.desc">
+        <source>Page sorting (Result may be unexpected)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.asc">
+        <source>Title A-Z</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.title.desc">
+        <source>Title Z-A</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_budget.asc">
+        <source>Budget (low to high)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_budget.desc">
+        <source>Budget (high to low)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_start_date.asc">
+        <source>Start date (oldest first)</source>
+      </trans-unit>
+      <trans-unit id="flexform.sorting.tx_academicprojects_start_date.desc">
+        <source>Start date (newest first)</source>
+      </trans-unit>
 
-			<!-- Wizard -->
+      <!-- Wizard -->
 
-			<trans-unit id="plugin.project_list.name">
-				<source>Projects</source>
-			</trans-unit>
-			<trans-unit id="plugin.project_list.description">
-				<source>List of academic projects with sorting and filtering</source>
-			</trans-unit>
-			<trans-unit id="plugin.project_selected.name">
-				<source>Projects (selected)</source>
-			</trans-unit>
-			<trans-unit id="plugin.project_selected.description">
-				<source>List of selected academic projects with sorting and filtering</source>
-			</trans-unit>
+      <trans-unit id="plugin.project_list.name">
+        <source>Projects</source>
+      </trans-unit>
+      <trans-unit id="plugin.project_list.description">
+        <source>List of academic projects with sorting and filtering</source>
+      </trans-unit>
+      <trans-unit id="plugin.project_selected.name">
+        <source>Projects (selected)</source>
+      </trans-unit>
+      <trans-unit id="plugin.project_selected.description">
+        <source>List of selected academic projects with sorting and filtering</source>
+      </trans-unit>
 
-			<!-- Doktype -->
+      <!-- Doktype -->
 
-			<trans-unit id="pages.doktype.item_group.academic">
-				<source>Academic Pages</source>
-			</trans-unit>
-			<trans-unit id="pages.doktype.item.academic_project">
-				<source>Project</source>
-			</trans-unit>
+      <trans-unit id="pages.doktype.item_group.academic">
+        <source>Academic Pages</source>
+      </trans-unit>
+      <trans-unit id="pages.doktype.item.academic_project">
+        <source>Project</source>
+      </trans-unit>
 
-			<!-- Labels for SysCategories -->
+      <!-- Labels for SysCategories -->
 
-			<trans-unit id="sys_category.projects.group">
-				<source>Academic Projects</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.department">
-				<source>Department</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.competence_field">
-				<source>Competence field</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.cooperation">
-				<source>Cooperation</source>
-			</trans-unit>
-			<trans-unit id="sys_category.projects.funding_partner">
-				<source>Funding partner</source>
-			</trans-unit>
+      <trans-unit id="sys_category.projects.group">
+        <source>Academic Projects</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.department">
+        <source>Department</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.competence_field">
+        <source>Competence field</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.cooperation">
+        <source>Cooperation</source>
+      </trans-unit>
+      <trans-unit id="sys_category.projects.funding_partner">
+        <source>Funding partner</source>
+      </trans-unit>
 
-			<!-- TCA -->
+      <!-- TCA -->
 
-			<trans-unit id="pages.div.project">
-				<source>Project</source>
-			</trans-unit>
-			<trans-unit id="pages.budget">
-				<source>Project budget</source>
-			</trans-unit>
-			<trans-unit id="pages.end_date">
-				<source>Project end</source>
-			</trans-unit>
-			<trans-unit id="pages.funders">
-				<source>Project funders</source>
-			</trans-unit>
-			<trans-unit id="pages.project_title">
-				<source>Project title</source>
-			</trans-unit>
-			<trans-unit id="pages.short_description">
-				<source>Project short description</source>
-			</trans-unit>
-			<trans-unit id="pages.start_date">
-				<source>Project start</source>
-			</trans-unit>
-		</body>
-	</file>
+      <trans-unit id="pages.div.project">
+        <source>Project</source>
+      </trans-unit>
+      <trans-unit id="pages.budget">
+        <source>Project budget</source>
+      </trans-unit>
+      <trans-unit id="pages.end_date">
+        <source>Project end</source>
+      </trans-unit>
+      <trans-unit id="pages.funders">
+        <source>Project funders</source>
+      </trans-unit>
+      <trans-unit id="pages.project_title">
+        <source>Project title</source>
+      </trans-unit>
+      <trans-unit id="pages.short_description">
+        <source>Project short description</source>
+      </trans-unit>
+      <trans-unit id="pages.start_date">
+        <source>Project start</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-study-plan/.editorconfig
+++ b/packages/fgtclb/academic-study-plan/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
-		<header/>
-		<body>
-			<trans-unit id="filter.label">
-				<source>Filter by category</source>
-				<target>Nach Kategorie filtern</target>
-			</trans-unit>
-			<trans-unit id="credits">
-				<source>CP</source>
-				<target>CP</target>
-			</trans-unit>
-			<trans-unit id="modal.close">
-				<source>Close</source>
-				<target>Schließen</target>
-			</trans-unit>
-			<trans-unit id="modal.description">
-				<source>Module description</source>
-				<target>Modulbeschreibung</target>
-			</trans-unit>
-			<trans-unit id="modal.audio">
-				<source>Audio content</source>
-				<target>Audioinhalt</target>
-			</trans-unit>
-			<trans-unit id="semester">
-				<source>Semester</source>
-				<target>Semester</target>
-			</trans-unit>
-		</body>
-	</file>
+  xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+    <header/>
+    <body>
+      <trans-unit id="filter.label">
+        <source>Filter by category</source>
+        <target>Nach Kategorie filtern</target>
+      </trans-unit>
+      <trans-unit id="credits">
+        <source>CP</source>
+        <target>CP</target>
+      </trans-unit>
+      <trans-unit id="modal.close">
+        <source>Close</source>
+        <target>Schließen</target>
+      </trans-unit>
+      <trans-unit id="modal.description">
+        <source>Module description</source>
+        <target>Modulbeschreibung</target>
+      </trans-unit>
+      <trans-unit id="modal.audio">
+        <source>Audio content</source>
+        <target>Audioinhalt</target>
+      </trans-unit>
+      <trans-unit id="semester">
+        <source>Semester</source>
+        <target>Semester</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang_be.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang_be.xlf
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
-		<header/>
-		<body>
-			<!-- Content Element Group -->
-			<trans-unit id="newContentElement.group.academic">
-				<source>Academic</source>
-				<target>Akademisch</target>
-			</trans-unit>
+  xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+    <header/>
+    <body>
+      <!-- Content Element Group -->
+      <trans-unit id="newContentElement.group.academic">
+        <source>Academic</source>
+        <target>Akademisch</target>
+      </trans-unit>
 
-			<!-- Content Element -->
-			<trans-unit id="tt_content.CType.academic_study_plan.title">
-				<source>Academic Study Plan</source>
-				<target>Akademischer Studienplan</target>
-			</trans-unit>
-			<trans-unit id="tt_content.CType.academic_study_plan.description">
-				<source>Display academic study plans with semesters and modules</source>
-				<target>Akademische Studienpläne mit Semestern und Modulen anzeigen</target>
-			</trans-unit>
-			<trans-unit id="tt_content.footer_note">
-				<source>Footer Note</source>
-				<target>Fußnote</target>
-			</trans-unit>
-			<trans-unit id="tt_content.semesters">
-				<source>Semesters</source>
-				<target>Semester</target>
-			</trans-unit>
+      <!-- Content Element -->
+      <trans-unit id="tt_content.CType.academic_study_plan.title">
+        <source>Academic Study Plan</source>
+        <target>Akademischer Studienplan</target>
+      </trans-unit>
+      <trans-unit id="tt_content.CType.academic_study_plan.description">
+        <source>Display academic study plans with semesters and modules</source>
+        <target>Akademische Studienpläne mit Semestern und Modulen anzeigen</target>
+      </trans-unit>
+      <trans-unit id="tt_content.footer_note">
+        <source>Footer Note</source>
+        <target>Fußnote</target>
+      </trans-unit>
+      <trans-unit id="tt_content.semesters">
+        <source>Semesters</source>
+        <target>Semester</target>
+      </trans-unit>
 
-			<!-- Category -->
-			<trans-unit id="tx_academicstudyplan_domain_model_category">
-				<source>Study Plan Category</source>
-				<target>Studienplan-Kategorie</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_category.label">
-				<source>Label</source>
-				<target>Bezeichnung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_category.colour">
-				<source>Colour</source>
-				<target>Farbe</target>
-			</trans-unit>
+      <!-- Category -->
+      <trans-unit id="tx_academicstudyplan_domain_model_category">
+        <source>Study Plan Category</source>
+        <target>Studienplan-Kategorie</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_category.label">
+        <source>Label</source>
+        <target>Bezeichnung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_category.colour">
+        <source>Colour</source>
+        <target>Farbe</target>
+      </trans-unit>
 
-			<!-- Semester -->
-			<trans-unit id="tx_academicstudyplan_domain_model_semester">
-				<source>Semester</source>
-				<target>Semester</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.label">
-				<source>Label</source>
-				<target>Bezeichnung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.note">
-				<source>Note</source>
-				<target>Hinweis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.credit_points">
-				<source>Credit Points</source>
-				<target>Leistungspunkte</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.modules">
-				<source>Modules</source>
-				<target>Module</target>
-			</trans-unit>
+      <!-- Semester -->
+      <trans-unit id="tx_academicstudyplan_domain_model_semester">
+        <source>Semester</source>
+        <target>Semester</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.label">
+        <source>Label</source>
+        <target>Bezeichnung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.note">
+        <source>Note</source>
+        <target>Hinweis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.credit_points">
+        <source>Credit Points</source>
+        <target>Leistungspunkte</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.modules">
+        <source>Modules</source>
+        <target>Module</target>
+      </trans-unit>
 
-			<!-- Module -->
-			<trans-unit id="tx_academicstudyplan_domain_model_module">
-				<source>Module</source>
-				<target>Modul</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.label">
-				<source>Label</source>
-				<target>Bezeichnung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.note">
-				<source>Note</source>
-				<target>Hinweis</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.credit_points">
-				<source>Credit Points</source>
-				<target>Leistungspunkte</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.description">
-				<source>Description</source>
-				<target>Beschreibung</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.audio_file">
-				<source>Audio File</source>
-				<target>Audiodatei</target>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.categories">
-				<source>Categories</source>
-				<target>Kategorien</target>
-			</trans-unit>
-		</body>
-	</file>
+      <!-- Module -->
+      <trans-unit id="tx_academicstudyplan_domain_model_module">
+        <source>Module</source>
+        <target>Modul</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.label">
+        <source>Label</source>
+        <target>Bezeichnung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.note">
+        <source>Note</source>
+        <target>Hinweis</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.credit_points">
+        <source>Credit Points</source>
+        <target>Leistungspunkte</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.description">
+        <source>Description</source>
+        <target>Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.audio_file">
+        <source>Audio File</source>
+        <target>Audiodatei</target>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.categories">
+        <source>Categories</source>
+        <target>Kategorien</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
-		<header/>
-		<body>
-			<trans-unit id="filter.label">
-				<source>Filter by category</source>
-			</trans-unit>
-			<trans-unit id="credits">
-				<source>CP</source>
-			</trans-unit>
-			<trans-unit id="modal.close">
-				<source>Close</source>
-			</trans-unit>
-			<trans-unit id="modal.description">
-				<source>Module description</source>
-			</trans-unit>
-			<trans-unit id="modal.audio">
-				<source>Audio content</source>
-			</trans-unit>
-			<trans-unit id="semester">
-				<source>Semester</source>
-			</trans-unit>
-		</body>
-	</file>
+  xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+    <header/>
+    <body>
+      <trans-unit id="filter.label">
+        <source>Filter by category</source>
+      </trans-unit>
+      <trans-unit id="credits">
+        <source>CP</source>
+      </trans-unit>
+      <trans-unit id="modal.close">
+        <source>Close</source>
+      </trans-unit>
+      <trans-unit id="modal.description">
+        <source>Module description</source>
+      </trans-unit>
+      <trans-unit id="modal.audio">
+        <source>Audio content</source>
+      </trans-unit>
+      <trans-unit id="semester">
+        <source>Semester</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang_be.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang_be.xlf
@@ -1,78 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
-	xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
-		<header/>
-		<body>
-			<!-- Content Element Group -->
-			<trans-unit id="newContentElement.group.academic">
-				<source>Academic</source>
-			</trans-unit>
+  xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+    <header/>
+    <body>
+      <!-- Content Element Group -->
+      <trans-unit id="newContentElement.group.academic">
+        <source>Academic</source>
+      </trans-unit>
 
-			<!-- Content Element -->
-			<trans-unit id="tt_content.CType.academic_study_plan.title">
-				<source>Academic Study Plan</source>
-			</trans-unit>
-			<trans-unit id="tt_content.CType.academic_study_plan.description">
-				<source>Display academic study plans with semesters and modules</source>
-			</trans-unit>
-			<trans-unit id="tt_content.footer_note">
-				<source>Footer Note</source>
-			</trans-unit>
-			<trans-unit id="tt_content.semesters">
-				<source>Semesters</source>
-			</trans-unit>
+      <!-- Content Element -->
+      <trans-unit id="tt_content.CType.academic_study_plan.title">
+        <source>Academic Study Plan</source>
+      </trans-unit>
+      <trans-unit id="tt_content.CType.academic_study_plan.description">
+        <source>Display academic study plans with semesters and modules</source>
+      </trans-unit>
+      <trans-unit id="tt_content.footer_note">
+        <source>Footer Note</source>
+      </trans-unit>
+      <trans-unit id="tt_content.semesters">
+        <source>Semesters</source>
+      </trans-unit>
 
-			<!-- Category -->
-			<trans-unit id="tx_academicstudyplan_domain_model_category">
-				<source>Study Plan Category</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_category.label">
-				<source>Label</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_category.colour">
-				<source>Colour</source>
-			</trans-unit>
+      <!-- Category -->
+      <trans-unit id="tx_academicstudyplan_domain_model_category">
+        <source>Study Plan Category</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_category.label">
+        <source>Label</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_category.colour">
+        <source>Colour</source>
+      </trans-unit>
 
-			<!-- Semester -->
-			<trans-unit id="tx_academicstudyplan_domain_model_semester">
-				<source>Semester</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.label">
-				<source>Label</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.note">
-				<source>Note</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.credit_points">
-				<source>Credit Points</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_semester.modules">
-				<source>Modules</source>
-			</trans-unit>
+      <!-- Semester -->
+      <trans-unit id="tx_academicstudyplan_domain_model_semester">
+        <source>Semester</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.label">
+        <source>Label</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.note">
+        <source>Note</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.credit_points">
+        <source>Credit Points</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_semester.modules">
+        <source>Modules</source>
+      </trans-unit>
 
-			<!-- Module -->
-			<trans-unit id="tx_academicstudyplan_domain_model_module">
-				<source>Module</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.label">
-				<source>Label</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.note">
-				<source>Note</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.credit_points">
-				<source>Credit Points</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.description">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.audio_file">
-				<source>Audio File</source>
-			</trans-unit>
-			<trans-unit id="tx_academicstudyplan_domain_model_module.categories">
-				<source>Categories</source>
-			</trans-unit>
-		</body>
-	</file>
+      <!-- Module -->
+      <trans-unit id="tx_academicstudyplan_domain_model_module">
+        <source>Module</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.label">
+        <source>Label</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.note">
+        <source>Note</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.credit_points">
+        <source>Credit Points</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.description">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.audio_file">
+        <source>Audio File</source>
+      </trans-unit>
+      <trans-unit id="tx_academicstudyplan_domain_model_module.categories">
+        <source>Categories</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/typo3-category-types/.editorconfig
+++ b/packages/fgtclb/typo3-category-types/.editorconfig
@@ -53,8 +53,12 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
-max_line_length = 180
+indent_style = space
+indent_size = 2
+# Label content is a single line by design. Wrapping it embeds literal
+# whitespace in the rendered label on TYPO3 v13 and older, which do not
+# collapse it (see TYPO3 #70867).
+max_line_length = off
 
 # SQL-Files
 [*.sql]

--- a/packages/fgtclb/typo3-category-types/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/typo3-category-types/Resources/Private/Language/de.locallang.xlf
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		target-language="de"
-		datatype="plaintext"
-		original="EXT:category_types/Resources/Private/Language/locallang.xlf"
-		date="2023-03-20T13:05:33Z"
-		product-name="category_types"
-	>
-		<header/>
-		<body>
-			<trans-unit id="sys_category.type">
-				<source>Type</source>
-				<target>Typ</target>
-			</trans-unit>
-			<trans-unit id="sys_category.type.default">
-				<source>Default</source>
-				<target>Standard</target>
-			</trans-unit>
-			<trans-unit id="sys_category.not_set">
-				<source>Not set</source>
-				<target>Nicht gesetzt</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:category_types/Resources/Private/Language/locallang.xlf"
+    date="2023-03-20T13:05:33Z"
+    product-name="category_types"
+  >
+    <header/>
+    <body>
+      <trans-unit id="sys_category.type">
+        <source>Type</source>
+        <target>Typ</target>
+      </trans-unit>
+      <trans-unit id="sys_category.type.default">
+        <source>Default</source>
+        <target>Standard</target>
+      </trans-unit>
+      <trans-unit id="sys_category.not_set">
+        <source>Not set</source>
+        <target>Nicht gesetzt</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/packages/fgtclb/typo3-category-types/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/typo3-category-types/Resources/Private/Language/locallang.xlf
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file
-		source-language="en"
-		datatype="plaintext"
-		original="EXT:category_types/Resources/Private/Language/locallang.xlf"
-		date="2023-03-20T13:05:33Z"
-		product-name="category_types"
-	>
-		<header/>
-		<body>
-			<trans-unit id="sys_category.type">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="sys_category.type.default">
-				<source>Default</source>
-			</trans-unit>
-			<trans-unit id="sys_category.not_set">
-				<source>Not set</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:category_types/Resources/Private/Language/locallang.xlf"
+    date="2023-03-20T13:05:33Z"
+    product-name="category_types"
+  >
+    <header/>
+    <body>
+      <trans-unit id="sys_category.type">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="sys_category.type.default">
+        <source>Default</source>
+      </trans-unit>
+      <trans-unit id="sys_category.not_set">
+        <source>Not set</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>


### PR DESCRIPTION
TYPO3 v14 normalised all core XLF files to two-space indentation and updated its
`.editorconfig` accordingly (important #107971) — that is the formatting Crowdin
and PHP's `\DOMDocument` produce. Every XLF file here still used tabs: **9603
indented lines across 48 files**.

Found during the TYPO3 v14 changelog audit (finding A4, cosmetic half).
Resolves ACE-292.

## This is a pure reformat

Only *leading* whitespace is rewritten, one level becoming two spaces. Everything
from the first non-whitespace character onwards is byte-identical, so no rendered
label changes — indentation between XML tags has no effect on parsing on any core
version.

The diff is symmetric by construction: **9621 insertions, 9621 deletions**.

Verified rather than assumed. The script extracts every `trans-unit` id with its
`<source>`/`<target>` text before and after and refuses to write if they differ;
afterwards each file was re-checked against `HEAD` and re-parsed:

```
48 files checked, 0 with content differences, all parse OK
```

## `.editorconfig` had to come along

All 13 `.editorconfig` files — the root one and the twelve shipped with the
extensions — carried an identical block:

```ini
[*.xlf]
indent_style = tab
max_line_length = 180
```

Leaving that would make every editor undo the reformat on the next edit.

**`max_line_length` is dropped, not raised.** Seven label lines now exceed 180
characters — all of them lines ACE-291 deliberately joined. An editor honouring
the limit would re-wrap exactly those, and re-wrapping is what embeds literal
whitespace in the rendered label on TYPO3 v13 and older (#70867). The replacement
block records that reasoning inline.

## Scope

`main` only, deliberately. The convention comes from TYPO3 v14, which branch `2`
does not support, and reformatting every XLF file there would buy nothing while
conflicting with every later backport.

## Verification

Full local gates, both core versions, PHP 8.2, SQLite — 12/12 green, plus
`checkRstRenderingAll`.