### PR TITLE
[BUGFIX] ACE-293: Fix plugin FlexForms broken on v13

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -643,7 +643,10 @@ case ${TEST_SUITE} in
         esac
         ;;
     lintPhp)
-        COMMAND="find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
+        # The DDEV instances install their own vendor tree next to the sources.
+        # It is git ignored and holds third party files that are not ours to
+        # lint - class-alias-loader ships a template that is not valid PHP.
+        COMMAND="find . -name \\*.php ! -path "./.Build/\\*" ! -path "./ddev-instances/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name lint-php-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/packages-dev/testing-helper/Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php
+++ b/packages-dev/testing-helper/Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\TestingHelper\FunctionalTestCase;
+
+use TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsOverrides;
+use TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+
+/**
+ * Resolves the FlexForm data structure of a plugin content type the way
+ * FormEngine does when the record is opened in the backend.
+ *
+ * The two data providers below are the first ones in the FormEngine chain that
+ * touch `pi_flexform`: `TcaColumnsOverrides` merges the type specific
+ * `columnsOverrides` into the columns, and `TcaFlexPrepare` resolves the `ds`
+ * reference into the parsed data structure. Everything that can go wrong with a
+ * plugin data structure goes wrong in one of those two, which is why the
+ * assertion runs through them instead of through a full `FormDataCompiler` —
+ * no backend user, no page tree and no request are needed.
+ *
+ * The defect this exists for: assigning the data structure as a plain string
+ * (`'FILE:EXT:…'`) is a TYPO3 v14 idiom. TYPO3 v13 requires an array and
+ * `FlexFormTools` throws, so the whole record fails to open — while a v14 run
+ * stays perfectly green.
+ *
+ * @see https://docs.typo3.org/permalink/changelog:breaking-107945-1750669512
+ */
+trait PluginFlexFormDataStructureTrait
+{
+    /**
+     * @return array<string, mixed> The resolved data structure, as FormEngine would render it
+     */
+    private function resolvePluginFlexFormDataStructure(string $cType): array
+    {
+        $result = [
+            'tableName' => 'tt_content',
+            'command' => 'edit',
+            'recordTypeValue' => $cType,
+            'userTsConfig' => [],
+            'databaseRow' => [
+                'uid' => 1,
+                'pid' => 1,
+                'CType' => $cType,
+                // TYPO3 v13 resolves the data structure through the
+                // `ds_pointerField` "list_type,CType" and needs the field to be
+                // present in the row; TYPO3 v14 dropped the column entirely.
+                'list_type' => '',
+                'pi_flexform' => '',
+            ],
+            'processedTca' => $GLOBALS['TCA']['tt_content'],
+        ];
+        if (class_exists(TcaSchemaFactory::class)) {
+            // TYPO3 v14 resolves the data structure through the record type of
+            // the table schema. This is what FormEngine's InitializeProcessedTca
+            // puts into the result.
+            $result['tcaSchemata'] = $this->get(TcaSchemaFactory::class)->all();
+        }
+
+        $result = $this->get(TcaColumnsOverrides::class)->addData($result);
+        $result = $this->get(TcaFlexPrepare::class)->addData($result);
+
+        return $result['processedTca']['columns']['pi_flexform']['config']['ds'] ?? [];
+    }
+
+    /**
+     * Asserts that the plugin's FlexForm is resolved to actual fields.
+     *
+     * An empty sheet is the failure mode to watch on TYPO3 v14: `TcaFlexPrepare`
+     * swallows an unresolvable data structure there and leaves the caller with
+     * `['sheets' => ['sDEF' => []]]`, so the backend renders an empty tab
+     * instead of raising anything.
+     */
+    private function assertPluginFlexFormIsResolved(string $cType, string $sheetName = 'sDEF'): void
+    {
+        $dataStructure = $this->resolvePluginFlexFormDataStructure($cType);
+
+        self::assertArrayHasKey(
+            $sheetName,
+            $dataStructure['sheets'] ?? [],
+            sprintf('FlexForm of content type "%s" has no sheet "%s".', $cType, $sheetName),
+        );
+        self::assertNotEmpty(
+            $dataStructure['sheets'][$sheetName]['ROOT']['el'] ?? [],
+            sprintf(
+                'FlexForm sheet "%s" of content type "%s" resolved to no fields at all.',
+                $sheetName,
+                $cType,
+            ),
+        );
+    }
+}

--- a/packages/fgtclb/academic-base/Classes/TcaManipulator.php
+++ b/packages/fgtclb/academic-base/Classes/TcaManipulator.php
@@ -142,6 +142,35 @@ final class TcaManipulator
     }
 
     /**
+     * Assign the FlexForm data structure of a plugin content element in a way
+     * that works on both TYPO3 v13 and v14.
+     *
+     * The two core versions want a different shape and neither tolerates the
+     * other, which makes this the one place a version switch is unavoidable:
+     *
+     * * TYPO3 v13 resolves `ds` through `ds_pointerField` and requires an array.
+     *   Given a string it throws, and the whole content element can no longer be
+     *   opened in the backend (`FlexFormTools`, code 1463826960).
+     * * TYPO3 v14 resolves the data structure through the record type of the TCA
+     *   schema and requires the string. Given an array it throws
+     *   `InvalidTcaException` (code 1751796940) — which `TcaFlexPrepare` catches,
+     *   so the backend silently renders an **empty** FlexForm tab instead of
+     *   failing visibly.
+     *
+     * FOR USE IN files in `Configuration/TCA/Overrides/*.php`.
+     *
+     * @param string $cType Content element type the data structure belongs to
+     * @param string $dataStructure Data structure reference, e.g. `FILE:EXT:my_ext/Configuration/FlexForms/List.xml`
+     */
+    public function addContentElementPluginFlexForm(string $cType, string $dataStructure): void
+    {
+        $GLOBALS['TCA']['tt_content']['types'][$cType]['columnsOverrides']['pi_flexform']['config']['ds']
+            = (new Typo3Version())->getMajorVersion() >= 14
+                ? $dataStructure
+                : ['default' => $dataStructure];
+    }
+
+    /**
      * Add `$definitionToAdd` as last item to the general tab for page types.
      *
      * FOR USE IN files in `Configuration/TCA/Overrides/*.php`.

--- a/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
@@ -6,6 +6,7 @@ namespace FGTCLB\AcademicBase\Tests\Unit;
 
 use FGTCLB\AcademicBase\TcaManipulator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -555,5 +556,43 @@ final class TcaManipulatorTest extends UnitTestCase
         array $expected,
     ): void {
         $this->assertSame($expected, (new TcaManipulator())->addToPageTypesGeneralTab($tca, $definitionToAdd, $types, $excludeTypes));
+    }
+
+    /**
+     * TYPO3 v13 resolves `ds` through `ds_pointerField` and requires an array;
+     * a string makes the content element unopenable in the backend.
+     */
+    #[Group('not-core-14')]
+    #[Test]
+    public function pluginFlexFormIsAssignedAsArrayOnCoreV13(): void
+    {
+        unset($GLOBALS['TCA']['tt_content']);
+        (new TcaManipulator())->addContentElementPluginFlexForm(
+            'academicexample_list',
+            'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
+        );
+        $this->assertSame(
+            ['default' => 'FILE:EXT:academic_example/Configuration/FlexForms/List.xml'],
+            $GLOBALS['TCA']['tt_content']['types']['academicexample_list']['columnsOverrides']['pi_flexform']['config']['ds'],
+        );
+    }
+
+    /**
+     * TYPO3 v14 resolves the data structure through the record type of the TCA
+     * schema and requires the string; an array leaves the FlexForm tab empty.
+     */
+    #[Group('not-core-13')]
+    #[Test]
+    public function pluginFlexFormIsAssignedAsStringOnCoreV14(): void
+    {
+        unset($GLOBALS['TCA']['tt_content']);
+        (new TcaManipulator())->addContentElementPluginFlexForm(
+            'academicexample_list',
+            'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
+        );
+        $this->assertSame(
+            'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
+            $GLOBALS['TCA']['tt_content']['types']['academicexample_list']['columnsOverrides']['pi_flexform']['config']['ds'],
+        );
     }
 }

--- a/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -19,8 +19,10 @@ defined('TYPO3') or die;
         'academic_bite_jobs'
     );
 
-    $GLOBALS['TCA']['tt_content']['types']['academicbitejobs_list']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_bite_jobs/Configuration/FlexForms/AcademicBiteJobsList.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicbitejobs_list',
+        'FILE:EXT:academic_bite_jobs/Configuration/FlexForms/AcademicBiteJobsList.xml',
+    );
 
     ExtensionManagementUtility::addToAllTCAtypes(
         'tt_content',

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBiteJobs\Tests\Functional\Tca;
+
+use FGTCLB\AcademicBiteJobs\Tests\Functional\AbstractAcademicBiteJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicBiteJobsTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Job list' => ['academicbitejobs_list'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/Overrides/tt_content.php
@@ -34,6 +34,8 @@ if (!defined('TYPO3')) {
     );
 
     // Link the FlexForm configuration to the pi_flexform field
-    $GLOBALS['TCA']['tt_content']['types']['academiccontacts4pages_list']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_contacts4pages/Configuration/FlexForms/ContactsList.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academiccontacts4pages_list',
+        'FILE:EXT:academic_contacts4pages/Configuration/FlexForms/ContactsList.xml',
+    );
 })();

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Tca;
+
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicContacts4PagesTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Contact list' => ['academiccontacts4pages_list'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/Overrides/tt_content.php
@@ -29,8 +29,10 @@ if (!defined('TYPO3')) {
         'academicjobs_newjobform',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicjobs_newjobform']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_jobs/Configuration/FlexForms/Plugin_NewJobForm.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicjobs_newjobform',
+        'FILE:EXT:academic_jobs/Configuration/FlexForms/Plugin_NewJobForm.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicjobs_list
@@ -53,8 +55,10 @@ if (!defined('TYPO3')) {
         'academicjobs_list',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicjobs_list']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_jobs/Configuration/FlexForms/PluginList.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicjobs_list',
+        'FILE:EXT:academic_jobs/Configuration/FlexForms/PluginList.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicjobs_detail

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Tca;
+
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicJobsTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'New job form' => ['academicjobs_newjobform'];
+        yield 'Job list' => ['academicjobs_list'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/tt_content.php
@@ -18,8 +18,10 @@ defined('TYPO3') or die;
         ],
         'academic_partners'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpartners_list']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_partners/Configuration/FlexForms/ListSettings.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpartners_list',
+        'FILE:EXT:academic_partners/Configuration/FlexForms/ListSettings.xml',
+    );
 
     // Plugin: academicpartners_map
     (new TcaManipulator())->addContentElementPlugin(
@@ -31,8 +33,10 @@ defined('TYPO3') or die;
         ],
         'academic_partners'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpartners_map']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_partners/Configuration/FlexForms/ListSettings.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpartners_map',
+        'FILE:EXT:academic_partners/Configuration/FlexForms/ListSettings.xml',
+    );
 
     // Add configuration tab for list and map plugins
     ExtensionManagementUtility::addToAllTCAtypes(

--- a/packages/fgtclb/academic-partners/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicPartnersTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Partner list' => ['academicpartners_list'];
+        yield 'Partner map' => ['academicpartners_map'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/Overrides/tt_content.php
@@ -36,8 +36,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_list',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_list']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_list',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_listanddetail
@@ -61,8 +63,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_listanddetail',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_listanddetail']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_listanddetail',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_detail
@@ -85,8 +89,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_detail',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_detail']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/Detail.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_detail',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/Detail.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_card
@@ -109,8 +115,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_card',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_card']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_card',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/List.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_selectedprofiles
@@ -133,8 +141,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_selectedprofiles',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_selectedprofiles']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/SelectedProfiles.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_selectedprofiles',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/SelectedProfiles.xml',
+    );
 
     //==================================================================================================================
     // Plugin: academicpersons_selectedcontracts
@@ -157,7 +167,9 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'academicpersons_selectedcontracts',
         'after:header'
     );
-    $GLOBALS['TCA']['tt_content']['types']['academicpersons_selectedcontracts']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_persons/Configuration/FlexForms/SelectedContracts.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicpersons_selectedcontracts',
+        'FILE:EXT:academic_persons/Configuration/FlexForms/SelectedContracts.xml',
+    );
 
 })();

--- a/packages/fgtclb/academic-persons/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicPersonsTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Profile list' => ['academicpersons_list'];
+        yield 'Profile list and detail' => ['academicpersons_listanddetail'];
+        yield 'Profile detail' => ['academicpersons_detail'];
+        yield 'Profile card' => ['academicpersons_card'];
+        yield 'Selected profiles' => ['academicpersons_selectedprofiles'];
+        yield 'Selected contracts' => ['academicpersons_selectedcontracts'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/tt_content.php
@@ -30,8 +30,10 @@ defined('TYPO3') or die;
         'after:subheader',
     );
 
-    $GLOBALS['TCA']['tt_content']['types']['academicprograms_programlist']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_programs/Configuration/FlexForms/ProgramListSettings.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicprograms_programlist',
+        'FILE:EXT:academic_programs/Configuration/FlexForms/ProgramListSettings.xml',
+    );
 
     (new TcaManipulator())->addContentElementPlugin(
         [

--- a/packages/fgtclb/academic-programs/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicProgramsTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Program list' => ['academicprograms_programlist'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/tt_content.php
@@ -40,8 +40,10 @@ defined('TYPO3') or die;
     );
 
     // Link the FlexForm configuration to the pi_flexform field
-    $GLOBALS['TCA']['tt_content']['types']['academicprojects_projectlist']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_projects/Configuration/FlexForms/ProjectSettings.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicprojects_projectlist',
+        'FILE:EXT:academic_projects/Configuration/FlexForms/ProjectSettings.xml',
+    );
 
     // ------------------------------------------------------------------------
     // Add the academicprojects_projectlistsingle plugin
@@ -71,8 +73,10 @@ defined('TYPO3') or die;
 
     // Link the FlexForm configuration to the pi_flexform field
     // @todo Add FlexForm options to select a list of projects
-    $GLOBALS['TCA']['tt_content']['types']['academicprojects_projectlistsingle']['columnsOverrides']['pi_flexform']['config']['ds']
-        = 'FILE:EXT:academic_projects/Configuration/FlexForms/ProjectSettings.xml';
+    (new TcaManipulator())->addContentElementPluginFlexForm(
+        'academicprojects_projectlistsingle',
+        'FILE:EXT:academic_projects/Configuration/FlexForms/ProjectSettings.xml',
+    );
 
     ExtensionManagementUtility::addToAllTCAtypes(
         'tt_content',

--- a/packages/fgtclb/academic-projects/Tests/Functional/Tca/PluginFlexFormTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Tca/PluginFlexFormTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Tca;
+
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\PluginFlexFormDataStructureTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Guards the FlexForm data structure of the plugins against a shape that only
+ * works on one of the supported core versions.
+ *
+ * @see PluginFlexFormDataStructureTrait
+ */
+final class PluginFlexFormTest extends AbstractAcademicProjectsTestCase
+{
+    use PluginFlexFormDataStructureTrait;
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function pluginContentTypeDataProvider(): \Generator
+    {
+        yield 'Project list' => ['academicprojects_projectlist'];
+        yield 'Single project list' => ['academicprojects_projectlistsingle'];
+    }
+
+    #[Test]
+    #[DataProvider('pluginContentTypeDataProvider')]
+    public function pluginFlexFormIsResolvedForContentType(string $cType): void
+    {
+        $this->assertPluginFlexFormIsResolved($cType);
+    }
+}


### PR DESCRIPTION
Fixes the FlexForm data structure of all plugin content elements, which
could not be opened at all in the TYPO3 v13 backend on this branch.

## What is broken

Opening any of the 15 academic plugin content elements on v13 aborts before
the "Configuration" tab is rendered:

```
TCA misconfiguration in table "tt_content" field "pi_flexform" config section:
The field is configured as type="flex" and no "ds_pointerField" is defined and
"ds" is not an array.                        (FlexFormTools, code 1463826960)
```

Registering the data structure as a plain string is the TYPO3 v14 form. It was
introduced here when `ExtensionManagementUtility::addPiFlexFormValue()` was
dropped for its v14 deprecation.

## Why it needs a version switch

The two core versions want different shapes and neither tolerates the other:

| `ds` in `columnsOverrides` | TYPO3 v13.4.33 | TYPO3 v14.3.5 |
|---|---|---|
| `'FILE:EXT:…'` | throws, record cannot be opened | OK |
| `['default' => 'FILE:EXT:…']` | OK | `InvalidTcaException` — **silently swallowed**, empty FlexForm tab |

On v14 `TcaFlexPrepare` catches the exception and leaves the caller with
`['sheets' => ['sDEF' => []]]`, so the array form does not fail loudly there —
it just renders an empty tab. The assignment therefore moves into
`TcaManipulator`, next to the other place where the two versions have to be
told apart, and the 15 call sites use it.

## Tests

* `PluginFlexFormTest` per affected extension resolves the data structure the
  way FormEngine does — through `TcaColumnsOverrides` and `TcaFlexPrepare` —
  and asserts the sheet **contains fields**. Asserting the sheet alone would
  pass on v14 against the empty fallback. No backend user and no page tree are
  needed, which keeps it to one small file per extension.
* Two unit tests on `TcaManipulator`, grouped `not-core-13` / `not-core-14`,
  pin the shape each core version gets.

Both were confirmed to fail against the previous implementation before the fix
was committed.

## Why CI was green

Nothing in the suite renders or compiles a backend form, so TCA that is fatal
in the v13 backend passes `cgl`, `phpstan`, `unit` and `functional` on both
core versions. The defect was found by compiling FormEngine data for all 59
record types against the `ddev-instances/core-13` and `core-14` installations.
After the fix, all 59 compile **and** render on both, and all 15 plugin
FlexForms resolve to their fields.

## Also here

`lintPhp` skips `ddev-instances/`. Reproducing this needs those instances
installed, and their git-ignored vendor tree was still being linted —
`typo3/class-alias-loader` ships a template that is not valid PHP, so the gate
failed for reasons that have nothing to do with the repository sources.

## Not affected

Branch `2` still calls `addPiFlexFormValue()` and is fine on v12 and v13. No
backport.

Issue: ACE-293
