### PR TITLE
[DOCS] ACE-294: Record the TYPO3 v15 blockers

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -205,13 +205,40 @@ the `#[AsEventListener]` attribute from `symfony.
 `phpstan` core-version aware configurations requires to add the related core version
 folder to the `paths` configuration; note that core-version aware functional tests
 should be handled in related subfolders (`Tests/Unit/Core13/`) and using phpunit
-phpattribute for the group using the `not-core14` as execute only for not that group
+phpattribute for the group using the `not-core-14` as execute only for not that group
 selection (there should be examples). If it is only about database fixuters or simpler
 stuff keep the tests in the shared folder using only the attributes.
 
 Note: extensions here still use `Configuration/Services.php` (PHP-form) for DI
 rather than Symfony attributes. Match the surrounding extension's existing DI
 style when editing it.
+
+## TYPO3 v15 blockers — do not migrate these yet
+
+Three APIs on `main` are deprecated in TYPO3 v14 and removed in v15. **None of
+them can be migrated while the branch still supports TYPO3 v13**, because the
+replacement does not exist there. Verified against both vendor trees:
+
+| API | Replacement | Present on v13.4.33? | Call sites |
+|---|---|---|---|
+| `Extbase\Annotation\*` | `Extbase\Attribute\*` | no — `cms-extbase/Classes/Attribute/` absent | 10 in 6 files |
+| `Install\Updates\*`, `Install\Attribute\UpgradeWizard` | `Core\Upgrades\*`, `Core\Attribute\UpgradeWizard` | no — `cms-core/Classes/Upgrades/` absent | 8 wizards in 5 extensions |
+| `Core\Service\FlexFormService` | `Core\Configuration\FlexForm\FlexFormTools` | class exists on v13, but without `convertFlexFormContentToArray()` on `FlexFormTools` | 1 file |
+
+They are tracked as **ACE-294** (epic) with ACE-295, ACE-296 and ACE-297.
+Static analysis and IDE inspections will keep suggesting the replacements —
+ignore them here. A "helpful" import rewrite is a fatal error on v13.
+
+Two ways out, and the choice belongs to the epic, not to an individual change:
+drop v13 support first (expected), or introduce the `Core13/Core14` split
+described above — disproportionate for ~19 call sites.
+
+**Not on this list:** references to core labels marked `x-unused-since="14.0"`.
+They look the same — the replacements are v14-only XLIFF 2.0 files — but they
+are labels on *our own* TCA, so shipping our own text resolves them today on
+both core versions (**ACE-298**). It also has to happen before backend-form
+tests are added, because the suite runs with `failOnDeprecation` and those
+labels emit `E_USER_DEPRECATED` on every form render on v14.
 
 ## Releasing / versions
 


### PR DESCRIPTION
Documentation only. Adds a "TYPO3 v15 blockers" section to `AGENT.md`, closing
out the v14 changelog audit's scheduling step.

## Why

Three APIs on this branch are deprecated in TYPO3 v14 and removed in v15, and
none can be migrated while TYPO3 v13 is supported — the replacement does not
exist there:

| API | Replacement | On v13.4.33? |
|---|---|---|
| `Extbase\Annotation\*` | `Extbase\Attribute\*` | no — `cms-extbase/Classes/Attribute/` absent |
| `Install\Updates\*`, `Install\Attribute\UpgradeWizard` | `Core\Upgrades\*`, `Core\Attribute\UpgradeWizard` | no — `cms-core/Classes/Upgrades/` absent |
| `Core\Service\FlexFormService` | `Core\Configuration\FlexForm\FlexFormTools` | class exists, but `FlexFormTools` has no `convertFlexFormContentToArray()` there |

Nothing in the code marks them, so static analysis, IDE inspections and rector
rules will keep proposing the replacement — and taking that advice is a fatal
error on v13. The section records the mapping, the evidence, and that the
choice between "drop v13 first" and the `Core13/Core14` split belongs to the
epic rather than to whoever next touches one of the files.

## Issues filed alongside

* **ACE-294** — epic, TYPO3 v15 preparation
  * **ACE-295** — Extbase annotations → attributes (10 usages, 6 files)
  * **ACE-296** — upgrade wizards → `EXT:core` API (8 wizards, 5 extensions)
  * **ACE-297** — `FlexFormService` → `FlexFormTools` (1 file)
* **ACE-298** — core labels deprecated in v14 (21 references, 4 extensions)

ACE-298 is deliberately **not** in the epic. It looked like a fourth blocker,
because the replacement labels exist only as v14-only XLIFF 2.0 files. But they
are labels on *our own* TCA, so shipping our own text resolves them today on
both core versions. It also has to happen before backend-form tests are added:
the suite runs with `failOnDeprecation`, and those labels emit
`E_USER_DEPRECATED` on every form render on v14.

## Also here

The phpunit group name in the core-version-aware section is corrected to
`not-core-14`. `runTests.sh` builds the excluded group as
`not-core-${CORE_VERSION}`, so the documented `not-core14` never matched
anything.

No code changes.

Issue: ACE-294
