### PR TITLE
[BUGFIX] ACE-298: Ship own labels for retired core keys

### DIFF
--- a/packages-dev/testing-helper/Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php
+++ b/packages-dev/testing-helper/Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\TestingHelper\FunctionalTestCase;
+
+/**
+ * Guards against TCA pointing at core labels that TYPO3 v14 retired.
+ *
+ * TYPO3 v14 marks a set of labels `x-unused-since="14.0"` (#107938, #108086).
+ * They still resolve there, through an `.x-unused` fallback that raises
+ * `E_USER_DEPRECATED` on every backend form render — but the v14 language packs
+ * no longer ship translations for them, so a German backend falls back to the
+ * English source. The replacements core offers live in v14-only XLIFF 2.0 files
+ * and cannot be referenced while TYPO3 v13 is supported, so the extensions ship
+ * these labels themselves (ACE-298).
+ *
+ * The assertion walks the *compiled* TCA rather than the source files, so it
+ * also covers labels that are assembled at runtime.
+ *
+ * **Assert this on TYPO3 v14 only** (`#[Group('not-core-13')]`). On v13 the
+ * labels are not deprecated at all, and core's own `TcaEnrichment` adds them to
+ * every table that declares `transOrigPointerField` without defining the column
+ * — so a v13 run reports core's labels, which are none of our business. On v14
+ * that same enrichment uses `core.db.general:l18n_parent`, so whatever the scan
+ * finds there is genuinely ours.
+ */
+trait DeprecatedCoreLabelsTrait
+{
+    /**
+     * Core label references retired in TYPO3 v14, mapped to what replaced them
+     * in `EXT:academic_base/Resources/Private/Language/locallang_tca.xlf`.
+     *
+     * @var array<string, string>
+     */
+    private array $deprecatedCoreLabels = [
+        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent' => 'l18n_parent',
+        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hide_at_login' => 'fe_group.hide_at_login',
+        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.any_login' => 'fe_group.any_login',
+        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.usergroups' => 'fe_group.usergroups',
+        'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general' => 'palette.general',
+        'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access' => 'palette.access',
+        'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden' => 'field.hidden',
+    ];
+
+    /**
+     * @param string[] $tablePrefixes Tables to inspect, by prefix
+     */
+    private function assertTcaHasNoDeprecatedCoreLabelReferences(array $tablePrefixes): void
+    {
+        $findings = [];
+        foreach ($GLOBALS['TCA'] ?? [] as $table => $configuration) {
+            foreach ($tablePrefixes as $prefix) {
+                if (str_starts_with((string)$table, $prefix)) {
+                    $findings = [...$findings, ...$this->findDeprecatedLabels($configuration, (string)$table)];
+                    break;
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            $findings,
+            'TCA references core labels that TYPO3 v14 retired. Use the replacement in'
+            . ' EXT:academic_base/Resources/Private/Language/locallang_tca.xlf instead:' . PHP_EOL
+            . implode(PHP_EOL, $findings),
+        );
+    }
+
+    /**
+     * @param mixed $configuration
+     * @return string[]
+     */
+    private function findDeprecatedLabels(mixed $configuration, string $path): array
+    {
+        if (is_string($configuration)) {
+            foreach ($this->deprecatedCoreLabels as $deprecated => $replacement) {
+                if (str_contains($configuration, $deprecated)) {
+                    return [sprintf('  %s: %s -> use "%s"', $path, $deprecated, $replacement)];
+                }
+            }
+            return [];
+        }
+        if (!is_array($configuration)) {
+            return [];
+        }
+        $findings = [];
+        foreach ($configuration as $key => $value) {
+            $findings = [...$findings, ...$this->findDeprecatedLabels($value, $path . '.' . $key)];
+        }
+        return $findings;
+    }
+}

--- a/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang_tca.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/de.locallang_tca.xlf
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file
+    source-language="en"
+    target-language="de"
+    datatype="plaintext"
+    original="EXT:academic_base/Resources/Private/Language/locallang_tca.xlf"
+    product-name="academic_base"
+  >
+    <header/>
+    <body>
+      <!--
+        Translations taken verbatim from the upstream TYPO3 core language packs,
+        so the German wording stays identical to what editors saw before.
+        See the source file for why these labels are ours now.
+      -->
+      <trans-unit id="l18n_parent">
+        <source>Transl.Orig</source>
+        <target>Ursprungstext</target>
+      </trans-unit>
+      <trans-unit id="fe_group.hide_at_login">
+        <source>Hide at login</source>
+        <target>Nach Anmeldung verbergen</target>
+      </trans-unit>
+      <trans-unit id="fe_group.any_login">
+        <source>Show at any login</source>
+        <target>Anzeigen, wenn angemeldet</target>
+      </trans-unit>
+      <trans-unit id="fe_group.usergroups">
+        <source>__Usergroups:__</source>
+        <target>__Benutzergruppen:__</target>
+      </trans-unit>
+      <trans-unit id="palette.general">
+        <source>Content Element</source>
+        <target>Inhaltselement</target>
+      </trans-unit>
+      <trans-unit id="palette.access">
+        <source>Publish Dates and Access Rights</source>
+        <target>Veröffentlichungsdaten und Zugriffsrechte</target>
+      </trans-unit>
+      <trans-unit id="field.hidden">
+        <source>Visibility of content element</source>
+        <target>Sichtbarkeit des Inhaltselements</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/fgtclb/academic-base/Resources/Private/Language/locallang_tca.xlf
+++ b/packages/fgtclb/academic-base/Resources/Private/Language/locallang_tca.xlf
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file
+    source-language="en"
+    datatype="plaintext"
+    original="EXT:academic_base/Resources/Private/Language/locallang_tca.xlf"
+    product-name="academic_base"
+  >
+    <header/>
+    <body>
+      <!--
+        Labels for TCA fields that every academic extension declares itself.
+
+        They used to point at core labels that TYPO3 v14 marks
+        x-unused-since="14.0" (#107938, #108086). Those still resolve on v14,
+        but the v14 language packs no longer ship translations for them, so a
+        German backend rendered them in English. The replacements core offers
+        instead live in v14-only XLIFF 2.0 files and cannot be referenced while
+        TYPO3 v13 is supported.
+
+        Source and translations are taken from the upstream core language packs
+        so the wording stays the one editors know. The ids match the core keys
+        they replace, to keep the mapping obvious.
+      -->
+      <trans-unit id="l18n_parent">
+        <source>Transl.Orig</source>
+      </trans-unit>
+      <trans-unit id="fe_group.hide_at_login">
+        <source>Hide at login</source>
+      </trans-unit>
+      <trans-unit id="fe_group.any_login">
+        <source>Show at any login</source>
+      </trans-unit>
+      <trans-unit id="fe_group.usergroups">
+        <source>__Usergroups:__</source>
+      </trans-unit>
+      <trans-unit id="palette.general">
+        <source>Content Element</source>
+      </trans-unit>
+      <trans-unit id="palette.access">
+        <source>Publish Dates and Access Rights</source>
+      </trans-unit>
+      <trans-unit id="field.hidden">
+        <source>Visibility of content element</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/fgtclb/academic-base/Tests/Functional/Language/TcaLabelsTest.php
+++ b/packages/fgtclb/academic-base/Tests/Functional/Language/TcaLabelsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Functional\Language;
+
+use FGTCLB\AcademicBase\Tests\Functional\AbstractAcademicBaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+
+/**
+ * Pins the shared TCA labels that replaced the core labels TYPO3 v14 retired.
+ *
+ * Their whole point is that the wording stays the one editors know, so the
+ * expected values are the upstream core texts, copied from the official
+ * language packs. If someone rewords one of them, this test says so.
+ */
+final class TcaLabelsTest extends AbstractAcademicBaseTestCase
+{
+    private const LABEL_FILE = 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:';
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string}>
+     */
+    public static function labelDataProvider(): \Generator
+    {
+        yield 'l18n_parent' => ['l18n_parent', 'Transl.Orig'];
+        yield 'fe_group.hide_at_login' => ['fe_group.hide_at_login', 'Hide at login'];
+        yield 'fe_group.any_login' => ['fe_group.any_login', 'Show at any login'];
+        yield 'fe_group.usergroups' => ['fe_group.usergroups', '__Usergroups:__'];
+        yield 'palette.general' => ['palette.general', 'Content Element'];
+        yield 'palette.access' => ['palette.access', 'Publish Dates and Access Rights'];
+        yield 'field.hidden' => ['field.hidden', 'Visibility of content element'];
+    }
+
+    #[DataProvider('labelDataProvider')]
+    #[Test]
+    public function labelResolvesToUpstreamSourceText(string $identifier, string $expected): void
+    {
+        $languageService = $this->get(LanguageServiceFactory::class)->create('default');
+        $this->assertSame($expected, $languageService->sL(self::LABEL_FILE . $identifier));
+    }
+
+    /**
+     * The German file is the reason this issue existed: TYPO3 v14 dropped these
+     * keys from its language packs, so a German backend silently fell back to
+     * the English source. Shipping our own translation is only a fix as long as
+     * the file actually carries every key.
+     */
+    #[DataProvider('labelDataProvider')]
+    #[Test]
+    public function germanTranslationIsShippedForLabel(string $identifier, string $sourceText): void
+    {
+        $file = __DIR__ . '/../../../Resources/Private/Language/de.locallang_tca.xlf';
+        $this->assertFileExists($file);
+
+        $document = new \DOMDocument();
+        $this->assertTrue($document->load($file));
+
+        $targets = [];
+        foreach ($document->getElementsByTagName('trans-unit') as $unit) {
+            $target = $unit->getElementsByTagName('target')->item(0);
+            if ($target !== null) {
+                $targets[(string)$unit->getAttribute('id')] = $target->textContent;
+            }
+        }
+
+        $this->assertArrayHasKey($identifier, $targets, sprintf('No German translation for "%s".', $identifier));
+        $this->assertNotSame(
+            $sourceText,
+            $targets[$identifier],
+            sprintf('German translation of "%s" is still the English source text.', $identifier),
+        );
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_role.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_role.php
@@ -55,7 +55,7 @@ return [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Tca;
+
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\DeprecatedCoreLabelsTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @see DeprecatedCoreLabelsTrait
+ */
+final class DeprecatedCoreLabelsTest extends AbstractAcademicContacts4PagesTestCase
+{
+    use DeprecatedCoreLabelsTrait;
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function tcaDoesNotReferenceCoreLabelsRetiredInV14(): void
+    {
+        $this->assertTcaHasNoDeprecatedCoreLabelReferences(['tx_academiccontacts4pages_']);
+    }
+}

--- a/packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php
+++ b/packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php
@@ -31,7 +31,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -355,7 +355,7 @@ $tcaConfiguration = [
             ',
         ],
         'access' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:palette.access',
             'showitem' => '
                 starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel,
                 endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel,

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Tca;
+
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\DeprecatedCoreLabelsTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @see DeprecatedCoreLabelsTrait
+ */
+final class DeprecatedCoreLabelsTest extends AbstractAcademicJobsTestCase
+{
+    use DeprecatedCoreLabelsTrait;
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function tcaDoesNotReferenceCoreLabelsRetiredInV14(): void
+    {
+        $this->assertTcaHasNoDeprecatedCoreLabelReferences(['tx_academicjobs_']);
+    }
+}

--- a/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/tx_academicpartners_domain_model_role.php
@@ -55,7 +55,7 @@ return [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-partners/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\DeprecatedCoreLabelsTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @see DeprecatedCoreLabelsTrait
+ */
+final class DeprecatedCoreLabelsTest extends AbstractAcademicPartnersTestCase
+{
+    use DeprecatedCoreLabelsTrait;
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function tcaDoesNotReferenceCoreLabelsRetiredInV14(): void
+    {
+        $this->assertTcaHasNoDeprecatedCoreLabelReferences(['tx_academicpartners_']);
+    }
+}

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_address.php
@@ -66,7 +66,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_contract.php
@@ -60,7 +60,7 @@ $tcaConfiguration = [
             ],
         ],
         'l10n_parent' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_email.php
@@ -59,7 +59,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -126,7 +126,7 @@ $tcaConfiguration = [
     ],
     'palettes' => [
         'general' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:palette.general',
             'showitem' => implode(',', [
                 'email',
                 'type',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_function_type.php
@@ -52,7 +52,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_location.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_location.php
@@ -52,7 +52,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -90,7 +90,7 @@ $tcaConfiguration = [
     ],
     'palettes' => [
         'general' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:palette.general',
             'showitem' => implode(',', [
                 'title',
             ]),

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_organisational_unit.php
@@ -52,7 +52,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_phone_number.php
@@ -59,7 +59,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -127,7 +127,7 @@ $tcaConfiguration = [
     ],
     'palettes' => [
         'general' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.general',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:palette.general',
             'showitem' => implode(',', [
                 'phone_number',
                 'type',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile.php
@@ -91,15 +91,15 @@ $tcaConfiguration = [
                 'maxitems' => 20,
                 'items' => [
                     [
-                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hide_at_login',
+                        'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:fe_group.hide_at_login',
                         'value' => -1,
                     ],
                     [
-                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.any_login',
+                        'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:fe_group.any_login',
                         'value' => -2,
                     ],
                     [
-                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.usergroups',
+                        'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:fe_group.usergroups',
                         'value' => '--div--',
                     ],
                 ],
@@ -115,7 +115,7 @@ $tcaConfiguration = [
             ],
         ],
         'l10n_parent' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'config' => [
                 'type' => 'select',
@@ -448,7 +448,7 @@ $tcaConfiguration = [
         ],
         'hidden' => [
             'showitem' => implode(',', [
-                'hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden',
+                'hidden;LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:field.hidden',
                 'skip_sync;LLL:EXT:academic_persons/Resources/Private/Language/locallang_tca.xlf:tx_academicpersons_domain_model_profile.columns.skip_sync.label',
             ]),
         ],
@@ -459,7 +459,7 @@ $tcaConfiguration = [
             ]),
         ],
         'access' => [
-            'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:palette.access',
             'showitem' => implode(',', [
                 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel',
                 'endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel',

--- a/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
+++ b/packages/fgtclb/academic-persons/Configuration/TCA/tx_academicpersons_domain_model_profile_information.php
@@ -61,7 +61,7 @@ $tcaConfiguration = [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'label' => 'LLL:EXT:academic_base/Resources/Private/Language/locallang_tca.xlf:l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/packages/fgtclb/academic-persons/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\DeprecatedCoreLabelsTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @see DeprecatedCoreLabelsTrait
+ */
+final class DeprecatedCoreLabelsTest extends AbstractAcademicPersonsTestCase
+{
+    use DeprecatedCoreLabelsTrait;
+
+    #[Group('not-core-13')]
+    #[Test]
+    public function tcaDoesNotReferenceCoreLabelsRetiredInV14(): void
+    {
+        $this->assertTcaHasNoDeprecatedCoreLabelReferences(['tx_academicpersons_']);
+    }
+}


### PR DESCRIPTION
Twenty-one TCA labels pointed at core keys that TYPO3 v14 marks
`x-unused-since="14.0"` (#107938, #108086). This turned out to be more than a
deprecation.

## The visible part

TYPO3 v14 dropped those keys from its **language packs**. Resolved on a running
instance with the German pack installed (`typo3 language:update de`):

| Label | v13.4.33 (de) | v14.3.5 (de) |
|---|---|---|
| `LGL.l18n_parent` | Ursprungstext | **Transl.Orig** |
| `LGL.hide_at_login` | Nach Anmeldung verbergen | **Hide at login** |
| `LGL.any_login` | Anzeigen, wenn angemeldet | **Show at any login** |
| `LGL.usergroups` | \_\_Benutzergruppen:\_\_ | **\_\_Usergroups:\_\_** |
| `palette.general` | Inhaltselement | **Content Element** |
| `palette.access` | Veröffentlichungsdaten und Zugriffsrechte | **Publish Dates and Access Rights** |
| `field.default.hidden` | Sichtbarkeit des Inhaltselements | **Visibility of content element** |

Every one of them rendered in English in a German v14 backend. The same run
raised 14 `E_USER_DEPRECATED`, from the `.x-unused` fallback in
`LanguageService` — which fires on every backend form render, and would fail the
first backend-form test written under `failOnDeprecation`.

## The fix

Core's replacements live in XLIFF 2.0 files that only exist on v14
(`core.db.general:…`), so they cannot be referenced while v13 is supported. But
nothing forces us to use core's keys — these are labels on **our own** TCA
fields.

They now live in `EXT:academic_base`, which all four affected extensions already
require. Source and German are taken **verbatim from the upstream core language
packs**, so the wording editors know does not change, and the unit ids match the
core keys they replace so the eventual migration stays mechanical.

After the change, both core versions resolve all seven to the correct German and
raise zero deprecations.

## Tests

* `DeprecatedCoreLabelsTrait` walks the **compiled** TCA and reports any
  reference to a retired key together with its replacement. One test per
  affected extension.
* `TcaLabelsTest` pins the seven texts and asserts the German file carries a
  translation for each that is not merely the English source — the exact failure
  mode that made this invisible.

The guard asserts on **v14 only**, and finding out why was worth the detour: on
v13 these labels are not deprecated, and core's own `TcaEnrichment` adds them to
every table declaring `transOrigPointerField` without defining the column. The
first v13 run reported two such core-generated cases in `academic_partners` and
`academic_contacts4pages` — core's labels, not ours. On v14 that same enrichment
uses `core.db.general:l18n_parent`, so anything the scan finds there is genuinely
ours.

## Not changed

One bare `'LGL.l18n_parent'` remains in the `test_jobcontact_schema` functional
fixture. It has no `LLL:` prefix, so it never resolves through `LanguageService`
and raises no deprecation — contrary to what the issue assumed. It is a sloppy
fixture label, not an instance of this defect.

Verified green on TYPO3 v13.4.33 and v14.3.5: `cgl -n`, `lintPhp`, `phpstan`,
`unit`, `functional`.

Issue: ACE-298
