### PR TITLE
[BUGFIX] ACE-276: Update profile on image removal

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons-edit/Classes/Controller/ProfileController.php
@@ -178,7 +178,18 @@ final class ProfileController extends AbstractActionController
         $image = $profile->getImage();
         if ($image !== null) {
             $imageFile = $image->getOriginalResource()->getOriginalFile();
-            $imageFile->getStorage()->deleteFile($imageFile);
+            // The relation is dropped first, for two reasons: deleting the file alone leaves
+            // the reference count on the profile record pointing at a reference that no longer
+            // exists, and the file can only be checked for other usages once this profile does
+            // not reference it any more.
+            $profile->setImage(null);
+            $this->profileRepository->update($profile);
+            $this->persistenceManager->remove($image);
+            $this->persistenceManager->persistAll();
+
+            if ($this->countFileReferences($imageFile) === 0) {
+                $imageFile->getStorage()->deleteFile($imageFile);
+            }
         }
         return new RedirectResponse($this->userSessionService->loadRefererFromSession($this->request), 303);
     }

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Important-RemovingProfileImageUpdatesTheProfileRecord.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Important-RemovingProfileImageUpdatesTheProfileRecord.rst
@@ -1,0 +1,52 @@
+..  _important-removing-profile-image-updates-the-profile-record:
+
+========================================================
+Important: Removing a profile image updates the relation
+========================================================
+
+Description
+===========
+
+Removing the profile image in the `academicpersonsedit_profileediting` plugin
+deleted the image file, but never wrote the profile record afterwards. TYPO3
+removes the file index entry and its file references when a file is deleted, so
+the reference itself disappeared — but the reference count stored in
+`tx_academicpersons_domain_model_profile.image` kept its previous value.
+
+`FGTCLB\\AcademicPersonsEdit\\Controller\\ProfileController::removeImageAction()`
+now drops the relation through Extbase before touching the file, so the record
+and its references stay consistent.
+
+The same action deleted the file unconditionally. It now checks whether any other
+record still references the file and keeps it in that case, which is how
+`addImageAction()` has treated the file it replaces since the migration to the
+native Extbase upload handling.
+
+Impact
+======
+
+*   The profile record no longer reports a profile image after the image was
+    removed. Code reading the column directly instead of resolving the relation
+    — raw queries, exports, integrity checks — saw a profile image that did not
+    exist. The frontend was not affected, because it resolves the relation.
+
+*   A file that another record still references is no longer deleted. Removing a
+    profile image previously deleted the file for every record using it, leaving
+    those records pointing at a missing file.
+
+Affected Installations
+======================
+
+Installations using the profile editing plugin
+(`academicpersonsedit_profileediting`) whose editors remove profile images.
+
+Migration
+=========
+
+No configuration change is required.
+
+Profile records that were left with a stale image count keep it until the record
+is written again — editing and saving the profile in the backend or through the
+plugin recalculates the value. The stale count has no effect on rendering.
+
+.. index:: Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use Psr\Http\Message\ResponseInterface;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Session\UserSessionManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Renders the `academicpersonsedit_profileediting` plugin in the frontend as a logged in
+ * frontend user and walks its actions the way a visitor does.
+ *
+ * The plugin links carry a cHash covering the plugin arguments and its forms carry request
+ * bound hidden fields, so neither can be hardcoded — every URI has to be taken from the
+ * page that renders it.
+ */
+abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPersonsEditTestCase
+{
+    use SiteBasedTestTrait;
+
+    protected const FRONTEND_USER_ID = 1;
+    protected const PROFILE_ID = 1;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+            'features' => [
+                'subrequestPageErrors' => true,
+            ],
+        ],
+        'FE' => [
+            'debug' => false,
+        ],
+    ];
+
+    /**
+     * Session cookie of the logged in frontend user, see `logInFrontendUser()`.
+     */
+    private string $frontendUserSessionCookie = '';
+
+    protected function setUp(): void
+    {
+        $this->coreExtensionsToLoad = array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            'typo3/cms-fluid-styled-content',
+        ]);
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        parent::tearDown();
+    }
+
+    protected function setUpTestCase(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsEditProfilePlugin/profileEditingPage.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons_edit/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons_edit/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons_edit/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: 'https://www.acme.com/',
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+            ],
+        );
+        $this->logInFrontendUser();
+    }
+
+    /**
+     * Creates one frontend user session up front and reuses its cookie for every request.
+     *
+     * `InternalRequestContext::withFrontendUserId()` cannot be used here: it creates a new
+     * session per request, while the plugin stores the referrer it redirects to after an
+     * upload in the session of the request that rendered the form.
+     */
+    private function logInFrontendUser(): void
+    {
+        $userSessionManager = UserSessionManager::create('FE');
+        $userSession = $userSessionManager->elevateToFixatedUserSession(
+            $userSessionManager->createAnonymousSession(),
+            self::FRONTEND_USER_ID,
+        );
+        $this->frontendUserSessionCookie = $userSession->getJwt();
+    }
+
+    protected function requestAsFrontendUser(InternalRequest $request): ResponseInterface
+    {
+        return $this->executeFrontendSubRequest(
+            $request->withCookieParams(['fe_typo_user' => $this->frontendUserSessionCookie]),
+            new InternalRequestContext(),
+        );
+    }
+
+    protected function getPageAsFrontendUser(string $url): string
+    {
+        $response = $this->requestAsFrontendUser(new InternalRequest($url));
+        $this->assertSame(200, $response->getStatusCode(), sprintf('Request to "%s" failed.', $url));
+
+        return (string)$response->getBody();
+    }
+
+    /**
+     * Returns the absolute URI of the link the given Extbase action is rendered with. The
+     * links carry a cHash covering the plugin arguments and can therefore neither be
+     * hardcoded nor derived from each other.
+     */
+    protected function extractActionLink(string $content, string $action): string
+    {
+        preg_match_all('@href="([^"]+)"@', $content, $matches);
+        foreach ($matches[1] as $href) {
+            $href = html_entity_decode($href);
+            if (!str_contains($href, urlencode('[action]') . '=' . $action)
+                && !str_contains($href, '[action]=' . $action)
+            ) {
+                continue;
+            }
+            return str_starts_with($href, '/') ? 'https://www.acme.com' . $href : $href;
+        }
+        $this->fail(sprintf('No link to action "%s" found in the rendered page.', $action));
+    }
+
+    /**
+     * Returns the rendered profile detail page, which is the plugin view every image
+     * action is reached from.
+     */
+    protected function getProfileShowPage(): string
+    {
+        $listPage = $this->getPageAsFrontendUser('https://www.acme.com/home');
+
+        return $this->getPageAsFrontendUser($this->extractActionLink($listPage, 'show'));
+    }
+
+    /**
+     * @return list<array{uid: int, identifier: string, mime_type: string}>
+     */
+    protected function getStoredFiles(): array
+    {
+        $rows = $this->getConnectionPool()
+            ->getConnectionForTable('sys_file')
+            ->executeQuery('SELECT uid, identifier, mime_type FROM sys_file ORDER BY uid')
+            ->fetchAllAssociative();
+
+        $files = [];
+        foreach ($rows as $row) {
+            $files[] = [
+                'uid' => (int)$row['uid'],
+                'identifier' => (string)$row['identifier'],
+                'mime_type' => (string)$row['mime_type'],
+            ];
+        }
+
+        return $files;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageRemoveTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageRemoveTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Follows the "delete image" link of the `academicpersonsedit_profileediting` plugin.
+ *
+ * Unlike the upload counterpart this runs on both supported core versions: the profile
+ * image is seeded through the file abstraction layer instead of being uploaded, so none
+ * of the upload permission checks that differ between TYPO3 v13 and v14 are involved.
+ */
+final class AcademicPersonsEditProfileImageRemoveTest extends AbstractProfileEditingPluginTestCase
+{
+    private const PROFILE_PAGE_ID = 100;
+    private const IMAGE_IDENTIFIER = '/profile-images/profile-image.png';
+
+    /**
+     * Puts a profile image in place the way a completed upload leaves it behind: the file
+     * exists in the storage and is indexed, a file reference points from the profile to it,
+     * and the profile record carries the resulting reference count.
+     */
+    private function seedProfileImage(): int
+    {
+        $targetFolder = $this->instancePath . '/fileadmin/profile-images';
+        GeneralUtility::mkdir_deep($targetFolder);
+        copy(__DIR__ . '/Fixtures/Uploads/profile-image.png', $targetFolder . '/profile-image.png');
+
+        // Reading the file through the storage indexes it, so `sys_file` ends up with the
+        // same values an upload would have produced.
+        $storage = $this->get(StorageRepository::class)->findByUid(1);
+        $this->assertNotNull($storage, 'The default file storage is missing.');
+        $file = $storage->getFile(self::IMAGE_IDENTIFIER);
+        $this->assertInstanceOf(File::class, $file);
+
+        $this->addFileReference($file->getUid(), 'tx_academicpersons_domain_model_profile', 'image', self::PROFILE_ID);
+        $this->getConnectionPool()
+            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
+            ->update(
+                'tx_academicpersons_domain_model_profile',
+                ['image' => 1],
+                ['uid' => self::PROFILE_ID],
+            );
+
+        return $file->getUid();
+    }
+
+    private function addFileReference(int $fileUid, string $tableName, string $fieldName, int $recordUid): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('sys_file_reference')
+            ->insert(
+                'sys_file_reference',
+                [
+                    'pid' => self::PROFILE_PAGE_ID,
+                    'uid_local' => $fileUid,
+                    'uid_foreign' => $recordUid,
+                    'tablenames' => $tableName,
+                    'fieldname' => $fieldName,
+                    'sorting_foreign' => 1,
+                ],
+            );
+    }
+
+    /**
+     * @return list<array{tablenames: string, fieldname: string, uid_foreign: int}>
+     */
+    private function getFileReferences(int $fileUid): array
+    {
+        $rows = $this->getConnectionPool()
+            ->getConnectionForTable('sys_file_reference')
+            ->executeQuery(
+                'SELECT tablenames, fieldname, uid_foreign FROM sys_file_reference'
+                . ' WHERE uid_local = ? AND deleted = 0 ORDER BY uid',
+                [$fileUid],
+            )
+            ->fetchAllAssociative();
+
+        $references = [];
+        foreach ($rows as $row) {
+            $references[] = [
+                'tablenames' => (string)$row['tablenames'],
+                'fieldname' => (string)$row['fieldname'],
+                'uid_foreign' => (int)$row['uid_foreign'],
+            ];
+        }
+
+        return $references;
+    }
+
+    /**
+     * Returns the raw reference count column of the profile record, which is what goes
+     * stale when the relation is not persisted.
+     */
+    private function getPersistedProfileImageCount(): int
+    {
+        return (int)$this->getConnectionPool()
+            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
+            ->executeQuery(
+                'SELECT image FROM tx_academicpersons_domain_model_profile WHERE uid = ?',
+                [self::PROFILE_ID],
+            )
+            ->fetchOne();
+    }
+
+    private function removeProfileImage(): void
+    {
+        $removeLink = $this->extractActionLink($this->getProfileShowPage(), 'removeImage');
+        $response = $this->requestAsFrontendUser(new InternalRequest($removeLink));
+
+        // TYPO3 v13 sends the redirect of an Extbase plugin with `header()` from
+        // `Extbase\Core\Bootstrap::handleFrontendRequest()` and returns the plugin output as
+        // content, so a functional sub request cannot observe it and sees the rendered page.
+        // TYPO3 v14 propagates the response of the action, which makes the redirect visible.
+        $expectedStatusCode = (new Typo3Version())->getMajorVersion() >= 14 ? 303 : 200;
+        $this->assertSame(
+            $expectedStatusCode,
+            $response->getStatusCode(),
+            'Removing the profile image did not answer as expected.',
+        );
+    }
+
+    #[Test]
+    public function removingProfileImageDeletesFileAndClearsTheRelation(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $imagePath = $this->instancePath . '/fileadmin' . self::IMAGE_IDENTIFIER;
+        $this->assertFileExists($imagePath);
+        $this->assertSame(1, $this->getPersistedProfileImageCount());
+
+        $this->removeProfileImage();
+
+        $this->assertFileDoesNotExist($imagePath, 'The profile image file was not deleted.');
+        $this->assertSame([], $this->getStoredFiles(), 'The file index still lists the removed image.');
+        $this->assertSame([], $this->getFileReferences($fileUid), 'The file reference was not removed.');
+        // The whole point of ACE-276: deleting the file alone left this counter at 1, while
+        // no file reference existed any more.
+        $this->assertSame(0, $this->getPersistedProfileImageCount(), 'The profile image count is stale.');
+    }
+
+    #[Test]
+    public function removingProfileImageKeepsAFileThatIsStillUsedElsewhere(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->addFileReference($fileUid, 'tt_content', 'assets', 1);
+        $imagePath = $this->instancePath . '/fileadmin' . self::IMAGE_IDENTIFIER;
+
+        $this->removeProfileImage();
+
+        $this->assertFileExists($imagePath, 'A file still referenced by another record was deleted.');
+        $this->assertCount(1, $this->getStoredFiles(), 'The file was removed from the file index.');
+        $this->assertSame(
+            [['tablenames' => 'tt_content', 'fieldname' => 'assets', 'uid_foreign' => 1]],
+            $this->getFileReferences($fileUid),
+            'Only the profile reference must be removed.',
+        );
+        $this->assertSame(0, $this->getPersistedProfileImageCount(), 'The profile image count is stale.');
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
 
-use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
-use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Http\UploadedFile;
-use TYPO3\CMS\Core\Session\UserSessionManager;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**
  * Submits the profile image form of the `academicpersonsedit_profileediting` plugin and
@@ -32,145 +27,15 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
  * @todo Drop the group once TYPO3 v13 support ends.
  */
 #[Group('not-core-13')]
-final class AcademicPersonsEditProfileImageUploadTest extends AbstractAcademicPersonsEditTestCase
+final class AcademicPersonsEditProfileImageUploadTest extends AbstractProfileEditingPluginTestCase
 {
-    use SiteBasedTestTrait;
-
-    private const FRONTEND_USER_ID = 1;
-    private const PROFILE_ID = 1;
-
-    /**
-     * Session cookie of the logged in frontend user, see `logInFrontendUser()`.
-     */
-    private string $frontendUserSessionCookie = '';
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
-
-    protected const LANGUAGE_PRESETS = [
-        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
-    ];
-
-    protected function setUp(): void
-    {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            'typo3/cms-fluid-styled-content',
-        ]);
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
-        parent::tearDown();
-    }
-
-    private function setUpTestCase(): void
-    {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsEditProfilePlugin/profileEditingPage.csv');
-        $this->setUpFrontendRootPage(
-            pageId: 1,
-            typoScriptFiles: [
-                'constants' => [
-                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
-                    'EXT:academic_persons_edit/Configuration/TypoScript/constants.typoscript',
-                ],
-                'setup' => [
-                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
-                    'EXT:academic_persons_edit/Configuration/TypoScript/setup.typoscript',
-                    'EXT:academic_persons_edit/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
-                ],
-            ],
-        );
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
-            ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
-        $this->logInFrontendUser();
-    }
-
-    /**
-     * Creates one frontend user session up front and reuses its cookie for every request.
-     *
-     * `InternalRequestContext::withFrontendUserId()` cannot be used here: it creates a new
-     * session per request, while the plugin stores the referrer it redirects to after an
-     * upload in the session of the request that rendered the form.
-     */
-    private function logInFrontendUser(): void
-    {
-        $userSessionManager = UserSessionManager::create('FE');
-        $userSession = $userSessionManager->elevateToFixatedUserSession(
-            $userSessionManager->createAnonymousSession(),
-            self::FRONTEND_USER_ID,
-        );
-        $this->frontendUserSessionCookie = $userSession->getJwt();
-    }
-
-    private function requestAsFrontendUser(InternalRequest $request): ResponseInterface
-    {
-        return $this->executeFrontendSubRequest(
-            $request->withCookieParams(['fe_typo_user' => $this->frontendUserSessionCookie]),
-            new InternalRequestContext(),
-        );
-    }
-
-    private function getPageAsFrontendUser(string $url): string
-    {
-        $response = $this->requestAsFrontendUser(new InternalRequest($url));
-        $this->assertSame(200, $response->getStatusCode(), sprintf('Request to "%s" failed.', $url));
-
-        return (string)$response->getBody();
-    }
-
-    /**
-     * Returns the absolute URI of the link the given Extbase action is rendered with. The
-     * links carry a cHash covering the plugin arguments and can therefore neither be
-     * hardcoded nor derived from each other.
-     */
-    private function extractActionLink(string $content, string $action): string
-    {
-        preg_match_all('@href="([^"]+)"@', $content, $matches);
-        foreach ($matches[1] as $href) {
-            $href = html_entity_decode($href);
-            if (!str_contains($href, urlencode('[action]') . '=' . $action)
-                && !str_contains($href, '[action]=' . $action)
-            ) {
-                continue;
-            }
-            return str_starts_with($href, '/') ? 'https://www.acme.com' . $href : $href;
-        }
-        $this->fail(sprintf('No link to action "%s" found in the rendered page.', $action));
-    }
-
     /**
      * Walks the plugin from the profile list to the profile image form the same way a
      * visitor does and returns the URI of that form page.
      */
     private function getProfileImageFormUrl(): string
     {
-        $listPage = $this->getPageAsFrontendUser('https://www.acme.com/home');
-        $showPage = $this->getPageAsFrontendUser($this->extractActionLink($listPage, 'show'));
-
-        return $this->extractActionLink($showPage, 'editImage');
+        return $this->extractActionLink($this->getProfileShowPage(), 'editImage');
     }
 
     /**
@@ -302,28 +167,6 @@ final class AcademicPersonsEditProfileImageUploadTest extends AbstractAcademicPe
             $current = &$current[$key];
         }
         $current = $value;
-    }
-
-    /**
-     * @return list<array{uid: int, identifier: string, mime_type: string}>
-     */
-    private function getStoredFiles(): array
-    {
-        $rows = $this->getConnectionPool()
-            ->getConnectionForTable('sys_file')
-            ->executeQuery('SELECT uid, identifier, mime_type FROM sys_file ORDER BY uid')
-            ->fetchAllAssociative();
-
-        $files = [];
-        foreach ($rows as $row) {
-            $files[] = [
-                'uid' => (int)$row['uid'],
-                'identifier' => (string)$row['identifier'],
-                'mime_type' => (string)$row['mime_type'],
-            ];
-        }
-
-        return $files;
     }
 
     #[Test]


### PR DESCRIPTION
Fixes two defects in `ProfileController::removeImageAction()` of
`EXT:academic_persons_edit` — ACE-276.

## The stale reference count

Removing the profile image deleted the image file but never wrote the profile
record. TYPO3 drops the file index entry and the file references together with
the file, so the reference itself disappeared, while
`tx_academicpersons_domain_model_profile.image` kept its previous value:

|                                                 | before remove | after remove |
|-------------------------------------------------|---------------|--------------|
| `sys_file` rows                                  | 1             | 0            |
| `sys_file_reference` rows                        | 1             | 0            |
| `tx_academicpersons_domain_model_profile.image`  | 1             | **1**        |

The frontend was not affected, it resolves the relation. Everything reading the
column directly — raw queries, exports, integrity checks — saw a profile image
that did not exist.

The action now drops the relation through Extbase before it touches the file,
which clears the reference and the count together.

## The unconditionally deleted file

The action deleted the file without checking whether another record still
referenced it, so removing a profile image deleted the file for those records
as well. It is now kept when a reference remains, the way `addImageAction()`
has treated a replaced file since the migration to the native Extbase file
upload handling.

## Tests

`AcademicPersonsEditProfileImageRemoveTest` follows the rendered "delete" link
of the plugin and covers both defects. It runs on **both** core versions: the
profile image is seeded through the file abstraction layer instead of being
uploaded, so the upload permission checks that differ between v13 and v14 are
not involved.

Verified to fail without the fix — the first test on the stale count (`1` is
not `0`), the second on the wrongly deleted shared file.

The frontend request helpers shared with the upload test moved into
`AbstractProfileEditingPluginTestCase`.

One version difference is pinned rather than worked around: TYPO3 v13 sends the
redirect of an Extbase plugin through `header()` in
`Extbase\Core\Bootstrap::handleFrontendRequest()` and returns the plugin output
as content, so a functional sub request sees `200`. TYPO3 v14 propagates the
response and the `303` is visible.

## Not in this change

The issue records a third observation: `Show.html` renders the "add image" link
only when the profile has none, so replacing an image always takes two steps and
the replacement handling added in ACE-274 is unreachable from the shipped
template. That is a UI change needing a new label and its own changelog entry,
and branch `2` has no replacement handling at all — it is better decided on its
own than folded into a backportable bugfix.

## Gates

`cgl -n`, `lintPhp`, `phpstan`, `unit` and the complete `functional` suite are
green on TYPO3 v13.4 and v14.3 with PHP 8.2. Documentation renders clean.

Backport to branch `2` follows once this is merged.
