### PR TITLE
[TASK] ACE-305: Share plugin rendering test harness

### DIFF
--- a/packages-dev/testing-helper/Classes/FunctionalTestCase/FrontendPluginRenderingTrait.php
+++ b/packages-dev/testing-helper/Classes/FunctionalTestCase/FrontendPluginRenderingTrait.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\TestingHelper\FunctionalTestCase;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * Shared setup for functional tests that render a plugin in the frontend.
+ *
+ * Every plugin rendering test needs the same scaffolding — an instance configuration
+ * that surfaces sub request errors, a site to request, a way to fire that request and a
+ * teardown that removes the written site configuration again. Written out per test class
+ * that is roughly sixty lines before the first assertion, which is why it moved here.
+ *
+ * The test class has to use `SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait` as
+ * well and declare its own `LANGUAGE_PRESETS`: which languages a test needs is part of
+ * what it tests, so it stays with the test.
+ *
+ * Typical use:
+ *
+ * ```php
+ * protected function setUp(): void
+ * {
+ *     $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+ *     $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+ *     parent::setUp();
+ * }
+ *
+ * protected function tearDown(): void
+ * {
+ *     $this->removeWrittenSiteConfiguration();
+ *     parent::tearDown();
+ * }
+ * ```
+ */
+trait FrontendPluginRenderingTrait
+{
+    /**
+     * Base URL of the site the helpers below write and request.
+     */
+    protected const FRONTEND_PLUGIN_TEST_BASE = 'https://www.acme.com/';
+
+    /**
+     * `subrequestPageErrors` is what makes a failing plugin fail the test: without it the
+     * frontend swallows the exception of a sub request and answers a rendered error page,
+     * so an assertion on the status code alone would pass.
+     *
+     * @param array<string, mixed> $additionalConfiguration Merged recursively, so a single
+     *        key can be added to `FE` without repeating the rest of it.
+     * @return array<string, mixed>
+     */
+    protected function frontendPluginTestConfiguration(array $additionalConfiguration = []): array
+    {
+        $configuration = [
+            'SYS' => [
+                'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
+                'features' => [
+                    'subrequestPageErrors' => true,
+                ],
+            ],
+            'FE' => [
+                'debug' => false,
+            ],
+        ];
+
+        return array_replace_recursive($configuration, $additionalConfiguration);
+    }
+
+    protected function addCoreExtensionsToLoad(string ...$extensionKeys): void
+    {
+        $this->coreExtensionsToLoad = array_values(array_unique([
+            ...array_values($this->coreExtensionsToLoad),
+            ...$extensionKeys,
+        ]));
+    }
+
+    protected function addTestExtensionsToLoad(string ...$extensionPaths): void
+    {
+        $this->testExtensionsToLoad = array_values(array_unique([
+            ...array_values($this->testExtensionsToLoad),
+            ...$extensionPaths,
+        ]));
+    }
+
+    /**
+     * A written site configuration outlives the test instance, so it has to be removed
+     * explicitly — otherwise the next test finds a site it did not write.
+     */
+    protected function removeWrittenSiteConfiguration(): void
+    {
+        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+    }
+
+    /**
+     * Writes the site every helper here assumes, identified as `acme`.
+     *
+     * @param array<int, array<string, mixed>> $languages Build them with
+     *        `buildDefaultLanguageConfiguration()` / `buildLanguageConfiguration()`.
+     */
+    protected function writeFrontendPluginTestSite(array $languages, int $rootPageId = 1): void
+    {
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: $rootPageId,
+                base: self::FRONTEND_PLUGIN_TEST_BASE,
+            ),
+            languages: $languages,
+        );
+    }
+
+    /**
+     * @param string|InternalRequest $request An absolute URL, or a prepared request when the
+     *        test needs anything beyond a plain GET.
+     */
+    protected function requestFrontendPage(
+        string|InternalRequest $request,
+        ?InternalRequestContext $context = null,
+    ): ResponseInterface {
+        return $this->executeFrontendSubRequest(
+            is_string($request) ? new InternalRequest($request) : $request,
+            $context ?? new InternalRequestContext(),
+        );
+    }
+
+    /**
+     * Requests a page and returns its body, failing the test when the request did not
+     * answer `200` — which is what a plugin exception looks like from the outside.
+     */
+    protected function renderFrontendPage(
+        string|InternalRequest $request,
+        ?InternalRequestContext $context = null,
+    ): string {
+        $response = $this->requestFrontendPage($request, $context);
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            sprintf(
+                'Request to "%s" failed.',
+                is_string($request) ? $request : (string)$request->getUri(),
+            ),
+        );
+
+        return (string)$response->getBody();
+    }
+}

--- a/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/AcademicBiteJobsListPluginTest.php
+++ b/packages/fgtclb/academic-bite-jobs/Tests/Functional/Plugins/AcademicBiteJobsListPluginTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicBiteJobs\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicBiteJobs\Tests\Functional\AbstractAcademicBiteJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**
  * Renders the `academicbitejobs_list` plugin in the frontend.
@@ -25,19 +23,8 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
  */
 final class AcademicBiteJobsListPluginTest extends AbstractAcademicBiteJobsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -45,20 +32,15 @@ final class AcademicBiteJobsListPluginTest extends AbstractAcademicBiteJobsTestC
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            'typo3/cms-fluid-styled-content',
-        ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            'tests/test-bitejobs-stub',
-        ]);
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('tests/test-bitejobs-stub');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -79,30 +61,17 @@ final class AcademicBiteJobsListPluginTest extends AbstractAcademicBiteJobsTestC
                 ],
             ],
         );
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
     }
 
     private function renderHomePage(): string
     {
-        $response = $this->executeFrontendSubRequest(
-            new InternalRequest('https://www.acme.com/home'),
-            new InternalRequestContext(),
-        );
-        $this->assertSame(200, $response->getStatusCode());
-
-        return (string)$response->getBody();
+        return $this->renderFrontendPage('https://www.acme.com/home');
     }
 
     #[Test]

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormPluginTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormPluginTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**
  * Renders the `academicjobs_newjobform` plugin in the frontend.
@@ -22,30 +20,26 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
  */
 final class AcademicJobsNewJobFormPluginTest extends AbstractAcademicJobsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'MAIL' => [
-            'transport' => 'null',
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
     ];
 
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'MAIL' => [
+                'transport' => 'null',
+            ],
+        ]);
+        parent::setUp();
+    }
+
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -72,30 +66,17 @@ final class AcademicJobsNewJobFormPluginTest extends AbstractAcademicJobsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicJobsNewJobFormPlugin/newJobFormPage.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
     }
 
     private function renderHomePage(): string
     {
-        $response = $this->executeFrontendSubRequest(
-            new InternalRequest('https://www.acme.com/home'),
-            new InternalRequestContext(),
-        );
-        $this->assertSame(200, $response->getStatusCode());
-
-        return (string)$response->getBody();
+        return $this->renderFrontendPage('https://www.acme.com/home');
     }
 
     #[Test]

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicJobs\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Http\UploadedFile;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**
  * Submits the `academicjobs_newjobform` plugin with a file upload and verifies the
@@ -33,30 +32,26 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
 #[Group('not-core-13')]
 final class AcademicJobsNewJobFormUploadTest extends AbstractAcademicJobsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'MAIL' => [
-            'transport' => 'null',
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
     ];
 
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'MAIL' => [
+                'transport' => 'null',
+            ],
+        ]);
+        parent::setUp();
+    }
+
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -78,19 +73,12 @@ final class AcademicJobsNewJobFormUploadTest extends AbstractAcademicJobsTestCas
                 ],
             ],
         );
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
     }
 
     /**
@@ -102,12 +90,7 @@ final class AcademicJobsNewJobFormUploadTest extends AbstractAcademicJobsTestCas
      */
     private function renderFormAndExtractSubmitData(): array
     {
-        $response = $this->executeFrontendSubRequest(
-            new InternalRequest('https://www.acme.com/home'),
-            new InternalRequestContext(),
-        );
-        $this->assertSame(200, $response->getStatusCode());
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
 
         $this->assertSame(1, preg_match('@<form [^>]*action="([^"]+)"@', $content, $actionMatch));
 
@@ -183,7 +166,7 @@ final class AcademicJobsNewJobFormUploadTest extends AbstractAcademicJobsTestCas
                 ],
             ]);
 
-        return $this->executeFrontendSubRequest($request, new InternalRequestContext());
+        return $this->requestFrontendPage($request);
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use Psr\Http\Message\ResponseInterface;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Session\UserSessionManager;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
@@ -22,6 +22,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
  */
 abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPersonsEditTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
 
     protected const FRONTEND_USER_ID = 1;
@@ -31,18 +32,6 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
     ];
 
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
-
     /**
      * Session cookie of the logged in frontend user, see `logInFrontendUser()`.
      */
@@ -50,16 +39,14 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            'typo3/cms-fluid-styled-content',
-        ]);
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -80,19 +67,12 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
                 ],
             ],
         );
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
         $this->logInFrontendUser();
     }
 
@@ -115,18 +95,17 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
 
     protected function requestAsFrontendUser(InternalRequest $request): ResponseInterface
     {
-        return $this->executeFrontendSubRequest(
-            $request->withCookieParams(['fe_typo_user' => $this->frontendUserSessionCookie]),
-            new InternalRequestContext(),
-        );
+        return $this->requestFrontendPage($this->withFrontendUserSession($request));
     }
 
     protected function getPageAsFrontendUser(string $url): string
     {
-        $response = $this->requestAsFrontendUser(new InternalRequest($url));
-        $this->assertSame(200, $response->getStatusCode(), sprintf('Request to "%s" failed.', $url));
+        return $this->renderFrontendPage($this->withFrontendUserSession(new InternalRequest($url)));
+    }
 
-        return (string)$response->getBody();
+    private function withFrontendUserSession(InternalRequest $request): InternalRequest
+    {
+        return $request->withCookieParams(['fe_typo_user' => $this->frontendUserSessionCookie]);
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfilePluginTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfilePluginTest.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**
@@ -25,21 +24,10 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
  */
 final class AcademicPersonsEditProfilePluginTest extends AbstractAcademicPersonsEditTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
 
     private const FRONTEND_USER_ID = 1;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -47,16 +35,14 @@ final class AcademicPersonsEditProfilePluginTest extends AbstractAcademicPersons
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            'typo3/cms-fluid-styled-content',
-        ]);
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -77,30 +63,20 @@ final class AcademicPersonsEditProfilePluginTest extends AbstractAcademicPersons
                 ],
             ],
         );
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
     }
 
     private function renderHomePageAsFrontendUser(): string
     {
-        $response = $this->executeFrontendSubRequest(
-            new InternalRequest('https://www.acme.com/home'),
-            (new InternalRequestContext())->withFrontendUserId(self::FRONTEND_USER_ID),
+        return $this->renderFrontendPage(
+            'https://www.acme.com/home',
+            (new InternalRequestContext())->withFrontendUserId(self::FRONTEND_USER_ID)
         );
-        $this->assertSame(200, $response->getStatusCode());
-
-        return (string)$response->getBody();
     }
 
     #[Test]

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsDetailPluginTest.php
@@ -5,32 +5,14 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'cacheHash' => [
-                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
-                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
-                'enforceValidation' => true,
-            ],
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -40,25 +22,23 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            ...array_values([
-                'typo3/cms-fluid-styled-content',
-            ]),
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'FE' => [
+                'cacheHash' => [
+                    'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                    'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                    'enforceValidation' => true,
+                ],
+            ],
         ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            ...array_values([
-                'georgringer/numbered-pagination',
-                'tests/plugin-templates',
-            ]),
-        ]);
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -88,19 +68,11 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/defaultLanguageOnly.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
-            ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration('EN', '/'),
-            ],
-        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration('EN', '/'),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/home?' . http_build_query([
                 'tx_academicpersons_detail' => [
                     'controller' => 'Profile',
@@ -110,10 +82,6 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
                 'cHash' => '13c8ec3ab2a317651a40bd164df8a366',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
 
@@ -137,8 +105,7 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
             ],
         );
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/de/home?' . http_build_query([
                 'tx_academicpersons_detail' => [
                     'controller' => 'Profile',
@@ -148,10 +115,6 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
                 'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
 
@@ -160,28 +123,20 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/de/home?' . http_build_query([
                 'tx_academicpersons_detail' => [
                     'controller' => 'Profile',
@@ -191,10 +146,6 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
                 'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
@@ -207,28 +158,20 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/de/home?' . http_build_query([
                 'tx_academicpersons_detail' => [
                     'controller' => 'Profile',
@@ -238,10 +181,6 @@ final class AcademicPersonsDetailPluginTest extends AbstractAcademicPersonsTestC
                 'cHash' => '008c1ca1df782f9191ecb45d4a4123e3',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListAndDetailPluginTest.php
@@ -5,33 +5,15 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPersonsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'cacheHash' => [
-                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
-                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
-                'enforceValidation' => true,
-            ],
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -41,25 +23,23 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            ...array_values([
-                'typo3/cms-fluid-styled-content',
-            ]),
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'FE' => [
+                'cacheHash' => [
+                    'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                    'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                    'enforceValidation' => true,
+                ],
+            ],
         ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            ...array_values([
-                'georgringer/numbered-pagination',
-                'tests/plugin-templates',
-            ]),
-        ]);
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -89,26 +69,14 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
         $this->assertStringContainsString('#1(2): [EN] Horst Huber', $content);
@@ -119,22 +87,14 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/home?' . http_build_query([
                 'tx_academicpersons_listanddetail' => [
                     'controller' => 'Profile',
@@ -144,10 +104,6 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
                 'cHash' => 'fee6f7f7bcd9035d23f9d6062fc6b7c5',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
@@ -157,26 +113,14 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_oneProfileSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringNotContainsString('Max Müllermann', $content);
@@ -187,26 +131,14 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/defaultLanguageOnly_selectedProfiles.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
@@ -217,26 +149,18 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/de/home?' . http_build_query([
                 'tx_academicpersons_listanddetail' => [
                     'controller' => 'Profile',
@@ -246,10 +170,6 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
                 'cHash' => 'f497a1175d10a3c77454c5958cc1fc5c',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
         $this->assertStringContainsString('#1: [DE] Max Müllermann', $content);
     }
@@ -259,28 +179,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/localizedPagesAndTtContent_notLocalizedProfile.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest(
+        $content = $this->renderFrontendPage(
             'https://www.acme.com/de/home?' . http_build_query([
                 'tx_academicpersons_listanddetail' => [
                     'controller' => 'Profile',
@@ -290,10 +202,6 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
                 'cHash' => 'f497a1175d10a3c77454c5958cc1fc5c',
             ])
         );
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
         $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
         $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
     }
@@ -303,30 +211,18 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -337,30 +233,18 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
@@ -371,32 +255,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringNotContainsString('Horst Huber', $content);
@@ -407,32 +279,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -443,32 +303,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -479,30 +327,18 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [DE] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -536,32 +372,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
         }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringNotContainsString('[EN] Horst Huber', $content);
@@ -574,30 +398,18 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -610,32 +422,20 @@ final class AcademicPersonsListAndDetailPluginTest extends AbstractAcademicPerso
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListAndDetailPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -5,33 +5,15 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
 use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'cacheHash' => [
-                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
-                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
-                'enforceValidation' => true,
-            ],
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -41,25 +23,23 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            ...array_values([
-                'typo3/cms-fluid-styled-content',
-            ]),
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'FE' => [
+                'cacheHash' => [
+                    'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                    'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                    'enforceValidation' => true,
+                ],
+            ],
         ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            ...array_values([
-                'georgringer/numbered-pagination',
-                'tests/plugin-templates',
-            ]),
-        ]);
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -89,26 +69,14 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): Max Müllermann', $content);
         $this->assertStringContainsString('#1(2): Horst Huber', $content);
@@ -119,26 +87,14 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_oneProfileSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringNotContainsString('Max Müllermann', $content);
@@ -149,26 +105,14 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/defaultLanguageOnly_selectedProfiles.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/'
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/'
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
@@ -179,30 +123,18 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [EN] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -213,30 +145,18 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [DE] Horst Huber', $content);
@@ -247,32 +167,20 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringNotContainsString('Horst Huber', $content);
@@ -283,32 +191,20 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -319,32 +215,20 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalizedPagesAndTtContent_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringContainsString('#1(3): [EN] Horst Huber', $content);
@@ -373,12 +257,7 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
             ],
         );
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [DE] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -412,32 +291,20 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
         }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(1): [DE] Max Müllermann', $content);
         $this->assertStringNotContainsString('[EN] Horst Huber', $content);
@@ -450,30 +317,18 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -486,32 +341,20 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -5,32 +5,14 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicPersonsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'cacheHash' => [
-                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
-                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
-                'enforceValidation' => true,
-            ],
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -40,25 +22,23 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            ...array_values([
-                'typo3/cms-fluid-styled-content',
-            ]),
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'FE' => [
+                'cacheHash' => [
+                    'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                    'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                    'enforceValidation' => true,
+                ],
+            ],
         ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            ...array_values([
-                'georgringer/numbered-pagination',
-                'tests/plugin-templates',
-            ]),
-        ]);
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -88,26 +68,14 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_allContractsSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
         $this->assertStringContainsString('#0(2): Manager', $content);
         $this->assertStringContainsString('#1(1): Worker', $content);
@@ -118,26 +86,14 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/defaultLanguageOnly_oneContractSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ],
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
         $this->assertStringContainsString('#0(2): Manager', $content);
         $this->assertStringNotContainsString('Worker', $content);
@@ -148,32 +104,20 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_allContractsLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'content_fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'content_fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
         $this->assertStringContainsString('#0(3): [DE] Manager', $content);
         $this->assertStringContainsString('#1(1): [DE] Arbeiter', $content);
@@ -186,32 +130,20 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Manager', $content);
         $this->assertStringContainsString('#1(1): [DE] Arbeiter', $content);
@@ -224,32 +156,20 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'content_fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'content_fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Manager', $content);
         $this->assertStringContainsString('#1(1): [DE] Arbeiter', $content);

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -5,32 +5,14 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
 
 use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use PHPUnit\Framework\Attributes\Test;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPersonsTestCase
 {
+    use FrontendPluginRenderingTrait;
     use SiteBasedTestTrait;
-
-    protected array $configurationToUseInTestInstance = [
-        'SYS' => [
-            'encryptionKey' => '4408d27a916d51e624b69af3554f516dbab61037a9f7b9fd6f81b4d3bedeccb6',
-            'features' => [
-                'subrequestPageErrors' => true,
-            ],
-        ],
-        'FE' => [
-            'cacheHash' => [
-                'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
-                'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
-                'enforceValidation' => true,
-            ],
-            'debug' => false,
-        ],
-    ];
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -40,25 +22,23 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
 
     protected function setUp(): void
     {
-        $this->coreExtensionsToLoad = array_unique([
-            ...array_values($this->coreExtensionsToLoad),
-            ...array_values([
-                'typo3/cms-fluid-styled-content',
-            ]),
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration([
+            'FE' => [
+                'cacheHash' => [
+                    'requireCacheHashPresenceParameters' => ['value', 'testing[value]', 'tx_testing_link[value]'],
+                    'excludedParameters' => ['L', 'tx_testing_link[excludedValue]'],
+                    'enforceValidation' => true,
+                ],
+            ],
         ]);
-        $this->testExtensionsToLoad = array_unique([
-            ...array_values($this->testExtensionsToLoad),
-            ...array_values([
-                'georgringer/numbered-pagination',
-                'tests/plugin-templates',
-            ]),
-        ]);
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        $this->removeWrittenSiteConfiguration();
         parent::tearDown();
     }
 
@@ -88,26 +68,14 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_allProfilesSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ]
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringContainsString('#1(1): Max Müllermann', $content);
@@ -118,26 +86,14 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/defaultLanguageOnly_oneProfileSelected.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-            ]
-        );
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/home');
         $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
         $this->assertStringContainsString('#0(2): Horst Huber', $content);
         $this->assertStringNotContainsString('Max Müllermann', $content);
@@ -148,32 +104,20 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_allProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'content_fallback',
-                ),
-            ]
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'content_fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
         $this->assertStringContainsString('#0(3): [DE] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -186,32 +130,20 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: [],
-                    fallbackType: 'strict',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'strict',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
@@ -224,32 +156,20 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
         $this->setUpFrontendRootPageForTestCase();
-        $this->writeSiteConfiguration(
-            identifier: 'acme',
-            site: $this->buildSiteConfiguration(
-                rootPageId: 1,
-                base: 'https://www.acme.com/',
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
             ),
-            languages: [
-                $this->buildDefaultLanguageConfiguration(
-                    identifier: 'EN',
-                    base: '/',
-                ),
-                $this->buildLanguageConfiguration(
-                    identifier: 'DE',
-                    base: '/de/',
-                    fallbackIdentifiers: ['EN'],
-                    fallbackType: 'content_fallback',
-                ),
-            ],
-        );
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'content_fallback',
+            ),
+        ]);
 
-        $requestContext = new InternalRequestContext();
-        $request = new InternalRequest('https://www.acme.com/de/home');
-        $response = $this->executeFrontendSubRequest($request, $requestContext);
-        $this->assertSame(200, $response->getStatusCode());
-
-        $content = (string)$response->getBody();
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
         $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
         $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
         $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);


### PR DESCRIPTION
Preparation for the S7 rendering-test coverage work — ACE-305.

Every functional test that renders a plugin in the frontend repeated the same
scaffolding before it could assert anything: an instance configuration
surfacing sub request errors, the `fluid_styled_content` load, a written site
configuration, the request execution with a status check, and a teardown
removing the site again. Nine test classes in four extensions carried it, with
small undocumented differences between them.

## What moved

`FrontendPluginRenderingTrait` in `fgtclb/academics-monorepo-testing-helper`,
next to the traits already shared there:

| Helper | Replaces |
|---|---|
| `frontendPluginTestConfiguration()` | the copied `$configurationToUseInTestInstance`, merged recursively so `MAIL` / `FE.cacheHash` are added without repeating the rest |
| `addCoreExtensionsToLoad()` / `addTestExtensionsToLoad()` | the `array_unique([...array_values(...)])` blocks |
| `writeFrontendPluginTestSite()` | the 12-line `writeSiteConfiguration()` call, ~20 call sites |
| `requestFrontendPage()` / `renderFrontendPage()` | the request + `assertSame(200, …)` + `getBody()` sequence, ~40 call sites |
| `removeWrittenSiteConfiguration()` | the `GeneralUtility::rmdir(…/typoconf/sites)` teardown |

`LANGUAGE_PRESETS` deliberately stays with the test class: which languages a
test declares is part of what it tests.

The trait also writes down why `subrequestPageErrors` is needed at all — without
it the frontend swallows the exception of a sub request and answers a rendered
error page, so asserting the status code alone passes while the plugin is
broken. That was copied into nine files without a word of explanation.

## Scope

**No test behaviour changes.** Assertions, fixtures and the plugin code are
untouched. Net −539 lines across the nine test classes.

## Gates

Run against **TYPO3 v13 first** and green there before v14 was touched, per the
working rule for this round: a v14-only failure is a question about production
code, not about the assertion. Nothing diverged here, which is the expected
result for a pure refactor.

* v13.4: `cgl -n`, `lintPhp`, `phpstan`, `unit`, full `functional` — 462 tests
* v14.3: `cgl -n`, `lintPhp`, `phpstan`, `unit`, full `functional` — 469 tests

## Next

The twelve uncovered plugins, one PR per extension (their fixtures and site
setup are per extension, so `academic_partners`' four plugins share one setup).
