### PR TITLE
[TASK] ACE-313: Run CI containers with docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ name: "CI"
 # configuration only and does *not* reinstall dependencies, which is why every
 # job that needs a vendor tree runs "composerUpdate" for its own core version
 # first.
+#
+# Every step also passes "-b docker" (ACE-313). The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor the
+# testing image changing. Selecting docker here avoids crun entirely and leaves
+# the script default and local runs untouched. Drop the flag once GitHub stops
+# producing the mismatch.
 
 on:
   pull_request:
@@ -85,14 +95,14 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "CGL"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
 
 # @todo Disabled until the correct file header has been determined for extensions.
 #      - name: "CGL (header comments)"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cglHeader"
+#        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cglHeader"
 
   phpstan:
     name: "phpstan (v${{ matrix.typo3 }})"
@@ -120,10 +130,10 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Static code analyzer"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s phpstan"
 
   lint:
     name: "lint (PHP ${{ matrix.php-version }})"
@@ -142,7 +152,7 @@ jobs:
       # nor a TYPO3 version. The previous workflows installed dependencies here
       # for nothing, once per PHP version.
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -p ${{ matrix.php-version }} -s lintPhp"
 
   unit:
     name: "unit (v${{ matrix.typo3 }}, PHP ${{ matrix.php-version }})"
@@ -168,13 +178,13 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Execute unit tests"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
 
       - name: "Execute unit tests in random order"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"
 
   functional-sqlite:
     name: "functional sqlite (v${{ matrix.typo3 }}, PHP ${{ matrix.php-version }})"
@@ -200,10 +210,10 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Execute functional tests with SQLite"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
 
   functional-dbms:
     name: "functional ${{ matrix.dbms.name }} ${{ matrix.dbms.version }} (v${{ matrix.typo3 }}, PHP ${{ matrix.php-version }})"
@@ -236,10 +246,10 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "Execute functional tests with ${{ matrix.dbms.name }} ${{ matrix.dbms.version }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d ${{ matrix.dbms.name }} -i ${{ matrix.dbms.version }} -s functional"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d ${{ matrix.dbms.name }} -i ${{ matrix.dbms.version }} -s functional"
 
   documentation:
     name: "documentation"
@@ -275,7 +285,7 @@ jobs:
       # "--fail-on-log --fail-on-error", so a warning fails the job.
       # "checkRstRenderingSingle <extension>" renders a single one locally.
       - name: "Render documentation of all extensions"
-        run: "Build/Scripts/runTests.sh -s checkRstRenderingAll"
+        run: "Build/Scripts/runTests.sh -b docker -s checkRstRenderingAll"
 
       - name: "Upload rendered documentation"
         uses: actions/upload-artifact@v6

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -636,7 +636,13 @@ case ${TEST_SUITE} in
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid "
+                # "mode=1777" is required for docker and harmless for podman: docker runs the
+                # container as "--user $(id -u)" with group 0, while the tmpfs comes up owned by
+                # root with mode 0755, so the test databases cannot be created and every test
+                # fails with "unable to open database file". Rootless podman needs no "--user"
+                # (it is root inside the user namespace), which is why this only shows with
+                # docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 "
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;


### PR DESCRIPTION
Fixes the sporadic pipeline failures seen since 2026-07-29 — ACE-313.

```
Trying to pull ghcr.io/typo3/core-testing-php82:latest...
Error: OCI runtime error: crun: unknown version specified
```

exit code 126, always at the first container start of a job. Any job: `lint`,
`phpstan`, `unit`, `functional` (sqlite and DBMS), both core versions, both
runner labels.

| Date | Runs | Attempts needed |
|---|---|---|
| 2026-07-27 | 6 | 1 each |
| 2026-07-28 | 3 | 1 each |
| 2026-07-29 | 3 | **5, 6 and 4** |

#364, #365 and #366 needed fifteen rerun rounds between them. Every job passed
on a rerun; none failed twice for the same reason.

## Nothing of ours changed

* **Runner image identical** — `ubuntu-24.04` `20260720.247.2` on the green runs
  of 2026-07-28 and the failing ones of 2026-07-29.
* **Testing image identical** — the GHCR manifest of
  `ghcr.io/typo3/core-testing-php82:latest` is still the multi-arch index built
  `2026-06-11T10:44:41Z`, same digest. Not a rebuild.
* **Not the matrix fan-out** — matrix jobs each get their own runner, so they do
  not contend. `lint (PHP 8.2)` and `phpstan (v12)`, which have no concurrent
  siblings, failed too. A smaller matrix would expose fewer jobs, not lower the
  rate per job, and would cost coverage.

`crun: unknown version specified` is crun refusing the OCI runtime spec version
in the `config.json` podman generated. Same image, same runner label,
intermittent per job, cleared by a rerun onto another host — variance in the
GitHub host fleet.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever present and only falls back
to docker. That default stays: it is correct for the script, and podman-only
runners are exactly what it is built for. GitHub hosted runners happen to ship
both, which is the single place this repository meets the broken combination —
so the override belongs in the workflow, not in the script.

`-b docker` added to all 14 `runTests.sh` invocations in `ci.yml`, with the
reasoning in the header comment so it can be dropped knowingly later.

Verified locally before proposing:

```
CI=true Build/Scripts/runTests.sh -t 13 -p 8.2 -b docker -s lintPhp                    → SUCCESS
CI=true Build/Scripts/runTests.sh -t 13 -p 8.2 -b docker -d sqlite -s functional <path> → SUCCESS
```

`CI=true` matters — without it the script keeps the interactive `-it` flags and
docker aborts with "cannot attach stdin to a TTY-enabled container". CI mode
already drops them, so this only bites when simulating CI locally.

## Selecting docker exposed a second, unrelated defect

The first run with `-b docker` had all 12 source-gate jobs green on the first
attempt — and all four `functional sqlite` jobs failing, every one of their 462
tests, with `unable to open database file`. That is **not** the flake; it is the
SQLite tmpfs mount relying on the podman user model.

A probe inside the actual container on the runner:

```
drwxr-xr-x 2 0 0  .Build/Web/typo3temp/var/tests/functional-sqlite-dbs   ← tmpfs: root:root, 0755
uid=1001 gid=0(root)                                                     ← container user
SQLITE DIR WRITE: DENIED
TESTS DIR WRITE: OK
```

docker runs the container as `--user $(id -u)` with group 0, while the tmpfs
comes up owned by root with mode `0755`. Rootless podman passes no `--user` and
is root inside its user namespace, so the same mount is writable — which is why
this never showed before. Two earlier guesses (tmpfs size, mount permissions of
the runner's docker in general) were measured and disproved; the runner gives a
7.8G tmpfs at mode 1777 for a *fresh* path.

Fixed in `runTests.sh` by mounting with `mode=1777`. Docker needs it, podman
does not mind, and it stays regardless of which runtime the workflow selects.

## This pull request is its own proof

The pipeline below runs with both changes.

## Branch `2`

Affected the same way — #365 needed six attempts. Backport pending your go-ahead;
its `ci.yml` has the same steps.
