### PR TITLE
[TASK] ACE-313: Run CI containers with docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,16 @@ name: "CI"
 # configuration only and does *not* reinstall dependencies, which is why every
 # job that needs a vendor tree runs "composerUpdate" for its own core version
 # first.
+#
+# Every step also passes "-b docker" (ACE-313). The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor the
+# testing image changing. Selecting docker here avoids crun entirely and leaves
+# the script default and local runs untouched. Drop the flag once GitHub stops
+# producing the mismatch.
 
 on:
   pull_request:
@@ -88,14 +98,14 @@ jobs:
             composer-${{ matrix.php-version }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
 
       - name: "CGL"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cgl -n"
 
 # @todo Disabled until the correct file header has been determined for extensions.
 #      - name: "CGL (header comments)"
-#        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cglHeader"
+#        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s cglHeader"
 
   phpstan:
     name: "phpstan (v${{ matrix.combo.typo3 }})"
@@ -124,10 +134,10 @@ jobs:
             composer-${{ matrix.combo.php }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.combo.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
 
       - name: "Static code analyzer"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s phpstan"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s phpstan"
 
   lint:
     name: "lint (PHP ${{ matrix.php-version }})"
@@ -146,7 +156,7 @@ jobs:
       # nor a TYPO3 version. The previous workflows installed dependencies here
       # for nothing, once per PHP version.
       - name: "Run PHP lint"
-        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s lintPhp"
+        run: "Build/Scripts/runTests.sh -b docker -p ${{ matrix.php-version }} -s lintPhp"
 
   unit:
     name: "unit (v${{ matrix.combo.typo3 }}, PHP ${{ matrix.combo.php }})"
@@ -175,13 +185,13 @@ jobs:
             composer-${{ matrix.combo.php }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.combo.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
 
       - name: "Execute unit tests"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s unit"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s unit"
 
       - name: "Execute unit tests in random order"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s unitRandom"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s unitRandom"
 
   functional-sqlite:
     name: "functional sqlite (v${{ matrix.combo.typo3 }}, PHP ${{ matrix.combo.php }})"
@@ -210,10 +220,10 @@ jobs:
             composer-${{ matrix.combo.php }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.combo.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
 
       - name: "Execute functional tests with SQLite"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -d sqlite -s functional"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -d sqlite -s functional"
 
   functional-dbms:
     name: "functional ${{ matrix.dbms.name }} ${{ matrix.dbms.version }} (v${{ matrix.combo.typo3 }}, PHP ${{ matrix.combo.php }})"
@@ -249,10 +259,10 @@ jobs:
             composer-${{ matrix.combo.php }}-
 
       - name: "Prepare dependencies for TYPO3 v${{ matrix.combo.typo3 }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -s composerUpdate"
 
       - name: "Execute functional tests with ${{ matrix.dbms.name }} ${{ matrix.dbms.version }}"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -d ${{ matrix.dbms.name }} -i ${{ matrix.dbms.version }} -s functional"
+        run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.combo.typo3 }} -p ${{ matrix.combo.php }} -d ${{ matrix.dbms.name }} -i ${{ matrix.dbms.version }} -s functional"
 
   documentation:
     name: "documentation"
@@ -288,7 +298,7 @@ jobs:
       # "--fail-on-log --fail-on-error", so a warning fails the job.
       # "checkRstRenderingSingle <extension>" renders a single one locally.
       - name: "Render documentation of all extensions"
-        run: "Build/Scripts/runTests.sh -s checkRstRenderingAll"
+        run: "Build/Scripts/runTests.sh -b docker -s checkRstRenderingAll"
 
       - name: "Upload rendered documentation"
         uses: actions/upload-artifact@v6

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -642,7 +642,13 @@ case ${TEST_SUITE} in
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid "
+                # "mode=1777" is required for docker and harmless for podman: docker runs the
+                # container as "--user $(id -u)" with group 0, while the tmpfs comes up owned by
+                # root with mode 0755, so the test databases cannot be created and every test
+                # fails with "unable to open database file". Rootless podman needs no "--user"
+                # (it is root inside the user namespace), which is why this only shows with
+                # docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 "
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;


### PR DESCRIPTION
Backport of #367 to branch `2` — ACE-313.

## The flake

Since 2026-07-29 pipelines fail sporadically at the first container start of a
job:

```
Trying to pull ghcr.io/typo3/core-testing-php8x:latest...
Error: OCI runtime error: crun: unknown version specified
```

exit code 126. #365 on this branch needed **six** rerun rounds. Nothing of ours
changed — the runner image and the testing image are the same as on the days
that were green first time — and it is not the matrix fan-out, since matrix jobs
run on separate runners and jobs without concurrent siblings failed too.

`runTests.sh` prefers podman whenever present. That default is correct for the
script and stays; GitHub hosted runners happen to ship both, which is the single
place this repository meets the broken combination, so the override belongs in
the workflow. `-b docker` added to all 14 invocations in `ci.yml`, with the
reasoning in the header comment so it can be dropped knowingly later.

## The latent defect it exposes

This branch carries the same SQLite tmpfs mount as `main` did, and it relies on
the podman user model. On `main`, switching to docker made all four
`functional sqlite` jobs fail every one of their tests with
`unable to open database file`. A probe inside the container on the runner:

```
drwxr-xr-x 2 0 0  .Build/Web/typo3temp/var/tests/functional-sqlite-dbs   ← tmpfs: root:root, 0755
uid=1001 gid=0(root)                                                     ← container user
SQLITE DIR WRITE: DENIED
```

Docker runs the container as `--user $(id -u)` with group 0; rootless podman
passes no `--user` and is root inside its user namespace, so the same mount is
writable there. Mounting with `mode=1777` fixes it for docker and is ignored by
podman. That part is a genuine fix and stays regardless of which runtime the
workflow selects.

## What local runs do and do not prove

`CI=true Build/Scripts/runTests.sh -t 12 -p 8.2 -b docker -d sqlite -s functional`
passes here — but it also passes **without** the tmpfs change, because this
machine's docker gives that path mode 1777. The defect only reproduces on the
runner (docker 28.0.4). So local runs show the suite works under docker; the
pipeline below is the actual proof, as it was on `main` (32/32 green on the
first attempt).

## Verified locally on this branch

* `-b docker -s composerUpdate` for TYPO3 v12 — success
* `-b docker -d sqlite -s functional`, full suite, TYPO3 v12 — success
