### PR TITLE
[TASK] ACE-307: Add projects plugin rendering tests

### DIFF
--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/AcademicProjectsProjectListPluginTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/AcademicProjectsProjectListPluginTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academicprojects_projectlist` and `academicprojects_projectlistsingle` plugins
+ * in the frontend.
+ *
+ * Projects are pages of doktype 30 mapped onto the `pages` table, so the fixtures are page
+ * records carrying the `tx_academicprojects_*` columns. Both plugins run the same
+ * `ProjectController::listAction()` and differ only in their content element configuration:
+ * `academicprojects_projectlistsingle` reads the selected projects from the `pages` field of
+ * the content element, while `academicprojects_projectlist` uses it as a page restriction.
+ */
+final class AcademicProjectsProjectListPluginTest extends AbstractAcademicProjectsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicProjectsPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_projects/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_projects/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_projects/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    #[Test]
+    public function projectListPluginRendersAllVisibleProjects(): void
+    {
+        $this->setUpTestCase('projectListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-projects-list', $content);
+        // The project title column takes precedence over the page title, see `Project/Item`.
+        $this->assertStringContainsString('Quantum research project', $content);
+        $this->assertStringContainsString('Solar fields', $content);
+        $this->assertStringContainsString('Photovoltaics on former farmland.', $content);
+        $this->assertStringNotContainsString('Hidden lab', $content);
+    }
+
+    #[Test]
+    public function projectListPluginRendersTheFilterAndSortingForm(): void
+    {
+        $this->setUpTestCase('projectListPage');
+
+        $this->assertStringContainsString('academic-projects-filtersorting', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function projectListPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('projectListPage');
+        // Rendering a header is what requires the `record` view variable on TYPO3 v14.
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => 'Our research projects'], ['uid' => 1]);
+
+        $this->assertStringContainsString('Our research projects', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function projectListPluginRendersHiddenProjectsWhenConfigured(): void
+    {
+        $this->setUpTestCase('projectListPage_showHiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Quantum research project', $content);
+        $this->assertStringContainsString('Hidden lab', $content);
+    }
+
+    #[Test]
+    public function projectListPluginRendersNoProjectsFoundLabelWithoutProjects(): void
+    {
+        $this->setUpTestCase('projectListPage_noProjects');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-projects-list', $content);
+        $this->assertStringContainsString('No projects found.', $content);
+    }
+
+    #[Test]
+    public function projectListSinglePluginRendersOnlySelectedProjects(): void
+    {
+        $this->setUpTestCase('projectListSinglePage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-projects-list', $content);
+        $this->assertStringContainsString('Solar fields', $content);
+        $this->assertStringNotContainsString('Quantum research project', $content);
+        $this->assertStringNotContainsString('Hidden lab', $content);
+    }
+
+    #[Test]
+    public function projectListSinglePluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('projectListSinglePage');
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => 'Featured project'], ['uid' => 1]);
+
+        $this->assertStringContainsString('Featured project', $this->renderHomePage());
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","tx_academicprojects_project_title","tx_academicprojects_short_description"
+,1,0,1,0,0,0,0,0,"/","Site Root","",""
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",""
+,10,1,30,0,0,0,0,0,"/quantum-research","Quantum Research","Quantum research project","Investigating quantum effects."
+,11,1,30,0,0,0,0,0,"/solar-fields","Solar fields","","Photovoltaics on former farmland."
+,12,1,30,0,1,0,0,0,"/hidden-lab","Hidden lab","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicprojects_projectlist","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">0</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage_noProjects.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage_noProjects.csv
@@ -1,0 +1,7 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicprojects_projectlist","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">0</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListPage_showHiddenRecords.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","tx_academicprojects_project_title","tx_academicprojects_short_description"
+,1,0,1,0,0,0,0,0,"/","Site Root","",""
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",""
+,10,1,30,0,0,0,0,0,"/quantum-research","Quantum Research","Quantum research project","Investigating quantum effects."
+,11,1,30,0,0,0,0,0,"/solar-fields","Solar fields","","Photovoltaics on former farmland."
+,12,1,30,0,1,0,0,0,"/hidden-lab","Hidden lab","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicprojects_projectlist","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">0</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListSinglePage.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsPlugin/projectListSinglePage.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","tx_academicprojects_project_title","tx_academicprojects_short_description"
+,1,0,1,0,0,0,0,0,"/","Site Root","",""
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",""
+,10,1,30,0,0,0,0,0,"/quantum-research","Quantum Research","Quantum research project","Investigating quantum effects."
+,11,1,30,0,0,0,0,0,"/solar-fields","Solar fields","","Photovoltaics on former farmland."
+,12,1,30,0,1,0,0,0,"/hidden-lab","Hidden lab","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicprojects_projectlistsingle","","11","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">1</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">1</value></field><field index=""settings.hideSorting""><value index=""vDEF"">1</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}


### PR DESCRIPTION
Adds frontend rendering tests for the two `EXT:academic_projects` plugins,
`academicprojects_projectlist` and `academicprojects_projectlistsingle`
(ACE-307).

Both plugins run the same `ProjectController::listAction()` and differ only in
their content element configuration, so they share one set of fixtures. Projects
are pages of doktype 30 mapped onto `pages`, so the fixtures are page records
carrying the `tx_academicprojects_*` columns.

Covered:

* the project list, with the project title taking precedence over the page title
* the filter and sorting form
* the content element header
* the `showHiddenRecords` FlexForm setting
* the empty result label
* the selected-projects restriction of the single variant

The scaffolding comes from `FrontendPluginRenderingTrait` (ACE-305).

### On the expected TYPO3 v14 header defect

The content element header was expected to fail on v14, the way it does for
plugins whose own template renders the `EXT:fluid_styled_content` `Header/All`
partial without the `record` view variable. It does not: the project templates
render no header themselves, so it comes from `lib.contentElement`, which
provides the record through its own data processor. No production code change is
needed here.

Tests were written against v13 first and green there before v14 was run; both
are green, as are cgl, lintPhp, phpstan, unit and the full functional suite for
both core versions.
