### PR TITLE
[TASK] ACE-308: Add partners plugin rendering tests

### DIFF
--- a/packages/fgtclb/academic-partners/Resources/Private/Templates/Partner/PartnershipsTeaser.html
+++ b/packages/fgtclb/academic-partners/Resources/Private/Templates/Partner/PartnershipsTeaser.html
@@ -26,7 +26,7 @@
                                     arguments="{
                                         partner: partnership.partner,
                                         data: data,
-                                        settings: settings
+                                        settings: settings,
                                         grouped: 'true'
                                     }"
                                 />

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/AcademicPartnersPluginTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/AcademicPartnersPluginTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders all four plugins of this extension in the frontend: `academicpartners_list`,
+ * `academicpartners_map`, `academicpartners_partnershipslist` and
+ * `academicpartners_partnershipsteaser`. They share one page tree, one site and one
+ * TypoScript setup, which is why they share one test class.
+ *
+ * Partners are pages of doktype 40 mapped onto the `pages` table, so the fixtures are page
+ * records carrying the partner columns. The two list-like plugins read their configuration
+ * from the FlexForm of the content element, while the two partnership plugins take none and
+ * resolve their records from the page the content element sits on
+ * (`PartnershipRepository::findByPid()`).
+ */
+final class AcademicPartnersPluginTest extends AbstractAcademicPartnersTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPartnersPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_partners/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_partners/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_partners/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    /**
+     * The header of the content element is not part of any template of this extension — it
+     * comes from `lib.contentElement`, which is what `PLUGIN_TYPE_CONTENT_ELEMENT` wires up.
+     * On TYPO3 v14 that header partial renders through the `record` view variable, so this is
+     * the assertion that fails should the plugin ever be registered without it.
+     */
+    private function setContentElementHeader(string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => 1]);
+    }
+
+    /**
+     * A partnership rendered inside a role group passes `grouped` down to `Partner/Header`,
+     * which renders the partner title one level below the role heading — `h3` instead of the
+     * `h2` an ungrouped item gets. Asserting the level is what proves the argument arrives.
+     */
+    private function assertGroupedPartnerHeading(string $content): void
+    {
+        $this->assertMatchesRegularExpression(
+            '#<h3 class="card-title">\s*<a href="/alpha-university">Alpha University</a>\s*</h3>#',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function partnerListPluginRendersAllVisiblePartners(): void
+    {
+        $this->setUpTestCase('partnerListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partners-list', $content);
+        $this->assertStringContainsString('academic-partners-itemlist', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Beta Institute', $content);
+        // Partners are collected across the whole site, not only below the current page.
+        $this->assertStringContainsString('Delta Regional College', $content);
+        $this->assertStringNotContainsString('Gamma Hidden Partner', $content);
+    }
+
+    #[Test]
+    public function partnerListPluginRendersTheFilterAndSortingForm(): void
+    {
+        $this->setUpTestCase('partnerListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partners-filtersorting', $content);
+        $this->assertStringContainsString('Sorting field', $content);
+        $this->assertStringContainsString('Sorting direction', $content);
+    }
+
+    #[Test]
+    public function partnerListPluginHidesTheFilterAndSortingFormWhenConfigured(): void
+    {
+        $this->setUpTestCase('partnerListPage_hideFilterAndSorting');
+
+        $content = $this->renderHomePage();
+        $this->assertStringNotContainsString('academic-partners-filtersorting', $content);
+        // The list itself is unaffected by hiding the form.
+        $this->assertStringContainsString('Alpha University', $content);
+    }
+
+    #[Test]
+    public function partnerListPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('partnerListPage');
+        $this->setContentElementHeader('Our academic partners');
+
+        $this->assertStringContainsString('Our academic partners', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function partnerListPluginRendersHiddenPartnersWhenConfigured(): void
+    {
+        $this->setUpTestCase('partnerListPage_showHiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Gamma Hidden Partner', $content);
+    }
+
+    #[Test]
+    public function partnerListPluginRestrictsPartnersToTheSelectedPages(): void
+    {
+        $this->setUpTestCase('partnerListPage_pageRestriction');
+
+        $content = $this->renderHomePage();
+        // The `pages` field of the content element restricts by storage page, so only the
+        // partner below the selected folder is left.
+        $this->assertStringContainsString('Delta Regional College', $content);
+        $this->assertStringNotContainsString('Alpha University', $content);
+        $this->assertStringNotContainsString('Beta Institute', $content);
+    }
+
+    #[Test]
+    public function partnerListPluginRendersNoPartnersFoundLabelWithoutPartners(): void
+    {
+        $this->setUpTestCase('partnerListPage_noPartners');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partners-list', $content);
+        $this->assertStringContainsString('No partners found.', $content);
+    }
+
+    #[Test]
+    public function partnerMapPluginRendersPartnersAsMapMarkers(): void
+    {
+        $this->setUpTestCase('partnerMapPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partners-map', $content);
+        $this->assertStringContainsString('id="map-partners"', $content);
+        $this->assertStringContainsString('id="partner-10"', $content);
+        $this->assertStringContainsString('data-lat="48.137154"', $content);
+        $this->assertStringContainsString('data-lng="11.576124"', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringNotContainsString('Gamma Hidden Partner', $content);
+    }
+
+    #[Test]
+    public function partnerMapPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('partnerMapPage');
+        $this->setContentElementHeader('Where our partners are');
+
+        $this->assertStringContainsString('Where our partners are', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function partnershipsListPluginRendersPartnershipsGroupedByRole(): void
+    {
+        $this->setUpTestCase('partnershipsListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partnerships-list', $content);
+        $this->assertStringContainsString('academic-partnerships-list-item', $content);
+        // With a role assigned the partnerships are grouped, and the role name becomes the
+        // heading of each group.
+        $this->assertStringContainsString('Research partner', $content);
+        $this->assertStringContainsString('Funding partner', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Beta Institute', $content);
+        // Grouped items render one heading level below the role heading, which is only the
+        // case when `grouped` reaches `Partner/Header`.
+        $this->assertGroupedPartnerHeading($content);
+    }
+
+    #[Test]
+    public function partnershipsListPluginRendersPartnershipsWithoutRole(): void
+    {
+        $this->setUpTestCase('partnershipsListPage_withoutRoles');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partnerships-list', $content);
+        $this->assertStringContainsString('academic-partnerships-list-item', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Beta Institute', $content);
+        $this->assertStringNotContainsString('Research partner', $content);
+    }
+
+    #[Test]
+    public function partnershipsListPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('partnershipsListPage');
+        $this->setContentElementHeader('Our partnerships');
+
+        $this->assertStringContainsString('Our partnerships', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function partnershipsTeaserPluginRendersPartnershipsGroupedByRole(): void
+    {
+        $this->setUpTestCase('partnershipsTeaserPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partnerships-teaser', $content);
+        $this->assertStringContainsString('academic-partnerships-teaser-item', $content);
+        $this->assertStringContainsString('Research partner', $content);
+        $this->assertStringContainsString('Funding partner', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Beta Institute', $content);
+        $this->assertGroupedPartnerHeading($content);
+    }
+
+    #[Test]
+    public function partnershipsTeaserPluginRendersPartnershipsWithoutRole(): void
+    {
+        $this->setUpTestCase('partnershipsTeaserPage_withoutRoles');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-partnerships-teaser', $content);
+        $this->assertStringContainsString('academic-partnerships-teaser-item', $content);
+        $this->assertStringContainsString('Alpha University', $content);
+        $this->assertStringContainsString('Beta Institute', $content);
+        $this->assertStringNotContainsString('Research partner', $content);
+    }
+
+    #[Test]
+    public function partnershipsTeaserPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('partnershipsTeaserPage');
+        $this->setContentElementHeader('Selected partnerships');
+
+        $this->assertStringContainsString('Selected partnerships', $this->renderHomePage());
+    }
+}

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_list","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_hideFilterAndSorting.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_hideFilterAndSorting.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_list","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">1</value></field><field index=""settings.hideSorting""><value index=""vDEF"">1</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_noPartners.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_noPartners.csv
@@ -1,0 +1,8 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_list","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_pageRestriction.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_pageRestriction.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_list","","3","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerListPage_showHiddenRecords.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_list","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerMapPage.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnerMapPage.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_map","","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsListPage.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsListPage.csv
@@ -1,0 +1,20 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_partnershipslist","","",""
+"tx_academicpartners_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","name","description"
+,1,1,0,0,0,0,16,"Research partner","Joint research and publications."
+,2,1,0,0,0,0,32,"Funding partner","Financial support."
+"tx_academicpartners_domain_model_partnership",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","partner","role"
+,1,1,0,0,0,0,16,2,10,1
+,2,1,0,0,0,0,32,2,11,2

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsListPage_withoutRoles.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsListPage_withoutRoles.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_partnershipslist","","",""
+"tx_academicpartners_domain_model_partnership",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","partner","role"
+,1,1,0,0,0,0,16,2,10,0
+,2,1,0,0,0,0,32,2,11,0

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsTeaserPage.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsTeaserPage.csv
@@ -1,0 +1,20 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_partnershipsteaser","","",""
+"tx_academicpartners_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","name","description"
+,1,1,0,0,0,0,16,"Research partner","Joint research and publications."
+,2,1,0,0,0,0,32,"Funding partner","Financial support."
+"tx_academicpartners_domain_model_partnership",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","partner","role"
+,1,1,0,0,0,0,16,2,10,1
+,2,1,0,0,0,0,32,2,11,2

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsTeaserPage_withoutRoles.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/AcademicPartnersPlugin/partnershipsTeaserPage_withoutRoles.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","description","geocode_latitude","geocode_longitude","show_on_map"
+,1,0,1,0,0,0,0,0,"/","Site Root","","","",1
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","","","",1
+,3,1,254,0,0,0,0,0,"/regional-partners","Regional partners","","","",1
+,10,1,40,0,0,0,0,0,"/alpha-university","Alpha University","Joint research on quantum optics.","48.137154","11.576124",1
+,11,1,40,0,0,0,0,0,"/beta-institute","Beta Institute","Applied materials science.","52.520008","13.404954",1
+,12,1,40,0,1,0,0,0,"/gamma-partner","Gamma Hidden Partner","","","",1
+,13,3,40,0,0,0,0,0,"/delta-regional-college","Delta Regional College","Regional teaching cooperation.","","",1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicpartners_partnershipsteaser","","",""
+"tx_academicpartners_domain_model_partnership",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","partner","role"
+,1,1,0,0,0,0,16,2,10,0
+,2,1,0,0,0,0,32,2,11,0

--- a/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}


### PR DESCRIPTION
Adds frontend rendering tests for all four plugins of
`EXT:academic_partners` — the largest uncovered plugin surface in the
repository (ACE-308).

## What is covered

One test class, 15 tests, for `academicpartners_list`,
`academicpartners_map`, `academicpartners_partnershipslist` and
`academicpartners_partnershipsteaser`. The four plugins share one page
tree, one site and one TypoScript setup, so they share one class and
one fixture directory rather than four.

Per plugin: the expected records render, the content element header
renders, the FlexForm settings the controller actually reads take
effect (hide filter/sorting, show hidden records, restrict to the
selected pages), and an empty result renders its label.

The fixtures model the real record graph: partners are pages of
doktype 40 carrying the partner columns, the partnership plugins take
no FlexForm and resolve their records from the page the content
element sits on (`PartnershipRepository::findByPid()`), including both
the grouped-by-role and the role-less case.

## On the expected TYPO3 v14 header defect

There is none here, and the tests prove it rather than assume it.

The v14 `record` view variable is only needed by a plugin whose own
template renders the `EXT:fluid_styled_content` `Header/All` partial.
These templates render their own `Partner/Header` partial instead, so
the header comes from `lib.contentElement`, which builds the record
itself. The header assertion stays in every test regardless — it is
cheap, and it is the assertion that would catch a regression.

## The template typo the tests surfaced

`PartnershipsTeaser` rendered `Partnerships/Teaser/Item` with a comma
missing between two of the arguments it passes (`settings: settings` /
`grouped: 'true'`). Fluid collects the pairs of an inline array with
`preg_match_all`, so `grouped` arrived regardless — verified on Fluid
4.6 (v13) and 5.3 (v14), and pinned by the heading level the grouped
tests assert.

The second commit adds the comma. The rendered output is therefore
unchanged; what it buys is not depending on that parser detail staying
as forgiving as it is today. No other inline array in any template of
this repository is missing a separator — checked by walking every
multi-line `="{ … }"` block rather than by grep.

## Gates

`cgl -n`, `lintPhp`, `phpstan`, `unit` and the full `functional` suite
run locally for **both** core versions, each after its own
`composerUpdate`, and re-run after the template change:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 484 tests, 2 skipped | 491 tests, 2 skipped |
