### PR TITLE
[TASK] ACE-309: Add programs plugin rendering tests

### DIFF
--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/AcademicProgramsPluginTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/AcademicProgramsPluginTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders both plugins of this extension in the frontend: `academicprograms_programlist`
+ * and `academicprograms_programdetails`. They share one page tree, one site and one
+ * TypoScript setup, which is why they share one test class.
+ *
+ * Programs are pages of doktype 20 mapped onto the `pages` table, so the fixtures are
+ * page records carrying the program columns. The list plugin reads its configuration from
+ * the FlexForm of the content element plus its `pages`/`recursive` fields, while the
+ * details plugin takes no configuration at all and resolves its program from the page the
+ * content element sits on (`DetailsController::showAction()`).
+ */
+final class AcademicProgramsPluginTest extends AbstractAcademicProgramsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicProgramsPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_programs/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_programs/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_programs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    /**
+     * The header of the content element is not part of any template of this extension — it
+     * comes from `lib.contentElement`, which is what `PLUGIN_TYPE_CONTENT_ELEMENT` wires up.
+     * On TYPO3 v14 that header partial renders through the `record` view variable, so this is
+     * the assertion that fails should the plugin ever be registered without it.
+     */
+    private function setContentElementHeader(string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => 1]);
+    }
+
+    private function assertRenderedInOrder(string $content, string $first, string $second): void
+    {
+        $positionOfFirst = strpos($content, $first);
+        $positionOfSecond = strpos($content, $second);
+        $this->assertIsInt($positionOfFirst, sprintf('"%s" is not rendered at all.', $first));
+        $this->assertIsInt($positionOfSecond, sprintf('"%s" is not rendered at all.', $second));
+        $this->assertLessThan(
+            $positionOfSecond,
+            $positionOfFirst,
+            sprintf('"%s" is expected to be rendered before "%s".', $first, $second),
+        );
+    }
+
+    #[Test]
+    public function programListPluginRendersAllVisiblePrograms(): void
+    {
+        $this->setUpTestCase('programListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-programs-list', $content);
+        $this->assertStringContainsString('academic-programs-itemlist', $content);
+        $this->assertStringContainsString('Applied Physics', $content);
+        $this->assertStringContainsString('Molecular Chemistry', $content);
+        // Programs are collected across the whole site, not only below the current page.
+        $this->assertStringContainsString('Regional Teaching', $content);
+        $this->assertStringContainsString('Quantum Optics', $content);
+        $this->assertStringNotContainsString('Archived Studies', $content);
+    }
+
+    #[Test]
+    public function programListPluginLinksEachProgramToItsPage(): void
+    {
+        $this->setUpTestCase('programListPage');
+
+        $this->assertMatchesRegularExpression(
+            '#<h2 class="card-title">\s*<a href="/applied-physics">Applied Physics</a>\s*</h2>#',
+            $this->renderHomePage(),
+        );
+    }
+
+    #[Test]
+    public function programListPluginRendersTheDegreeOfEachProgram(): void
+    {
+        $this->setUpTestCase('programListPage');
+
+        $content = $this->renderHomePage();
+        // The item partial renders the `degree` category type only, which is what makes
+        // the assignment of a single type observable in the list.
+        $this->assertStringContainsString('Bachelor of Science', $content);
+        $this->assertStringContainsString('Master of Science', $content);
+        // Assigned to a program, but of a type the item partial does not render.
+        $this->assertStringNotContainsString('<b>Type of program:</b>', $content);
+    }
+
+    #[Test]
+    public function programListPluginRendersTheFilterAndSortingForm(): void
+    {
+        $this->setUpTestCase('programListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-programs-filtersorting', $content);
+        $this->assertStringContainsString('Sorting field', $content);
+        $this->assertStringContainsString('Sorting direction', $content);
+        // The filter selects are built from the category types applicable to the listed
+        // programs, so both types assigned in the fixture become a filter.
+        $this->assertStringContainsString('id="degree"', $content);
+        $this->assertStringContainsString('id="program_type"', $content);
+    }
+
+    #[Test]
+    public function programListPluginHidesTheFilterAndSortingFormWhenConfigured(): void
+    {
+        $this->setUpTestCase('programListPage_hideFilterAndSorting');
+
+        $content = $this->renderHomePage();
+        $this->assertStringNotContainsString('academic-programs-filtersorting', $content);
+        // The list itself is unaffected by hiding the form.
+        $this->assertStringContainsString('Applied Physics', $content);
+    }
+
+    #[Test]
+    public function programListPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('programListPage');
+        $this->setContentElementHeader('Our study programs');
+
+        $this->assertStringContainsString('Our study programs', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function programListPluginRendersHiddenProgramsWhenConfigured(): void
+    {
+        $this->setUpTestCase('programListPage_showHiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Applied Physics', $content);
+        $this->assertStringContainsString('Archived Studies', $content);
+    }
+
+    #[Test]
+    public function programListPluginSortsProgramsAsConfigured(): void
+    {
+        $this->setUpTestCase('programListPage');
+
+        $this->assertRenderedInOrder($this->renderHomePage(), 'Applied Physics', 'Quantum Optics');
+    }
+
+    #[Test]
+    public function programListPluginSortsProgramsDescendingWhenConfigured(): void
+    {
+        $this->setUpTestCase('programListPage_sortingTitleDescending');
+
+        $this->assertRenderedInOrder($this->renderHomePage(), 'Quantum Optics', 'Applied Physics');
+    }
+
+    #[Test]
+    public function programListPluginRestrictsProgramsToTheSelectedPages(): void
+    {
+        $this->setUpTestCase('programListPage_pageRestriction');
+
+        $content = $this->renderHomePage();
+        // The `pages` field of the content element restricts by storage page, so only the
+        // program directly below the selected page is left.
+        $this->assertStringContainsString('Regional Teaching', $content);
+        $this->assertStringNotContainsString('Applied Physics', $content);
+        $this->assertStringNotContainsString('Molecular Chemistry', $content);
+        // One level deeper, and therefore out of reach without a recursive depth.
+        $this->assertStringNotContainsString('Quantum Optics', $content);
+    }
+
+    #[Test]
+    public function programListPluginIncludesProgramsOfSubPagesWhenRecursive(): void
+    {
+        $this->setUpTestCase('programListPage_pageRestrictionRecursive');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Regional Teaching', $content);
+        // A recursive depth of one adds the sub pages of the selected page, which is where
+        // this program is stored.
+        $this->assertStringContainsString('Quantum Optics', $content);
+        $this->assertStringNotContainsString('Applied Physics', $content);
+    }
+
+    #[Test]
+    public function programListPluginRestrictsProgramsToTheSelectedCategories(): void
+    {
+        $this->setUpTestCase('programListPage_categoryRestriction');
+
+        $content = $this->renderHomePage();
+        // The category selected on the content element is resolved through the relations of
+        // its `pi_flexform` field, so only the program carrying it is listed.
+        $this->assertStringContainsString('Applied Physics', $content);
+        $this->assertStringNotContainsString('Molecular Chemistry', $content);
+        $this->assertStringNotContainsString('Regional Teaching', $content);
+    }
+
+    #[Test]
+    public function programListPluginRendersNoProgramsFoundLabelWithoutPrograms(): void
+    {
+        $this->setUpTestCase('programListPage_noPrograms');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-programs-list', $content);
+        $this->assertStringContainsString('No programs found.', $content);
+    }
+
+    #[Test]
+    public function programDetailsPluginRendersCategoriesOfItsProgramPage(): void
+    {
+        $this->setUpTestCase('programDetailsPage');
+
+        // The details plugin sits on the program page, so that page is the one to request.
+        $content = $this->renderFrontendPage('https://www.acme.com/applied-physics');
+        $this->assertStringContainsString('academic-programs-detail-categories', $content);
+        $this->assertStringContainsString('Degree', $content);
+        $this->assertStringContainsString('Bachelor of Science', $content);
+        $this->assertStringContainsString('Type of program', $content);
+        $this->assertStringContainsString('Full-time', $content);
+        // Assigned to another program only.
+        $this->assertStringNotContainsString('Master of Science', $content);
+    }
+
+    #[Test]
+    public function programDetailsPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('programDetailsPage');
+        $this->setContentElementHeader('Program at a glance');
+
+        $this->assertStringContainsString(
+            'Program at a glance',
+            $this->renderFrontendPage('https://www.acme.com/applied-physics'),
+        );
+    }
+}

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programDetailsPage.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programDetailsPage.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,10,0,0,0,0,"academicprograms_programdetails","","",0,""

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_categoryRestriction.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_categoryRestriction.csv
@@ -1,0 +1,26 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+,1,1,"tt_content","pi_flexform",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">1</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_hideFilterAndSorting.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_hideFilterAndSorting.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">1</value></field><field index=""settings.hideSorting""><value index=""vDEF"">1</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_noPrograms.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_noPrograms.csv
@@ -1,0 +1,20 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_pageRestriction.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_pageRestriction.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","3",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_pageRestrictionRecursive.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_pageRestrictionRecursive.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","3",1,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_showHiddenRecords.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_sortingTitleDescending.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/AcademicProgramsPlugin/programListPage_sortingTitleDescending.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","abstract","credit_points","categories"
+,1,0,1,0,0,0,0,0,"/","Site Root","",0,0
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",0,0
+,3,1,1,0,0,0,0,0,"/departments","Departments","",0,0
+,4,3,1,0,0,0,0,0,"/departments/physics","Physics Department","",0,0
+,5,1,254,0,0,0,0,0,"/categories","Categories","",0,0
+,10,1,20,0,0,0,0,0,"/applied-physics","Applied Physics","Optics, photonics and applied quantum mechanics.",180,2
+,11,1,20,0,0,0,0,0,"/molecular-chemistry","Molecular Chemistry","Synthesis and analysis of molecular structures.",120,1
+,12,1,20,0,1,0,0,0,"/archived-studies","Archived Studies","",0,0
+,13,3,20,0,0,0,0,0,"/regional-teaching","Regional Teaching","Teaching degree offered with regional partners.",240,0
+,14,4,20,0,0,0,0,0,"/quantum-optics","Quantum Optics","Research oriented specialisation.",120,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"degree","Bachelor of Science",0,0
+,2,5,0,0,0,"degree","Master of Science",0,0
+,3,5,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,3,10,"pages","categories",0,2
+,2,11,"pages","categories",0,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","recursive","pi_flexform"
+,1,2,0,0,0,0,"academicprograms_programlist","","",0,"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideFilter""><value index=""vDEF"">0</value></field><field index=""settings.hideSorting""><value index=""vDEF"">0</value></field><field index=""settings.sorting""><value index=""vDEF"">title desc</value></field><field index=""settings.categories""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
@@ -218,10 +218,9 @@ class CategoryRepository
 
         $categoryCollection = $this->categoryCollectionFactory->createCategoryCollection($group);
 
-        if ($result->rowCount() === 0) {
-            return $categoryCollection;
-        }
-
+        // No early return on `rowCount()`: for a SELECT statement that value is
+        // driver dependent, and SQLite reports 0 for a result that does carry rows.
+        // Iterating the result is the only portable way to tell it is empty.
         foreach ($result->fetchAllAssociative() as $row) {
             $category = $this->buildCategoryObjectFromArray($group, $row);
             $categoryCollection->attach($category);


### PR DESCRIPTION
Adds frontend rendering tests for both plugins of `EXT:academic_programs`
(ACE-309) — and fixes a defect they turned up (ACE-314).

## What is covered

One test class, 15 tests, for `academicprograms_programlist` and
`academicprograms_programdetails`. Both plugins share one page tree, one
site and one TypoScript setup, so they share one class and one fixture
directory.

Per plugin: the expected programs render and link to their page, the
content element header renders, and the settings the controller actually
reads take effect — hiding the filter and sorting form, showing hidden
records, the configured sorting field and direction, the storage page
restriction with and without a recursive depth, the categories selected
on the content element, and the empty result label.

The fixtures model the real record graph: programs are pages of doktype
20 carrying the program columns, categories are `sys_category` records of
the `programs` group wired through `sys_category_record_mm`. The details
plugin takes no FlexForm and resolves its program from the page the
content element sits on, so its test requests the program page rather
than the page carrying a list.

## On the expected TYPO3 v14 header defect

There is none here, and the tests prove it rather than assume it — the
third extension in this series where that holds.

The v14 `record` view variable is only needed by a plugin whose own
template renders the `EXT:fluid_styled_content` `Header/All` partial.
These templates render their own `Program/Header` partial instead, so the
header comes from `lib.contentElement`, which builds the record itself.
The header assertion stays in every test regardless.

## The defect the tests found — ACE-314

`CategoryRepository::getByDatabaseFields()` in `EXT:category_types`
returned early on `Result::rowCount() === 0`. For a SELECT statement that
value is driver dependent, and **SQLite reports 0 for a result that does
carry rows** — measured: 0 reported for a query returning 3 rows. The
method therefore always returned an empty collection on SQLite.

Effect: any plugin that resolves its categories from the relations of a
content element field silently lost its filter. A program list
configured to show a single category showed every program instead.

Verified from both ends rather than reasoned about:

* the new `programListPluginRestrictsProgramsToTheSelectedCategories`
  test fails on SQLite without the fix,
* and passes on MariaDB 10.4 and PostgreSQL 10 **with the unpatched
  code**, which is what makes this driver specific rather than generally
  broken.

The check was redundant anyway — iterating the result already yields
nothing when it is empty, and that is the only portable way to tell. The
other three query methods of the class never had it, and this was the
only `rowCount()` call in the repository.

The fix is tracked as **ACE-314**, and travels with these tests because
ACE-309's category test cannot pass without it. Two things it
deliberately leaves open:

* branch `2` carries the identical line 221, so that backport is still
  outstanding and stays on ACE-314;
* a repository-level regression test in `EXT:category_types` would need a
  fixture extension there, since the extension registers no category
  group of its own. The guard today is the plugin test above.

## Also noticed, not touched

`Build/Scripts/runTests.sh` shuts down `mysql-func-${SUFFIX}` in the
**mariadb** branch (line 613 on `main`, 619 on `2`), so every mariadb
functional run prints `no container with name or ID "mysql-func-…"` and
then sleeps 10 seconds for a shutdown that never happened. Harmless to
results, but it is 8 CI jobs paying 10 seconds and an alarming log line.
The `mysql` branch has no such shutdown at all, so the pair looks like
leftovers.

## Gates

`cgl`, `lintPhp`, `phpstan`, `unit` and the full `functional` suite run
locally for **both** core versions, each after its own `composerUpdate`:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 499 tests, 2 skipped | 506 tests, 2 skipped |

Plus the two cross-DBMS runs described above, on v13 with MariaDB 10.4
and PostgreSQL 10.
