### PR TITLE
[BUGFIX] ACE-314: Fix category filter on SQLite

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
@@ -218,10 +218,9 @@ class CategoryRepository
 
         $categoryCollection = $this->categoryCollectionFactory->createCategoryCollection($group);
 
-        if ($result->rowCount() === 0) {
-            return $categoryCollection;
-        }
-
+        // No early return on `rowCount()`: for a SELECT statement that value is
+        // driver dependent, and SQLite reports 0 for a result that does carry rows.
+        // Iterating the result is the only portable way to tell it is empty.
         foreach ($result->fetchAllAssociative() as $row) {
             $category = $this->buildCategoryObjectFromArray($group, $row);
             $categoryCollection->attach($category);


### PR DESCRIPTION
Backport of #371's second commit to branch `2` (ACE-314).

## The defect

`CategoryRepository::getByDatabaseFields()` in `EXT:category_types`
returned early on `Result::rowCount() === 0`. For a **SELECT** statement
that value is driver dependent, and SQLite reports `0` for a result that
does carry rows — measured on `main`: `0` reported for a query returning
3 rows. The method therefore always returned an empty collection on
SQLite.

Effect: any plugin that resolves its categories from the relations of a
content element field silently lost its filter. An
`academicprograms_programlist` element configured to show a single
category showed every program instead. No error, no log entry.

The check was redundant anyway — iterating the result already yields
nothing when it is empty, and that is the only portable way to tell. The
other three query methods of the class never had it, and this was the
only `rowCount()` call in the repository on this branch too.

## What is *not* in this backport

The rendering test that surfaced the defect. It belongs to ACE-309 and
depends on the plugin rendering test harness of ACE-305, and neither
exists on branch `2` — so this branch keeps the fix without a regression
guard of its own. That is a known gap, recorded on ACE-314.

Consequently the evidence for this change is the `main` side: the ACE-309
test fails on SQLite without it, and passes on MariaDB 10.4 and
PostgreSQL 10 with the unpatched code. Here the change is verified only
as "changes nothing that is covered" — see the gates below.

## Gates

Run locally for **both** core versions this branch supports, each after
its own `composerUpdate`, using this branch's own matrix pairing:

| | TYPO3 v12 (PHP 8.1) | TYPO3 v13 (PHP 8.2) |
|---|---|---|
| cgl -n | pass | — (v12 only in CI) |
| lintPhp | pass | — (version independent) |
| phpstan | pass | pass |
| unit | pass | pass |
| functional | 434 tests, 2 skipped | 434 tests, 2 skipped |
