### PR TITLE
[TASK] ACE-310: Add jobs plugin rendering tests

### DIFF
--- a/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+++ b/packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
@@ -73,6 +73,16 @@ final class JobController extends ActionController
 
     public function showAction(?Job $job = null): ResponseInterface
     {
+        // Assigned before the early return below: the template renders the
+        // `EXT:fluid_styled_content` header partial in both cases, and on TYPO3 v14 that
+        // partial resolves the header through `record`. Leaving it unassigned made a
+        // request without a resolvable job fail with an exception instead of rendering the
+        // "not found" message.
+        $this->view->assignMultiple([
+            'data' => $this->getCurrentContentObjectRenderer()?->data,
+            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
+        ]);
+
         if ($job === null) {
             $this->addFlashMessage(
                 $this->translateAlert('job_not_found.body', 'Job not found.'),
@@ -107,11 +117,7 @@ final class JobController extends ActionController
 
         $this->setMetaTags($metaTags);
 
-        $this->view->assignMultiple([
-            'job' => $job,
-            'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'record' => $this->getCurrentContentRecord($this->getCurrentContentObjectRenderer()),
-        ]);
+        $this->view->assign('job', $job);
 
         return $this->htmlResponse();
     }

--- a/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Contact.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Contact.html
@@ -10,9 +10,9 @@
         partial="Job/SectionHeader"
         arguments="{
             header: '{f:translate(key: \'jobs.contact\', extensionName: \'academic_jobs\')}',
-            layout: 'data.header_layout',
+            layout: data.header_layout,
             positionClass: 'contact-title',
-            subheader: 'data.subheader',
+            subheader: data.subheader,
         }"
     />
 

--- a/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Item.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Item.html
@@ -20,7 +20,7 @@
                         pageUid: settings.detailPid,
                         arguments: {job: job}
                     )}',
-                    subheader: 'data.subheader'
+                    subheader: data.subheader
                 }"
             />
         </div>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Templates/Job/Show.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Templates/Job/Show.html
@@ -34,7 +34,7 @@
             }"
         />
 
-        <f:variable name="contact" value="{f:if(condition: job.contactName || job.contactEmail || job.contactPhone)}"/>
+        <f:variable name="contact" value="{f:if(condition: '{job.contactName} || {job.contactEmail} || {job.contactPhone}', then: 1, else: 0)}"/>
 
         <div class="row">
             <div class="col-12 {f:if(condition: contact, then: 'col-lg-8')}">

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsListAndDetailPluginTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsListAndDetailPluginTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academicjobs_list` and `academicjobs_detail` plugins in the frontend.
+ *
+ * Both plugins share one page tree and one class, because the detail plugin is reached
+ * through the link the list plugin renders: `showAction()` takes a `job` argument, so its
+ * URI carries a cHash and is not something a test should assemble by hand.
+ *
+ * Unlike the other extensions of this repository, these templates render the
+ * `EXT:fluid_styled_content` `Header/All` partial themselves. On TYPO3 v14 that partial
+ * resolves the header through the `record` view variable, which an Extbase view does not
+ * assign on its own — `JobController` does it explicitly via
+ * `GetCurrentContentRecordMethodTrait`. The header assertions here are what keeps that
+ * working.
+ */
+final class AcademicJobsListAndDetailPluginTest extends AbstractAcademicJobsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    private const LIST_CONTENT_ELEMENT = 1;
+    private const DETAIL_CONTENT_ELEMENT = 2;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicJobsListAndDetailPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_jobs/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/ListAndDetailConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_jobs/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderListPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function setContentElementHeader(int $uid, string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => $uid]);
+    }
+
+    /**
+     * Takes the detail link the list plugin rendered for a job and requests it. Extracting
+     * it instead of building it keeps the cHash valid and makes the list plugin's own link
+     * generation part of what the detail tests cover.
+     */
+    private function renderDetailPageOfJob(string $listContent, int $jobUid): string
+    {
+        $pattern = sprintf(
+            '#href="(?P<uri>[^"]*tx_academicjobs_detail%%5Bjob%%5D=%d[^"]*)"#',
+            $jobUid,
+        );
+        $this->assertMatchesRegularExpression(
+            $pattern,
+            $listContent,
+            sprintf('The list plugin rendered no detail link for job %d.', $jobUid),
+        );
+        preg_match($pattern, $listContent, $matches);
+        $uri = htmlspecialchars_decode($matches['uri']);
+
+        return $this->renderFrontendPage('https://www.acme.com' . $uri);
+    }
+
+    #[Test]
+    public function listPluginRendersAllVisibleJobs(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderListPage();
+        $this->assertStringContainsString('academic-jobs-list', $content);
+        $this->assertStringContainsString('academic-jobs-itemlist', $content);
+        $this->assertStringContainsString('Research Assistant Position', $content);
+        $this->assertStringContainsString('Student Assistant Sidejob', $content);
+        $this->assertStringContainsString('Master Thesis Topic', $content);
+        $this->assertStringNotContainsString('Archived Position', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('jobPages');
+        $this->setContentElementHeader(self::LIST_CONTENT_ELEMENT, 'Open positions');
+
+        $this->assertStringContainsString('Open positions', $this->renderListPage());
+    }
+
+    #[Test]
+    public function listPluginRendersThePropertiesOfEachJob(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderListPage();
+        $this->assertStringContainsString('Organization:', $content);
+        $this->assertStringContainsString('Acme University', $content);
+        $this->assertStringContainsString('Location:', $content);
+        $this->assertStringContainsString('Munich', $content);
+        // `type` and `employmentType` render through their own label keys rather than the
+        // stored integer.
+        $this->assertStringContainsString('Type of job:', $content);
+        $this->assertStringContainsString('Working hours:', $content);
+        $this->assertStringContainsString('Full-Time', $content);
+        $this->assertStringContainsString('Part-Time', $content);
+        $this->assertStringNotContainsString('jobs.type.1', $content);
+    }
+
+    #[Test]
+    public function listPluginRestrictsJobsToTheConfiguredJobType(): void
+    {
+        $this->setUpTestCase('jobPages_jobTypeFilter');
+
+        $content = $this->renderListPage();
+        $this->assertStringContainsString('Student Assistant Sidejob', $content);
+        $this->assertStringNotContainsString('Research Assistant Position', $content);
+        $this->assertStringNotContainsString('Master Thesis Topic', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersHiddenJobsWhenConfigured(): void
+    {
+        $this->setUpTestCase('jobPages_showHiddenRecords');
+
+        $content = $this->renderListPage();
+        $this->assertStringContainsString('Research Assistant Position', $content);
+        $this->assertStringContainsString('Archived Position', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersAnEmptyItemListWithoutJobs(): void
+    {
+        $this->setUpTestCase('jobPages_noJobs');
+
+        $content = $this->renderListPage();
+        // This extension has no "nothing found" label — the item list stays empty, and the
+        // plugin still has to render rather than fail.
+        $this->assertStringContainsString('academic-jobs-itemlist', $content);
+        $this->assertStringNotContainsString('academic-jobs-item"', $content);
+    }
+
+    #[Test]
+    public function listPluginLinksEachJobToTheDetailPage(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderListPage();
+        $this->assertStringContainsString('/job-detail?', $content);
+        $this->assertStringContainsString('tx_academicjobs_detail%5Bjob%5D=1', $content);
+        // A plugin argument only survives the frontend cache when the URI carries a cHash.
+        $this->assertStringContainsString('cHash=', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersItemHeadingLevelAccordingToHeaderLayout(): void
+    {
+        $this->setUpTestCase('jobPages_headerLayout');
+
+        // Header layout 1 without a subheader is the "one level up" case of the heading
+        // partial, so the item title has to be an `h2`.
+        $this->assertMatchesRegularExpression(
+            '#<h2 class="card-title">\s*<a href="[^"]*tx_academicjobs_detail[^"]*">Research Assistant Position</a>\s*</h2>#',
+            $this->renderListPage(),
+        );
+    }
+
+    #[Test]
+    public function detailPluginRendersTheRequestedJob(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderDetailPageOfJob($this->renderListPage(), 1);
+        $this->assertStringContainsString('academic-jobs-detail', $content);
+        $this->assertStringContainsString('Research Assistant Position', $content);
+        $this->assertStringContainsString('Join our quantum optics group.', $content);
+        // Another job of the same list must not leak into the detail view.
+        $this->assertStringNotContainsString('Student Assistant Sidejob', $content);
+    }
+
+    #[Test]
+    public function detailPluginRendersTheJobTitleAsFirstLevelHeading(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        // The detail view passes `detail` to the heading partial, which is the only place
+        // rendering an `h1`.
+        $this->assertMatchesRegularExpression(
+            '#<h1[^>]*>\s*Research Assistant Position\s*</h1>#',
+            $this->renderDetailPageOfJob($this->renderListPage(), 1),
+        );
+    }
+
+    #[Test]
+    public function detailPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('jobPages');
+        $this->setContentElementHeader(self::DETAIL_CONTENT_ELEMENT, 'Job description');
+
+        $this->assertStringContainsString(
+            'Job description',
+            $this->renderDetailPageOfJob($this->renderListPage(), 1),
+        );
+    }
+
+    #[Test]
+    public function detailPluginRendersContactInformationOfTheJob(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderDetailPageOfJob($this->renderListPage(), 1);
+        $this->assertStringContainsString('academic-jobs-contact', $content);
+        $this->assertStringContainsString('Dr. Ada Lovelace', $content);
+        $this->assertStringContainsString('href="tel:+49 89 1234"', $content);
+        $this->assertStringContainsString('ada@example.org', $content);
+    }
+
+    #[Test]
+    public function detailPluginOmitsContactBlockForJobWithoutContact(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderDetailPageOfJob($this->renderListPage(), 2);
+        $this->assertStringContainsString('Student Assistant Sidejob', $content);
+        $this->assertStringNotContainsString('academic-jobs-contact', $content);
+    }
+
+    #[Test]
+    public function detailPluginRendersContactSectionHeadingAccordingToHeaderLayout(): void
+    {
+        $this->setUpTestCase('jobPages_headerLayout');
+
+        $content = $this->renderDetailPageOfJob($this->renderListPage(), 1);
+        // Header layout 1 without a subheader renders the section heading as `h3` — one
+        // level below the `h2` of the default layout.
+        $this->assertMatchesRegularExpression(
+            '#<h3 class="contact-title">\s*Contact\s*</h3>#',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function detailPluginRendersBackLinkToTheConfiguredListPage(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        $content = $this->renderDetailPageOfJob($this->renderListPage(), 1);
+        $this->assertMatchesRegularExpression(
+            '#<a href="/home">\s*Back to job list\s*</a>#',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function detailPluginRendersNotFoundMessageWithoutJobArgument(): void
+    {
+        $this->setUpTestCase('jobPages');
+
+        // Requesting the detail page without the plugin argument is what a stale bookmark
+        // looks like: the plugin has to answer with its flash message, not with an error.
+        $content = $this->renderFrontendPage('https://www.acme.com/job-detail');
+        $this->assertStringContainsString('academic-jobs-detail', $content);
+        $this->assertStringContainsString('No job advert could be found.', $content);
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/job-detail","Job detail"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicjobs_domain_model_job",
+,"uid","pid","sys_language_uid","hidden","deleted","starttime","endtime","type","employment_type","title","slug","description","company_name","work_location","contact_name","contact_email","contact_phone"
+,1,100,0,0,0,0,0,1,1,"Research Assistant Position","research-assistant-position","<p>Join our quantum optics group.</p>","Acme University","Munich","Dr. Ada Lovelace","ada@example.org","+49 89 1234"
+,2,100,0,0,0,0,0,2,2,"Student Assistant Sidejob","student-assistant-sidejob","<p>Support our lab courses.</p>","Acme University","Munich","","",""
+,3,100,0,0,0,0,0,3,0,"Master Thesis Topic","master-thesis-topic","<p>Thesis on photonic crystals.</p>","Acme Institute","Berlin","","",""
+,4,100,0,1,0,0,0,1,1,"Archived Position","archived-position","<p>No longer offered.</p>","Acme University","Munich","","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","header_layout","subheader","pi_flexform"
+,1,2,0,0,0,0,"academicjobs_list","",0,"","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.job.type""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicjobs_detail","",0,"",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_headerLayout.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_headerLayout.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/job-detail","Job detail"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicjobs_domain_model_job",
+,"uid","pid","sys_language_uid","hidden","deleted","starttime","endtime","type","employment_type","title","slug","description","company_name","work_location","contact_name","contact_email","contact_phone"
+,1,100,0,0,0,0,0,1,1,"Research Assistant Position","research-assistant-position","<p>Join our quantum optics group.</p>","Acme University","Munich","Dr. Ada Lovelace","ada@example.org","+49 89 1234"
+,2,100,0,0,0,0,0,2,2,"Student Assistant Sidejob","student-assistant-sidejob","<p>Support our lab courses.</p>","Acme University","Munich","","",""
+,3,100,0,0,0,0,0,3,0,"Master Thesis Topic","master-thesis-topic","<p>Thesis on photonic crystals.</p>","Acme Institute","Berlin","","",""
+,4,100,0,1,0,0,0,1,1,"Archived Position","archived-position","<p>No longer offered.</p>","Acme University","Munich","","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","header_layout","subheader","pi_flexform"
+,1,2,0,0,0,0,"academicjobs_list","",1,"","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.job.type""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicjobs_detail","",1,"",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_jobTypeFilter.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_jobTypeFilter.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/job-detail","Job detail"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicjobs_domain_model_job",
+,"uid","pid","sys_language_uid","hidden","deleted","starttime","endtime","type","employment_type","title","slug","description","company_name","work_location","contact_name","contact_email","contact_phone"
+,1,100,0,0,0,0,0,1,1,"Research Assistant Position","research-assistant-position","<p>Join our quantum optics group.</p>","Acme University","Munich","Dr. Ada Lovelace","ada@example.org","+49 89 1234"
+,2,100,0,0,0,0,0,2,2,"Student Assistant Sidejob","student-assistant-sidejob","<p>Support our lab courses.</p>","Acme University","Munich","","",""
+,3,100,0,0,0,0,0,3,0,"Master Thesis Topic","master-thesis-topic","<p>Thesis on photonic crystals.</p>","Acme Institute","Berlin","","",""
+,4,100,0,1,0,0,0,1,1,"Archived Position","archived-position","<p>No longer offered.</p>","Acme University","Munich","","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","header_layout","subheader","pi_flexform"
+,1,2,0,0,0,0,"academicjobs_list","",0,"","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.job.type""><value index=""vDEF"">2</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicjobs_detail","",0,"",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_noJobs.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_noJobs.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/job-detail","Job detail"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","header_layout","subheader","pi_flexform"
+,1,2,0,0,0,0,"academicjobs_list","",0,"","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.job.type""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicjobs_detail","",0,"",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/AcademicJobsListAndDetailPlugin/jobPages_showHiddenRecords.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/job-detail","Job detail"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicjobs_domain_model_job",
+,"uid","pid","sys_language_uid","hidden","deleted","starttime","endtime","type","employment_type","title","slug","description","company_name","work_location","contact_name","contact_email","contact_phone"
+,1,100,0,0,0,0,0,1,1,"Research Assistant Position","research-assistant-position","<p>Join our quantum optics group.</p>","Acme University","Munich","Dr. Ada Lovelace","ada@example.org","+49 89 1234"
+,2,100,0,0,0,0,0,2,2,"Student Assistant Sidejob","student-assistant-sidejob","<p>Support our lab courses.</p>","Acme University","Munich","","",""
+,3,100,0,0,0,0,0,3,0,"Master Thesis Topic","master-thesis-topic","<p>Thesis on photonic crystals.</p>","Acme Institute","Berlin","","",""
+,4,100,0,1,0,0,0,1,1,"Archived Position","archived-position","<p>No longer offered.</p>","Acme University","Munich","","",""
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","header_layout","subheader","pi_flexform"
+,1,2,0,0,0,0,"academicjobs_list","",0,"","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.job.type""><value index=""vDEF"">0</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicjobs_detail","",0,"",""

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/ListAndDetailConfiguration.typoscript
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/ListAndDetailConfiguration.typoscript
@@ -1,0 +1,9 @@
+plugin.tx_academicjobs {
+    persistence {
+        storagePid = 100
+    }
+    # The list plugin builds its detail links against this page, and the detail
+    # plugin renders a "back to list" link when a list page is configured.
+    detailPid = 3
+    listPid = 2
+}


### PR DESCRIPTION
Adds frontend rendering tests for the two uncovered plugins of
`EXT:academic_jobs` (ACE-310) — and fixes the two defects they found
(ACE-315, ACE-316).

This is the first extension of the series where the TYPO3 v14 `record`
gap is **real**: unlike partners, programs and projects, these templates
render the `EXT:fluid_styled_content` `Header/All` partial themselves.

## What is covered

One test class, 16 tests, for `academicjobs_list` and
`academicjobs_detail`, next to the existing `academicjobs_newjobform`
one. Both plugins share the class and the page tree because the detail
plugin is reached through the link the list plugin renders:
`showAction()` has a `job` argument, so its URI carries a cHash that a
test should not assemble by hand. Extracting the rendered link instead
makes the list plugin's own link generation part of what the detail tests
cover.

List: the visible jobs, the job properties and their label keys (not the
stored integers), the configured job type restriction, showing hidden
records, an empty list without jobs, the detail link including its cHash,
and the item heading level for a content element header layout.

Detail: the requested job and only that one, the title as first level
heading, the contact block including its **absence** for a job without
contact data, the section heading level, the back link to the configured
list page, and the "not found" message for a request without a
resolvable job.

## ACE-315 — the v14 crash this series was written to find

`JobController::showAction()` returned early when no job could be
resolved, leaving the view without `data` and `record`. `Show.html`
renders the FSC header partial on that path too, and on v14 that partial
resolves the header through `{record -> f:render.text(...)}`:

```
InvalidArgumentValueException
The record argument must be an instance of … Given: null
```

So on TYPO3 v14 a stale bookmark, a link that lost its query string, or a
job deleted meanwhile **failed the whole page** instead of rendering "No
job advert could be found." TYPO3 v13 reads `data` there, so the omission
was invisible — no other gate in this repository could have caught it.

`main` only: branch `2` is v12+v13, whose partial reads `data`.

The same pattern was swept across every controller using
`GetCurrentContentRecordMethodTrait`, and the sweep was first checked
against the unfixed file so it was not vacuous: `showAction()` was the
only occurrence.

## ACE-316 — three template arguments that were literal strings

| File | Argument | Effect |
|---|---|---|
| `Partials/Job/Item.html` | `subheader: 'data.subheader'` | always truthy → every list item one heading level too deep for header layouts 1–4 |
| `Partials/Job/Contact.html` | `layout: 'data.header_layout'` | no `f:case` matches a literal → section heading always falls through to the default case |
| `Partials/Job/Contact.html` | `subheader: 'data.subheader'` | same as the first |
| `Templates/Job/Show.html` | inline `f:if` condition without braces | condition never evaluated as boolean → **empty grey contact box** rendered for a job with no contact data, and the description column narrowed to make room for it |

Adding only `then`/`else` to that condition does **not** help — verified,
the box still rendered. The missing brace interpolation is the cause.

Both patterns were swept across every template in the repository, each
detector first verified against the unfixed file:

* quoted variable paths in inline arguments, excluding keys that are
  literal by design (`key`, `format`, `positionClass`, …): **3
  occurrences**, all above, all in this extension;
* inline `condition:` using `||`/`&&` without braces: **1 occurrence**,
  the one above.

Branch `2` carries all four lines identically, so that backport is
outstanding and stays on ACE-316. It will land there without a regression
test, since the ACE-305 harness does not exist on that branch.

## Also fixed in passing

`jobPages_noJobs.csv` declares no job table at all rather than an empty
one — a table block with a header and no rows makes the testing framework
emit `foreach() argument must be of type array|object, null given`.

## Gates

`cgl`, `lintPhp`, `phpstan`, `unit` and the full `functional` suite run
locally for **both** core versions, each after its own `composerUpdate`:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 515 tests, 2 skipped | 522 tests, 2 skipped |

Each of the four fixed defects was confirmed to fail before its fix and
pass after, on both core versions where applicable — ACE-315 only fails
on v14, which is the point of it.
