### PR TITLE
[BUGFIX] ACE-316: Fix literal args in jobs templates

### DIFF
--- a/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Contact.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Contact.html
@@ -10,9 +10,9 @@
         partial="Job/SectionHeader"
         arguments="{
             header: '{f:translate(key: \'jobs.contact\', extensionName: \'academic_jobs\')}',
-            layout: 'data.header_layout',
+            layout: data.header_layout,
             positionClass: 'contact-title',
-            subheader: 'data.subheader',
+            subheader: data.subheader,
         }"
     />
 

--- a/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Item.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Partials/Job/Item.html
@@ -20,7 +20,7 @@
                         pageUid: settings.detailPid,
                         arguments: {job: job}
                     )}',
-                    subheader: 'data.subheader'
+                    subheader: data.subheader
                 }"
             />
         </div>

--- a/packages/fgtclb/academic-jobs/Resources/Private/Templates/Job/Show.html
+++ b/packages/fgtclb/academic-jobs/Resources/Private/Templates/Job/Show.html
@@ -34,7 +34,7 @@
             }"
         />
 
-        <f:variable name="contact" value="{f:if(condition: job.contactName || job.contactEmail || job.contactPhone)}"/>
+        <f:variable name="contact" value="{f:if(condition: '{job.contactName} || {job.contactEmail} || {job.contactPhone}', then: 1, else: 0)}"/>
 
         <div class="row">
             <div class="col-12 {f:if(condition: contact, then: 'col-lg-8')}">


### PR DESCRIPTION
Backport of #373's third commit to branch `2` (ACE-316).

## The defects

Three template arguments of `EXT:academic_jobs` were written as quoted
literals where a variable is meant, so they never carried a value:

| File | Argument | Effect |
|---|---|---|
| `Partials/Job/Item.html` | `subheader: 'data.subheader'` | always truthy → every list item one heading level too deep for header layouts 1–4 |
| `Partials/Job/Contact.html` | `layout: 'data.header_layout'` | no `f:case` matches a literal → section heading always falls through to the default case |
| `Partials/Job/Contact.html` | `subheader: 'data.subheader'` | as the first |
| `Templates/Job/Show.html` | inline `f:if` condition without braces | condition never evaluated as boolean → **empty grey contact box** for a job with no contact data, plus the description column narrowed to make room for it |

Adding only `then`/`else` to that condition does **not** help — verified
on `main`, the box still rendered. The missing brace interpolation is the
cause, so the condition is now written the way the working `f:if` further
down the same file already is.

Both patterns were swept across every template of this branch, each
detector first verified against the unfixed files so a clean result meant
something: **no other occurrence remains on `2`**.

## What is *not* in this backport

The regression tests. They belong to ACE-310 and build on the plugin
rendering harness of ACE-305, and neither exists on branch `2` — so this
branch gets the fix without a guard of its own. That is a known gap,
recorded on ACE-316.

The evidence is therefore the `main` side, where three assertions of
`AcademicJobsListAndDetailPluginTest` each fail without their
corresponding fix on both core versions. Here the change is verified only
as "changes nothing that is covered", plus the identical diff — see the
gates below.

Also **not** included: the ACE-315 controller fix from the same pull
request. That one addresses a TYPO3 v14 only crash and does not apply to
this branch, which supports v12 and v13.

## Gates

Run locally for both core versions this branch supports, each after its
own `composerUpdate`, using this branch's own matrix pairing:

| | TYPO3 v12 (PHP 8.1) | TYPO3 v13 (PHP 8.2) |
|---|---|---|
| cgl -n | pass | — (v12 only in CI) |
| lintPhp | pass | — (version independent) |
| phpstan | pass | pass |
| unit | 90 tests | 90 tests |
| functional | 434 tests, 2 skipped | 434 tests, 2 skipped |
