### PR TITLE
[TASK] ACE-311: Add contacts4pages plugin test

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/AcademicContacts4PagesListPluginTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/AcademicContacts4PagesListPluginTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academiccontacts4pages_list` plugin in the frontend.
+ *
+ * The plugin has no record selection of its own: `ContactRepository::findByPid()` matches
+ * the `page` field of a contact against the page the content element sits on, with the
+ * storage page deliberately ignored. Each contact points at an `EXT:academic_persons`
+ * contract, which points at a profile, and the template renders that profile through the
+ * `Profile/Item` partial of that extension — so the fixtures carry all three tables.
+ *
+ * The content element header is not part of this template. It comes from
+ * `lib.contentElement`, which `PLUGIN_TYPE_CONTENT_ELEMENT` wires up, and on TYPO3 v14 it
+ * renders through the `record` view variable — which is what the header assertion covers.
+ */
+final class AcademicContacts4PagesListPluginTest extends AbstractAcademicContacts4PagesTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicContacts4PagesListPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/constants.typoscript',
+                    'EXT:academic_contacts4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:academic_contacts4pages/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_contacts4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function setContentElementHeader(string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => 1]);
+    }
+
+    /**
+     * The item partial composes the heading from first, middle and last name, so an empty
+     * middle name leaves two spaces in the markup. Matching on `\s+` asserts the rendered
+     * name without depending on that spacing.
+     */
+    private function assertRendersProfileName(string $content, string $first, string $last): void
+    {
+        $this->assertMatchesRegularExpression(
+            sprintf('#%s\s+%s#u', preg_quote($first, '#'), preg_quote($last, '#')),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function listPluginRendersContactsGroupedByRole(): void
+    {
+        $this->setUpTestCase('contactsListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-contacts4pages', $content);
+        // Each role becomes the heading of its own group.
+        $this->assertStringContainsString('Dean&#039;s Office', $content);
+        $this->assertStringContainsString('Student Advisors', $content);
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Horst', 'Huber');
+        $this->assertRendersProfileName($content, 'Erika', 'Beispiel');
+    }
+
+    #[Test]
+    public function listPluginRendersGroupedContactsOneHeadingLevelDown(): void
+    {
+        $this->setUpTestCase('contactsListPage');
+
+        // A grouped contact renders through `Profile/SectionHeader`, which is one level
+        // below the `Profile/Header` an ungrouped one gets. Asserting the level is what
+        // proves `groupedProfiles` arrives in the partial.
+        $this->assertMatchesRegularExpression(
+            '#<h3 class="card-title">\s*<a href="[^"]*">Max\s+Müllermann</a>\s*</h3>#',
+            $this->renderHomePage(),
+        );
+    }
+
+    #[Test]
+    public function listPluginRendersContactsWithoutRole(): void
+    {
+        $this->setUpTestCase('contactsListPage_withoutRoles');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-contacts4pages', $content);
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Horst', 'Huber');
+        $this->assertStringNotContainsString('Dean&#039;s Office', $content);
+        // Without a role the flat branch renders, which uses `Profile/Header` and
+        // therefore one heading level higher.
+        $this->assertMatchesRegularExpression(
+            '#<h2 class="card-title">\s*<a href="[^"]*">Max\s+Müllermann</a>\s*</h2>#',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function listPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('contactsListPage');
+        $this->setContentElementHeader('Your contacts');
+
+        $this->assertStringContainsString('Your contacts', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function listPluginRendersTheContractDataOfEachContact(): void
+    {
+        $this->setUpTestCase('contactsListPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Professor', $content);
+        // A contract location is a relation, so the partial has to render its title
+        // rather than the object.
+        $this->assertStringContainsString('Main Campus', $content);
+        $this->assertStringNotContainsString('Domain\\Model\\Location', $content);
+        $this->assertStringContainsString('A 101', $content);
+        $this->assertStringContainsString('Lecturer', $content);
+    }
+
+    #[Test]
+    public function listPluginLinksEachContactToTheConfiguredDetailPage(): void
+    {
+        $this->setUpTestCase('contactsListPage');
+
+        $this->assertStringContainsString('href="/profiles?tx_academicpersons_detail', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function listPluginOnlyRendersContactsOfItsOwnPage(): void
+    {
+        $this->setUpTestCase('contactsListPage_onlyForeignContacts');
+
+        $content = $this->renderHomePage();
+        // The single contact of the fixture belongs to another page, so the plugin renders
+        // its wrapper and nothing else.
+        $this->assertStringContainsString('academic-contacts4pages', $content);
+        $this->assertStringNotContainsString('Nina', $content);
+    }
+
+    #[Test]
+    public function listPluginHidesHiddenContactsByDefault(): void
+    {
+        $this->setUpTestCase('contactsListPage_hiddenRecord');
+
+        $content = $this->renderHomePage();
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertStringNotContainsString('Horst', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersHiddenContactsWhenConfigured(): void
+    {
+        $this->setUpTestCase('contactsListPage_showHiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Horst', 'Huber');
+    }
+
+    #[Test]
+    public function listPluginRendersWrapperWithoutContacts(): void
+    {
+        $this->setUpTestCase('contactsListPage_noContacts');
+
+        $content = $this->renderHomePage();
+        // This extension has no "nothing found" label; the plugin still has to render
+        // rather than fail.
+        $this->assertStringContainsString('academic-contacts4pages', $content);
+        $this->assertStringNotContainsString('academic-persons-item', $content);
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage.csv
@@ -1,0 +1,35 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,1,100,0,0,0,1,2,1,1
+,2,100,0,0,0,2,2,2,1
+,3,100,0,0,0,3,2,3,2
+,4,100,0,0,0,4,4,4,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_hiddenRecord.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_hiddenRecord.csv
@@ -1,0 +1,33 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,1,100,0,0,0,1,2,1,1
+,2,100,0,1,0,2,2,2,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_noContacts.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_noContacts.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_onlyForeignContacts.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_onlyForeignContacts.csv
@@ -1,0 +1,32 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,4,100,0,0,0,4,4,4,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_showHiddenRecords.csv
@@ -1,0 +1,33 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,1,100,0,0,0,1,2,1,1
+,2,100,0,1,0,2,2,2,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_withoutRoles.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_withoutRoles.csv
@@ -1,0 +1,29 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,1,100,0,0,0,1,2,1,0
+,2,100,0,0,0,2,2,2,0
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript
@@ -1,0 +1,5 @@
+# The item partial of `EXT:academic_persons` builds its detail link against this
+# page, and this plugin inherits the setting from there.
+plugin.tx_academicpersons {
+    detailPid = 3
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}

--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
@@ -11,9 +11,12 @@
             {fieldName} == position
             || {fieldName} == room
             || {fieldName} == officeHours
-            || {fieldName} == location
         ">
             {contract.{fieldName}}
+        </f:if>
+
+        <f:if condition="{fieldName} == location">
+            {contract.location.title}
         </f:if>
 
         <f:if condition="{fieldName} == emailAddresses || {fieldName} == phoneNumbers">


### PR DESCRIPTION
Adds frontend rendering tests for the only plugin of
`EXT:academic_contacts4pages` (ACE-311) — and fixes a defect they found in
`EXT:academic_persons` (ACE-317).

## What is covered

One test class, 10 tests, for `academiccontacts4pages_list`.

The plugin has no record selection of its own: `findByPid()` matches the
`page` field of a contact against the page the content element sits on,
with the storage page deliberately ignored. Each contact points at an
`EXT:academic_persons` contract, which points at a profile, and the
template renders that profile through the `Profile/Item` partial of that
extension — so the fixtures carry profiles, locations, contracts, roles
and contacts.

Covered: contacts grouped by role including the role headings, the flat
branch when no role is assigned, that a grouped contact renders one
heading level below an ungrouped one, the contract data, the detail link
against the configured page, the content element header, hidden contacts
with **and** without the plugin setting, contacts belonging to another
page, and an empty result.

The heading level is asserted rather than only the name, because it is the
observable difference between the grouped and the flat branch — and thus
the only thing that proves `groupedProfiles` reaches the partial.

## ACE-317 — the location defect

A contract with a location rendered this on the public frontend:

```html
<li class="list-group-item">
    <b>Location:</b>
    FGTCLB\AcademicPersons\Domain\Model\Location:1
</li>
```

The class name and record uid instead of the title. `Field.html` grouped
`location` with the plain string fields, but `location` is a relation, so
printing it fell back to the entity string conversion. It does **not**
throw, which is why nothing noticed — it silently renders internals.

I expected an exception and was wrong; measuring it produced this
instead. The other relation fields each already had their own branch;
`location` was simply missed.

**Blast radius:** the partial is reached through `Profile/Item.html` and
`Profile/Contract/Item.html`, so every `EXT:academic_persons` plugin is
affected as soon as a contract has a location, not just this one.

**Why nothing caught it:** no fixture in the repository sets contract
`location` to a non-zero value — checked across every CSV of every
extension. The branch was never executed until this test set.

Branch `2` carries the identical line 14, so that backport is outstanding
and stays on ACE-317.

## A second defect, reported but deliberately not fixed

**A contact without a role disappears from the frontend** as soon as any
other contact on the same page has one. Measured with a throwaway fixture
(since removed): with contact A in a role and contact B in none, the role
heading and A render, and **B is absent entirely**.

`Templates/Contacts/List.html` iterates the collected roles and renders
only the contacts matching each one, so a role-less contact belongs to no
group and is dropped. Silent data loss, not a layout quirk.

I did not fix it, because where such contacts *should* appear — an own
group, an ungrouped block before or after the groups, a fallback role
label — is a product decision, not a defect with one obvious correction.
It wants an issue and a decision; no test in this pull request asserts
either behaviour, so nothing here bakes in a guess.

## On the TYPO3 v14 header gap

Not applicable here. This template renders no header of its own beyond
the role headings, so the content element header comes from
`lib.contentElement`. The header assertion is present anyway.

## Gates

`cgl`, `lintPhp`, `phpstan`, `unit` and the full `functional` suite run
locally for **both** core versions, each after its own `composerUpdate`:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 525 tests, 2 skipped | 532 tests, 2 skipped |

The ACE-317 fix was confirmed failing-before / passing-after on both core
versions.
