### PR TITLE
[BUGFIX] ACE-317: Render contract location title

### DIFF
--- a/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
+++ b/packages/fgtclb/academic-persons/Resources/Private/Partials/Profile/Contract/Field.html
@@ -11,9 +11,12 @@
             {fieldName} == position
             || {fieldName} == room
             || {fieldName} == officeHours
-            || {fieldName} == location
         ">
             {contract.{fieldName}}
+        </f:if>
+
+        <f:if condition="{fieldName} == location">
+            {contract.location.title}
         </f:if>
 
         <f:if condition="{fieldName} == emailAddresses || {fieldName} == phoneNumbers">


### PR DESCRIPTION
Backport of #375's second commit to branch `2` (ACE-317).

## The defect

A contract with a location rendered this on the public frontend:

```html
<li class="list-group-item">
    <b>Location:</b>
    FGTCLB\AcademicPersons\Domain\Model\Location:1
</li>
```

`Profile/Contract/Field.html` grouped `location` with the plain string
fields (`position`, `room`, `officeHours`) and printed the value
directly — but `location` is a relation to
`tx_academicpersons_domain_model_location`, so printing it fell back to
the entity string conversion: class name and record uid instead of the
title. It does not throw, which is why nothing noticed.

The blast radius is every plugin reaching the partial through
`Profile/Item.html` or `Profile/Contract/Item.html` — all
`EXT:academic_persons` plugins plus `academiccontacts4pages_list`.

The fix gives `location` its own branch, as the other relation fields
already have, and renders `{contract.location.title}`.

## What is *not* in this backport

The regression tests. They belong to ACE-311 and build on the plugin
rendering harness of ACE-305, and neither exists on branch `2` — so this
branch gets the one-line fix without a guard of its own. On `main` the
guard is
`AcademicContacts4PagesListPluginTest::listPluginRendersTheContractDataOfEachContact`,
which fails on both core versions without the fix.

No fixture on this branch sets a contract location to a non-zero value
either, so the defective branch of the partial was never executed by any
test here — the change is verified as "changes nothing that is covered",
plus the identical diff.

## Gates

Run locally for both core versions this branch supports, each after its
own `composerUpdate`, using this branch's own matrix pairing:

| | TYPO3 v12 (PHP 8.1) | TYPO3 v13 (PHP 8.2) |
|---|---|---|
| cgl -n | pass | — (v12 only in CI) |
| lintPhp | pass | — (version independent) |
| phpstan | pass | pass |
| unit | 90 tests | 90 tests |
| functional | 434 tests, 2 skipped | 434 tests, 2 skipped |
