### PR TITLE
[TASK] ACE-312: Add persons card plugin test

### DIFF
--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academicpersons_card` plugin in the frontend.
+ *
+ * Unlike the other plugin tests of this extension this one renders the shipped templates
+ * rather than the simplified ones of `EXT:test_plugin_templates`: that fixture extension
+ * carries no `Profile/Card.html`, and the point of the test is what a visitor gets — the
+ * card wrapper, the `Profile/Item` partial and the contract fields it renders.
+ *
+ * `cardAction()` only queries when a profile list is configured, and it builds its demand
+ * from three settings: the profile list, the hidden record option and the fallback flag.
+ * It is the one action of this controller without a storage page restriction.
+ *
+ * The content element header is not part of the template. It comes from
+ * `lib.contentElement`, and on TYPO3 v14 that renders through the `record` view variable,
+ * which is what the header assertion covers.
+ *
+ * Multi language is deliberately out of scope here: `cardAction()` carries a `@todo`
+ * stating it is broken for multi language sites, so covering it would mean asserting
+ * behaviour that is known to be wrong.
+ */
+final class AcademicPersonsCardPluginTest extends AbstractAcademicPersonsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsCardPlugin/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function setContentElementHeader(string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => 1]);
+    }
+
+    /**
+     * The item partial composes the heading from first, middle and last name, so an empty
+     * middle name leaves two spaces in the markup. Matching on `\s+` asserts the rendered
+     * name without depending on that spacing.
+     */
+    private function assertRendersProfileName(string $content, string $first, string $last): void
+    {
+        $this->assertMatchesRegularExpression(
+            sprintf('#%s\s+%s#u', preg_quote($first, '#'), preg_quote($last, '#')),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function cardPluginRendersTheSelectedProfiles(): void
+    {
+        $this->setUpTestCase('cardPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-persons-card', $content);
+        $this->assertStringContainsString('academic-persons-item', $content);
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Horst', 'Huber');
+        // Not part of the configured selection.
+        $this->assertStringNotContainsString('Erika', $content);
+    }
+
+    #[Test]
+    public function cardPluginRendersContentElementHeader(): void
+    {
+        $this->setUpTestCase('cardPage');
+        $this->setContentElementHeader('Our team');
+
+        $this->assertStringContainsString('Our team', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function cardPluginRendersProfileNameAsUngroupedHeading(): void
+    {
+        $this->setUpTestCase('cardPage');
+
+        // The card template passes no `groupedProfiles`, so the item renders through
+        // `Profile/Header` rather than `Profile/SectionHeader` — one level higher.
+        $this->assertMatchesRegularExpression(
+            '#<h2 class="card-title">\s*<a href="[^"]*">Max\s+Müllermann</a>\s*</h2>#',
+            $this->renderHomePage(),
+        );
+    }
+
+    #[Test]
+    public function cardPluginRendersTheContractDataOfEachProfile(): void
+    {
+        $this->setUpTestCase('cardPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Professor', $content);
+        $this->assertStringContainsString('A 101', $content);
+        $this->assertStringContainsString('Lecturer', $content);
+        // A contract location is a relation, so the partial has to render its title
+        // rather than the object.
+        $this->assertStringContainsString('Main Campus', $content);
+        $this->assertStringNotContainsString('Domain\\Model\\Location', $content);
+    }
+
+    #[Test]
+    public function cardPluginLinksEachProfileToTheConfiguredDetailPage(): void
+    {
+        $this->setUpTestCase('cardPage');
+
+        $this->assertStringContainsString('href="/profiles?tx_academicpersons_detail', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function cardPluginRestrictsRenderedFieldsWhenConfigured(): void
+    {
+        $this->setUpTestCase('cardPage_showFields');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Professor', $content);
+        // Only the configured field renders, so the other contract fields are gone.
+        $this->assertStringNotContainsString('A 101', $content);
+        $this->assertStringNotContainsString('Main Campus', $content);
+    }
+
+    #[Test]
+    public function cardPluginHidesHiddenProfilesByDefault(): void
+    {
+        $this->setUpTestCase('cardPage_hiddenProfile');
+
+        $content = $this->renderHomePage();
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertStringNotContainsString('Erika', $content);
+    }
+
+    #[Test]
+    public function cardPluginRendersHiddenProfilesWhenConfigured(): void
+    {
+        $this->setUpTestCase('cardPage_showHiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Erika', 'Beispiel');
+    }
+
+    #[Test]
+    public function cardPluginRendersNoProfilesFoundWithoutSelection(): void
+    {
+        $this->setUpTestCase('cardPage_withoutSelection');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-persons-card', $content);
+        $this->assertStringContainsString('No profiles found', $content);
+        $this->assertStringNotContainsString('academic-persons-item', $content);
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,1,0,0,"Erika","Beispiel","erika-beispiel"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_card","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.detailPid""><value index=""vDEF"">3</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_hiddenProfile.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_hiddenProfile.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,1,0,0,"Erika","Beispiel","erika-beispiel"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_card","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">3</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_showFields.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_showFields.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,1,0,0,"Erika","Beispiel","erika-beispiel"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_card","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">2,1</value></field><field index=""settings.detailPid""><value index=""vDEF"">3</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF"">contract.position</value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_showHiddenRecords.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_showHiddenRecords.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,1,0,0,"Erika","Beispiel","erika-beispiel"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_card","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">3</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">1</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_withoutSelection.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPlugin/cardPage_withoutSelection.csv
@@ -1,0 +1,22 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,1,0,0,"Erika","Beispiel","erika-beispiel"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_card","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.detailPid""><value index=""vDEF"">3</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"


### PR DESCRIPTION
Adds frontend rendering tests for `academicpersons_card` (ACE-312) — the
last uncovered plugin of the S7 series.

## What is covered

One test class, 9 tests. Per scenario: the configured profile selection
renders and nothing else, the profile name as an ungrouped heading, the
contract data including the location title, the detail link against the
configured page, the restricted field set, hidden profiles with **and**
without the plugin setting, the content element header, and the "no
profiles found" label when no selection is configured.

`cardAction()` only queries when a profile list is configured, and builds
its demand from three settings — the profile list, the hidden record
option and the fallback flag. It is the one action of this controller
without a storage page restriction, which the fixtures exercise by
keeping the records on a sysfolder the plugin never names.

## A departure from the five sibling tests

The existing plugin tests of this extension render the **simplified**
templates of `EXT:test_plugin_templates`, which lets them assert ordering
and language behaviour precisely. This one renders the **shipped**
templates instead, for two reasons:

* that fixture extension carries no `Profile/Card.html`, so there is
  nothing to fall back to;
* what this plugin needed covering for is what a visitor gets — the card
  wrapper, the `Profile/Item` partial and the contract fields.

The concrete payoff: the location assertion is a second guard for
ACE-317, this time inside the extension that actually owns the partial.
The simplified templates would not have exercised it at all.

## Deliberately out of scope

**Multi language.** `cardAction()` carries a `@todo` stating it is
literally broken for multi language sites and needs to be adopted first.
Covering it now would mean asserting behaviour that is known to be wrong,
so the tests stay on the default language. The `@todo` is untouched and
still describes real work.

Also noted while reading, not acted on: the action has a second `@todo`
asking whether the selected profiles should be sorted in the order they
were selected, as `listAction()` and `selectedProfilesAction()` do. No
test here asserts an order, so nothing bakes in either answer.

## On the TYPO3 v14 header gap

Not applicable. The template renders no header of its own, so the content
element header comes from `lib.contentElement`. The header assertion is
present anyway and passes on both versions.

## Gates

`cgl`, `lintPhp`, `phpstan`, `unit` and the full `functional` suite run
locally for **both** core versions, each after its own `composerUpdate`:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 534 tests, 2 skipped | 541 tests, 2 skipped |
