### PR TITLE
[TASK] ACE-320: Add study plan rendering test

### DIFF
--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
   xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+  <file source-language="en" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
     <header/>
     <body>
       <trans-unit id="filter.label">

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicStudyPlan\Tests\Functional\ContentElement;
+
+use FGTCLB\AcademicStudyPlan\Tests\Functional\AbstractAcademicStudyPlanTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academic_study_plan` content element in the frontend.
+ *
+ * Unlike the other rendering tests of this repository this is not a plugin: there is no
+ * Extbase controller at all. The content element is built straight from
+ * `lib.contentElement` with a `templateName` and a single data processor, which is why
+ * `FrontendPluginRenderingTrait` is used only for its scaffolding — instance
+ * configuration, site and request helpers — and no FlexForm is involved. The
+ * configuration lives on the content element record itself.
+ *
+ * The template renders the `EXT:fluid_styled_content` `Header/All` partial, which on
+ * TYPO3 v14 resolves the header through the `record` view variable. Here that variable
+ * comes from the record transformation of `lib.contentElement` rather than from a view,
+ * which is what `contentElementRendersHeader()` verifies rather than assumes.
+ */
+final class AcademicStudyPlanContentElementTest extends AbstractAcademicStudyPlanTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function setUpTestCase(string $dataSet): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicStudyPlanContentElement/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_study_plan/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:academic_study_plan/Tests/Functional/ContentElement/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+        ]);
+    }
+
+    private function renderHomePage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function setContentElementHeader(string $header): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tt_content')
+            ->update('tt_content', ['header' => $header], ['uid' => 1]);
+    }
+
+    #[Test]
+    public function contentElementRendersItsSemesters(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('academic-study-plan', $content);
+        $this->assertStringContainsString('data-study-plan="1"', $content);
+        $this->assertStringContainsString('First Semester', $content);
+        $this->assertStringContainsString('Second Semester', $content);
+        // The note of a semester is optional and only the first one has it.
+        $this->assertStringContainsString('Foundation courses', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersTheModulesOfEachSemester(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Mathematics I', $content);
+        $this->assertStringContainsString('Programming Basics', $content);
+        $this->assertStringContainsString('Statistics', $content);
+        $this->assertStringContainsString('Mandatory attendance', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersCreditPointsOfSemestersAndModules(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // Both the semester and the module render their credit points followed by the
+        // `credits` label, which this extension abbreviates to "CP".
+        $this->assertMatchesRegularExpression('#30\s+CP#', $content);
+        $this->assertMatchesRegularExpression('#10\s+CP#', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersHeader(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+        $this->setContentElementHeader('Study plan B.Sc.');
+
+        // The template renders the fluid_styled_content header partial, which resolves
+        // the header through `record` on TYPO3 v14. Here that comes from the record
+        // transformation of `lib.contentElement` rather than from an Extbase view.
+        $this->assertStringContainsString('Study plan B.Sc.', $this->renderHomePage());
+    }
+
+    #[Test]
+    public function contentElementRendersDialogForModuleWithDescription(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // A module with a description is clickable and gets its own dialog.
+        $this->assertStringContainsString('<dialog id="popup-1">', $content);
+        $this->assertStringContainsString('Linear algebra and analysis.', $content);
+        $this->assertStringContainsString('class="module clickable"', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersNoDialogForModuleWithoutContent(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // Module 2 has neither description nor audio file, so it stays inert.
+        $this->assertStringNotContainsString('<dialog id="popup-2">', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersModuleCategoriesAsDataAttribute(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // The categories of a module travel to the markup as JSON for the filter script.
+        $this->assertStringContainsString('Mandatory', $content);
+        $this->assertStringContainsString('Elective', $content);
+        $this->assertStringContainsString('#cc0000', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersFooterNote(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $this->assertStringContainsString(
+            'All modules are subject to change.',
+            $this->renderHomePage(),
+        );
+    }
+
+    #[Test]
+    public function contentElementOmitsFooterNoteWhenEmpty(): void
+    {
+        $this->setUpTestCase('studyPlanPage_withoutFooterNote');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('First Semester', $content);
+        $this->assertStringNotContainsString('All modules are subject to change.', $content);
+    }
+
+    #[Test]
+    public function contentElementHidesHiddenSemestersAndModules(): void
+    {
+        $this->setUpTestCase('studyPlanPage_hiddenRecords');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('First Semester', $content);
+        $this->assertStringContainsString('Mathematics I', $content);
+        $this->assertStringNotContainsString('Hidden Semester', $content);
+        $this->assertStringNotContainsString('Hidden Module', $content);
+    }
+
+    #[Test]
+    public function contentElementRendersWithoutSemesters(): void
+    {
+        $this->setUpTestCase('studyPlanPage_withoutSemesters');
+
+        $content = $this->renderHomePage();
+        // The element still renders, only the semester list is skipped.
+        $this->assertStringContainsString('academic-study-plan', $content);
+        $this->assertStringNotContainsString('<ul class="semesters row">', $content);
+    }
+}

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage.csv
@@ -1,0 +1,24 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","",2,"<p>All modules are subject to change.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","Foundation courses",30,2
+,2,2,0,0,0,0,2,1,"Second Semester","",30,1
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","Mandatory attendance",10,"Linear algebra and analysis.",2
+,2,2,0,0,0,0,2,1,"Programming Basics","",5,"",0
+,3,2,0,0,0,0,1,2,"Statistics","",8,"Descriptive and inductive.",0
+"tx_academicstudyplan_domain_model_category",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","label","colour"
+,1,2,0,0,0,0,1,"Mandatory","#cc0000"
+,2,2,0,0,0,0,2,"Elective","#0066cc"
+"tx_academicstudyplan_module_category_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,0,1
+,1,2,0,2

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_hiddenRecords.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_hiddenRecords.csv
@@ -1,0 +1,15 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","",2,"<p>All modules are subject to change.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","",30,2
+,2,2,0,1,0,0,2,1,"Hidden Semester","",30,0
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","",10,"",0
+,2,2,0,1,0,0,2,1,"Hidden Module","",5,"",0

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_withoutFooterNote.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_withoutFooterNote.csv
@@ -1,0 +1,13 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","",1,""
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","",30,1
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","",10,"",0

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_withoutSemesters.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElement/studyPlanPage_withoutSemesters.csv
@@ -1,0 +1,7 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","",0,"<p>All modules are subject to change.</p>"

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/TypoScript/Setup/Rendering.typoscript
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/TypoScript/Setup/Rendering.typoscript
@@ -1,0 +1,4 @@
+page = PAGE
+page {
+  10 < styles.content.get
+}


### PR DESCRIPTION
Adds frontend rendering tests for the `academic_study_plan` content
element (ACE-320) — and fixes the defect they found (ACE-321).

This closes the rendering-test series: every plugin and content element
of the repository now renders in a test.

## What is covered

One test class, 11 tests. The semesters with their notes, the modules of
each semester, the credit points of both, the dialog of a module that has
content and its absence for one that has none, the module categories, the
footer note including its absence, hidden semesters and modules, an
element without any semester, and the content element header.

Unlike ACE-307 to ACE-312 this is **not a plugin**: no Extbase controller
exists at all. The element is built straight from `lib.contentElement`
with a template name and one data processor, so the ACE-305 harness is
used only for scaffolding — instance configuration, site, request — and
there is no FlexForm, because the configuration lives on the content
element record.

## The v14 `record` question, answered

The template renders the `EXT:fluid_styled_content` `Header/All` partial —
the same partial behind the ACE-315 crash. The expectation was that it is
safe here because `lib.contentElement` supplies `record` through core's
record transformation rather than an Extbase view.

**Confirmed by test, not assumed:** `contentElementRendersHeader()` passes
on both core versions. The assertion stays in place regardless.

## ACE-321 — every frontend label empty on TYPO3 v14

The tests immediately found a different version split. On v14 the element
rendered:

```html
<nav role="navigation" aria-label="">
<button ... aria-label=": category-label-placeholder">
<span class="credits small">30 </span>
```

The credit-point suffix, the filter navigation label and both modal labels
were **all empty**, `aria-label` values included — worst for screen reader
users. v13 rendered them correctly.

Cause: `Resources/Private/Language/locallang.xlf`, the **default language**
file, declared `target-language="de"`. That belongs on `de.locallang.xlf`
only; with it on the default file, v14 treats the file as a translation
catalogue and the default language gets no labels at all. v13 parses it
leniently and still yields the `<source>` values.

Swept every `locallang.xlf` in the repository: this was the **only** one.
The other eight extensions declare `target-language` on their `de.` file
only.

`main` only in effect — branch `2` carries the same attribute but supports
v12 and v13, where the labels still resolve. Verified: the label rendered
correctly on v13 before the fix.

## Two findings reported, deliberately not fixed

Both are recorded on ACE-321 rather than acted on here:

* **`modal.open` does not exist.** The template translates that key for
  the visually hidden text of the modal trigger, but neither language file
  defines it, so the text is empty on **both** core versions. Adding it
  means inventing user-facing wording in two languages.
* **Three icon identifiers do not resolve.** `plus`, `minus` and
  `close-button` render as `default-not-found` placeholders on both v13
  and v14 — measured: 12 placeholders on v13, 18 on v14 for one study
  plan. Choosing replacements is a design decision.

Neither is asserted either way by the tests, so nothing here bakes in a
guess.

## Gates

`cgl`, `lintPhp`, `phpstan`, `unit`, the full `functional` suite and
`checkRstRenderingAll` run locally for **both** core versions, each after
its own `composerUpdate`:

| | TYPO3 v13 | TYPO3 v14 |
|---|---|---|
| unit | 91 tests | 91 tests |
| functional | 545 tests, 2 skipped | 552 tests, 2 skipped |

The ACE-321 fix was confirmed failing-before / passing-after on v14, and
neutral on v13.
