### PR TITLE
[TASK] ACE-333: Drop bogus mariadb shutdown call

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -610,8 +610,6 @@ case ${TEST_SUITE} in
                 CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mariadb-func-${SUFFIX} -e typo3DatabasePassword=funcp"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
-                ${CONTAINER_BIN} exec mysql-func-${SUFFIX} /usr/bin/mysqladmin -uroot -pfuncp shutdown
-                sleep 10
                 ;;
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"


### PR DESCRIPTION
Fixes ACE-333: the `mariadb` branch of the functional suite stopped the
wrong container and then waited for it.

## What it did

```bash
${CONTAINER_BIN} exec mysql-func-${SUFFIX} /usr/bin/mysqladmin -uroot -pfuncp shutdown
sleep 10
```

`mysql-func-${SUFFIX}` is started by the **mysql** branch. In a mariadb
run it does not exist, so every run ended with

```
Error: no container with name or ID "mysql-func-1494" found: no such container
```

followed by a ten second sleep for a shutdown that never happened. Test
results were never affected — `SUITE_EXIT_CODE` is captured before that
line — but eight jobs per pull request use mariadb (2 PHP × 2 core
versions × mariadb 10.4 and 10.6), and each paid the ten seconds and
printed the error.

## Why both lines go, instead of fixing the name

Three independent reasons, all checked rather than assumed:

* the TYPO3 Core `runTests.sh` this harness mirrors shuts **no** database
  container down, in any of its four DBMS branches;
* `cleanUp()` force removes every container attached to the run's network
  when the script ends, and it is also on the `SIGINT` trap;
* the database containers mount `/var/lib/mysql` as `tmpfs`, so there is
  no data to flush.

The `mysql` branch never had a shutdown step either, which was the other
half of the asymmetry.

## Measured

Single functional test file against mariadb 10.4, TYPO3 v14, PHP 8.2:

| | wall clock | output |
|---|---|---|
| before | 22.2s | `no such container` error |
| after | 12.5s | clean |

The test itself takes ~1.5s, so the sleep was the larger part of the run.
`podman ps -a` afterwards shows no leftover container, confirming
`cleanUp()` does the work on its own.

## Gates

`cgl -n`, `lintPhp`, `phpstan` and `unit` pass on the installed v14 tree;
the mysql and postgres branches of the functional suite were re-run and
still succeed. No PHP source is touched by this change, so the v13 gate
run was not repeated locally — CI covers both core versions.

Branch `2` carries the identical line (619 there) and gets the same
change once this is merged.
