### PR TITLE
[TASK] ACE-333: Drop bogus mariadb shutdown call

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -616,8 +616,6 @@ case ${TEST_SUITE} in
                 CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mariadb-func-${SUFFIX} -e typo3DatabasePassword=funcp"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
-                ${CONTAINER_BIN} exec mysql-func-${SUFFIX} /usr/bin/mysqladmin -uroot -pfuncp shutdown
-                sleep 10
                 ;;
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"


### PR DESCRIPTION
Backport of #379 to branch `2` — ACE-333.

The `mariadb` branch of the functional suite stopped `mysql-func-${SUFFIX}`,
a container that branch never starts, and then slept ten seconds waiting
for it. On branch `2` the two lines sat at 619/620 of
`Build/Scripts/runTests.sh`; everything else in the block already used
`mariadb-func-${SUFFIX}`.

Both lines are dropped rather than the name corrected, for the reasons
verified on `main`: TYPO3 Core's `runTests.sh` shuts no database container
down in any DBMS branch, `cleanUp()` force removes every container attached
to the run's network (and is on the `SIGINT` trap), and the DB containers
keep their data in a tmpfs. Branch `2` carries the identical `cleanUp()`,
trap and tmpfs mounts, so the same reasoning holds here — checked, not
assumed.

Test results were never affected: `SUITE_EXIT_CODE` is captured before the
removed line. Eight of this branch's 33 checks use mariadb (4 core/PHP
combinations × 10.4 and 10.6).

## Verified on this branch

`composerUpdate -t 13 -p 8.2`, then a single functional test file against
mariadb 10.4: **14.1s**, no `no such container` error, and `podman ps -a`
shows no leftover container afterwards.

`cgl -n`, `lintPhp`, `phpstan` and `unit` (90 tests) pass on the v13 tree.
No PHP source is touched, so the v12 gate run was not repeated locally —
CI covers both core versions.
