### PR TITLE
[BUGFIX] ACE-336: Wait longer for database readiness

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -49,10 +49,13 @@ printSummary() {
 waitFor() {
     local HOST=${1}
     local PORT=${2}
+    # 60 rather than 10 seconds: mysql:8.0 needs 12-13s under docker to initialise a fresh
+    # data directory, about twice as long as under podman, so an 11 second budget aborted
+    # the functional mysql suites at random.
     local TESTCOMMAND="
         COUNT=0;
         while ! nc -z ${HOST} ${PORT}; do
-            if [ \"\${COUNT}\" -gt 10 ]; then
+            if [ \"\${COUNT}\" -gt 60 ]; then
               echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
               exit 1;
             fi;
@@ -62,7 +65,11 @@ waitFor() {
     "
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_ALPINE} /bin/sh -c "${TESTCOMMAND}"
     if [[ $? -gt 0 ]]; then
-        kill -SIGINT -$$
+        # Not "kill -SIGINT -$$": the SIGINT trap is only installed when CI is not "true",
+        # so in CI the signal was a no-op, the run continued and the test suite connected
+        # to a database that was not listening.
+        cleanUp
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Fixes ACE-336. `waitFor()` gives a database container too little time to
become ready, and when the budget is exceeded the run does not stop.

## 1. The budget is too small

The poll aborts after `COUNT -gt 10`, eleven `sleep 1` iterations. Measured
on a workstation under docker, `/var/lib/mysql` on a tmpfs as the harness
mounts it, image pull excluded:

| image | `run -d` until the port accepts |
|---|---|
| `mysql:8.0` | **12.78s, 12.71s** |
| `mariadb:10.4` | 8.73s, 8.73s |

Only mysql crosses the limit, and only under docker — the same images need
7.0-7.2s and 7.8s under podman, whose entrypoint does not spend about twice
as long initialising a fresh data directory.

**ACE-313 made docker the CI runtime on 2026-07-29**, and `ci.yml` runs four
`mysql 8.0` jobs per pipeline on both branches, so those four sit on a
negative margin. It has not been observed failing here yet — the runs since
have been green — but `fgtclb/environment-state-manager` did begin to abort
intermittently once it made the same switch, which is what prompted looking.

The cap becomes 60, which also leaves mariadb a sensible margin.

## 2. The abort does not abort

```bash
if [[ $? -gt 0 ]]; then
    kill -SIGINT -$$
fi
```

The SIGINT trap is installed only under `if [ "${CI}" != "true" ]` (line 7),
so in CI there is no trap. Two different failure modes were seen, neither of
them the intended one:

* **locally** (`CI=true`, budget forced to 1s) the signal terminated the
  script before `cleanUp` could run, leaking `mysql-func-<suffix>` and the
  run's network — both had to be removed by hand;
* **in CI** the sibling repository observed the kill doing nothing at all, so
  the script carried on and ran the suite against a database that was not
  listening, reporting dozens of `Connection refused` errors instead of the
  readiness timeout that had actually occurred.

`cleanUp; exit 1` replaces it.

## Verified

With the budget forced to one second, the run now stops at

```
Can not connect to mysql-func-16051 port 3306. Aborting.
```

with exit code 1 and **no** container or network left behind.

With the real budget, on `-b docker` with `CI=true` so the CI path is the one
exercised:

| | v13 | v14 |
|---|---|---|
| `functional` mysql 8.0 | pass | pass |
| `functional` mariadb 10.4 | pass | — |
| `cgl -n`, `lintPhp`, `phpstan`, `unit` | pass | pass |

No PHP source is touched, so the source gates are only a regression check.

Backport to `2` follows once this is merged — the file is identical there.
