### PR TITLE
[TASK] ACE-337: Adopt the two ACE-324 harness fixes

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -450,6 +450,7 @@ handleDbmsOptions
 COMPOSER_ROOT_VERSION="3.0.0-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"
@@ -514,9 +515,24 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm ${USERSET} -v ${ROOT_DIR}:/project"
+    # docker creates the tmpfs owned by "root:root", while "${USERSET}" above passes a uid
+    # but no group, so the container runs as "uid=${HOST_UID} gid=0" and does not own the
+    # mount it has to write the test databases into. Whether that still works then depends
+    # on the mode docker happens to give the tmpfs: 1777 by default on docker 29, but 0755
+    # where it follows the umask, and then no test database can be created and every test
+    # fails with "unable to open database file".
+    #
+    # "uid"/"gid" remove that dependency at the source - the mount is owned by the user the
+    # container runs as. "mode=1777" is the workaround the docker adoption introduced
+    # instead, and is kept next to them: it is what has been proven on a GitHub hosted
+    # runner, and it costs nothing to leave in place.
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_GID},mode=1777"
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
+    # Rootless podman maps the container root to the host user, so the tmpfs is writable
+    # without an explicit owner. "mode=1777" is kept for the rootful case.
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,mode=1777"
     if [ $( uname ) = "Linux" ]; then
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
@@ -641,13 +657,11 @@ case ${TEST_SUITE} in
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
-                # "mode=1777" is required for docker and harmless for podman: docker runs the
-                # container as "--user $(id -u)" with group 0, while the tmpfs comes up owned by
-                # root with mode 0755, so the test databases cannot be created and every test
-                # fails with "unable to open database file". Rootless podman needs no "--user"
-                # (it is root inside the user namespace), which is why this only shows with
-                # docker.
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777 "
+                # "${TMPFS_MOUNT_OPTIONS}" carries the owner and mode the mount needs, which
+                # differ per container binary - see where it is assigned. Without them the
+                # test databases cannot be created and every test fails with "unable to open
+                # database file".
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:${TMPFS_MOUNT_OPTIONS} "
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -451,6 +451,9 @@ COMPOSER_ROOT_VERSION="3.0.0-dev"
 CONTAINER_INTERACTIVE="-it --init"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
+# Additional container parameters, provided by the environment. Empty unless the caller
+# exports it, which is how the portfolio harnesses inject CI specific flags.
+CI_PARAMS="${CI_PARAMS:-}"
 USERSET=""
 if [ $(uname) != "Darwin" ]; then
     USERSET="--user $HOST_UID"


### PR DESCRIPTION
Fixes ACE-337. Adopts the two `runTests.sh` fixes that landed in
`fgtclb/environment-state-manager` as ACE-324 (#33/#34), so the two copies of
this harness stop drifting.

**Neither is a defect today**, and the issue says so — this is drift-closing,
which is why it is separate from #381.

Two commits, the same split as the sibling repository.

## `[TASK] ACE-337: Own the sqlite tmpfs from the host`

`${USERSET}` passes `--user ${HOST_UID}` without a group, so a docker container
runs as `uid=${HOST_UID} gid=0(root)` and does not own the tmpfs it writes the
functional sqlite databases into.

The mount options move into `TMPFS_MOUNT_OPTIONS`, assigned next to the
container parameters they belong to, so each binary states what it needs:
docker adds `uid`/`gid` and keeps `mode=1777`, rootless podman maps the
container root to the host user and needs neither.

Measured with `--user $(id -u)` and an otherwise identical mount:

| options | owner | writable |
|---|---|---|
| `rw,noexec,nosuid,mode=1777` | `0 0` | yes |
| `rw,noexec,nosuid,uid=,gid=,mode=1777` | **`1000 1000`** | yes |
| `rw,noexec,nosuid` | `0 0` | yes |

**A correction to the sibling repository's reasoning:** its comment says the
tmpfs "inherits the mode of its host mountpoint", 0755 at a 0022 umask. That
does not hold on docker 29 — the third row above shows `--tmpfs` coming up
`drwxrwxrwt` with no mode given at all. The observable effect of this change is
therefore **ownership**, not mode, and the comment here says that instead.
`mode=1777` stays because it is what has been proven on a GitHub hosted runner
and costs nothing.

`${USERSET}` itself is left alone: appending a group there would change which
host group *every* container runs as, a different question from who owns a
tmpfs.

## `[TASK] ACE-337: Revive an unused harness variable`

`CI_PARAMS` is expanded six times across the podman arm and assigned nowhere.
It is not a leftover — the harnesses this one is modelled on treat it as an
escape hatch a caller can export — so the assignment is added rather than the
expansions removed.

Behaviourally inert, verified both ways: without `set -u` an unset variable
expands to the empty string exactly as `CI_PARAMS="${CI_PARAMS:-}"` does, and
an exported value already reached the expansion. It documents the hook and
survives a future `set -u`.

### Noted, deliberately not changed

`DOCUMENTATION_COMMON_PARAMS` is the mirror image: assigned in all three arms
and **read nowhere**, because the RST suites here build their command from
`${CONTAINER_COMMON_PARAMS}` (line 187). The sibling repository does consume
it, which is why its ACE-324 found nothing to do there. Removing it, or giving
the documentation run the parameters it was meant to carry, is a decision of
its own and is out of scope here. Branch `2` has the same dead assignments.

## Verified

`-b docker` with `CI=true`, so the CI path is the one exercised:

| | v13 | v14 |
|---|---|---|
| `cgl -n`, `lintPhp`, `phpstan`, `unit` | pass | pass |
| `functional` sqlite at `umask 0022` | pass | pass |
| `functional` sqlite at `umask 0002` | pass | pass |
| `functional` mariadb 10.4 | pass | pass |

Plus one `functional` sqlite run under **podman** (v14), to exercise the `else`
arm where `TMPFS_MOUNT_OPTIONS` keeps `mode=1777` alone — pass.

Both umasks are covered because 0022 is the one that makes the mode dependency
visible at all; 0002 is the workstation default and proves nothing regressed
there.

Backport to `2` follows once this is merged — both files are identical there.
