### PR TITLE
[TASK] ACE-339: Drop a variable nothing reads

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -517,7 +517,6 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
     # docker needs the add-host for xdebug remote debugging. podman has host.container.internal built in
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
-    DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm ${USERSET} -v ${ROOT_DIR}:/project"
     # docker creates the tmpfs owned by "root:root", while "${USERSET}" above passes a uid
     # but no group, so the container runs as "uid=${HOST_UID} gid=0" and does not own the
     # mount it has to write the test databases into. Whether that still works then depends
@@ -539,11 +538,9 @@ else
     if [ $( uname ) = "Linux" ]; then
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
-        DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR}:Z -v ${ROOT_DIR}:/project"
     else
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
-        DOCUMENTATION_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -v ${ROOT_DIR}:/project"
     fi
 fi
 


### PR DESCRIPTION
Fixes ACE-339. `DOCUMENTATION_COMMON_PARAMS` was assigned in all three
container-parameter arms of `runTests.sh` and read nowhere. The three
assignments go; nothing else changes.

## Why it was dead, and why it stays dead rather than getting wired up

`git log -S '${DOCUMENTATION_COMMON_PARAMS}'` over every branch returns nothing
— **no commit in this repository ever read it**. It arrived with the harness in
`b58166c2` (2025-03-13) without its consumer. Branches `1` and `2.2` do not even
carry the assignments.

It could not be used here as written, either. It hard-codes

```
-v ${ROOT_DIR}:/project
```

which suits a repository holding **one** extension —
`fgtclb/environment-state-manager` consumes exactly this variable that way, in a
`renderDocumentation` suite rendering its own root. This is a mono repository
and renders one extension at a time, so `executeRstRendering()` mounts per
extension:

```bash
${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name check-rst-rendering-…-${SUFFIX} \
  -w /project -v "${ROOT_DIR}/${extensionFolder}:/project" ${IMAGE_RSTRENDERING} …
```

Wiring the variable up unchanged would have mounted the repository root and
rendered the wrong thing.

The three assignments also disagreed with each other, the usual sign of a copied
fragment: the docker arm carried `${USERSET}` and one mount, the two podman arms
`${CI_PARAMS}` and two.

## The alternative, and the measurement that decided it

Considered: redefine the variable without the mount and let
`executeRstRendering()` use it, which would drop `--network` and `--add-host`
from the renderer.

The objection recorded on the issue was that the renderer might need the network
for intersphinx. **Measured, and that objection is void** — one extension,
harness flags, varying only the network:

| container network | result |
|---|---|
| no `--network` flag (what the variable would have given) | exit 0, clean |
| `--network <run network>` (what rendering uses today) | exit 0, clean |
| `--network none` | **exit 1**, `api.typo3.org` unresolvable, fatal via `--fail-on-log` |

Dropping `--network ${NETWORK}` never removed connectivity; it only moves the
container to docker's default bridge. Useful to know independently: the
documentation gate **does** need outbound access and would break on a
network-restricted runner.

Rejected anyway, on the two reasons that survive:

* the render container would no longer be attached to the run's network, which
  is where `cleanUp()` looks for leftovers;
* a variable of the same name would mean something different here than in the
  sibling harness — the drift #383 has just finished closing.

## Verified

`-b docker` with `CI=true`:

| | v13 | v14 |
|---|---|---|
| `checkRstRenderingAll` (the real documentation gate) | pass | pass |
| `cgl -n`, `lintPhp`, `phpstan`, `unit` | pass | pass |
| `functional` sqlite | pass | pass |

`checkRstRenderingAll` is the suite that would notice if this removal had
touched rendering — it renders all 12 extensions with `--fail-on-log
--fail-on-error`. `grep` confirms the identifier no longer occurs anywhere in
the repository. No PHP is touched.

Backport to `2` follows once this is merged — both branches carry the three
assignments identically.
