### PR TITLE
[BUGFIX] ACE-326: Add missing modal.open label

### DIFF
--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
@@ -12,6 +12,10 @@
         <source>CP</source>
         <target>CP</target>
       </trans-unit>
+      <trans-unit id="modal.open">
+        <source>Show module details</source>
+        <target>Moduldetails anzeigen</target>
+      </trans-unit>
       <trans-unit id="modal.close">
         <source>Close</source>
         <target>Schließen</target>

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
@@ -10,6 +10,9 @@
       <trans-unit id="credits">
         <source>CP</source>
       </trans-unit>
+      <trans-unit id="modal.open">
+        <source>Show module details</source>
+      </trans-unit>
       <trans-unit id="modal.close">
         <source>Close</source>
       </trans-unit>

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
@@ -145,6 +145,23 @@ final class AcademicStudyPlanContentElementTest extends AbstractAcademicStudyPla
     }
 
     #[Test]
+    public function contentElementLabelsTheModalTriggerForScreenReaders(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // The trigger carries no visible text, so its visually hidden span is the only
+        // thing announcing what the control does. A missing `modal.open` label does not
+        // fail loudly: `f:translate` resolves it to an empty string and the span
+        // degrades to a bare ": Mathematics I".
+        $this->assertMatchesRegularExpression(
+            '#First Semester,\s+Foundation courses,\s+30\s+CP\.\s+Show module details: Mathematics I#',
+            $content,
+        );
+        $this->assertDoesNotMatchRegularExpression('#CP\.\s+: Mathematics I#', $content);
+    }
+
+    #[Test]
     public function contentElementRendersNoDialogForModuleWithoutContent(): void
     {
         $this->setUpTestCase('studyPlanPage');


### PR DESCRIPTION
Fixes ACE-326.

`Resources/Private/Frontend/Default/Templates/AcademicStudyPlan.html` line 78
translates `modal.open` for the visually hidden text of the module dialog
trigger, but that key is defined in neither `locallang.xlf` nor
`de.locallang.xlf`. `f:translate` resolves a missing key to an empty string
rather than failing, so the span rendered as a bare `: Mathematics I` — on
**both** core versions, this is not the v14 split of ACE-321.

The trigger has no visible text at all, so that span is the only thing
announcing what the control does.

## Wording

Descriptive rather than a mirror of the adjacent `modal.close`:

| | en | de |
|---|---|---|
| `modal.open` | `Show module details` | `Moduldetails anzeigen` |

`Open` would render `30 CP. Open: Mathematics I` and still leave the target
unnamed; the sibling `modal.audio` already uses the descriptive shape
`Audio content: <module>`.

## Coverage

`contentElementLabelsTheModalTriggerForScreenReaders` asserts the resolved
sentence as a whole and that the `": <module>"` shape is gone. Verified to
fail without the label before committing — a “does the key appear in the
markup” check would not catch this, because the empty lookup result leaves
no trace.

## Deliberately not in this change

`modal.description` and `semester` are defined in both files and used in no
template, PHP, JavaScript or TypoScript (verified across the repository).
They stay: removing public label keys can break site packages overriding
these templates, so it belongs in its own change. Noted on the issue.

## Backport

Branch `2` carries the identical template line and the identical key set, so
the label fix backports. The test does not — `AcademicStudyPlanContentElementTest`
arrived with ACE-320 on `main` only.

## Verified

`cgl -n`, `phpstan`, and the `academic_study_plan` functional suite on
v13/PHP 8.2 and v14/PHP 8.3.
