### PR TITLE
[BUGFIX] ACE-326: Add missing modal.open label

### DIFF
--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/de.locallang.xlf
@@ -12,6 +12,10 @@
 				<source>CP</source>
 				<target>CP</target>
 			</trans-unit>
+			<trans-unit id="modal.open">
+				<source>Show module details</source>
+				<target>Moduldetails anzeigen</target>
+			</trans-unit>
 			<trans-unit id="modal.close">
 				<source>Close</source>
 				<target>Schließen</target>

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
@@ -10,6 +10,9 @@
 			<trans-unit id="credits">
 				<source>CP</source>
 			</trans-unit>
+			<trans-unit id="modal.open">
+				<source>Show module details</source>
+			</trans-unit>
 			<trans-unit id="modal.close">
 				<source>Close</source>
 			</trans-unit>


### PR DESCRIPTION
Backport of #387 (ACE-326) to `2`.

`AcademicStudyPlan.html` line 78 translates `modal.open` for the visually
hidden text of the module dialog trigger, and the key is defined in neither
language file — identical to `main`, verified in this branch's files. The
trigger has no visible text, so that span is the only thing announcing what
the control does; `f:translate` resolves the missing key to an empty string,
leaving a bare `": <module label>"`.

| | en | de |
|---|---|---|
| `modal.open` | `Show module details` | `Moduldetails anzeigen` |

## Label only

The regression test from #387 cannot follow: this branch has no
`AcademicStudyPlanContentElementTest` — it arrived on `main` with ACE-320.

Indentation stays as the files have it (tabs), so this is a two hunk change
rather than a reindent.

`modal.description` and `semester` remain untouched here as well, for the
same reason as on `main`.

## Note on ACE-321

While backporting: this branch's default `locallang.xlf` still declares
`target-language="de"`, which #378 removed on `main`. It is **inert here** —
v13's `XliffParser` picks the source-as-target branch from the language key
of the file being loaded (`$this->languageKey === 'default'`), not from that
attribute, so the labels resolve. It only bites on v14, which this branch
does not support. Left alone deliberately; not this change's business.

## Verified

`cgl -n` and the `academic_study_plan` functional suite on v13/PHP 8.2 and
v12/PHP 8.1.
