### PR TITLE
[BUGFIX] ACE-327: Ship the study plan control icons

### DIFF
--- a/packages/fgtclb/academic-study-plan/Configuration/Icons.php
+++ b/packages/fgtclb/academic-study-plan/Configuration/Icons.php
@@ -19,4 +19,18 @@ return [
         'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         'source' => 'EXT:academic_study_plan/Resources/Public/Icons/module.svg',
     ],
+    // Frontend controls of the study plan element, unlike the record icons above:
+    // drawn in `currentColor` so they take the colour of the surrounding text.
+    'academic-study-plan-plus' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/plus.svg',
+    ],
+    'academic-study-plan-minus' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/minus.svg',
+    ],
+    'academic-study-plan-close' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/close.svg',
+    ],
 ];

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Frontend/Default/Templates/AcademicStudyPlan.html
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Frontend/Default/Templates/AcademicStudyPlan.html
@@ -41,8 +41,8 @@
                                 </f:if>
                             </div>
 
-                            <core:icon identifier="plus" alternativeMarkupIdentifier="inline"/>
-                            <core:icon identifier="minus" alternativeMarkupIdentifier="inline"/>
+                            <core:icon identifier="academic-study-plan-plus" alternativeMarkupIdentifier="inline"/>
+                            <core:icon identifier="academic-study-plan-minus" alternativeMarkupIdentifier="inline"/>
                         </div>
 
                         <f:if condition="{semester.note}">
@@ -92,7 +92,7 @@
                                             </div>
 
                                             <button aria-label="{f:translate(key: 'modal.close', extensionName: 'academic_study_plan')}">
-                                                <core:icon identifier="close-button" alternativeMarkupIdentifier="inline" />
+                                                <core:icon identifier="academic-study-plan-close" alternativeMarkupIdentifier="inline" />
                                             </button>
                                         </div>
 

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Css/academic-study-plan.css
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Css/academic-study-plan.css
@@ -53,16 +53,16 @@
         .col {
             padding: 0;
 
-            .icon-minus {
+            .icon-academic-study-plan-minus {
                 display: none;
             }
 
             &.open {
-                .icon-plus {
+                .icon-academic-study-plan-plus {
                     display: none;
                 }
 
-                .icon-minus {
+                .icon-academic-study-plan-minus {
                     display: block;
                 }
 

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/close.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M4 4l8 8M12 4l-8 8"/>
+</svg>

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/minus.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/minus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M3 8h10"/>
+</svg>

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/plus.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M8 3v10M3 8h10"/>
+</svg>

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementTest.php
@@ -162,6 +162,23 @@ final class AcademicStudyPlanContentElementTest extends AbstractAcademicStudyPla
     }
 
     #[Test]
+    public function contentElementRendersOnlyResolvableIcons(): void
+    {
+        $this->setUpTestCase('studyPlanPage');
+
+        $content = $this->renderHomePage();
+        // `core:icon` never fails on an unknown identifier: it renders the
+        // `default-not-found` placeholder, the small red "broken" icon, and the
+        // identifier that was asked for is gone from the markup.
+        $this->assertStringNotContainsString('default-not-found', $content);
+        // The three identifiers the element actually asks for, so a rename in
+        // `Configuration/Icons.php` without one in the template is caught here too.
+        $this->assertStringContainsString('data-identifier="academic-study-plan-plus"', $content);
+        $this->assertStringContainsString('data-identifier="academic-study-plan-minus"', $content);
+        $this->assertStringContainsString('data-identifier="academic-study-plan-close"', $content);
+    }
+
+    #[Test]
     public function contentElementRendersNoDialogForModuleWithoutContent(): void
     {
         $this->setUpTestCase('studyPlanPage');


### PR DESCRIPTION
Fixes ACE-327.

`AcademicStudyPlan.html` asked for `plus`, `minus` and `close-button`. None of
the three is registered — verified against the actual declaration
(`EXT:core/Resources/Public/Icons/T3Icons/icons.json`, 787 icons + 192
aliases) and against every `Configuration/Icons.php` in the installed tree,
rather than by pattern-matching a registry. `core:icon` does not fail on an
unknown identifier; it renders the `default-not-found` placeholder, so a
single study plan shipped **six** broken icons on both v13 and v14.

## The fix

Own SVGs rather than core's backend artwork — these are frontend controls:

| identifier | file |
|---|---|
| `academic-study-plan-plus` | `Resources/Public/Icons/plus.svg` |
| `academic-study-plan-minus` | `Resources/Public/Icons/minus.svg` |
| `academic-study-plan-close` | `Resources/Public/Icons/close.svg` |

All three are drawn in `currentColor`, so they take the colour of the
surrounding text instead of a fixed backend palette.

## ⚠ CSS classes move with the identifiers

`Icon::wrappedIcon()` emits `icon-<identifier>` as a class, and
`academic-study-plan.css` toggles `.icon-plus` / `.icon-minus` for the
expand/collapse state of a semester. Both selectors are renamed to
`.icon-academic-study-plan-plus` / `-minus` in this change.

**Site packages that ship their own CSS for this element need the same
rename.** The class names are part of the rendered contract here, not an
internal detail — this is the one downstream-visible part of the change.

## Coverage

`contentElementRendersOnlyResolvableIcons()` asserts no `default-not-found`
in the output *and* that the three identifiers are present. The second half
catches a later rename in `Configuration/Icons.php` that misses the template,
which would otherwise put the placeholder back silently.

Before this change the same test reports `placeholders=12` (six icon
elements, each carrying the string twice — class and `data-identifier`).

## Verified

`cgl -n`, `phpstan` and the `academic_study_plan` functional suite on
v13/PHP 8.2 and v14/PHP 8.3.
