### PR TITLE
[BUGFIX] ACE-327: Ship the study plan control icons

### DIFF
--- a/packages/fgtclb/academic-study-plan/Configuration/Icons.php
+++ b/packages/fgtclb/academic-study-plan/Configuration/Icons.php
@@ -19,4 +19,18 @@ return [
         'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         'source' => 'EXT:academic_study_plan/Resources/Public/Icons/module.svg',
     ],
+    // Frontend controls of the study plan element, unlike the record icons above:
+    // drawn in `currentColor` so they take the colour of the surrounding text.
+    'academic-study-plan-plus' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/plus.svg',
+    ],
+    'academic-study-plan-minus' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/minus.svg',
+    ],
+    'academic-study-plan-close' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:academic_study_plan/Resources/Public/Icons/close.svg',
+    ],
 ];

--- a/packages/fgtclb/academic-study-plan/Resources/Private/Frontend/Default/Templates/AcademicStudyPlan.html
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Frontend/Default/Templates/AcademicStudyPlan.html
@@ -41,8 +41,8 @@
                                 </f:if>
                             </div>
 
-                            <core:icon identifier="plus" alternativeMarkupIdentifier="inline"/>
-                            <core:icon identifier="minus" alternativeMarkupIdentifier="inline"/>
+                            <core:icon identifier="academic-study-plan-plus" alternativeMarkupIdentifier="inline"/>
+                            <core:icon identifier="academic-study-plan-minus" alternativeMarkupIdentifier="inline"/>
                         </div>
 
                         <f:if condition="{semester.note}">
@@ -92,7 +92,7 @@
                                             </div>
 
                                             <button aria-label="{f:translate(key: 'modal.close', extensionName: 'academic_study_plan')}">
-                                                <core:icon identifier="close-button" alternativeMarkupIdentifier="inline" />
+                                                <core:icon identifier="academic-study-plan-close" alternativeMarkupIdentifier="inline" />
                                             </button>
                                         </div>
 

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Css/academic-study-plan.css
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Css/academic-study-plan.css
@@ -53,16 +53,16 @@
         .col {
             padding: 0;
 
-            .icon-minus {
+            .icon-academic-study-plan-minus {
                 display: none;
             }
 
             &.open {
-                .icon-plus {
+                .icon-academic-study-plan-plus {
                     display: none;
                 }
 
-                .icon-minus {
+                .icon-academic-study-plan-minus {
                     display: block;
                 }
 

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/close.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M4 4l8 8M12 4l-8 8"/>
+</svg>

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/minus.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/minus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M3 8h10"/>
+</svg>

--- a/packages/fgtclb/academic-study-plan/Resources/Public/Icons/plus.svg
+++ b/packages/fgtclb/academic-study-plan/Resources/Public/Icons/plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M8 3v10M3 8h10"/>
+</svg>


### PR DESCRIPTION
Backport of #389 (ACE-327) to `2`.

`AcademicStudyPlan.html` asked for `plus`, `minus` and `close-button`, none of
which is registered — identical three lines to `main`, verified in this
branch's file. `core:icon` does not fail on an unknown identifier; it renders
the `default-not-found` placeholder, so a single study plan shipped **six**
broken icons.

| identifier | file |
|---|---|
| `academic-study-plan-plus` | `Resources/Public/Icons/plus.svg` |
| `academic-study-plan-minus` | `Resources/Public/Icons/minus.svg` |
| `academic-study-plan-close` | `Resources/Public/Icons/close.svg` |

Own SVGs in `currentColor` rather than core's `actions-*` backend artwork —
these are frontend controls.

## ⚠ CSS classes move with the identifiers

`Icon::wrappedIcon()` emits `icon-<identifier>` as a class, and
`academic-study-plan.css` toggles `.icon-plus` / `.icon-minus` for the
expand/collapse state of a semester. Both are renamed to
`.icon-academic-study-plan-plus` / `-minus`.

**Site packages that ship their own CSS for this element need the same
rename.** The class names are part of the rendered contract here.

## Backport notes

* Without the regression test from #389 — this branch has no
  `AcademicStudyPlanContentElementTest`, it arrived on `main` with ACE-320.
* The four shared files are **byte identical** to `main` after this change
  (diffed, empty).
* `Configuration/Icons.php` is loaded on v12 too, by
  `AbstractServiceProvider::configureIcons()` — checked against the installed
  12.4.22 rather than assumed from v13.

## Verified

`cgl -n`, `phpstan` and the `academic_study_plan` functional suite on
v13/PHP 8.2 and v12/PHP 8.1.
