### PR TITLE
[TASK] ACE-328: Cover study plan translation path

### DIFF
--- a/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
+++ b/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
@@ -96,13 +96,17 @@ final class StudyPlanService
             ->select('c.*')
             ->from('tx_academicstudyplan_domain_model_category', 'c')
             ->join('c', 'tx_academicstudyplan_module_category_mm', 'mm', $queryBuilder->expr()->eq('mm.uid_foreign', 'c.uid'))
-            // @todo Consider to add additional join to `*_module` along with language/hidden/deleted constraints below
+            // Deliberately no join to `*_module`: this query is keyed by a single module
+            // uid that `fetchModules()` has already selected under the language, hidden
+            // and deleted constraints, so a join could only re-check that same row. The
+            // relations of a module that did not pass those constraints are unreachable
+            // for the same reason - it is never fetched, so its uid is never passed in.
+            // Verified by AcademicStudyPlanContentElementLocalizationTest.
             ->where(
                 $queryBuilder->expr()->eq('mm.uid_local', $queryBuilder->createNamedParameter($moduleUid, Connection::PARAM_INT)),
                 $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
-                // @todo Consider to add `*_module` constraints for language/hidden/deleted if join is added above
             )
             ->orderBy('c.label', 'ASC')
             // Ensuring deterministic sorting behaviour

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementLocalizationTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementLocalizationTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicStudyPlan\Tests\Functional\ContentElement;
+
+use FGTCLB\AcademicStudyPlan\Tests\Functional\AbstractAcademicStudyPlanTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academic_study_plan` content element in a second site language.
+ *
+ * The translation path of this element is hand written rather than inherited from
+ * Extbase: `StudyPlanProcessor` resolves the content element through its
+ * `transOrigPointerField` and hands the language to `StudyPlanService`, which selects
+ * `sys_language_uid IN (0, -1)` only and overlays every semester, module and category
+ * one by one through `PageRepository::getLanguageOverlay()`.
+ *
+ * Two consequences of that design decide what these tests assert, and both were read
+ * off core rather than assumed:
+ *
+ * - `getRecordOverlay()` keeps the **default language** `uid` on an overlaid row and
+ *   puts the translation uid into `_LOCALIZED_UID`. The service therefore walks the
+ *   record tree by default language uids, which is why the fixtures wire the mm rows
+ *   of a module to its default language uid only.
+ * - `getLanguageOverlay()` overlays nothing when the language aspect has
+ *   `OVERLAYS_OFF`, which is what a site language of `fallbackType: free` produces
+ *   (`LanguageAspectFactory::createFromSiteLanguage()`). The element then renders its
+ *   default language children on a translated page - documented by
+ *   {@see self::freeModeRendersDefaultLanguageChildrenForTranslatedContentElement()}
+ *   rather than silently accepted.
+ */
+final class AcademicStudyPlanContentElementLocalizationTest extends AbstractAcademicStudyPlanTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    /**
+     * @param 'strict'|'fallback'|'free' $fallbackType
+     */
+    private function setUpTestCase(string $dataSet, string $fallbackType = 'strict'): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicStudyPlanContentElementLocalization/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_study_plan/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:academic_study_plan/Tests/Functional/ContentElement/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: $fallbackType === 'fallback' ? ['EN'] : [],
+                fallbackType: $fallbackType,
+            ),
+        ]);
+    }
+
+    private function renderEnglishPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function renderGermanPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/de/home');
+    }
+
+    #[Test]
+    public function translatedContentElementRendersTranslatedSemesters(): void
+    {
+        $this->setUpTestCase('localizedStudyPlan');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Erstes Semester', $content);
+        $this->assertStringContainsString('[DE] Zweites Semester', $content);
+        $this->assertStringContainsString('[DE] Grundlagenkurse', $content);
+        $this->assertStringNotContainsString('First Semester', $content);
+        $this->assertStringNotContainsString('Second Semester', $content);
+    }
+
+    #[Test]
+    public function translatedContentElementRendersTranslatedModules(): void
+    {
+        $this->setUpTestCase('localizedStudyPlan');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Mathematik I', $content);
+        $this->assertStringContainsString('[DE] Programmiergrundlagen', $content);
+        $this->assertStringContainsString('[DE] Statistik', $content);
+        $this->assertStringContainsString('[DE] Anwesenheitspflicht', $content);
+        $this->assertStringContainsString('[DE] Lineare Algebra und Analysis.', $content);
+        $this->assertStringNotContainsString('Mathematics I', $content);
+    }
+
+    #[Test]
+    public function translatedContentElementRendersTranslatedCategories(): void
+    {
+        $this->setUpTestCase('localizedStudyPlan');
+
+        // The categories travel to the markup as a JSON data attribute for the filter
+        // script, so the translated label has to show up inside it.
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Pflicht', $content);
+        $this->assertStringContainsString('[DE] Wahlfach', $content);
+        $this->assertStringNotContainsString('Mandatory&quot;', $content);
+    }
+
+    #[Test]
+    public function defaultLanguageStillRendersDefaultLanguageRecords(): void
+    {
+        $this->setUpTestCase('localizedStudyPlan');
+
+        $content = $this->renderEnglishPage();
+        $this->assertStringContainsString('First Semester', $content);
+        $this->assertStringContainsString('Mathematics I', $content);
+        $this->assertStringNotContainsString('[DE]', $content);
+    }
+
+    #[Test]
+    public function categoriesAreResolvedThroughTheDefaultLanguageModule(): void
+    {
+        // The translated module carries mm rows of its own, pointing at the translated
+        // categories - what DataHandler leaves behind after localizing a module. The
+        // service must not pick them up: it walks the record tree by default language
+        // uids, so each category has to appear once, through the overlay, and the
+        // relations of the translated module have to stay unused.
+        $this->setUpTestCase('localizedStudyPlan_localizedMmRows');
+
+        $content = $this->renderGermanPage();
+        $this->assertSame(1, substr_count($content, '[DE] Pflicht'));
+        $this->assertSame(1, substr_count($content, '[DE] Wahlfach'));
+    }
+
+    #[Test]
+    public function freeModeRendersDefaultLanguageChildrenForTranslatedContentElement(): void
+    {
+        // Free mode is the one configuration in which the `l10n_parent` hop of
+        // `StudyPlanProcessor` is load bearing: no overlay happens, so the translated
+        // content element itself is rendered, uid and all. Its semesters point at the
+        // translated element, but the service only ever selects language 0 and -1, so
+        // without the hop to the default language element nothing would resolve at all.
+        $this->setUpTestCase('localizedStudyPlan', 'free');
+
+        $content = $this->renderGermanPage();
+        // The translated element is what renders ...
+        $this->assertStringContainsString('[DE] Studienplan', $content);
+        // ... while its children come from the default language, unoverlaid. This is
+        // current behaviour, not an endorsement: a free mode site shows English
+        // semesters below a German heading.
+        $this->assertStringContainsString('First Semester', $content);
+        $this->assertStringContainsString('Mathematics I', $content);
+        $this->assertStringNotContainsString('[DE] Erstes Semester', $content);
+    }
+
+    #[Test]
+    public function strictModeKeepsUntranslatedRecordsInTheDefaultLanguage(): void
+    {
+        // `getTranslatedRecord()` ends in `... ?? $row`, so a record without a
+        // translation survives as its default language row even though the site
+        // language is strict and core would drop an untranslated `tt_content`.
+        // Documented, not asserted as desirable.
+        $this->setUpTestCase('localizedStudyPlan_partiallyTranslated');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Erstes Semester', $content);
+        $this->assertStringContainsString('[DE] Mathematik I', $content);
+        $this->assertStringContainsString('Second Semester', $content);
+        $this->assertStringContainsString('Programming Basics', $content);
+        $this->assertStringContainsString('Statistics', $content);
+    }
+
+    #[Test]
+    public function fallbackModeKeepsUntranslatedRecordsInTheDefaultLanguage(): void
+    {
+        $this->setUpTestCase('localizedStudyPlan_partiallyTranslated', 'fallback');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Erstes Semester', $content);
+        $this->assertStringContainsString('[DE] Mathematik I', $content);
+        $this->assertStringContainsString('Second Semester', $content);
+        $this->assertStringContainsString('Programming Basics', $content);
+    }
+
+    #[Test]
+    public function categoryRelationsIgnoreHiddenDeletedAndTranslationOnlyRecords(): void
+    {
+        // The state the two `@todo`s in `fetchCategoriesForModule()` ask about. The
+        // relation query joins the mm table only, without the module table, and this
+        // is what that costs: nothing. Every category below hangs off the same module.
+        $this->setUpTestCase('localizedStudyPlan_categoryEdgeCases');
+
+        $content = $this->renderGermanPage();
+        // Translated, so the German label wins.
+        $this->assertStringContainsString('[DE] Pflicht', $content);
+        // Hidden and deleted categories never enter the result set.
+        $this->assertStringNotContainsString('Hidden Category', $content);
+        $this->assertStringNotContainsString('Deleted Category', $content);
+        // A record that exists only as a translation is not a default language row, so
+        // the `IN (0, -1)` constraint keeps it out - it can never be overlaid onto
+        // anything.
+        $this->assertStringNotContainsString('[DE] Nur uebersetzt', $content);
+        // A category whose translation is hidden falls back to the default language
+        // label rather than disappearing: the overlay finds nothing and
+        // `getTranslatedRecord()` returns the original row.
+        $this->assertStringContainsString('Elective', $content);
+        $this->assertStringNotContainsString('[DE] Wahlfach hidden', $content);
+        // And the relations of a hidden module stay unreachable, because that module is
+        // never fetched in the first place - which is precisely why joining the module
+        // table into this query would add nothing.
+        $this->assertStringNotContainsString('Hidden Module', $content);
+        $this->assertStringNotContainsString('Only On Hidden Module', $content);
+    }
+
+    #[Test]
+    public function recordsForAllLanguagesRenderInBothLanguages(): void
+    {
+        // `sys_language_uid = -1` is why the query says `IN (0, -1)` rather than `= 0`.
+        // Core returns such rows from the overlay untouched, so they have to show up
+        // unchanged in either language.
+        $this->setUpTestCase('localizedStudyPlan_allLanguagesRecords');
+
+        $english = $this->renderEnglishPage();
+        $this->assertStringContainsString('Shared Semester', $english);
+        $this->assertStringContainsString('Shared Module', $english);
+
+        $german = $this->renderGermanPage();
+        $this->assertStringContainsString('Shared Semester', $german);
+        $this->assertStringContainsString('Shared Module', $german);
+        $this->assertStringContainsString('[DE] Erstes Semester', $german);
+    }
+}

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan.csv
@@ -1,0 +1,33 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,1,2,0,"/home","Home (DE)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","Study plan",2,"<p>All modules are subject to change.</p>"
+,2,2,0,0,1,1,"academic_study_plan","[DE] Studienplan",2,"<p>[DE] Aenderungen vorbehalten.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","Foundation courses",30,2
+,2,2,0,0,0,0,2,1,"Second Semester","",30,1
+,3,2,0,0,1,1,1,2,"[DE] Erstes Semester","[DE] Grundlagenkurse",30,2
+,4,2,0,0,1,2,2,2,"[DE] Zweites Semester","",30,1
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","Mandatory attendance",10,"Linear algebra and analysis.",2
+,2,2,0,0,0,0,2,1,"Programming Basics","",5,"",0
+,3,2,0,0,0,0,1,2,"Statistics","",8,"Descriptive and inductive.",0
+,4,2,0,0,1,1,1,3,"[DE] Mathematik I","[DE] Anwesenheitspflicht",10,"[DE] Lineare Algebra und Analysis.",2
+,5,2,0,0,1,2,2,3,"[DE] Programmiergrundlagen","",5,"",0
+,6,2,0,0,1,3,1,4,"[DE] Statistik","",8,"[DE] Deskriptiv und induktiv.",0
+"tx_academicstudyplan_domain_model_category",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","label","colour"
+,1,2,0,0,0,0,1,"Mandatory","#cc0000"
+,2,2,0,0,0,0,2,"Elective","#0066cc"
+,3,2,0,0,1,1,1,"[DE] Pflicht","#cc0000"
+,4,2,0,0,1,2,2,"[DE] Wahlfach","#0066cc"
+"tx_academicstudyplan_module_category_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,0,1
+,1,2,0,2

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_allLanguagesRecords.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_allLanguagesRecords.csv
@@ -1,0 +1,19 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,1,2,0,"/home","Home (DE)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","Study plan",2,""
+,2,2,0,0,1,1,"academic_study_plan","[DE] Studienplan",2,""
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","",30,1
+,2,2,0,0,-1,0,2,1,"Shared Semester","",30,1
+,3,2,0,0,1,1,1,2,"[DE] Erstes Semester","",30,1
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","",10,"",0
+,2,2,0,0,-1,0,1,2,"Shared Module","",5,"",0
+,3,2,0,0,1,1,1,3,"[DE] Mathematik I","",10,"",0

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_categoryEdgeCases.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_categoryEdgeCases.csv
@@ -1,0 +1,36 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,1,2,0,"/home","Home (DE)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","Study plan",1,""
+,2,2,0,0,1,1,"academic_study_plan","[DE] Studienplan",1,""
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","",30,2
+,2,2,0,0,1,1,1,2,"[DE] Erstes Semester","",30,2
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","",10,"",4
+,2,2,0,1,0,0,2,1,"Hidden Module","",5,"",1
+,3,2,0,0,1,1,1,2,"[DE] Mathematik I","",10,"",4
+"tx_academicstudyplan_domain_model_category",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","label","colour"
+,1,2,0,0,0,0,1,"Mandatory","#cc0000"
+,2,2,0,0,0,0,2,"Elective","#0066cc"
+,3,2,0,1,0,0,3,"Hidden Category","#00cc00"
+,4,2,1,0,0,0,4,"Deleted Category","#cccc00"
+,5,2,0,0,1,1,1,"[DE] Pflicht","#cc0000"
+,6,2,0,1,1,2,2,"[DE] Wahlfach hidden","#0066cc"
+,7,2,0,0,1,0,5,"[DE] Nur uebersetzt","#333333"
+,8,2,0,0,0,0,6,"Only On Hidden Module","#999999"
+"tx_academicstudyplan_module_category_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,0,1
+,1,2,0,2
+,1,3,0,3
+,1,4,0,4
+,1,7,0,5
+,2,8,0,1

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_localizedMmRows.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_localizedMmRows.csv
@@ -1,0 +1,35 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,1,2,0,"/home","Home (DE)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","Study plan",2,"<p>All modules are subject to change.</p>"
+,2,2,0,0,1,1,"academic_study_plan","[DE] Studienplan",2,"<p>[DE] Aenderungen vorbehalten.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","Foundation courses",30,2
+,2,2,0,0,0,0,2,1,"Second Semester","",30,1
+,3,2,0,0,1,1,1,2,"[DE] Erstes Semester","[DE] Grundlagenkurse",30,2
+,4,2,0,0,1,2,2,2,"[DE] Zweites Semester","",30,1
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","Mandatory attendance",10,"Linear algebra and analysis.",2
+,2,2,0,0,0,0,2,1,"Programming Basics","",5,"",0
+,3,2,0,0,0,0,1,2,"Statistics","",8,"Descriptive and inductive.",0
+,4,2,0,0,1,1,1,3,"[DE] Mathematik I","[DE] Anwesenheitspflicht",10,"[DE] Lineare Algebra und Analysis.",2
+,5,2,0,0,1,2,2,3,"[DE] Programmiergrundlagen","",5,"",0
+,6,2,0,0,1,3,1,4,"[DE] Statistik","",8,"[DE] Deskriptiv und induktiv.",0
+"tx_academicstudyplan_domain_model_category",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","label","colour"
+,1,2,0,0,0,0,1,"Mandatory","#cc0000"
+,2,2,0,0,0,0,2,"Elective","#0066cc"
+,3,2,0,0,1,1,1,"[DE] Pflicht","#cc0000"
+,4,2,0,0,1,2,2,"[DE] Wahlfach","#0066cc"
+"tx_academicstudyplan_module_category_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,0,1
+,1,2,0,2
+,4,3,0,1
+,4,4,0,2

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_partiallyTranslated.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementLocalization/localizedStudyPlan_partiallyTranslated.csv
@@ -1,0 +1,20 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,1,2,0,"/home","Home (DE)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","Study plan",2,"<p>All modules are subject to change.</p>"
+,2,2,0,0,1,1,"academic_study_plan","[DE] Studienplan",2,"<p>[DE] Aenderungen vorbehalten.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules"
+,1,2,0,0,0,0,1,1,"First Semester","Foundation courses",30,2
+,2,2,0,0,0,0,2,1,"Second Semester","",30,1
+,3,2,0,0,1,1,1,2,"[DE] Erstes Semester","[DE] Grundlagenkurse",30,2
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories"
+,1,2,0,0,0,0,1,1,"Mathematics I","Mandatory attendance",10,"Linear algebra and analysis.",0
+,2,2,0,0,0,0,2,1,"Programming Basics","",5,"",0
+,3,2,0,0,0,0,1,2,"Statistics","",8,"Descriptive and inductive.",0
+,4,2,0,0,1,1,1,3,"[DE] Mathematik I","[DE] Anwesenheitspflicht",10,"[DE] Lineare Algebra und Analysis.",0


### PR DESCRIPTION
Closes ACE-328. `main` only — the ACE-305 rendering harness does not exist on `2`.

Ten rendering tests in a second site language for the hand-written translation
path of `EXT:academic_study_plan`, which no test executed.

## Read off core before writing fixtures

Two behaviours decide what the fixtures may even look like, so both were
checked in the installed core rather than assumed:

* `PageRepository::getRecordOverlay()` keeps the **default language** `uid` on
  an overlaid row and moves the translation uid to `_LOCALIZED_UID`. The
  service therefore walks the record tree by default-language uids — which is
  why the mm rows of a module hang off its default-language uid in the
  fixtures.
* `getLanguageOverlay()` overlays nothing when the aspect has `OVERLAYS_OFF`,
  which is what a site language of `fallbackType: free` produces
  (`LanguageAspectFactory::createFromSiteLanguage()`).

## Every test checked to fail for the right reason

Verified by mutating the production code, not by inspection:

| mutation | tests that fail |
|---|---|
| remove the `l10n_parent` hop in `StudyPlanProcessor` | **1** — the free-mode one |
| `getTranslatedRecord()` returns the row unoverlaid | **7** of 10 |
| narrow `IN (0, -1)` to `= 0` | **1** — the all-languages one |

The first row is the interesting one: under `strict` and `fallback` the
overlay already hands back the default-language uid, so **the hop is only
load-bearing in free mode**. Worth knowing before anyone simplifies it away.

## Two tests document current behaviour, not desirable behaviour

Both say so at the assertion:

* a `free` mode site renders **default-language** semesters below a translated
  heading — the children are never overlaid there;
* `getTranslatedRecord()` ends in `?? $row`, so an untranslated record
  survives in the default language even where the site language is `strict`
  and core would drop an untranslated `tt_content`.

Neither is changed here. Say the word if either should become an issue.

## The two `@todo`s are answered, by experiment

`fetchCategoriesForModule()` asked whether it should join `*_module` and
repeat the language/hidden/deleted constraints. **It should not**, and the
second commit replaces the question with the reason: the query is keyed by a
single module uid that `fetchModules()` already selected under exactly those
constraints, so a join could only re-check the same row. Relations of a
module that did not pass them are unreachable because that module is never
fetched.

The fixture behind that answer hangs all of these off one study plan: hidden
and deleted categories, a category existing only as a translation, a category
whose translation is hidden (falls back to the default label), and a category
reachable only through a hidden module.

## Unrelated finding, not touched here

`StudyPlanService::getLanguageFieldRestrictionForTable()` ignores its
`$tableName` parameter and hard-codes
`'tx_academicstudyplan_domain_model_semester'` (line 209). It is **inert**
today — all three tables declare `languageField = sys_language_uid`, checked
in their TCA — but the next table with a different language field would get
the wrong one silently. Worth its own issue rather than a rider here.

## Verified

`cgl -n`, `phpstan` and the full `academic_study_plan` functional suite (47
tests) on v13/PHP 8.2 and v14/PHP 8.3.
