### PR TITLE
[TASK] ACE-329: Cover card plugin in multi language

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -142,8 +142,17 @@ final class ProfileController extends ActionController
     }
 
     /**
-     * @todo This action is literally broken in multi language sites. Needs to be adopted and covered
-     *       with functional tests.
+     * This action used to carry a `@todo` calling it broken in multi language sites. That
+     * did not survive being reproduced: rendered across the language matrix in
+     * {@see \FGTCLB\AcademicPersons\Tests\Functional\Plugins\AcademicPersonsCardPluginLocalizationTest}
+     * it returns what the list plugin returns from the same selection.
+     *
+     * Two results in that matrix are still not desirable, and neither belongs to this
+     * action: a `fallbackType: free` site gets default language profiles, and before
+     * TYPO3 v14.3.6 a `strict` site keeps untranslated ones (forge #88886). Both come out
+     * of the shared `profileList` branch of `ProfileRepository::applyDemandForQuery()`,
+     * which turns language handling off before matching uids, and both were confirmed to
+     * hit `listAction()` in the same way.
      *
      * @return ResponseInterface
      */

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginLocalizationTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginLocalizationTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Renders the `academicpersons_card` plugin in a second site language.
+ *
+ * `cardAction()` carried a standing `@todo` claiming the action "is literally broken in
+ * multi language sites". These tests were written to reproduce that, and **it does not
+ * reproduce**: across the matrix below the card renders what the list plugin renders
+ * from the same selection, and the list behaviour is the covered and accepted one (see
+ * `AcademicPersonsListPluginTest`). The `@todo` was removed on the strength of these
+ * tests rather than acted on.
+ *
+ * That is not the same as calling every result here desirable. Two are not, and both are
+ * properties of the shared `profileList` path in
+ * `ProfileRepository::applyDemandForQuery()`, which disables language handling outright
+ * (`setRespectSysLanguage(false)`) before matching uids - so they hit the list plugin
+ * just as hard:
+ *
+ * - a site language with `fallbackType: free` renders **default language** profiles.
+ *   Verified by rendering the list plugin under the same configuration, which produced
+ *   the same English output.
+ * - under `fallbackType: strict` an untranslated profile is not dropped. That one is a
+ *   core Extbase defect (forge #88886) fixed in TYPO3 v14.3.6, and the two tests below
+ *   split on that version exactly as the list plugin tests do.
+ *
+ * If either should change it belongs in an issue against the repository query, not
+ * against this action.
+ */
+final class AcademicPersonsCardPluginLocalizationTest extends AbstractAcademicPersonsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    /**
+     * @param 'strict'|'fallback'|'free' $fallbackType
+     */
+    private function setUpTestCase(string $dataSet, string $fallbackType = 'strict'): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsCardPluginLocalization/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: $fallbackType === 'fallback' ? ['EN'] : [],
+                fallbackType: $fallbackType,
+            ),
+        ]);
+    }
+
+    private function renderEnglishPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function renderGermanPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/de/home');
+    }
+
+    /**
+     * The item partial composes the heading from first, middle and last name, so an empty
+     * middle name leaves two spaces in the markup.
+     */
+    private function assertRendersProfileName(string $content, string $first, string $last): void
+    {
+        $this->assertMatchesRegularExpression(
+            sprintf('#%s\s+%s#u', preg_quote($first, '#'), preg_quote($last, '#')),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function fullyLocalizedCardRendersTranslatedProfilesForRequestedLanguage(): void
+    {
+        $this->setUpTestCase('cardPage_fullyLocalized');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[DE] Horst', 'Huber');
+        $this->assertStringNotContainsString('[EN] Max', $content);
+        $this->assertStringNotContainsString('[EN] Horst', $content);
+    }
+
+    #[Test]
+    public function fullyLocalizedCardRendersTranslatedContractsAndLocations(): void
+    {
+        // The card renders contract data through the item partial, and a contract carries
+        // a location relation - three record types have to be overlaid, not just the
+        // profile itself.
+        $this->setUpTestCase('cardPage_fullyLocalized');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Professor', $content);
+        $this->assertStringContainsString('[DE] Dozent', $content);
+        $this->assertStringContainsString('[DE] Hauptgelaende', $content);
+        $this->assertStringNotContainsString('[EN] Main Campus', $content);
+    }
+
+    #[Test]
+    public function fullyLocalizedCardRendersDefaultLanguageProfilesForRequestedDefaultLanguage(): void
+    {
+        $this->setUpTestCase('cardPage_fullyLocalized');
+
+        $content = $this->renderEnglishPage();
+        $this->assertRendersProfileName($content, '[EN] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
+        $this->assertStringNotContainsString('[DE]', $content);
+    }
+
+    #[Test]
+    public function fullyLocalizedCardWithFallbackTypeFallbackRendersTranslatedProfiles(): void
+    {
+        $this->setUpTestCase('cardPage_fullyLocalized', 'fallback');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[DE] Horst', 'Huber');
+        $this->assertStringNotContainsString('[EN] Max', $content);
+    }
+
+    #[Test]
+    public function fullyLocalizedCardWithFallbackTypeFreeRendersDefaultLanguageProfiles(): void
+    {
+        // Current behaviour, and not a desirable one: a free mode site gets English
+        // profiles under a German heading. It is not specific to this action - the list
+        // plugin rendered under the same configuration produced the same English output.
+        // The cause is `applyDemandForQuery()` calling `setRespectSysLanguage(false)` for
+        // the `profileList` path, which both actions share.
+        $this->setUpTestCase('cardPage_fullyLocalized', 'free');
+
+        $content = $this->renderGermanPage();
+        // The translated content element is what renders ...
+        $this->assertStringContainsString('[DE] Unser Team', $content);
+        // ... with default language profiles inside it.
+        $this->assertRendersProfileName($content, '[EN] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
+        $this->assertStringNotContainsString('[DE] Max', $content);
+    }
+
+    /**
+     * Untranslated selected profiles are fetched through Extbase persistence, which did
+     * not honour "fallbackType: strict" before TYPO3 v14.3.6 (forge #88886, core change
+     * 66694 with 14.3 backport 94935, no v13.4 backport). This test states the corrected
+     * behaviour and therefore only runs from v14.3.6 on; the test below states what
+     * happens before it, so the action is covered on every supported core either way.
+     *
+     * @todo Verify this assertion once TYPO3 v14.3.6 or newer is installable here - it
+     *       mirrors `AcademicPersonsListPluginTest`, which carries the same open `@todo`.
+     * @see https://forge.typo3.org/issues/88886
+     */
+    #[Test]
+    public function partiallyLocalizedCardWithFallbackTypeStrictDropsUntranslatedProfiles(): void
+    {
+        if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
+            $this->markTestSkipped(
+                'Extbase honours "fallbackType: strict" for untranslated selected profiles only since '
+                . 'TYPO3 v14.3.6 (forge #88886).'
+            );
+        }
+        $this->setUpTestCase('cardPage_notAllProfilesLocalized');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertStringNotContainsString('Horst', $content);
+    }
+
+    /**
+     * The inverse of the test above: what every core this extension currently supports
+     * actually does. Measured on v13.4 and on v14.3.5, and identical to the list plugin
+     * under the same fixture - which is what settles that this action is not at fault.
+     *
+     * @see https://forge.typo3.org/issues/88886
+     */
+    #[Test]
+    public function partiallyLocalizedCardWithFallbackTypeStrictKeepsUntranslatedProfilesBeforeCoreFix(): void
+    {
+        if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '>=')) {
+            $this->markTestSkipped(
+                'Core fix for forge #88886 is present, see the test above for the corrected behaviour.'
+            );
+        }
+        $this->setUpTestCase('cardPage_notAllProfilesLocalized');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
+    }
+
+    #[Test]
+    public function partiallyLocalizedCardWithPluginFallbackFlagRendersUntranslatedProfiles(): void
+    {
+        // `settings.fallbackForNonTranslated` is the one language option this action does
+        // honour, and the reason it exists: show a profile that has no translation even
+        // where the site language is strict.
+        $this->setUpTestCase('cardPage_notAllProfilesLocalized_fallbackForNonTranslatedSet');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
+    }
+
+    #[Test]
+    public function partiallyLocalizedCardWithFallbackTypeFallbackRendersUntranslatedProfiles(): void
+    {
+        $this->setUpTestCase('cardPage_notAllProfilesLocalized', 'fallback');
+
+        $content = $this->renderGermanPage();
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
@@ -25,9 +25,9 @@ use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
  * `lib.contentElement`, and on TYPO3 v14 that renders through the `record` view variable,
  * which is what the header assertion covers.
  *
- * Multi language is deliberately out of scope here: `cardAction()` carries a `@todo`
- * stating it is broken for multi language sites, so covering it would mean asserting
- * behaviour that is known to be wrong.
+ * Multi language is out of scope here and covered by
+ * {@see AcademicPersonsCardPluginLocalizationTest} instead, which is also where the
+ * `@todo` claiming this action is broken in multi language sites was settled.
  */
 final class AcademicPersonsCardPluginTest extends AbstractAcademicPersonsTestCase
 {

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_fullyLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_fullyLocalized.csv
@@ -1,0 +1,29 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,5,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+,4,100,0,0,1,3,"[DE] Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"[EN] Main Campus"
+,2,100,0,0,1,1,"[DE] Hauptgelaende"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"[EN] Professor",1,"A 101"
+,2,100,0,0,1,1,2,"[DE] Professor",2,"A 101"
+,3,100,0,0,0,0,3,"[EN] Lecturer",1,"B 202"
+,4,100,0,0,1,3,4,"[DE] Dozent",2,"B 202"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_card","Our team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_card","[DE] Unser Team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_notAllProfilesLocalized.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_notAllProfilesLocalized.csv
@@ -1,0 +1,27 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,5,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"[EN] Main Campus"
+,2,100,0,0,1,1,"[DE] Hauptgelaende"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"[EN] Professor",1,"A 101"
+,2,100,0,0,1,1,2,"[DE] Professor",2,"A 101"
+,3,100,0,0,0,0,3,"[EN] Lecturer",1,"B 202"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_card","Our team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_card","[DE] Unser Team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/Fixtures/AcademicPersonsCardPluginLocalization/cardPage_notAllProfilesLocalized_fallbackForNonTranslatedSet.csv
@@ -1,0 +1,27 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)"
+,2,0,1,0,0,1,1,0,"/","Site Root (DE)"
+,3,1,1,0,0,0,0,0,"/home","Home (EN)"
+,4,1,1,0,0,1,3,0,"/home","Home (DE)"
+,5,1,1,0,0,0,0,0,"/profiles","Profiles"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,1,100,0,"/sysfolder-records","Datensatzsammlung"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,1,1,"[DE] Max","Müllermann","max-muellermann"
+,3,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"[EN] Main Campus"
+,2,100,0,0,1,1,"[DE] Hauptgelaende"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"[EN] Professor",1,"A 101"
+,2,100,0,0,1,1,2,"[DE] Professor",2,"A 101"
+,3,100,0,0,0,0,3,"[EN] Lecturer",1,"B 202"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,3,0,0,0,0,"academicpersons_card","Our team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,1,1,"academicpersons_card","[DE] Unser Team","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF"">1,3</value></field><field index=""settings.detailPid""><value index=""vDEF"">5</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">1</value></field><field index=""settings.showFields""><value index=""vDEF""></value></field></language></sheet></data></T3FlexForms>"


### PR DESCRIPTION
Closes ACE-329.

`cardAction()` carried a `@todo` calling itself *"literally broken in multi
language sites"*. Nobody had reproduced it, and the issue said so — step one
was a reproduction, not a fix.

**It does not reproduce.** Nine rendering tests in a second site language,
both core versions, translated page and translated content element each time:

| fixture | site language | plugin flag | rendered |
|---|---|---|---|
| fully translated | `strict` | – | German profiles, contracts, locations ✅ |
| fully translated | `fallback` | – | German ✅ |
| fully translated | default language request | – | English, no German leak ✅ |
| fully translated | `free` | – | **English profiles under a German heading** ⚠ |
| partly translated | `strict` | – | untranslated one kept ⚠ (core, see below) |
| partly translated | `strict` | `fallbackForNonTranslated` | German + English ✅ — what the flag is for |
| partly translated | `fallback` | – | German + English ✅ |

Everywhere the list plugin is covered, the card matches it.

## The two ⚠ rows are not this action's

Both come out of the `profileList` branch of
`ProfileRepository::applyDemandForQuery()`, which calls
`setRespectSysLanguage(false)` before matching uids — shared with
`listAction()`.

* **free mode** — checked rather than argued: I rendered the *list* plugin
  under the same site configuration and got the same English output.
* **strict keeping untranslated profiles** — core Extbase, forge
  [#88886](https://forge.typo3.org/issues/88886), fixed in v14.3.6. The list
  plugin tests already split on that version.

If either should change, it wants an issue against the repository query. Say
the word and I'll file it.

## Covering a fix that is not installable yet

v14.3.5 is the newest release available, so the corrected `strict` behaviour
cannot be observed anywhere today. The mirror of the list plugin's test (skip
below 14.3.6, assert the corrected behaviour) would therefore cover *nothing*
on every supported core — so this adds its inverse as well, asserting what
14.3.5 and 13.4 actually do. One of the two always runs.

## The `@todo` is gone

Replaced by what was measured, including which two results are still ugly and
where they come from, so the next reader inherits the answer instead of the
suspicion.

## Not backported

Branch `2` has the identical action, but no rendering harness — ACE-305 landed
on `main` only.

## Verified

`cgl -n`, `phpstan` and the full `academic_persons` functional suite (231 on
v13, 232 on v14) on v13/PHP 8.2 and v14/PHP 8.3.
