### PR TITLE
[TASK] ACE-340: Resolve language field per table

### DIFF
--- a/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
+++ b/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
@@ -34,7 +34,7 @@ final class StudyPlanService
             ->from('tx_academicstudyplan_domain_model_semester')
             ->where(
                 $queryBuilder->expr()->eq('content_element', $queryBuilder->createNamedParameter($contentElementUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_semester'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
             )
@@ -65,7 +65,7 @@ final class StudyPlanService
             ->from('tx_academicstudyplan_domain_model_module')
             ->where(
                 $queryBuilder->expr()->eq('semester', $queryBuilder->createNamedParameter($semesterUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_module'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
             )
@@ -104,7 +104,7 @@ final class StudyPlanService
             // Verified by AcademicStudyPlanContentElementLocalizationTest.
             ->where(
                 $queryBuilder->expr()->eq('mm.uid_local', $queryBuilder->createNamedParameter($moduleUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
             )
@@ -204,13 +204,16 @@ final class StudyPlanService
         return null;
     }
 
+    /**
+     * No `Context` argument, unlike the two restrictions below: which language a record
+     * belongs to is a property of the row, so there is no visibility aspect to consult.
+     */
     private function getLanguageFieldRestrictionForTable(
         QueryBuilder $queryBuilder,
-        Context $context,
         string $tableName,
         ?string $alias = null,
     ): string {
-        $languageFieldName = $this->getTableLanguageFieldName('tx_academicstudyplan_domain_model_semester');
+        $languageFieldName = $this->getTableLanguageFieldName($tableName);
         if ($languageFieldName === null || $languageFieldName === '') {
             // return empty string to omit condition
             return '';


### PR DESCRIPTION
Closes ACE-340.

`StudyPlanService::getLanguageFieldRestrictionForTable()` took a `$tableName`
and then asked `getTableLanguageFieldName()` for the **semester** table
regardless, so the semester table decided the language column for the module
and category queries too. Its two siblings,
`getHiddenRestrictionForTable()` and `getDeletedRestrictionForTable()`, pass
their argument through as intended — which is what marks this as a slip
rather than a decision.

## No behaviour change, and that is the point

All three tables declare `languageField = sys_language_uid` — checked in their
TCA, not assumed — so the resolved name and the emitted SQL are identical
before and after. What changes is the guarantee: the constraint now follows
whichever table it is built for, instead of holding only for as long as the
three happen to agree.

## No test comes with this, deliberately

A test can only observe the defect once two of the tables disagree on their
language field, which no fixture can arrange without a schema change — the
ACE-328 localisation coverage passes on both the old and the new code. Rather
than build something contrived, the 47 `academic_study_plan` functional tests
were run on both core versions to confirm the opposite of a regression:
nothing moved.

This was called out in the issue before the fix was written, so the absence of
a test here is a stated position rather than an oversight.

## Drive-by, as the issue proposed

The unused `Context` argument goes with it. The other two restrictions read the
visibility aspect from it and genuinely need it; which language a record
belongs to is a property of the row. Private method, three call sites, all in
this class — no API concern.

## Verified

`cgl -n`, `phpstan` and the `academic_study_plan` functional suite (47 tests)
on v13/PHP 8.2 and v14/PHP 8.3.
