### PR TITLE
[TASK] ACE-340: Resolve language field per table

### DIFF
--- a/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
+++ b/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
@@ -34,7 +34,7 @@ final class StudyPlanService
             ->from('tx_academicstudyplan_domain_model_semester')
             ->where(
                 $queryBuilder->expr()->eq('content_element', $queryBuilder->createNamedParameter($contentElementUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_semester'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_semester'),
             )
@@ -65,7 +65,7 @@ final class StudyPlanService
             ->from('tx_academicstudyplan_domain_model_module')
             ->where(
                 $queryBuilder->expr()->eq('semester', $queryBuilder->createNamedParameter($semesterUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_module'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_module'),
             )
@@ -99,7 +99,7 @@ final class StudyPlanService
             // @todo Consider to add additional join to `*_module` along with language/hidden/deleted constraints below
             ->where(
                 $queryBuilder->expr()->eq('mm.uid_local', $queryBuilder->createNamedParameter($moduleUid, Connection::PARAM_INT)),
-                $this->getLanguageFieldRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
+                $this->getLanguageFieldRestrictionForTable($queryBuilder, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getHiddenRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
                 $this->getDeletedRestrictionForTable($queryBuilder, $context, 'tx_academicstudyplan_domain_model_category', 'c'),
                 // @todo Consider to add `*_module` constraints for language/hidden/deleted if join is added above
@@ -200,13 +200,16 @@ final class StudyPlanService
         return null;
     }
 
+    /**
+     * No `Context` argument, unlike the two restrictions below: which language a record
+     * belongs to is a property of the row, so there is no visibility aspect to consult.
+     */
     private function getLanguageFieldRestrictionForTable(
         QueryBuilder $queryBuilder,
-        Context $context,
         string $tableName,
         ?string $alias = null,
     ): string {
-        $languageFieldName = $this->getTableLanguageFieldName('tx_academicstudyplan_domain_model_semester');
+        $languageFieldName = $this->getTableLanguageFieldName($tableName);
         if ($languageFieldName === null || $languageFieldName === '') {
             // return empty string to omit condition
             return '';


### PR DESCRIPTION
Backport of #393 (ACE-340) to `2`.

`StudyPlanService::getLanguageFieldRestrictionForTable()` took a `$tableName`
and then asked `getTableLanguageFieldName()` for the **semester** table
regardless, so the semester table decided the language column for the module
and category queries too. Identical code and identical line on this branch.

## No behaviour change here either

All three tables declare `languageField = sys_language_uid` — checked in
**this branch's** TCA, not carried over from `main` — so the emitted SQL is
the same before and after. What changes is the guarantee: the constraint
follows the table it is built for instead of holding only while the three
agree.

## No test, deliberately

A test can only observe this once two tables disagree on their language field,
which no fixture can arrange without a schema change. This branch has no study
plan rendering coverage in any case (ACE-305 landed on `main` only), so the 24
`academic_study_plan` functional tests were run on both core versions to
confirm the opposite of a regression: nothing moved.

## Drive-by

The unused `Context` argument goes with it — the other two restrictions read
the visibility aspect from it and need it; the language of a row is not a
context question. Private method, three call sites, all in this class.

The two `@todo`s in `fetchCategoriesForModule()` stay untouched here: they
were answered on `main` under ACE-328, which is not backportable without that
branch's coverage.

## Verified

`cgl -n`, `phpstan` and the `academic_study_plan` functional suite on
v13/PHP 8.2 and v12/PHP 8.1.
