### PR TITLE
[BUGFIX] ACE-341: Overlay selected records in free mode

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -147,12 +147,13 @@ final class ProfileController extends ActionController
      * {@see \FGTCLB\AcademicPersons\Tests\Functional\Plugins\AcademicPersonsCardPluginLocalizationTest}
      * it returns what the list plugin returns from the same selection.
      *
-     * Two results in that matrix are still not desirable, and neither belongs to this
-     * action: a `fallbackType: free` site gets default language profiles, and before
-     * TYPO3 v14.3.6 a `strict` site keeps untranslated ones (forge #88886). Both come out
-     * of the shared `profileList` branch of `ProfileRepository::applyDemandForQuery()`,
-     * which turns language handling off before matching uids, and both were confirmed to
-     * hit `listAction()` in the same way.
+     * One result in that matrix is still not desirable, and it does not belong to this
+     * action: before TYPO3 v14.3.6 a `strict` site keeps untranslated profiles (forge
+     * #88886, core). The other one - a `fallbackType: free` site rendering default
+     * language profiles - was ours and is fixed, see
+     * `ProfileRepository::matchSelectedUidsAcrossLanguages()` and ACE-341. Both came out
+     * of the shared `profileList` branch of `applyDemandForQuery()` and hit
+     * `listAction()` in the same way.
      *
      * @return ResponseInterface
      */

--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
@@ -159,6 +159,34 @@ class ProfileRepository extends Repository
     }
 
     /**
+     * Prepare a query that matches records by uid taken from a manual selection.
+     *
+     * FormEngine persists such a selection as **default language** uids, so the language
+     * restriction has to come off - otherwise nothing matches in a translation. That
+     * alone is not enough: with `fallbackType: free` the aspect carries `OVERLAYS_OFF`,
+     * and the default language rows would then be handed to the frontend unoverlaid. So
+     * the aspect is lifted to `OVERLAYS_ON_WITH_FLOATING` first, and only then is the
+     * restriction dropped.
+     *
+     * Adopted from the generic Extbase backend implementation, and the same shape as
+     * `ContractRepository`, `EXT:academic_contacts4pages` `ContactRepository` and
+     * `EXT:academic_partners` `PartnershipRepository`.
+     *
+     * @param QueryInterface<Profile> $query
+     */
+    private function matchSelectedUidsAcrossLanguages(QueryInterface $query): void
+    {
+        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
+        $changedLanguageAspect = new LanguageAspect(
+            $currentLanguageAspect->getId(),
+            $currentLanguageAspect->getContentId(),
+            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
+        );
+        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+    }
+
+    /**
      * @param QueryInterface<Profile> $query
      */
     private function applyDemandForQuery(QueryInterface $query, DemandInterface $demand): void
@@ -166,7 +194,7 @@ class ProfileRepository extends Repository
         // Direct selected profiles make all other filters and orderings obsolete and is handled first.
         if ($demand->getProfileList() !== '') {
             $profileUidArray = GeneralUtility::intExplode(',', $demand->getProfileList(), true);
-            $query->getQuerySettings()->setRespectSysLanguage(false);
+            $this->matchSelectedUidsAcrossLanguages($query);
             $query->matching($query->in('uid', $profileUidArray));
             return;
         }
@@ -231,18 +259,8 @@ class ProfileRepository extends Repository
     public function findByUids(array $uids, bool $showHidden = false): QueryResultInterface
     {
         $query = $this->createQuery();
-        // Selected uid's are default language and we need to configure extbase in away to
-        // properly handle the overlay. This is adopted from the generic extbase backend
-        // implementation.
-        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
-        $changedLanguageAspect = new LanguageAspect(
-            $currentLanguageAspect->getId(),
-            $currentLanguageAspect->getContentId(),
-            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
-        );
-        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $this->matchSelectedUidsAcrossLanguages($query);
         $query->getQuerySettings()->setRespectStoragePage(false);
-        $query->getQuerySettings()->setRespectSysLanguage(false);
         if ($showHidden === true) {
             $this->includeHiddenRecords($query);
         }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginLocalizationTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginLocalizationTest.php
@@ -20,21 +20,17 @@ use TYPO3\CMS\Core\Information\Typo3Version;
  * `AcademicPersonsListPluginTest`). The `@todo` was removed on the strength of these
  * tests rather than acted on.
  *
- * That is not the same as calling every result here desirable. Two are not, and both are
- * properties of the shared `profileList` path in
- * `ProfileRepository::applyDemandForQuery()`, which disables language handling outright
- * (`setRespectSysLanguage(false)`) before matching uids - so they hit the list plugin
- * just as hard:
+ * That is not the same as calling every result here desirable. Two were not, and neither
+ * belonged to this action - both came out of the shared `profileList` path in
+ * `ProfileRepository::applyDemandForQuery()`, so they hit the list plugin just as hard:
  *
- * - a site language with `fallbackType: free` renders **default language** profiles.
- *   Verified by rendering the list plugin under the same configuration, which produced
- *   the same English output.
+ * - a site language with `fallbackType: free` rendered **default language** profiles,
+ *   because dropping the language restriction for a selection of default language uids
+ *   left `OVERLAYS_OFF` in place and nothing overlaid the rows. Fixed under ACE-341;
+ *   the free mode test below asserts the corrected output.
  * - under `fallbackType: strict` an untranslated profile is not dropped. That one is a
  *   core Extbase defect (forge #88886) fixed in TYPO3 v14.3.6, and the two tests below
  *   split on that version exactly as the list plugin tests do.
- *
- * If either should change it belongs in an issue against the repository query, not
- * against this action.
  */
 final class AcademicPersonsCardPluginLocalizationTest extends AbstractAcademicPersonsTestCase
 {
@@ -165,22 +161,20 @@ final class AcademicPersonsCardPluginLocalizationTest extends AbstractAcademicPe
     }
 
     #[Test]
-    public function fullyLocalizedCardWithFallbackTypeFreeRendersDefaultLanguageProfiles(): void
+    public function fullyLocalizedCardWithFallbackTypeFreeRendersTranslatedProfiles(): void
     {
-        // Current behaviour, and not a desirable one: a free mode site gets English
-        // profiles under a German heading. It is not specific to this action - the list
-        // plugin rendered under the same configuration produced the same English output.
-        // The cause is `applyDemandForQuery()` calling `setRespectSysLanguage(false)` for
-        // the `profileList` path, which both actions share.
+        // Free mode used to render English profiles under a German heading (ACE-341):
+        // a manual selection holds default language uids, so the language restriction
+        // has to come off - but with `OVERLAYS_OFF` nothing then overlaid the rows that
+        // came back. `matchSelectedUidsAcrossLanguages()` lifts the aspect first.
         $this->setUpTestCase('cardPage_fullyLocalized', 'free');
 
         $content = $this->renderGermanPage();
-        // The translated content element is what renders ...
         $this->assertStringContainsString('[DE] Unser Team', $content);
-        // ... with default language profiles inside it.
-        $this->assertRendersProfileName($content, '[EN] Max', 'Müllermann');
-        $this->assertRendersProfileName($content, '[EN] Horst', 'Huber');
-        $this->assertStringNotContainsString('[DE] Max', $content);
+        $this->assertRendersProfileName($content, '[DE] Max', 'Müllermann');
+        $this->assertRendersProfileName($content, '[DE] Horst', 'Huber');
+        $this->assertStringNotContainsString('[EN] Max', $content);
+        $this->assertStringNotContainsString('[EN] Horst', $content);
     }
 
     /**

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -336,6 +336,38 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
+    /**
+     * The list plugin reaches the same `profileList` branch of
+     * `ProfileRepository::applyDemandForQuery()` as the card plugin, and used to render
+     * default language profiles on a `fallbackType: free` site for the same reason
+     * (ACE-341). Kept here as well so a regression in that shared query cannot pass by
+     * only breaking one of the two plugins.
+     */
+    #[Test]
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageWithFallbackTypeFree(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: [],
+                fallbackType: 'free',
+            ),
+        ]);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
+        $this->assertStringContainsString('[DE] Horst Huber', $content);
+        $this->assertStringContainsString('[DE] Max Müllermann', $content);
+        $this->assertStringNotContainsString('[EN] Horst Huber', $content);
+        $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
     #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {

--- a/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
@@ -8,8 +8,10 @@ use FGTCLB\AcademicProjects\Domain\Model\Dto\ActiveState;
 use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
 use FGTCLB\AcademicProjects\Domain\Model\Project;
 use FGTCLB\AcademicProjects\Enumeration\PageTypes;
+use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -39,11 +41,7 @@ class ProjectRepository extends Repository
         if (!empty($demand->getPages())) {
             if ($demand->getShowSelected() === true) {
                 $constraints[] = $query->in('uid', $demand->getPages());
-                // Selecting record ids in the backend (FormEngine) are always persisted using the default language
-                // uid of the records unrelated to the language and leads to missing translated contend depending on
-                // the site configuration and frontend context. In these cases we need to disable respecting the
-                // system langauge to tell Extbase ORM to do proper overlay handling in this case.
-                $query->getQuerySettings()->setRespectSysLanguage(false);
+                $this->matchSelectedUidsAcrossLanguages($query);
             } else {
                 $constraints[] = $query->in('pid', $demand->getPages());
                 $query->getQuerySettings()->setRespectStoragePage(true);
@@ -90,5 +88,33 @@ class ProjectRepository extends Repository
         );
 
         return $query->execute();
+    }
+
+    /**
+     * Prepare a query that matches records by uid taken from a manual selection.
+     *
+     * FormEngine persists such a selection as **default language** uids, so the language
+     * restriction has to come off - otherwise nothing matches in a translation. That
+     * alone is not enough: with `fallbackType: free` the aspect carries `OVERLAYS_OFF`,
+     * and the default language rows are then handed to the frontend unoverlaid, which is
+     * how a German page ended up listing English projects (ACE-341). So the aspect is
+     * lifted to `OVERLAYS_ON_WITH_FLOATING` first, and only then is the restriction
+     * dropped.
+     *
+     * Adopted from the generic Extbase backend implementation, and the same shape as
+     * `EXT:academic_persons` `ProfileRepository::matchSelectedUidsAcrossLanguages()`.
+     *
+     * @param QueryInterface<Project> $query
+     */
+    private function matchSelectedUidsAcrossLanguages(QueryInterface $query): void
+    {
+        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
+        $changedLanguageAspect = new LanguageAspect(
+            $currentLanguageAspect->getId(),
+            $currentLanguageAspect->getContentId(),
+            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
+        );
+        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
     }
 }

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/AcademicProjectsProjectListLocalizationTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/AcademicProjectsProjectListLocalizationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Plugins;
+
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+
+/**
+ * Renders the `academicprojects_projectlistsingle` plugin in a second site language.
+ *
+ * A project is a page, and the plugin holds a manual selection of page uids. As in
+ * `EXT:academic_persons`, FormEngine stores that selection as default language uids, so
+ * `ProjectRepository` drops the language restriction before matching them - the shape
+ * that cost the persons plugins their translations under `fallbackType: free` (ACE-341).
+ *
+ * It was tempting to assume `pages` escapes that, since
+ * `PageRepository::getLanguageOverlay()` routes pages through `getPageOverlay()` even in
+ * free mode. Rendering it said otherwise: before the fix this plugin listed
+ * `[EN] Solar fields project` on the German page, exactly like the persons ones. Hence
+ * the same `matchSelectedUidsAcrossLanguages()` here.
+ */
+final class AcademicProjectsProjectListLocalizationTest extends AbstractAcademicProjectsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+        'DE' => ['id' => 1, 'title' => 'Deutsch', 'locale' => 'de_DE.UTF8', 'iso' => 'de', 'hrefLang' => 'de-DE', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    /**
+     * @param 'strict'|'fallback'|'free' $fallbackType
+     */
+    private function setUpTestCase(string $dataSet, string $fallbackType = 'strict'): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicProjectsProjectListLocalization/' . $dataSet . '.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_projects/Configuration/TypoScript/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_projects/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_projects/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: $fallbackType === 'fallback' ? ['EN'] : [],
+                fallbackType: $fallbackType,
+            ),
+        ]);
+    }
+
+    private function renderGermanPage(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/de/home');
+    }
+
+    #[Test]
+    public function selectedProjectRendersTranslatedWithFallbackTypeStrict(): void
+    {
+        $this->setUpTestCase('projectListSinglePage_fullyLocalized');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Solarfelder Projekt', $content);
+        $this->assertStringNotContainsString('[EN] Solar fields project', $content);
+    }
+
+    #[Test]
+    public function selectedProjectRendersTranslatedWithFallbackTypeFallback(): void
+    {
+        $this->setUpTestCase('projectListSinglePage_fullyLocalized', 'fallback');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Solarfelder Projekt', $content);
+        $this->assertStringNotContainsString('[EN] Solar fields project', $content);
+    }
+
+    #[Test]
+    public function selectedProjectRendersTranslatedWithFallbackTypeFree(): void
+    {
+        // The case that broke the persons plugins, and this one with them: without the
+        // aspect fix-up the German page listed the English project title.
+        $this->setUpTestCase('projectListSinglePage_fullyLocalized', 'free');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringContainsString('[DE] Unser Projekt', $content);
+        $this->assertStringContainsString('[DE] Solarfelder Projekt', $content);
+        $this->assertStringNotContainsString('[EN] Solar fields project', $content);
+    }
+
+    #[Test]
+    public function selectedProjectDoesNotLeakTheUnselectedOne(): void
+    {
+        $this->setUpTestCase('projectListSinglePage_fullyLocalized', 'free');
+
+        $content = $this->renderGermanPage();
+        $this->assertStringNotContainsString('Quantenforschungsprojekt', $content);
+        $this->assertStringNotContainsString('Quantum research project', $content);
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsProjectListLocalization/projectListSinglePage_fullyLocalized.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Plugins/Fixtures/AcademicProjectsProjectListLocalization/projectListSinglePage_fullyLocalized.csv
@@ -1,0 +1,13 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title","tx_academicprojects_project_title","tx_academicprojects_short_description"
+,1,0,1,0,0,0,0,0,"/","Site Root (EN)","",""
+,2,1,1,0,0,0,0,0,"/home","Home (EN)","",""
+,3,1,1,0,0,1,2,0,"/home","Home (DE)","",""
+,10,1,30,0,0,0,0,0,"/quantum-research","Quantum Research","[EN] Quantum research project","[EN] Investigating quantum effects."
+,11,1,30,0,0,0,0,0,"/solar-fields","Solar fields","[EN] Solar fields project","[EN] Photovoltaics on former farmland."
+,20,1,30,0,0,1,10,0,"/quantum-research","Quantenforschung","[DE] Quantenforschungsprojekt","[DE] Untersuchung von Quanteneffekten."
+,21,1,30,0,0,1,11,0,"/solar-fields","Solarfelder","[DE] Solarfelder Projekt","[DE] Photovoltaik auf ehemaligem Ackerland."
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","pi_flexform"
+,1,2,0,0,0,0,"academicprojects_projectlistsingle","Our project","11","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">1</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">1</value></field><field index=""settings.hideSorting""><value index=""vDEF"">1</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,2,0,0,1,1,"academicprojects_projectlistsingle","[DE] Unser Projekt","11","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.hideActiveState""><value index=""vDEF"">1</value></field><field index=""settings.activeState""><value index=""vDEF"">all</value></field><field index=""settings.hideFilter""><value index=""vDEF"">1</value></field><field index=""settings.hideSorting""><value index=""vDEF"">1</value></field><field index=""settings.sorting""><value index=""vDEF"">title asc</value></field><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"


### PR DESCRIPTION
Closes ACE-341.

A manually selected set of records rendered in the **default language** on a
site language using `fallbackType: free` — a German page listing English
profiles or an English project title.

FormEngine persists such a selection as default-language uids, so the
repositories drop the language restriction before matching them; otherwise
nothing matches in a translation. On its own that is not enough: free mode
gives the aspect `OVERLAYS_OFF`, so the rows that come back are never overlaid
and reach the template verbatim. `matchSelectedUidsAcrossLanguages()` lifts
the aspect to `OVERLAYS_ON_WITH_FLOATING` first and only then drops the
restriction.

## Two extensions, and the second one was not a formality

`EXT:academic_persons` — `ProfileRepository::applyDemandForQuery()`. The
helper is shared with `findByUids()`, which already had the correct shape
inline, so the two cannot drift apart again.

`EXT:academic_projects` — `ProjectRepository`, the "show selected" branch. The
issue asked for this one to be **reproduced before being touched**, and that
was worth doing: I expected it *not* to reproduce, because
`PageRepository::getLanguageOverlay()` routes the `pages` table through
`getPageOverlay()` even in free mode. Rendering it said otherwise — the German
page listed `[EN] Solar fields project`. Had I trusted the reasoning, this
extension would have been left broken with a confident comment explaining why
it was fine.

## Tests

| | |
|---|---|
| card plugin, free mode | rewritten — it was written under ACE-329 to fail the day this was fixed, and did |
| list plugin, free mode | **new** — both plugins reach the same branch, so a regression must not be able to pass by breaking only one |
| projects, 3 language modes + selection isolation | **new** — this extension had no second-language coverage at all |

All three new/changed cases were run against the pre-fix code and fail there.

## Correction to the issue text

ACE-341 claimed four call sites already handled this "exactly". Two shapes
exist, and I checked each rather than trusting my own write-up:

* `ProfileRepository::findByUids()` and `ContractRepository` — conditional
  `OVERLAYS_OFF → OVERLAYS_ON_WITH_FLOATING`, what this change adopts;
* `EXT:academic_contacts4pages` `ContactRepository` and
  `EXT:academic_partners` `PartnershipRepository` — unconditional
  `OVERLAYS_ON`, which also avoids this defect but changes overlay behaviour
  in the other modes too.

Both are immune to ACE-341. The inconsistency is left alone here; it is worth
its own look, not a rider on a bugfix.

## Unchanged

`fallbackType: strict` still keeps untranslated selected profiles — core
Extbase, forge [#88886](https://forge.typo3.org/issues/88886), fixed in TYPO3
v14.3.6 (not yet released). Already covered from both sides.

## Verified

`cgl -n`, `phpstan` and the `academic_persons` (232/233) and
`academic_projects` (35) functional suites on v13/PHP 8.2 and v14/PHP 8.3.
