### PR TITLE
[BUGFIX] ACE-341: Overlay selected records in free mode

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
+++ b/packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php
@@ -159,6 +159,34 @@ class ProfileRepository extends Repository
     }
 
     /**
+     * Prepare a query that matches records by uid taken from a manual selection.
+     *
+     * FormEngine persists such a selection as **default language** uids, so the language
+     * restriction has to come off - otherwise nothing matches in a translation. That
+     * alone is not enough: with `fallbackType: free` the aspect carries `OVERLAYS_OFF`,
+     * and the default language rows would then be handed to the frontend unoverlaid. So
+     * the aspect is lifted to `OVERLAYS_ON_WITH_FLOATING` first, and only then is the
+     * restriction dropped.
+     *
+     * Adopted from the generic Extbase backend implementation, and the same shape as
+     * `ContractRepository`, `EXT:academic_contacts4pages` `ContactRepository` and
+     * `EXT:academic_partners` `PartnershipRepository`.
+     *
+     * @param QueryInterface<Profile> $query
+     */
+    private function matchSelectedUidsAcrossLanguages(QueryInterface $query): void
+    {
+        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
+        $changedLanguageAspect = new LanguageAspect(
+            $currentLanguageAspect->getId(),
+            $currentLanguageAspect->getContentId(),
+            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
+        );
+        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+    }
+
+    /**
      * @param QueryInterface<Profile> $query
      */
     private function applyDemandForQuery(QueryInterface $query, DemandInterface $demand): void
@@ -166,7 +194,7 @@ class ProfileRepository extends Repository
         // Direct selected profiles make all other filters and orderings obsolete and is handled first.
         if ($demand->getProfileList() !== '') {
             $profileUidArray = GeneralUtility::intExplode(',', $demand->getProfileList(), true);
-            $query->getQuerySettings()->setRespectSysLanguage(false);
+            $this->matchSelectedUidsAcrossLanguages($query);
             $query->matching($query->in('uid', $profileUidArray));
             return;
         }
@@ -231,18 +259,8 @@ class ProfileRepository extends Repository
     public function findByUids(array $uids, bool $showHidden = false): QueryResultInterface
     {
         $query = $this->createQuery();
-        // Selected uid's are default language and we need to configure extbase in away to
-        // properly handle the overlay. This is adopted from the generic extbase backend
-        // implementation.
-        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
-        $changedLanguageAspect = new LanguageAspect(
-            $currentLanguageAspect->getId(),
-            $currentLanguageAspect->getContentId(),
-            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
-        );
-        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $this->matchSelectedUidsAcrossLanguages($query);
         $query->getQuerySettings()->setRespectStoragePage(false);
-        $query->getQuerySettings()->setRespectSysLanguage(false);
         if ($showHidden === true) {
             $this->includeHiddenRecords($query);
         }

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php
@@ -467,6 +467,50 @@ final class AcademicPersonsListPluginTest extends AbstractAcademicPersonsTestCas
         $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
     }
 
+    /**
+     * The list plugin reaches the `profileList` branch of
+     * `ProfileRepository::applyDemandForQuery()`, which used to render default language
+     * profiles on a `fallbackType: free` site (ACE-341). On `main` the card plugin covers
+     * the same branch; this branch has no card rendering test, so this is the only guard
+     * against a regression in that shared query here.
+     */
+    #[Test]
+    public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageWithFallbackTypeFree(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsListPlugin/fullyLocalized_selectedProfiles.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: 'https://www.acme.com/',
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+                $this->buildLanguageConfiguration(
+                    identifier: 'DE',
+                    base: '/de/',
+                    fallbackIdentifiers: [],
+                    fallbackType: 'free',
+                ),
+            ],
+        );
+
+        $requestContext = new InternalRequestContext();
+        $request = new InternalRequest('https://www.acme.com/de/home');
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $content = (string)$response->getBody();
+        $this->assertStringContainsString('[DE] Horst Huber', $content);
+        $this->assertStringContainsString('[DE] Max Müllermann', $content);
+        $this->assertStringNotContainsString('[EN] Horst Huber', $content);
+        $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
     #[Test]
     public function fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageInSelectedOrderWithFallbackTypeFallbackWhenNotAllProfilesAreLocalized(): void
     {

--- a/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
+++ b/packages/fgtclb/academic-projects/Classes/Domain/Repository/ProjectRepository.php
@@ -8,8 +8,10 @@ use FGTCLB\AcademicProjects\Domain\Model\Dto\ActiveState;
 use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
 use FGTCLB\AcademicProjects\Domain\Model\Project;
 use FGTCLB\AcademicProjects\Enumeration\PageTypes;
+use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -39,11 +41,7 @@ class ProjectRepository extends Repository
         if (!empty($demand->getPages())) {
             if ($demand->getShowSelected() === true) {
                 $constraints[] = $query->in('uid', $demand->getPages());
-                // Selecting record ids in the backend (FormEngine) are always persisted using the default language
-                // uid of the records unrelated to the language and leads to missing translated contend depending on
-                // the site configuration and frontend context. In these cases we need to disable respecting the
-                // system langauge to tell Extbase ORM to do proper overlay handling in this case.
-                $query->getQuerySettings()->setRespectSysLanguage(false);
+                $this->matchSelectedUidsAcrossLanguages($query);
             } else {
                 $constraints[] = $query->in('pid', $demand->getPages());
                 $query->getQuerySettings()->setRespectStoragePage(true);
@@ -90,5 +88,33 @@ class ProjectRepository extends Repository
         );
 
         return $query->execute();
+    }
+
+    /**
+     * Prepare a query that matches records by uid taken from a manual selection.
+     *
+     * FormEngine persists such a selection as **default language** uids, so the language
+     * restriction has to come off - otherwise nothing matches in a translation. That
+     * alone is not enough: with `fallbackType: free` the aspect carries `OVERLAYS_OFF`,
+     * and the default language rows are then handed to the frontend unoverlaid, which is
+     * how a German page ended up listing English projects (ACE-341). So the aspect is
+     * lifted to `OVERLAYS_ON_WITH_FLOATING` first, and only then is the restriction
+     * dropped.
+     *
+     * Adopted from the generic Extbase backend implementation, and the same shape as
+     * `EXT:academic_persons` `ProfileRepository::matchSelectedUidsAcrossLanguages()`.
+     *
+     * @param QueryInterface<Project> $query
+     */
+    private function matchSelectedUidsAcrossLanguages(QueryInterface $query): void
+    {
+        $currentLanguageAspect = $query->getQuerySettings()->getLanguageAspect();
+        $changedLanguageAspect = new LanguageAspect(
+            $currentLanguageAspect->getId(),
+            $currentLanguageAspect->getContentId(),
+            $currentLanguageAspect->getOverlayType() === LanguageAspect::OVERLAYS_OFF ? LanguageAspect::OVERLAYS_ON_WITH_FLOATING : $currentLanguageAspect->getOverlayType()
+        );
+        $query->getQuerySettings()->setLanguageAspect($changedLanguageAspect);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
     }
 }


### PR DESCRIPTION
Backport of #395 (ACE-341) to `2`.

A manually selected set of records rendered in the **default language** on a
site language using `fallbackType: free`. Both defects exist on this branch
identically — verified in this branch's files, not inferred from `main`:

* `ProfileRepository::applyDemandForQuery()`, the `profileList` branch;
* `ProjectRepository`, the "show selected" branch.

`matchSelectedUidsAcrossLanguages()` lifts the language aspect to
`OVERLAYS_ON_WITH_FLOATING` before dropping the language restriction. Both
repository files are **byte identical to `main`** after this change (diffed,
empty).

## What could not follow, and why

| | |
|---|---|
| card plugin free-mode test | this branch has no card rendering test — ACE-329 is `main` only |
| projects localisation tests | this extension has **no** frontend rendering harness on this branch at all |
| list plugin free-mode test | **kept**, rewritten in this branch's own harness |

That last one matters: `main`'s version uses `writeFrontendPluginTestSite()`
from the testing helper, which does not exist here. Copying it across would
have errored rather than failed — so it is rewritten with
`writeSiteConfiguration()` / `InternalRequest`, the idiom the neighbouring
localisation tests in this file already use, and then checked against the
pre-fix code to confirm it fails there.

With the card plugin uncovered here, that single test is the whole guard for
the persons half on this branch. The projects half has no rendering coverage
here at all; the four tests that prove it live on `main`, where the defect was
reproduced first.

## `ProfileController` keeps its `@todo`

The note claiming `cardAction()` is broken in multi language sites stays. It
was disproved under ACE-329 by tests that do not exist on this branch —
removing it here would leave the claim neither stated nor answered.

## Verified

`cgl -n`, `phpstan` and the `academic_persons` (208) and `academic_projects`
(22) functional suites on v13/PHP 8.2 and v12/PHP 8.1.
