### PR TITLE
[BUGFIX] ACE-330: Sort card by selection order

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -114,16 +115,10 @@ final class ProfileController extends ActionController
 
         // If profiles were selected manually, sort them by order in selection
         if (!empty($demand->getProfileList())) {
-            $selectedProfiles = [];
-            $profileUidArray = GeneralUtility::intExplode(',', $demand->getProfileList(), true);
-            foreach ($profileUidArray as $uid) {
-                foreach ($profiles as $profile) {
-                    if ($profile->getUid() === $uid) {
-                        $selectedProfiles[] = $profile;
-                    }
-                }
-            }
-            $profiles = $selectedProfiles;
+            $profiles = $this->sortBySelectionOrder(
+                $profiles,
+                GeneralUtility::intExplode(',', $demand->getProfileList(), true),
+            );
         }
 
         $this->view->assignMultiple([
@@ -134,6 +129,36 @@ final class ProfileController extends ActionController
         $this->addCacheTags('profile_list_view');
 
         return $this->htmlResponse();
+    }
+
+    /**
+     * Bring records into the order the editor put them in.
+     *
+     * A selection is an ordered list in the FlexForm, but the query that fetches it
+     * matches `uid IN (...)` and returns whatever order the DBMS yields - the
+     * `profileList` branch of `ProfileRepository::applyDemandForQuery()` returns before
+     * any `setOrderings()` at all. So the order has to be restored here.
+     *
+     * Records not in the selection are dropped and a uid listed twice yields the record
+     * twice, which is what the three hand written copies of this loop did before it was
+     * extracted.
+     *
+     * @template T of AbstractEntity
+     * @param iterable<T> $records
+     * @param int[] $uids
+     * @return list<T>
+     */
+    private function sortBySelectionOrder(iterable $records, array $uids): array
+    {
+        $sorted = [];
+        foreach ($uids as $uid) {
+            foreach ($records as $record) {
+                if ($record->getUid() === $uid) {
+                    $sorted[] = $record;
+                }
+            }
+        }
+        return $sorted;
     }
 
     public function initializeCardAction(): void
@@ -180,10 +205,11 @@ final class ProfileController extends ActionController
                 $profileDemand->setFallbackForNonTranslated($fallbackForNonTranslated);
             }
             $profileDemand->setShowHiddenRecords((bool)($this->settings['showHiddenRecords'] ?? false));
-            $profiles = $this->profileRepository->findByDemand($profileDemand);
+            $profiles = $this->sortBySelectionOrder(
+                $this->profileRepository->findByDemand($profileDemand),
+                GeneralUtility::intExplode(',', $this->settings['demand']['profileList'], true),
+            );
         }
-
-        // @todo Add enforced sorting based on selected uid's order, similar to listAction/selectedProfilesAction ?
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
@@ -287,19 +313,9 @@ final class ProfileController extends ActionController
         ));
         $profiles = $event->getProfiles();
 
-        // Sort profiles by order in selection
-        $sortedProfiles = [];
-        foreach ($profileUids as $uid) {
-            foreach ($profiles as $profile) {
-                if ($profile->getUid() === $uid) {
-                    $sortedProfiles[] = $profile;
-                }
-            }
-        }
-
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profiles' => $sortedProfiles,
+            'profiles' => $this->sortBySelectionOrder($profiles, $profileUids),
         ]);
 
         return $this->htmlResponse();
@@ -328,19 +344,9 @@ final class ProfileController extends ActionController
         ));
         $contracts = $event->getContracts();
 
-        // Sort profiles by order in selection
-        $sortedContracts = [];
-        foreach ($contractUids as $uid) {
-            foreach ($contracts as $contract) {
-                if ($contract->getUid() === $uid) {
-                    $sortedContracts[] = $contract;
-                }
-            }
-        }
-
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'contracts' => $sortedContracts,
+            'contracts' => $this->sortBySelectionOrder($contracts, $contractUids),
         ]);
 
         return $this->htmlResponse();

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsCardPluginTest.php
@@ -116,6 +116,22 @@ final class AcademicPersonsCardPluginTest extends AbstractAcademicPersonsTestCas
     }
 
     #[Test]
+    public function cardPluginRendersSelectedProfilesInSelectedOrder(): void
+    {
+        $this->setUpTestCase('cardPage');
+
+        // The FlexForm selection is `2,1` - Horst before Max, the reverse of the uid
+        // order. The query behind it matches `uid IN (...)` without any ordering, so
+        // the sequence has to be restored from the selection (ACE-330).
+        $content = $this->renderHomePage();
+        $horst = strpos($content, 'Horst');
+        $max = strpos($content, 'Max');
+        $this->assertIsInt($horst);
+        $this->assertIsInt($max);
+        $this->assertLessThan($max, $horst, 'Horst is selected first and has to render first.');
+    }
+
+    #[Test]
     public function cardPluginRendersContentElementHeader(): void
     {
         $this->setUpTestCase('cardPage');


### PR DESCRIPTION
Closes ACE-330.

The card plugin rendered its profiles in whatever order the database returned,
while its three sibling actions rebuilt the result in the order the editor
dragged the entries into. The same selection on the same page came out in a
different sequence depending on which plugin variant was picked, with nothing
in the backend to tell an editor which they would get.

There was no order to preserve, either: the `profileList` branch of
`ProfileRepository::applyDemandForQuery()` returns before any `setOrderings()`,
so the result is whatever the DBMS yields for `uid IN (...)`. The order exists
only in the FlexForm and has to be restored after the query.

## The `@todo` ended in a question mark

So the argument is worth stating rather than assuming: three of four actions
honour the order, the odd one out is the card, and a selection widget that lets
you drag entries into place has already promised that the order means
something. Answered by doing it.

## One helper instead of three copies

`listAction()`, `selectedProfilesAction()` and `selectedContractsAction()` each
carried their own copy of the same nested loop. All three now call
`sortBySelectionOrder()`, and `cardAction()` calls it too.

The helper keeps the exact semantics of the copies it replaces, including the
two easiest to lose in a rewrite: a record **not** in the selection is dropped,
and a uid listed **twice** yields its record twice.

## Why the extraction is safe to do in the same change

Mutation-checked rather than eyeballed:

| mutation | result |
|---|---|
| card sorting removed | the one new test fails |
| helper reverses the order | **12 tests** fail across all four actions |

The second row is the point — every call site of the extracted helper is
covered by existing tests, so a silent behaviour change during extraction had
somewhere to show up.

## Coverage

`cardPluginRendersSelectedProfilesInSelectedOrder` mirrors the assertion the
list plugin already has. The `cardPage` fixture selects `2,1` — Horst before
Max, the reverse of uid order — so the test is meaningful rather than
accidentally passing.

## Verified

`cgl -n`, `phpstan`, unit and the full `academic_persons` functional suite
(233 on v13, 234 on v14) on v13/PHP 8.2 and v14/PHP 8.3.
