### PR TITLE
[BUGFIX] ACE-330: Sort card by selection order

### DIFF
--- a/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
+++ b/packages/fgtclb/academic-persons/Classes/Controller/ProfileController.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -115,16 +116,10 @@ final class ProfileController extends ActionController
 
         // If profiles were selected manually, sort them by order in selection
         if (!empty($demand->getProfileList())) {
-            $selectedProfiles = [];
-            $profileUidArray = GeneralUtility::intExplode(',', $demand->getProfileList(), true);
-            foreach ($profileUidArray as $uid) {
-                foreach ($profiles as $profile) {
-                    if ($profile->getUid() === $uid) {
-                        $selectedProfiles[] = $profile;
-                    }
-                }
-            }
-            $profiles = $selectedProfiles;
+            $profiles = $this->sortBySelectionOrder(
+                $profiles,
+                GeneralUtility::intExplode(',', $demand->getProfileList(), true),
+            );
         }
 
         $this->view->assignMultiple([
@@ -135,6 +130,36 @@ final class ProfileController extends ActionController
         $this->addCacheTags('profile_list_view');
 
         return $this->htmlResponse();
+    }
+
+    /**
+     * Bring records into the order the editor put them in.
+     *
+     * A selection is an ordered list in the FlexForm, but the query that fetches it
+     * matches `uid IN (...)` and returns whatever order the DBMS yields - the
+     * `profileList` branch of `ProfileRepository::applyDemandForQuery()` returns before
+     * any `setOrderings()` at all. So the order has to be restored here.
+     *
+     * Records not in the selection are dropped and a uid listed twice yields the record
+     * twice, which is what the three hand written copies of this loop did before it was
+     * extracted.
+     *
+     * @template T of AbstractEntity
+     * @param iterable<T> $records
+     * @param int[] $uids
+     * @return list<T>
+     */
+    private function sortBySelectionOrder(iterable $records, array $uids): array
+    {
+        $sorted = [];
+        foreach ($uids as $uid) {
+            foreach ($records as $record) {
+                if ($record->getUid() === $uid) {
+                    $sorted[] = $record;
+                }
+            }
+        }
+        return $sorted;
     }
 
     public function initializeCardAction(): void
@@ -171,10 +196,11 @@ final class ProfileController extends ActionController
                 $profileDemand->setFallbackForNonTranslated($fallbackForNonTranslated);
             }
             $profileDemand->setShowHiddenRecords((bool)($this->settings['showHiddenRecords'] ?? false));
-            $profiles = $this->profileRepository->findByDemand($profileDemand);
+            $profiles = $this->sortBySelectionOrder(
+                $this->profileRepository->findByDemand($profileDemand),
+                GeneralUtility::intExplode(',', $this->settings['demand']['profileList'], true),
+            );
         }
-
-        // @todo Add enforced sorting based on selected uid's order, similar to listAction/selectedProfilesAction ?
 
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
@@ -278,19 +304,9 @@ final class ProfileController extends ActionController
         ));
         $profiles = $event->getProfiles();
 
-        // Sort profiles by order in selection
-        $sortedProfiles = [];
-        foreach ($profileUids as $uid) {
-            foreach ($profiles as $profile) {
-                if ($profile->getUid() === $uid) {
-                    $sortedProfiles[] = $profile;
-                }
-            }
-        }
-
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'profiles' => $sortedProfiles,
+            'profiles' => $this->sortBySelectionOrder($profiles, $profileUids),
         ]);
 
         return $this->htmlResponse();
@@ -319,19 +335,9 @@ final class ProfileController extends ActionController
         ));
         $contracts = $event->getContracts();
 
-        // Sort profiles by order in selection
-        $sortedContracts = [];
-        foreach ($contractUids as $uid) {
-            foreach ($contracts as $contract) {
-                if ($contract->getUid() === $uid) {
-                    $sortedContracts[] = $contract;
-                }
-            }
-        }
-
         $this->view->assignMultiple([
             'data' => $this->getCurrentContentObjectRenderer()?->data,
-            'contracts' => $sortedContracts,
+            'contracts' => $this->sortBySelectionOrder($contracts, $contractUids),
         ]);
 
         return $this->htmlResponse();


### PR DESCRIPTION
Backport of #397 (ACE-330) to `2`.

The card plugin rendered its profiles in database order while its three sibling
actions rebuilt the result in the order the editor dragged the entries into.
The `@todo` and all three duplicated loops are present on this branch
identically — verified in this branch's file.

There was no order to preserve: the `profileList` branch of
`ProfileRepository::applyDemandForQuery()` returns before any `setOrderings()`,
so the sequence was whatever the DBMS yielded for `uid IN (...)`.

## One helper instead of three copies

`listAction()`, `selectedProfilesAction()`, `selectedContractsAction()` and now
`cardAction()` share `sortBySelectionOrder()`. The helper keeps the exact
semantics of the copies it replaces, including the two easiest to lose: a
record **not** in the selection is dropped, and a uid listed **twice** yields
its record twice.

The controller is byte identical to `main`'s for every hunk of this change —
the `main`-only docblocks from ACE-329 and ACE-341 are not present here and
were not dragged in by the cherry-pick.

## No test here, and what that does and does not leave uncovered

This branch has no card plugin rendering test — ACE-312 landed on `main` only —
so the assertion that proves the *fix* lives there and cannot follow.

The *refactor* is still verified here: reversing the shared helper fails **16**
tests on this branch, across the other three actions. So the risky half of this
change — touching three working code paths — has real coverage on `2`; only the
card behaviour itself rests on `main`'s test.

## Verified

`cgl -n`, `phpstan` and the `academic_persons` functional suite (208 tests) on
v13/PHP 8.2 and v12/PHP 8.1.
