### PR TITLE
[TASK] ACE-331: Fix default label file language

### DIFF
--- a/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-study-plan/Resources/Private/Language/locallang.xlf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2"
 	xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
+	<file source-language="en" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z" product-name="academic_study_plan">
 		<header/>
 		<body>
 			<trans-unit id="filter.label">


### PR DESCRIPTION
Closes ACE-331. Branch `2` only — `main` was fixed under ACE-321 (#378, commit
`449ccda1`).

The default `locallang.xlf` of `academic_study_plan` declared
`target-language="de"`. That attribute belongs on `de.locallang.xlf`, which has
it and keeps it; a default file is the source catalogue and has no target
language.

## Nothing changes for users of this branch — measured, not assumed

On v12 and v13 the XLIFF parser reads the file leniently and yields the
`<source>` values either way. I verified that rather than repeating the issue's
claim: resolving `credits`, `filter.label` and `modal.close` through
`LanguageServiceFactory`, in the default language and in German, gives
identical results with and without the attribute, on both core versions.

Only v14 treats such a file as a translation catalogue and drops the default
language entirely — which is why the same change on `main` was a **bugfix** and
this one is **housekeeping**.

## Why do it anyway

The declaration is wrong on its own terms, and it is the kind of thing that
becomes a release-day surprise the moment a branch's core support moves. One
attribute, no behaviour change.

## No test, deliberately

I wrote a label-resolution test to verify this and then **discarded it**: its
assertions pass identically before and after the change on every core this
branch supports, so committing it would have looked like coverage without
being any. The guard on `main` is a rendering test, and that harness does not
exist here.

## Scope

A sweep of every default label file on this branch found no second occurrence;
`main` is clean.

## Verified

`cgl -n`, the `academic_study_plan` functional suite (24 tests) and
`checkRstRenderingAll` on v13/PHP 8.2 and v12/PHP 8.1.
