### PR TITLE
[TASK] ACE-332: Test the category filter directly

### DIFF
--- a/packages/fgtclb/typo3-category-types/Tests/Functional/AbstractCategoryTypesTestCase.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/AbstractCategoryTypesTestCase.php
@@ -13,4 +13,18 @@ abstract class AbstractCategoryTypesTestCase extends FunctionalTestCase
         'fgtclb/academic-base',
         'fgtclb/category-types',
     ];
+
+    /**
+     * Add a fixture extension for a single test case, without restating the list above.
+     * Must be called before `parent::setUp()`. Mirrors the helper of the
+     * `EXT:academic_persons` test case.
+     */
+    protected function addTestExtension(string ...$extensions): void
+    {
+        foreach ($extensions as $extension) {
+            if ($extension !== '' && !in_array($extension, $this->testExtensionsToLoad, true)) {
+                $this->testExtensionsToLoad[] = $extension;
+            }
+        }
+    }
 }

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Domain\Repository;
+
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Direct coverage for `CategoryRepository::getByDatabaseFields()`.
+ *
+ * The method used to return early when `Result::rowCount()` reported zero. For a SELECT
+ * that value is driver dependent: SQLite answers `0` for a result that does carry rows,
+ * so the category filter of every consuming plugin silently found nothing there (ACE-314).
+ *
+ * Until now the fix was guarded only from `EXT:academic_programs`, through a plugin, a
+ * FlexForm, a demand factory and a frontend request - and only on `main`. The method has
+ * three consumers (`academic_programs`, `academic_partners`, `academic_projects`), so a
+ * regression would have been reported by the wrong extension's suite, or by none. These
+ * tests call it directly instead, which also puts it on the DBMS matrix where the defect
+ * actually lives.
+ *
+ * `EXT:category_types` registers no category group of its own, so the group and the two
+ * types come from the `test_category_types_group` fixture extension.
+ */
+final class CategoryRepositoryTest extends AbstractCategoryTypesTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+    }
+
+    #[Test]
+    public function categorisedContentElementReturnsItsCategories(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categorisedContentElements.csv');
+
+        $collection = $this->get(CategoryRepository::class)->getByDatabaseFields('testing', 1);
+
+        // The assertion that fails on SQLite without the fix: the rows are there, only
+        // the row count lied about them.
+        $this->assertCount(2, $collection);
+
+        $titles = [];
+        foreach ($collection as $category) {
+            $titles[] = $category->getTitle();
+        }
+        sort($titles);
+        $this->assertSame(['First Category', 'Second Category'], $titles);
+    }
+
+    #[Test]
+    public function contentElementWithoutCategoriesReturnsAnEmptyCollection(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categorisedContentElements.csv');
+
+        // Guards the other direction, so the removed early return cannot come back as an
+        // optimisation of the no-rows path.
+        $this->assertCount(0, $this->get(CategoryRepository::class)->getByDatabaseFields('testing', 2));
+    }
+
+    #[Test]
+    public function categoriesOutsideTheRequestedGroupAreIgnored(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categorisedContentElements.csv');
+
+        // Content element 3 carries a category whose `type` belongs to no registered
+        // type of the group, so the `sys_category.type IN (...)` constraint filters it.
+        $this->assertCount(0, $this->get(CategoryRepository::class)->getByDatabaseFields('testing', 3));
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categorisedContentElements.csv
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categorisedContentElements.csv
@@ -1,0 +1,19 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,2,1,254,0,0,0,0,"/categories","Categories"
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,2,0,0,0,"testing_first","First Category",0,0
+,2,2,0,0,0,"testing_second","Second Category",0,0
+,3,2,0,0,0,"","Untyped Category",0,0
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header"
+,1,1,0,0,0,0,"list","Categorised element"
+,2,1,0,0,0,0,"list","Uncategorised element"
+,3,1,0,0,0,0,"list","Element with an untyped category"
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,1,"tt_content","pi_flexform",0,1
+,2,1,"tt_content","pi_flexform",0,2
+,3,3,"tt_content","pi_flexform",0,1

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Configuration/CategoryTypes.yaml
@@ -1,0 +1,13 @@
+groups:
+  - identifier: testing
+    title: 'Testing'
+    icon: 'EXT:core/Resources/Public/Icons/T3Icons/svgs/apps/apps-pagetree-folder-contains-category.svg'
+types:
+  - identifier: testing_first
+    title: 'Testing first'
+    group: testing
+    icon: 'EXT:core/Resources/Public/Icons/T3Icons/svgs/apps/apps-pagetree-folder-contains-category.svg'
+  - identifier: testing_second
+    title: 'Testing second'
+    group: testing
+    icon: 'EXT:core/Resources/Public/Icons/T3Icons/svgs/apps/apps-pagetree-folder-contains-category.svg'

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/composer.json
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "tests/category-types-group",
+    "description": "Extension registering a category type group for tests",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech",
+            "role": "Maintainer"
+        }
+    ],
+    "require": {
+        "typo3/cms-core": "~13.4.0@dev || ~14.3.0@dev",
+        "fgtclb/category-types": "~3.0.0@dev"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_category_types_group",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
+        }
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/ext_emconf.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/ext_emconf.php
@@ -1,0 +1,18 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'TESTS: Category Types Group',
+    'description' => 'Extension registering a category type group for tests',
+    'version' => '3.0.0',
+    'category' => 'misc',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'hello@fgtclb.com',
+    'author_company' => 'FGTCLB GmbH',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-14.3.99',
+            'category_types' => '3.0.0',
+        ],
+    ],
+];


### PR DESCRIPTION
Closes ACE-332 (`main` half — branch `2` follows).

`CategoryRepository::getByDatabaseFields()` carried the ACE-314 fix with no
test of its own. The only guard was `AcademicProgramsPluginTest` — another
extension, reaching the method through a plugin, a FlexForm, a demand factory
and a frontend request. The method has **three** consumers (`academic_programs`,
`academic_partners`, `academic_projects`), so a regression would have been
reported by the wrong extension's suite, or by none.

## The guard was verified against the real defect

I restored the pre-ACE-314 early return and ran it on two DBMS:

| | sqlite | mariadb |
|---|---|---|
| pre-ACE-314 code | **fails** | passes |
| current code | passes | passes |

That is the defect exactly: `Result::rowCount()` is driver-dependent for a
SELECT, and SQLite answers `0` for a result that does carry rows. It is also
the argument for the test living here rather than in a plugin suite — this
repository runs functional tests across four DBMS, and the bug exists on only
one of them.

## Three cases

| test | asserts |
|---|---|
| element with two categories of the group | the collection has both — the one that fails on SQLite without the fix |
| element with no categories | empty collection, so the early return cannot come back as a "no-rows optimisation" |
| element whose only category has a type outside the group | empty, covering the `sys_category.type IN (...)` constraint |

## Fixture extension

`EXT:category_types` registers no category group of its own, so
`test_category_types_group` provides one group and two types — the same shape
as the six fixture extensions already in this repository. Adding it needs a
`composerUpdate` for autoloading.

`AbstractCategoryTypesTestCase` gains the `addTestExtension()` helper the
`academic_persons` test case already has, so a single test can add a fixture
extension without restating the whole `$testExtensionsToLoad` list and letting
the two drift apart.

## Verified

`cgl -n`, `phpstan`, `lintPhp`, unit and the `category_types` functional suite
on v13/PHP 8.2 and v14/PHP 8.3, plus a targeted mariadb run for the table
above.
