### PR TITLE
[BUGFIX] ACE-322: Render contacts without a role

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
@@ -28,18 +28,28 @@ final class ContactsController extends ActionController
             $showHiddenRecords
         );
 
+        // Contacts without a role are collected here rather than filtered in the
+        // template: the grouped branch can only render a contact that belongs to one of
+        // the roles, so without this list they were dropped from the output entirely as
+        // soon as any other contact on the page had a role (ACE-322). Keeping the split
+        // in the controller also lets the template ask whether the ungrouped block is
+        // needed at all, instead of emitting an empty row.
         $roles = [];
+        $contactsWithoutRole = [];
         foreach ($contacts as $contact) {
             $role = $contact->getRole();
             if ($role !== null) {
                 $roles[$role->getUid()] = $role;
+                continue;
             }
+            $contactsWithoutRole[] = $contact;
         }
 
         $this->view->assignMultiple([
             'data' => $contentElementData,
             'contacts' => $contacts,
             'roles' => $roles,
+            'contactsWithoutRole' => $contactsWithoutRole,
         ]);
 
         return $this->htmlResponse();

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Templates/Contacts/List.html
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Templates/Contacts/List.html
@@ -18,7 +18,7 @@
                     />
 
                     <f:for each="{contacts}" as="contact">
-                        <f:if condition="{contact.role} == {role}">
+                        <f:if condition="{contact.role.uid} == {role.uid}">
                             <div class="col-12 col-md-6 col-lg-4 col-xl-3">
                                 <f:render
                                     partial="Profile/Item"
@@ -35,6 +35,24 @@
                     </f:for>
                 </div>
             </f:for>
+
+            <f:if condition="{contactsWithoutRole}">
+                <div class="row">
+                    <f:for each="{contactsWithoutRole}" as="contact">
+                        <div class="col-12 col-md-6 col-lg-4 col-xl-3">
+                            <f:render
+                                partial="Profile/Item"
+                                arguments="{
+                                    profile: contact.contract.profile,
+                                    contract: contact.contract,
+                                    settings: settings,
+                                    data: data
+                                }"
+                            />
+                        </div>
+                    </f:for>
+                </div>
+            </f:if>
         </f:then>
         <f:else>
             <div class="row">

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/AcademicContacts4PagesListPluginTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/AcademicContacts4PagesListPluginTest.php
@@ -144,6 +144,63 @@ final class AcademicContacts4PagesListPluginTest extends AbstractAcademicContact
     }
 
     #[Test]
+    public function listPluginRendersContactsWithoutRoleBesideGroupedOnes(): void
+    {
+        // The mixed case: some contacts of the page carry a role, one does not. Before
+        // ACE-322 the grouped branch was taken for all of them and the role-less contact
+        // was dropped from the markup entirely - no notice, no placeholder.
+        $this->setUpTestCase('contactsListPage_mixedRoles');
+
+        $content = $this->renderHomePage();
+        $this->assertStringContainsString('Dean&#039;s Office', $content);
+        $this->assertRendersProfileName($content, 'Max', 'Müllermann');
+        $this->assertRendersProfileName($content, 'Horst', 'Huber');
+        $this->assertRendersProfileName($content, 'Erika', 'Beispiel');
+        // The role she used to hold is no longer held by anyone, so its group is gone.
+        $this->assertStringNotContainsString('Student Advisors', $content);
+    }
+
+    #[Test]
+    public function listPluginRendersUngroupedContactsAfterTheRoleGroups(): void
+    {
+        $this->setUpTestCase('contactsListPage_mixedRoles');
+
+        $content = $this->renderHomePage();
+        $roleHeading = strpos($content, 'Dean&#039;s Office');
+        $grouped = strpos($content, 'Müllermann');
+        $ungrouped = strpos($content, 'Beispiel');
+        $this->assertIsInt($roleHeading);
+        $this->assertIsInt($grouped);
+        $this->assertIsInt($ungrouped);
+        $this->assertLessThan($ungrouped, $roleHeading, 'The role groups come first.');
+        $this->assertLessThan($ungrouped, $grouped, 'A role-less contact renders after the grouped ones.');
+    }
+
+    #[Test]
+    public function listPluginRendersUngroupedContactsOneHeadingLevelUp(): void
+    {
+        $this->setUpTestCase('contactsListPage_mixedRoles');
+
+        // The ungrouped block renders through `Profile/Header` rather than
+        // `Profile/SectionHeader`, so a role-less contact keeps the higher heading level
+        // it has on a page with no roles at all - the two branches stay consistent.
+        $this->assertMatchesRegularExpression(
+            '#<h2 class="card-title">\s*<a href="[^"]*">Erika\s+Beispiel</a>\s*</h2>#',
+            $this->renderHomePage(),
+        );
+    }
+
+    #[Test]
+    public function listPluginEmitsNoEmptyRowWhenEveryContactHasARole(): void
+    {
+        // The ungrouped block is conditional, so the fully grouped page must render
+        // exactly the rows of its two role groups and nothing extra.
+        $this->setUpTestCase('contactsListPage');
+
+        $this->assertSame(2, substr_count($this->renderHomePage(), '<div class="row">'));
+    }
+
+    #[Test]
     public function listPluginRendersContentElementHeader(): void
     {
         $this->setUpTestCase('contactsListPage');

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_mixedRoles.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Plugins/Fixtures/AcademicContacts4PagesListPlugin/contactsListPage_mixedRoles.csv
@@ -1,0 +1,35 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+,3,1,1,0,0,0,0,0,"/profiles","Profiles"
+,4,1,1,0,0,0,0,0,"/other-page","Other page"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"Horst","Huber","horst-huber"
+,3,100,0,0,0,0,"Erika","Beispiel","erika-beispiel"
+,4,100,0,0,0,0,"Nina","Nebenan","nina-nebenan"
+"tx_academicpersons_domain_model_location",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","title"
+,1,100,0,0,0,0,"Main Campus"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position","location","room"
+,1,100,0,0,0,0,1,"Professor",1,"A 101"
+,2,100,0,0,0,0,2,"Lecturer",0,"B 202"
+,3,100,0,0,0,0,3,"Assistant",0,"C 303"
+,4,100,0,0,0,0,4,"Coordinator",0,"D 404"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role"
+,1,100,0,0,0,1,2,1,1
+,2,100,0,0,0,2,2,2,1
+,3,100,0,0,0,3,2,3,0
+,4,100,0,0,0,4,4,4,1
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pi_flexform"
+,1,2,0,0,0,0,"academiccontacts4pages_list","","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.showHiddenRecords""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"


### PR DESCRIPTION
Closes ACE-322.

A contact with **no role** disappeared from the frontend as soon as some other
contact on the same page had one — no notice, no placeholder, nothing in the
log. Re-measured on current `main` before touching anything: with a mixed page,
the role heading and the roled contacts render and the role-less contact is
absent from the markup entirely.

The template branches on whether *any* role exists. If one does, the grouped
branch renders each group and, inside it, only the contacts matching that role
— so a role-less contact belongs to no group and is never reached. The
ungrouped `<f:else>` runs only when **no** contact has a role, which is why the
loss shows up in the mixed case alone.

## The decision

Where such contacts belong was a product question, not a defect with one
correction. Stefan chose: **an ungrouped block after the role groups**.

Rejected alternatives and their cost: before the groups (same cost, different
reading order); an own "Other contacts" group — this extension ships **no**
frontend label file at all, so that means creating `locallang.xlf` +
`de.locallang.xlf` and inventing wording in two languages; making the role
required in TCA — does nothing for existing records, which stay invisible until
an editor opens each one.

## Split in the controller, not filtered in the template

So the template can ask whether the block is needed at all instead of emitting
an empty `<div class="row">` on a fully grouped page.

## Four tests, each checked against a different mutation

| mutation | fails |
|---|---|
| ungrouped block removed | 3 tests — the mixed case, the ordering, the heading level |
| block rendered unconditionally | 1 test — the empty-row guard |

The ungrouped contacts keep the `<h2>` heading level they already have on a
page with no roles at all, so the two branches stay consistent.

## Folded in, as the issue proposed

The group match compared two domain objects with `==`. It works through
Extbase's identity map but says nothing about intent — now
`{contact.role.uid} == {role.uid}`.

## Verified

`cgl -n`, `phpstan` and the `academic_contacts4pages` functional suite (25 on
v13, 26 on v14) on v13/PHP 8.2 and v14/PHP 8.3.

Branch `2` carries identical controller and template logic (diffed, empty), so
the backport applies unchanged.
