### PR TITLE
[BUGFIX] ACE-322: Render contacts without a role

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
@@ -28,18 +28,28 @@ final class ContactsController extends ActionController
             $showHiddenRecords
         );
 
+        // Contacts without a role are collected here rather than filtered in the
+        // template: the grouped branch can only render a contact that belongs to one of
+        // the roles, so without this list they were dropped from the output entirely as
+        // soon as any other contact on the page had a role (ACE-322). Keeping the split
+        // in the controller also lets the template ask whether the ungrouped block is
+        // needed at all, instead of emitting an empty row.
         $roles = [];
+        $contactsWithoutRole = [];
         foreach ($contacts as $contact) {
             $role = $contact->getRole();
             if ($role !== null) {
                 $roles[$role->getUid()] = $role;
+                continue;
             }
+            $contactsWithoutRole[] = $contact;
         }
 
         $this->view->assignMultiple([
             'data' => $contentElementData,
             'contacts' => $contacts,
             'roles' => $roles,
+            'contactsWithoutRole' => $contactsWithoutRole,
         ]);
 
         return $this->htmlResponse();

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Templates/Contacts/List.html
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Templates/Contacts/List.html
@@ -18,7 +18,7 @@
                     />
 
                     <f:for each="{contacts}" as="contact">
-                        <f:if condition="{contact.role} == {role}">
+                        <f:if condition="{contact.role.uid} == {role.uid}">
                             <div class="col-12 col-md-6 col-lg-4 col-xl-3">
                                 <f:render
                                     partial="Profile/Item"
@@ -35,6 +35,24 @@
                     </f:for>
                 </div>
             </f:for>
+
+            <f:if condition="{contactsWithoutRole}">
+                <div class="row">
+                    <f:for each="{contactsWithoutRole}" as="contact">
+                        <div class="col-12 col-md-6 col-lg-4 col-xl-3">
+                            <f:render
+                                partial="Profile/Item"
+                                arguments="{
+                                    profile: contact.contract.profile,
+                                    contract: contact.contract,
+                                    settings: settings,
+                                    data: data
+                                }"
+                            />
+                        </div>
+                    </f:for>
+                </div>
+            </f:if>
         </f:then>
         <f:else>
             <div class="row">


### PR DESCRIPTION
Backport of #402 (ACE-322) to `2`.

A contact with no role disappeared from the frontend as soon as another contact
on the same page had one. Identical controller and template logic on this
branch — verified in this branch's files, not inferred from `main`.

Role-less contacts now render in an ungrouped block **after** the role groups,
per Stefan's decision on the issue. The split is made in the controller so the
template can ask whether the block is needed instead of emitting an empty
`<div class="row">` on a fully grouped page. The `==` comparison of two domain
objects becomes `{contact.role.uid} == {role.uid}`.

Both files are **byte identical to `main`** after this change (diffed, empty).

## No test here, and what that leaves unverified

This branch has no plugin rendering harness for `academic_contacts4pages` —
ACE-311 landed on `main` only, and there is no `Tests/Functional/Plugins`
directory at all. The four tests that prove the behaviour live there, each
checked against a different mutation (removing the block fails three; making it
unconditional fails the fourth).

TYPO3 **v13 is common to both branches**, so that evidence carries. On **v12**
the rendering is genuinely unverified: the change is plain Fluid — an `f:if` on
an array and a uid comparison — but that is an argument, not a measurement, and
it is stated here rather than glossed.

## Verified

`cgl -n`, `phpstan` and the `academic_contacts4pages` functional suite (10
tests — repository level, no rendering) on v13/PHP 8.2 and v12/PHP 8.1.
