### PR TITLE
[TASK] ACE-342: Retry failed container image pulls

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -46,6 +46,38 @@ printSummary() {
     exit $SUITE_EXIT_CODE
 }
 
+# Make sure an image is available locally, retrying a failed pull.
+#
+# `run` pulls implicitly on a cache miss, and a single failed pull ends the whole
+# job with exit 125 before a test has run - twice within three hours on GitHub
+# Actions, both times on a docker.io image (ACE-342). Anonymous Docker Hub pulls
+# are rate limited per source IP and hosted runners share address space, which
+# also explains why no ghcr.io pull has failed; only the docker.io images are
+# guarded here.
+#
+# The local check comes first so a warm cache still works offline and a pinned
+# image is not re-fetched on every local run.
+ensureImage() {
+    local IMAGE=${1}
+    local MAX_ATTEMPTS=3
+    local ATTEMPT=1
+    if ${CONTAINER_BIN} image inspect "${IMAGE}" >/dev/null 2>&1; then
+        return 0
+    fi
+    while [ ${ATTEMPT} -le ${MAX_ATTEMPTS} ]; do
+        if ${CONTAINER_BIN} pull "${IMAGE}"; then
+            return 0
+        fi
+        if [ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]; then
+            echo "Pulling ${IMAGE} failed (attempt ${ATTEMPT} of ${MAX_ATTEMPTS}), retrying in $((ATTEMPT * 5))s." >&2
+            sleep $((ATTEMPT * 5))
+        fi
+        ATTEMPT=$((ATTEMPT + 1))
+    done
+    echo "Could not pull ${IMAGE} after ${MAX_ATTEMPTS} attempts. Aborting." >&2
+    return 1
+}
+
 waitFor() {
     local HOST=${1}
     local PORT=${2}
@@ -63,6 +95,7 @@ waitFor() {
             COUNT=\$((COUNT + 1));
         done;
     "
+    ensureImage "${IMAGE_ALPINE}" || { cleanUp; exit 1; }
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_ALPINE} /bin/sh -c "${TESTCOMMAND}"
     if [[ $? -gt 0 ]]; then
         # Not "kill -SIGINT -$$": the SIGINT trap is only installed when CI is not "true",
@@ -627,6 +660,8 @@ case ${TEST_SUITE} in
         case ${DBMS} in
             mariadb)
                 echo "Using driver: ${DATABASE_DRIVER}"
+                ensureImage "${IMAGE_MARIADB}"
+                SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 ${CONTAINER_BIN} run --name mariadb-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MARIADB} >/dev/null
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 waitFor mariadb-func-${SUFFIX} 3306
@@ -636,6 +671,8 @@ case ${TEST_SUITE} in
                 ;;
             mysql)
                 echo "Using driver: ${DATABASE_DRIVER}"
+                ensureImage "${IMAGE_MYSQL}"
+                SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 ${CONTAINER_BIN} run --name mysql-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MYSQL} >/dev/null
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 waitFor mysql-func-${SUFFIX} 3306
@@ -644,6 +681,8 @@ case ${TEST_SUITE} in
                 SUITE_EXIT_CODE=$?
                 ;;
             postgres)
+                ensureImage "${IMAGE_POSTGRES}"
+                SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 ${CONTAINER_BIN} run --name postgres-func-${SUFFIX} --network ${NETWORK} -d -e POSTGRES_PASSWORD=funcp -e POSTGRES_USER=funcu --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid ${IMAGE_POSTGRES} >/dev/null
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 waitFor postgres-func-${SUFFIX} 5432


### PR DESCRIPTION
Closes ACE-342.

A functional job died with **exit 125** before a single test ran when the
runtime could not reach Docker Hub:

```
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
        context deadline exceeded
```

Twice within three hours, two different DBMS, two different core versions
(#398, #403). Both were re-run by hand and went green; no code was involved
either time.

## Why the Docker Hub images specifically

The harness splits across two registries — `ghcr.io` for the PHP and docs
images, `docker.io` for mariadb/mysql/postgres/alpine/selenium. **Both failures
were `docker.io`; no `ghcr.io` pull has ever failed**, even though the
`ghcr.io` PHP image is pulled by every job of every run. Anonymous Docker Hub
pulls are rate-limited per source IP and hosted runners share address space,
which fits that asymmetry better than "the network was briefly bad".

Volume is not small: the DBMS matrix is **16 jobs per pull request**, each
pulling a database image plus `alpine` for `waitFor()`.

## The change

`ensureImage()` — returns immediately when the image is present locally,
otherwise pulls with **three attempts and a growing backoff**. Wired into the
four Docker Hub pull sites: the three DBMS branches and `waitFor()`'s alpine.

The local check comes first deliberately: a warm cache still works **offline**,
and a pinned image is not re-fetched on every local run.

**Why in the script rather than the workflow:** it then helps a local run on a
flaky connection as much as CI, covers `alpine` (which a workflow-level pre-pull
step would likely miss), and needs no secret — unlike the `docker/login-action`
option, which forks could not use anyway.

## Verified, both runtimes and both cache states

| check | result |
|---|---|
| image present (podman) | returns in **56 ms**, no network |
| unpullable image | 3 attempts, 5s + 10s backoff, aborts after **18 s** |
| `postgres:10-alpine` removed, podman | pulled by the guard, suite passes |
| `alpine:3.8` removed, **docker** (CI's runtime) | pulled by the guard, suite passes |
| repeat warm run | **0** pulls |
| mariadb / mysql / sqlite paths | unaffected, all green |

Plus `cgl -n`, `lintPhp` and `bash -n`.

## Deliberately not covered

The `ghcr.io` images — no observed failures there. The helper is generic, so
extending it is a one-line change if that stops being true.

## Note

`fgtclb/environment-state-manager` pins the same `docker.io` images from the
same shared `runTests.sh` original; this shape belongs there too, as recorded on
the issue.
