### PR TITLE
[DOCS] ACE-303: Document the WebP requirement

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
@@ -31,3 +31,46 @@ assigned profile and that meets the criteria logs in.
 
     A comma-separated list of language IDs. These IDs configure in which languages a
     persons profile can be translated by a frontend user.
+
+..  _configuration-general-webp:
+
+Image processing: WebP is required
+==================================
+
+The profile detail view of the profile editing plugin renders the profile image
+as `WebP`_ only. TYPO3 has to be allowed to produce that format, otherwise
+rendering a profile **that has an image** fails with:
+
+..  code-block:: text
+
+    Unable to render image uri in "tt_content:1": The extension webp is not
+    specified in $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'] as a valid
+    image file extension and can not be processed.
+
+On **TYPO3 v13** `webp` is part of the default value of
+:php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']` and nothing has to be
+done.
+
+On **TYPO3 v12** it is not. An instance running v12 has to add it, either in
+:guilabel:`Admin Tools > Settings > Configure Installation-Wide Options >
+[GFX][imagefile_ext]` or in :file:`config/system/settings.php`:
+
+..  code-block:: php
+    :caption: config/system/settings.php
+
+    return [
+        'GFX' => [
+            'imagefile_ext' => 'gif,jpg,jpeg,tif,tiff,bmp,pcx,tga,png,pdf,ai,svg,webp',
+        ],
+    ];
+
+..  note::
+
+    Many installations already carry `webp` because another extension or the
+    project setup added it, which is why this is not hit everywhere on v12.
+
+Adding the extension to that list only permits the format. Whether the images
+can actually be produced depends on the configured image processor - GraphicsMagick
+or ImageMagick have to be built with WebP support.
+
+..  _WebP: https://developers.google.com/speed/webp

--- a/packages/fgtclb/academic-persons-edit/Documentation/Installation/Index.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Installation/Index.rst
@@ -48,5 +48,12 @@ download and install it using one of the following methods.
         #.  Enable :guilabel:`Upload Extension`.
         #.  Select or drag the extension ZIP archive and upload the file.
 
+..  note::
+
+    On **TYPO3 v12** one additional setting is required before the profile
+    editing plugin can render a profile image: `webp` has to be listed in
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`. See
+    :ref:`configuration-general-webp`. On TYPO3 v13 it is part of the default.
+
 ..  _TER: https://extensions.typo3.org/extension/academic_persons_edit
 ..  _GitHub Releases: https://github.com/fgtclb/academic-persons-edit/releases


### PR DESCRIPTION
Closes ACE-303 for branch `2` — **direction 4**: document it, do not change the
markup.

The profile detail view of the profile editing plugin renders the profile image
as **WebP only**. TYPO3 v12 does not allow that target format by default —
`GFX/imagefile_ext` gained `webp` with v13 — so a v12 instance that keeps the
default fails to render any profile that *has* an image.

## Why documented rather than fixed here

v12 support ends with this branch, and every alternative on the issue changes
rendered markup or introduces a setting on a branch in maintenance. Weighed and
chosen deliberately.

## Where it went, and why there

| page | what |
|---|---|
| `Configuration/General` | the requirement itself — where an integrator looks for things to configure |
| `Installation` | a short note pointing at it — where someone setting up a v12 instance actually is |

The section quotes the **exception text verbatim**, so searching for the error
lands on the page, and gives both places to set it: the Install Tool and
`config/system/settings.php`.

It also states what enabling the extension does **not** do: permitting the
format is not the same as being able to produce it — that depends on the image
processor being built with WebP support.

## Verified

`checkRstRenderingAll` — the real documentation gate, `--fail-on-log
--fail-on-error`. Checked in the rendered HTML that the section exists with the
`configuration-general-webp` anchor and that the cross-reference from
Installation resolves to it (`../Configuration/General/Index.html#configuration-general-webp`)
rather than to a dangling label.

## `main` is separate, and not this

`main` renders the identical partial but requires v13/v14, where `webp` is part
of the default — the crash cannot occur there. Stefan chose the markup fix plus
documentation for `main`; that lands in its own pull request, and the wording
here is v12-specific on purpose.
