### PR TITLE
[BUGFIX] ACE-303: Give the profile image a fallback

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
@@ -31,3 +31,32 @@ assigned profile and that meets the criteria logs in.
 
     A comma-separated list of language IDs. These IDs configure in which languages a
     persons profile can be translated by a frontend user.
+
+..  _configuration-general-webp:
+
+Image processing: WebP
+======================
+
+The profile detail view of the profile editing plugin offers the profile image
+as `WebP`_ through the :html:`<picture>` candidates, with the :html:`<img>`
+fallback in the source format. TYPO3 has to be allowed to produce WebP,
+otherwise rendering a profile **that has an image** fails with:
+
+..  code-block:: text
+
+    Unable to render image uri in "tt_content:1": The extension webp is not
+    specified in $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'] as a valid
+    image file extension and can not be processed.
+
+On TYPO3 v13 and v14 `webp` is part of the default value of
+:php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`, so nothing has to be
+done. An installation that **removes** it from that list - some restrict the
+allowed formats deliberately - has to put it back, either in
+:guilabel:`Admin Tools > Settings > Configure Installation-Wide Options >
+[GFX][imagefile_ext]` or in :file:`config/system/settings.php`.
+
+Permitting the format is not the same as being able to produce it: the
+configured image processor, GraphicsMagick or ImageMagick, has to be built with
+WebP support.
+
+..  _WebP: https://developers.google.com/speed/webp

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Show/Image.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Show/Image.html
@@ -17,6 +17,7 @@
                     maxWidth: '390',
                     fileExtension: 'webp',
                 )}"
+                type="image/webp"
                 media="(min-width: 992px)"
             >
             <source
@@ -25,6 +26,7 @@
                     maxWidth: '370',
                     fileExtension: 'webp',
                 )}"
+                type="image/webp"
                 media="(min-width: 768px)"
             >
             <source
@@ -33,6 +35,7 @@
                     maxWidth: '690',
                     fileExtension: 'webp',
                 )}"
+                type="image/webp"
                 media="(min-width: 576px)"
             >
             <source
@@ -41,12 +44,12 @@
                     maxWidth: '535',
                     fileExtension: 'webp',
                 )}"
+                type="image/webp"
             >
             <img
                 src="{f:uri.image(
                     image: profile.image,
                     maxWidth: 690,
-                    fileExtension: 'webp',
                 )}"
                 alt="{profile.image.alternative}"
                 title="{profile.image.title}"

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
@@ -200,6 +200,32 @@ final class AcademicPersonsEditProfileImageUploadTest extends AbstractProfileEdi
     }
 
     #[Test]
+    public function profileDetailPageOffersAFallbackForBrowsersWithoutWebpSupport(): void
+    {
+        $this->setUpTestCase();
+        $this->uploadProfileImage($this->getProfileImageFormUrl());
+
+        $content = $this->getProfileShowPage();
+
+        // Every candidate declares its format, so a browser that cannot decode WebP
+        // skips the `source` instead of picking it by media query and failing: without
+        // `type` the `picture` element offers no format fallback at all (ACE-303).
+        preg_match_all('#<source\b[^>]*>#s', $content, $sources);
+        $this->assertCount(4, $sources[0]);
+        foreach ($sources[0] as $source) {
+            $this->assertStringContainsString('type="image/webp"', $source);
+            $this->assertStringContainsString('.webp', $source);
+        }
+
+        // ... and the `img` fallback keeps the source format, so it stays renderable
+        // when the candidates are not.
+        preg_match('#<img\b[^>]*>#s', $content, $img);
+        $this->assertNotEmpty($img, 'Profile detail page renders no img element.');
+        $this->assertStringNotContainsString('.webp', $img[0]);
+        $this->assertMatchesRegularExpression('#src="[^"]+\.png"#', $img[0]);
+    }
+
+    #[Test]
     public function replacedProfileImageFileIsDeleted(): void
     {
         $this->setUpTestCase();


### PR DESCRIPTION
Closes ACE-303 for `main` — **markup fix + documentation**, per Stefan's
decision. The branch `2` half is #406 (documentation only, direction 4).

## The crash cannot happen on `main`

`main` requires `~13.4.0@dev || ~14.3.0@dev`, and both ship `webp` in the
default `GFX/imagefile_ext` — which is also why the test-harness workaround for
this exists only on branch `2`. So this is not a fix for the reported failure;
it is the markup defect underneath it.

## What was actually wrong

The four `<picture>` candidates and the `<img>` fallback all requested WebP, and
**none declared a type**. A browser therefore picks a `<source>` by media query
alone and must decode WebP — per spec it does **not** fall back to `<img>` when
it cannot — and the `<img>` was WebP too. There was no fallback at any point.

| | before | after |
|---|---|---|
| four `<source>` | webp, no `type` | webp + `type="image/webp"` |
| `<img>` fallback | webp | **source format** |

**No user-visible change is expected today** — every browser in support has
handled WebP since 2020. The markup was wrong on its own terms and is cheap to
correct; that is the reason, and I would rather state it than dress this up as
a live defect.

## What can still fail here, and is documented instead

An installation that **removes** `webp` from `imagefile_ext` deliberately. The
candidates are processed server-side, so declaring a type does not save them.
`Configuration/General` now covers that, plus the point that permitting the
format is not the same as being able to produce it — the image processor has to
be built with WebP support.

## Test

Asserts both halves: four candidates each carrying `type="image/webp"` and a
`.webp` URI, and an `<img>` whose `src` is **not** webp but the source `.png`.
Checked against the old partial, where it fails.

It lives in the upload test class because that is where a profile with a real,
**processed** image exists — the assertions run against genuinely generated
image URIs, not a fixture string. That class is `#[Group('not-core-13')]`, so it
runs on v14; the v13 suite was run separately to confirm nothing moved.

## Unrelated finding, not touched here

The same partial reads `{image.properties.show_copyright}`,
`{image.properties.copyright}` and `{image.description}`, but **no `image`
variable is ever assigned to the view** — `showAction()` assigns `data`,
`profile`, `profileFormData` and `cancelUrl`. The copyright line and the
`<figcaption>` are therefore dead on both branches. Worth its own issue; say the
word and I will file it.

## Verified

`cgl -n`, `phpstan`, `checkRstRenderingAll` and the `academic_persons_edit`
functional suite — 46 tests on v14/PHP 8.3, 43 on v13/PHP 8.2.
