### PR TITLE
[!!!][FEATURE] ACE-304: Replace a profile image

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Configuration/Icons.php
+++ b/packages/fgtclb/academic-persons-edit/Configuration/Icons.php
@@ -26,6 +26,10 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons_edit/Resources/Public/Icons/add-image-icon.svg',
     ],
+    'academic-persons-edit-replace-image' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:academic_persons_edit/Resources/Public/Icons/replace-image-icon.svg',
+    ],
     'academic-persons-edit-add-item' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:academic_persons_edit/Resources/Public/Icons/add-item-icon.svg',

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-AdaptedFrontendEditingFluidFiles.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-AdaptedFrontendEditingFluidFiles.rst
@@ -1,0 +1,89 @@
+..  _breaking-adapted-frontend-editing-fluid-files:
+
+==============================================
+Breaking: Adapted frontend editing Fluid files
+==============================================
+
+Description
+===========
+
+Version 3.0 changes Fluid templates and partials that
+`EXT:academic_persons_edit` ships for its frontend editing plugin. They
+are shipped files, not API, and an installation that overrides one of
+them keeps its own copy — and therefore does not receive the change.
+
+This page collects all of those changes for 3.0 in one place. It is
+extended whenever another shipped Fluid file is adapted.
+
+Profile image actions
+---------------------
+
+:file:`Resources/Private/Templates/Profile/Show.html`
+
+The profile image actions used to be rendered as an either/or: while the
+profile had an image only the "Delete" link was offered, and the
+:php:`editImage` action — the upload form — was only linked while the
+profile had none.
+
+Both are now rendered next to each other for a profile that has an
+image: a "Replace" link pointing to :php:`editImage` and, as before, the
+"Delete" link pointing to :php:`removeImage`. See
+:ref:`feature-replace-profile-image` for what this enables.
+
+The added link uses the new `actions.replace` label and the new
+`academic-persons-edit-replace-image` icon identifier.
+
+Profile image form
+------------------
+
+:file:`Resources/Private/Templates/Profile/EditImage.html`
+
+The upload form renders the image that is currently in place above the
+file field, by rendering the existing
+:file:`Resources/Private/Partials/Profile/Show/Image.html` partial.
+Reached as "Replace", the form otherwise gives no indication of what is
+being replaced.
+
+Profile image markup
+--------------------
+
+:file:`Resources/Private/Partials/Profile/Show/Image.html`
+
+Every :html:`<source>` candidate of the :html:`<picture>` element
+declares :html:`type="image/webp"`, and the :html:`<img>` fallback is no
+longer requested as WebP but rendered in the source format. Without a
+declared type a browser picks a candidate by media query alone and, per
+specification, does not fall back to the :html:`<img>` when it cannot
+decode it — which was WebP as well, so there was no fallback at any
+point.
+
+Impact
+======
+
+Installations that override any of the listed Fluid files keep the
+behaviour of their own copy:
+
+* an overridden :file:`Profile/Show.html` continues to offer no replace
+  link, so the replacement handling of :php:`addImageAction()` stays
+  unreachable through the user interface,
+* an overridden :file:`Profile/EditImage.html` does not show the image
+  being replaced,
+* an overridden :file:`Profile/Show/Image.html` continues to offer no
+  format fallback for the profile image.
+
+Nothing breaks at runtime — the overrides keep working. What is lost is
+the new behaviour.
+
+Affected Installations
+======================
+
+All installations using the `EXT:academic_persons_edit` extension that
+override the profile detail template, the profile image form template or
+the profile image partial.
+
+Migration
+=========
+
+Re-apply the project specific overrides on top of the updated files.
+
+.. index:: Fluid, Frontend, Template, NotScanned

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Feature-ReplaceProfileImageInFrontendEditing.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Feature-ReplaceProfileImageInFrontendEditing.rst
@@ -1,0 +1,64 @@
+..  _feature-replace-profile-image:
+
+========================================================
+Feature: Replace a profile image in the frontend editing
+========================================================
+
+Description
+===========
+
+The profile detail view of the frontend editing plugin of
+`EXT:academic_persons_edit` now offers a "Replace" action for a profile
+that already has an image, next to the existing "Delete" action.
+
+Replacing an image previously meant deleting it first and uploading a
+new one afterwards. Between those two steps the profile had no image at
+all, and the old file was already gone before the replacement was known
+to be valid — an upload rejected by the file size or mime type
+validation left the profile without an image.
+
+The replacement itself is not new. The migration to the native Extbase
+file upload handling
+(:ref:`important-migrated-profile-image-upload-to-native-extbase-file-upload-handling`)
+already implemented it completely: the upload configuration permits the
+already referenced file plus the upload, the previously referenced file
+is determined before the upload rewires the relation, and it is deleted
+afterwards — but only when no other record still references it. None of
+that could be reached from the shipped templates, because the link to
+the upload form was rendered only while the profile had no image.
+
+The form the "Replace" action leads to now also renders the image that
+is about to be replaced.
+
+..  note::
+
+    This feature changes the frontend editing Fluid templates and is
+    therefore breaking for projects that override them. See
+    :ref:`breaking-adapted-frontend-editing-fluid-files` for the
+    required adaptions.
+
+Impact
+======
+
+Profile owners using the `EXT:academic_persons_edit` frontend editing
+can exchange a profile image in a single step. The profile keeps its
+current image until the replacement passed validation, and the replaced
+file is removed from the storage unless another record still uses it.
+
+Affected Installations
+======================
+
+All installations using the `EXT:academic_persons_edit` extension
+starting with version 3.0.
+
+Migration
+=========
+
+No migration is required for installations using the shipped templates.
+
+Installations overriding
+:file:`Resources/Private/Templates/Profile/Show.html` have to re-apply
+their override on top of the updated template to offer the action, see
+:ref:`breaking-adapted-frontend-editing-fluid-files`.
+
+.. index:: Fluid, Frontend, Template

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/de.locallang.xlf
@@ -554,6 +554,10 @@
         <source>Add</source>
         <target>Hinzufügen</target>
       </trans-unit>
+      <trans-unit id="actions.replace">
+        <source>Replace</source>
+        <target>Ersetzen</target>
+      </trans-unit>
       <trans-unit id="actions.sortUp">
         <source>Move upwards</source>
         <target>Nach oben verschieben</target>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Language/locallang.xlf
@@ -426,6 +426,9 @@
       <trans-unit id="actions.add">
         <source>Add</source>
       </trans-unit>
+      <trans-unit id="actions.replace">
+        <source>Replace</source>
+      </trans-unit>
       <trans-unit id="actions.sortUp">
         <source>Move upwards</source>
       </trans-unit>

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/EditImage.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/EditImage.html
@@ -28,6 +28,15 @@
         }"
     />
 
+    <f:if condition="{profile.image}">
+        <div class="profile-image">
+            <f:render
+                partial="Profile/Show/Image"
+                arguments="{_all}"
+            />
+        </div>
+    </f:if>
+
     <f:form
         action="addImage"
         name="profile"

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/Show.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Templates/Profile/Show.html
@@ -39,6 +39,12 @@
 
                 <f:if condition="{profile.image}">
                     <f:then>
+                        <f:link.action action="editImage" arguments="{profile: profile}" class="btn btn-primary">
+                            {f:translate(key: 'actions.replace', extensionName: 'academic_persons_edit')}
+
+                            <core:icon identifier="academic-persons-edit-replace-image" alternativeMarkupIdentifier="inline"/>
+                        </f:link.action>
+
                         <f:link.action action="removeImage" arguments="{profile: profile}" class="btn btn-danger">
                             {f:translate(key: 'actions.delete', extensionName: 'academic_persons_edit')}
 

--- a/packages/fgtclb/academic-persons-edit/Resources/Public/Icons/replace-image-icon.svg
+++ b/packages/fgtclb/academic-persons-edit/Resources/Public/Icons/replace-image-icon.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+    focusable="false">
+    <path d="M1 10.5H26V5L35 12L26 19V13.5H1V10.5Z" fill="#1C1B1F" />
+    <path d="M35 22.5H10V17L1 24L10 31V25.5H35V22.5Z" fill="#1C1B1F" />
+</svg>

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AbstractProfileEditingPluginTestCase.php
@@ -8,7 +8,10 @@ use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestC
 use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
 use Psr\Http\Message\ResponseInterface;
 use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Session\UserSessionManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
@@ -27,6 +30,8 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
 
     protected const FRONTEND_USER_ID = 1;
     protected const PROFILE_ID = 1;
+    protected const PROFILE_PAGE_ID = 100;
+    protected const IMAGE_IDENTIFIER = '/profile-images/profile-image.png';
 
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
@@ -137,6 +142,57 @@ abstract class AbstractProfileEditingPluginTestCase extends AbstractAcademicPers
         $listPage = $this->getPageAsFrontendUser('https://www.acme.com/home');
 
         return $this->getPageAsFrontendUser($this->extractActionLink($listPage, 'show'));
+    }
+
+    /**
+     * Puts a profile image in place the way a completed upload leaves it behind: the file
+     * exists in the storage and is indexed, a file reference points from the profile to it,
+     * and the profile record carries the resulting reference count.
+     *
+     * Seeding instead of uploading is what lets the image related views be tested on both
+     * supported core versions - see `AcademicPersonsEditProfileImageUploadTest` for why an
+     * upload cannot run on TYPO3 v13.
+     */
+    protected function seedProfileImage(): int
+    {
+        $targetFolder = $this->instancePath . '/fileadmin/profile-images';
+        GeneralUtility::mkdir_deep($targetFolder);
+        copy(__DIR__ . '/Fixtures/Uploads/profile-image.png', $targetFolder . '/profile-image.png');
+
+        // Reading the file through the storage indexes it, so `sys_file` ends up with the
+        // same values an upload would have produced.
+        $storage = $this->get(StorageRepository::class)->findByUid(1);
+        $this->assertNotNull($storage, 'The default file storage is missing.');
+        $file = $storage->getFile(self::IMAGE_IDENTIFIER);
+        $this->assertInstanceOf(File::class, $file);
+
+        $this->addFileReference($file->getUid(), 'tx_academicpersons_domain_model_profile', 'image', self::PROFILE_ID);
+        $this->getConnectionPool()
+            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
+            ->update(
+                'tx_academicpersons_domain_model_profile',
+                ['image' => 1],
+                ['uid' => self::PROFILE_ID],
+            );
+
+        return $file->getUid();
+    }
+
+    protected function addFileReference(int $fileUid, string $tableName, string $fieldName, int $recordUid): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('sys_file_reference')
+            ->insert(
+                'sys_file_reference',
+                [
+                    'pid' => self::PROFILE_PAGE_ID,
+                    'uid_local' => $fileUid,
+                    'uid_foreign' => $recordUid,
+                    'tablenames' => $tableName,
+                    'fieldname' => $fieldName,
+                    'sorting_foreign' => 1,
+                ],
+            );
     }
 
     /**

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageRemoveTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageRemoveTest.php
@@ -6,9 +6,6 @@ namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
 
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Information\Typo3Version;
-use TYPO3\CMS\Core\Resource\File;
-use TYPO3\CMS\Core\Resource\StorageRepository;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 
 /**
@@ -20,56 +17,6 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
  */
 final class AcademicPersonsEditProfileImageRemoveTest extends AbstractProfileEditingPluginTestCase
 {
-    private const PROFILE_PAGE_ID = 100;
-    private const IMAGE_IDENTIFIER = '/profile-images/profile-image.png';
-
-    /**
-     * Puts a profile image in place the way a completed upload leaves it behind: the file
-     * exists in the storage and is indexed, a file reference points from the profile to it,
-     * and the profile record carries the resulting reference count.
-     */
-    private function seedProfileImage(): int
-    {
-        $targetFolder = $this->instancePath . '/fileadmin/profile-images';
-        GeneralUtility::mkdir_deep($targetFolder);
-        copy(__DIR__ . '/Fixtures/Uploads/profile-image.png', $targetFolder . '/profile-image.png');
-
-        // Reading the file through the storage indexes it, so `sys_file` ends up with the
-        // same values an upload would have produced.
-        $storage = $this->get(StorageRepository::class)->findByUid(1);
-        $this->assertNotNull($storage, 'The default file storage is missing.');
-        $file = $storage->getFile(self::IMAGE_IDENTIFIER);
-        $this->assertInstanceOf(File::class, $file);
-
-        $this->addFileReference($file->getUid(), 'tx_academicpersons_domain_model_profile', 'image', self::PROFILE_ID);
-        $this->getConnectionPool()
-            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
-            ->update(
-                'tx_academicpersons_domain_model_profile',
-                ['image' => 1],
-                ['uid' => self::PROFILE_ID],
-            );
-
-        return $file->getUid();
-    }
-
-    private function addFileReference(int $fileUid, string $tableName, string $fieldName, int $recordUid): void
-    {
-        $this->getConnectionPool()
-            ->getConnectionForTable('sys_file_reference')
-            ->insert(
-                'sys_file_reference',
-                [
-                    'pid' => self::PROFILE_PAGE_ID,
-                    'uid_local' => $fileUid,
-                    'uid_foreign' => $recordUid,
-                    'tablenames' => $tableName,
-                    'fieldname' => $fieldName,
-                    'sorting_foreign' => 1,
-                ],
-            );
-    }
-
     /**
      * @return list<array{tablenames: string, fieldname: string, uid_foreign: int}>
      */

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageReplaceTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageReplaceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+
+/**
+ * Covers the image actions the profile detail view of the
+ * `academicpersonsedit_profileediting` plugin offers, and the replace form they lead to.
+ *
+ * The point of ACE-304: `editImage` used to be rendered only while the profile had no
+ * image, so the replacement handling of `addImageAction()` could not be reached from the
+ * shipped templates at all. These tests assert the link set of both states, which is what
+ * makes that path reachable.
+ *
+ * The image is seeded rather than uploaded, so this runs on both supported core versions -
+ * see `AcademicPersonsEditProfileImageUploadTest` for why an upload cannot.
+ */
+final class AcademicPersonsEditProfileImageReplaceTest extends AbstractProfileEditingPluginTestCase
+{
+    /**
+     * Returns the markup of every anchor that links an Extbase action, keyed by that action,
+     * so both the link target and its label can be asserted together.
+     *
+     * @return array<string, string> action name => anchor markup
+     */
+    private function getActionAnchors(string $content): array
+    {
+        preg_match_all('@<a\b[^>]*href="([^"]*)"[^>]*>(.*?)</a>@s', $content, $matches, PREG_SET_ORDER);
+
+        $anchors = [];
+        foreach ($matches as $match) {
+            $href = html_entity_decode($match[1]);
+            if (preg_match('@\[action]=([^&]+)@', urldecode($href), $actionMatch) !== 1) {
+                continue;
+            }
+            $anchors[$actionMatch[1]] = $match[0];
+        }
+
+        return $anchors;
+    }
+
+    #[Test]
+    public function profileWithoutAnImageOffersAddingOneOnly(): void
+    {
+        $this->setUpTestCase();
+
+        $anchors = $this->getActionAnchors($this->getProfileShowPage());
+
+        $this->assertArrayHasKey('editImage', $anchors, 'The profile offers no way to add an image.');
+        $this->assertStringContainsString('Add', $anchors['editImage']);
+        // Nothing to remove yet.
+        $this->assertArrayNotHasKey('removeImage', $anchors);
+    }
+
+    #[Test]
+    public function profileWithAnImageOffersReplacingItNextToRemovingIt(): void
+    {
+        $this->setUpTestCase();
+        $this->seedProfileImage();
+
+        $anchors = $this->getActionAnchors($this->getProfileShowPage());
+
+        // Before ACE-304 this key was absent: the two links were rendered as an either/or,
+        // so a profile that had an image could only have it deleted.
+        $this->assertArrayHasKey('editImage', $anchors, 'The profile offers no way to replace its image.');
+        $this->assertStringContainsString('Replace', $anchors['editImage']);
+        $this->assertStringNotContainsString('Add', $anchors['editImage']);
+        $this->assertArrayHasKey('removeImage', $anchors, 'The profile offers no way to remove its image.');
+    }
+
+    #[Test]
+    public function replaceFormShowsTheImageItIsAboutToReplace(): void
+    {
+        $this->setUpTestCase();
+        $this->seedProfileImage();
+
+        $replaceUrl = $this->extractActionLink($this->getProfileShowPage(), 'editImage');
+        $content = $this->getPageAsFrontendUser($replaceUrl);
+
+        // The form alone does not say which image is being replaced.
+        $this->assertMatchesRegularExpression(
+            '@<img\b[^>]+src="[^"]*profile-image[^"]*\.png"@',
+            $content,
+            'The replace form does not render the image it replaces.',
+        );
+        $this->assertMatchesRegularExpression('@<form\b[^>]+enctype="multipart/form-data"@', $content);
+    }
+
+    #[Test]
+    public function addFormShowsNoImageForAProfileWithoutOne(): void
+    {
+        $this->setUpTestCase();
+
+        $addUrl = $this->extractActionLink($this->getProfileShowPage(), 'editImage');
+        $content = $this->getPageAsFrontendUser($addUrl);
+
+        $this->assertStringNotContainsString('<picture>', $content);
+        $this->assertMatchesRegularExpression('@<form\b[^>]+enctype="multipart/form-data"@', $content);
+    }
+
+    /**
+     * A missing label renders as an empty string, which the anchor assertions above would
+     * not notice, and the German file is maintained by hand.
+     */
+    #[Test]
+    public function replaceLabelIsShippedInBothLanguages(): void
+    {
+        $languageService = $this->get(LanguageServiceFactory::class)->create('default');
+        $this->assertSame(
+            'Replace',
+            $languageService->sL(
+                'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang.xlf:actions.replace'
+            ),
+        );
+
+        $file = __DIR__ . '/../../../Resources/Private/Language/de.locallang.xlf';
+        $this->assertFileExists($file);
+        $document = new \DOMDocument();
+        $this->assertTrue($document->load($file));
+
+        $targets = [];
+        foreach ($document->getElementsByTagName('trans-unit') as $unit) {
+            $target = $unit->getElementsByTagName('target')->item(0);
+            if ($target !== null) {
+                $targets[(string)$unit->getAttribute('id')] = $target->textContent;
+            }
+        }
+        $this->assertArrayHasKey('actions.replace', $targets, 'No German translation for "actions.replace".');
+        $this->assertSame('Ersetzen', $targets['actions.replace']);
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php
@@ -237,7 +237,10 @@ final class AcademicPersonsEditProfileImageUploadTest extends AbstractProfileEdi
         $replacedFilePath = $this->instancePath . '/fileadmin' . $replacedFiles[0]['identifier'];
         $this->assertFileExists($replacedFilePath);
 
-        $this->assertSame(303, $this->uploadProfileImage($formUrl)->getStatusCode());
+        // The form URI is taken from the detail page again rather than reused, so the second
+        // upload goes through the link a visitor has. Before ACE-304 that link was rendered
+        // only while the profile had no image, which made this whole path unreachable.
+        $this->assertSame(303, $this->uploadProfileImage($this->getProfileImageFormUrl())->getStatusCode());
 
         // The native handling cannot overwrite the previous file, because it generates a new
         // file name for every upload. The replaced file is therefore deleted explicitly.


### PR DESCRIPTION
Resolves ACE-304.

The profile detail view of the profile editing plugin rendered its two image
actions as an either/or: with an image it offered "Delete", and the `editImage`
action — the upload form — only while there was none. Replacing therefore meant
deleting first and uploading afterwards, with the profile carrying no image in
between and the old file already gone before the replacement was known to pass
validation.

The replacement itself has been complete since the migration to the native
Extbase file upload handling (ACE-274), but could not be reached from the
shipped templates, so the code path was dead in every installation that does not
override them.

## What changed

* `Profile/Show.html` offers "Replace" next to "Delete" for a profile that has
  an image.
* `Profile/EditImage.html` renders the image it is about to replace.
* New label `actions.replace`, English and German. Plain `f:translate` key, not
  the label domain syntax TYPO3 v14 introduced — v13 is still supported.
* New icon `academic-persons-edit-replace-image`, drawn in the style of the
  other action icons of the extension.

## Documentation

`[!!!]` because shipped Fluid files change: an installation overriding them
keeps its own copy and does not get the action.

* `Feature-ReplaceProfileImageInFrontendEditing.rst`
* `Breaking-AdaptedFrontendEditingFluidFiles.rst` — a collective entry for the
  3.0 changes to shipped Fluid files, to be extended rather than duplicated when
  the next one lands. It also picks up the `Profile/Show/Image.html` change of
  ACE-303, which had no entry although it has the same consequence for an
  override.

## Branch `2`

Deliberately not backported. Its `addImageAction()` has no replacement handling
at all — the removed file upload type converter built a deterministic file name
and overwrote the file in place — so offering the same link there would be a
different change with different behaviour.

## Tests

`AcademicPersonsEditProfileImageReplaceTest` asserts the link set of both states,
that the replace form shows the image being replaced and that the label is
shipped in both languages. The image is seeded rather than uploaded, so it runs
on both core versions — an upload cannot on v13.

`AcademicPersonsEditProfileImageUploadTest::replacedProfileImageFileIsDeleted`
now takes the form URI from the detail page for its second upload instead of
reusing the first one: that is the link a visitor has, and before this change it
did not exist.

Both templates were mutated back and the tests fail against them (3 failures for
`Show.html`, 1 for `EditImage.html`).

Verified locally: `cgl -n`, `lintPhp`, `phpstan` and `unit` plus the functional
suite of the extension on v13/8.2 and v14/8.3, and `checkRstRenderingAll` with
the three new cross references confirmed to resolve in the rendered output.
