### PR TITLE
[BUGFIX] ACE-343: Render profile image metadata

### DIFF
--- a/packages-dev/monorepo-shared/composer.json
+++ b/packages-dev/monorepo-shared/composer.json
@@ -31,6 +31,7 @@
         "typo3/cms-extensionmanager": "~13.4.0@dev || ~14.3.0@dev",
         "typo3/cms-felogin": "~13.4.0@dev || ~14.3.0@dev",
         "typo3/cms-filelist": "~13.4.0@dev || ~14.3.0@dev",
+        "typo3/cms-filemetadata": "~13.4.0@dev || ~14.3.0@dev",
         "typo3/cms-fluid": "~13.4.0@dev || ~14.3.0@dev",
         "typo3/cms-fluid-styled-content": "~13.4.0@dev || ~14.3.0@dev",
         "typo3/cms-frontend": "~13.4.0@dev || ~14.3.0@dev",

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-AdaptedProfileImagePartial.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-AdaptedProfileImagePartial.rst
@@ -1,0 +1,67 @@
+.. _important-1785686400:
+
+========================================
+Important: Adapted profile image partial
+========================================
+
+Description
+===========
+
+`Resources/Private/Partials/Profile/Show/Image.html` read the image metadata from
+a view variable `image` that is never assigned. The profile detail view of the
+`academicpersonsedit_profileediting` plugin therefore never rendered the caption,
+and it emitted an empty `alt` and `title` attribute even when the file carried
+that metadata.
+
+The profile carries a `\TYPO3\CMS\Extbase\Domain\Model\FileReference`, and that
+class exposes nothing but `getOriginalResource()`. Every other property path on it
+resolves to `null` — which is why `{profile.image.alternative}` was as empty as
+`{image.description}`. All values are now read through `originalResource`:
+
+..  code-block:: html
+
+    <!-- before -->
+    <img alt="{profile.image.alternative}" title="{profile.image.title}">
+    <f:if condition="{image.description}">
+        <figcaption class="visually-hidden">{image.description}</figcaption>
+    </f:if>
+
+    <!-- after -->
+    <img alt="{profile.image.originalResource.alternative}"
+         title="{profile.image.originalResource.title}">
+    <f:if condition="{profile.image.originalResource.description}">
+        <figcaption class="visually-hidden">{profile.image.originalResource.description}</figcaption>
+    </f:if>
+
+The same partial rendered a copyright, which never worked either and was removed
+instead of repaired — see :ref:`breaking-adapted-frontend-editing-fluid-files`.
+
+Impact
+======
+
+The profile detail view of the frontend editing plugin now renders
+
+*   the `alt` and `title` attribute of the profile image from the file metadata
+    instead of always empty,
+*   a `figcaption` when the image has a description.
+
+Note that nothing in this extension writes image metadata — an image uploaded
+through the plugin has none until it is maintained in the backend. Installations
+that never maintained the metadata of their profile images therefore see no
+change in the rendered output.
+
+Affected Installations
+======================
+
+Installations using the `academicpersonsedit_profileediting` plugin, and any
+installation overriding `Partials/Profile/Show/Image.html`.
+
+Migration
+=========
+
+No configuration change is required.
+
+Installations that override the partial keep their own copy and stay unaffected —
+including its defect. Adopt the property paths above to render the metadata.
+
+.. index:: Fluid, Frontend, NotScanned

--- a/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-AdaptedFrontendEditingFluidFiles.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Changelog/3.0/Breaking-AdaptedFrontendEditingFluidFiles.rst
@@ -57,6 +57,35 @@ specification, does not fall back to the :html:`<img>` when it cannot
 decode it — which was WebP as well, so there was no fallback at any
 point.
 
+Profile image copyright
+-----------------------
+
+:file:`Resources/Private/Partials/Profile/Show/Image.html`
+
+The partial rendered a copyright above the image:
+
+..  code-block:: html
+
+    <f:if condition="{image.properties.show_copyright} && {image.properties.copyright}">
+        <span class="copyright">&copy; {image.properties.copyright}</span>
+    </f:if>
+
+That block is removed. It has never rendered anything in any released
+version, for two independent reasons: the view variable `image` is never
+assigned — see :ref:`important-1785686400` — and `show_copyright` is not
+a field of TYPO3. It exists in no system extension, in no extension this
+package depends on or suggests, and nowhere in this repository except
+that condition. The `copyright` field itself is real, but comes with the
+system extension :file:`EXT:filemetadata`, which is not a dependency
+here.
+
+Repairing the property paths would therefore not have produced a working
+copyright — it would have produced a second, differently broken
+condition. Rendering the copyright of a profile image is a feature, not a
+defect fix: it needs a decision about where the value comes from, a
+declared dependency on whatever provides it, and test coverage proving it
+renders. It should be introduced that way if it is wanted.
+
 Impact
 ======
 
@@ -69,7 +98,8 @@ behaviour of their own copy:
 * an overridden :file:`Profile/EditImage.html` does not show the image
   being replaced,
 * an overridden :file:`Profile/Show/Image.html` continues to offer no
-  format fallback for the profile image.
+  format fallback for the profile image, and keeps its copy of the
+  copyright block — which renders nothing there either.
 
 Nothing breaks at runtime — the overrides keep working. What is lost is
 the new behaviour.

--- a/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Show/Image.html
+++ b/packages/fgtclb/academic-persons-edit/Resources/Private/Partials/Profile/Show/Image.html
@@ -6,10 +6,6 @@
 
 <f:if condition="{profile.image}">
     <figure>
-        <f:if condition="{image.properties.show_copyright} && {image.properties.copyright}">
-            <span class="copyright">&copy; {image.properties.copyright}</span>
-        </f:if>
-
         <picture>
             <source
                 srcset="{f:uri.image(
@@ -51,14 +47,14 @@
                     image: profile.image,
                     maxWidth: 690,
                 )}"
-                alt="{profile.image.alternative}"
-                title="{profile.image.title}"
+                alt="{profile.image.originalResource.alternative}"
+                title="{profile.image.originalResource.title}"
                 loading="lazy"
             >
         </picture>
 
-        <f:if condition="{image.description}">
-            <figcaption class="visually-hidden">{image.description}</figcaption>
+        <f:if condition="{profile.image.originalResource.description}">
+            <figcaption class="visually-hidden">{profile.image.originalResource.description}</figcaption>
         </f:if>
     </figure>
 </f:if>

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageFileMetadataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageFileMetadataTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Renders the profile image with `EXT:filemetadata` installed.
+ *
+ * That system extension adds the `copyright` field to `sys_file_metadata`, which the
+ * profile image partial used to reference through a view variable that is never assigned —
+ * so a copyright was never rendered in any released version. The output was removed with
+ * ACE-343 instead of being repaired: rendering a file copyright is a feature and has to be
+ * introduced as one. These tests hold that line, and make sure the extension being
+ * installed changes nothing else about the rendering.
+ *
+ * `AcademicPersonsEditProfileImageMetadataTest` covers the same partial without the
+ * extension, where the column does not exist at all.
+ */
+final class AcademicPersonsEditProfileImageFileMetadataTest extends AbstractProfileEditingPluginTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addCoreExtensionsToLoad('typo3/cms-filemetadata');
+        parent::setUp();
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    private function setFileMetadata(int $fileUid, array $values): void
+    {
+        $updatedRows = $this->getConnectionPool()
+            ->getConnectionForTable('sys_file_metadata')
+            ->update('sys_file_metadata', $values, ['file' => $fileUid]);
+
+        $this->assertSame(1, $updatedRows, 'Indexing the file did not create a metadata record.');
+    }
+
+    private function getRenderedFigure(): string
+    {
+        $showPage = $this->getProfileShowPage();
+        if (preg_match('@<figure>.*?</figure>@s', $showPage, $matches) !== 1) {
+            $this->fail('The profile detail view rendered no <figure> element for the profile image.');
+        }
+
+        return $matches[0];
+    }
+
+    #[Test]
+    public function copyrightOfTheImageIsNotRendered(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->setFileMetadata($fileUid, ['copyright' => 'Acme University']);
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringNotContainsString(
+            'Acme University',
+            $figure,
+            'The profile image partial renders a copyright.',
+        );
+        $this->assertStringNotContainsString(
+            'class="copyright"',
+            $figure,
+            'The profile image partial renders a copyright element.',
+        );
+    }
+
+    #[Test]
+    public function remainingImageMetadataIsRendered(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->setFileMetadata($fileUid, [
+            'alternative' => 'Portrait of the profile owner',
+            'title' => 'Profile portrait',
+            'description' => 'Taken at the faculty building',
+        ]);
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringContainsString(
+            'alt="Portrait of the profile owner"',
+            $figure,
+            'The image is rendered without its alternative text.',
+        );
+        $this->assertStringContainsString(
+            'title="Profile portrait"',
+            $figure,
+            'The image is rendered without its title.',
+        );
+        $this->assertStringContainsString(
+            '<figcaption class="visually-hidden">Taken at the faculty building</figcaption>',
+            $figure,
+            'The image description is not rendered as a caption.',
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageMetadataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageMetadataTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Renders the profile image of the `academicpersonsedit_profileediting` plugin and checks
+ * the values `Partials/Profile/Show/Image.html` takes from the file metadata.
+ *
+ * All of them are read through `originalResource`, because the profile carries an
+ * `\TYPO3\CMS\Extbase\Domain\Model\FileReference`, and that class exposes nothing but
+ * `getOriginalResource()` — every other property path resolves to `null` and renders as an
+ * empty string, which is what ACE-343 fixes.
+ *
+ * `EXT:filemetadata` is deliberately *not* loaded here, which is the case on a default
+ * installation — see `AcademicPersonsEditProfileImageFileMetadataTest` for the other one.
+ */
+final class AcademicPersonsEditProfileImageMetadataTest extends AbstractProfileEditingPluginTestCase
+{
+    /**
+     * Writes the metadata of the file itself, the way a backend editor maintains it. The
+     * frontend editing plugin never writes these fields.
+     *
+     * @param array<string, string> $values
+     */
+    private function setFileMetadata(int $fileUid, array $values): void
+    {
+        $updatedRows = $this->getConnectionPool()
+            ->getConnectionForTable('sys_file_metadata')
+            ->update('sys_file_metadata', $values, ['file' => $fileUid]);
+
+        $this->assertSame(1, $updatedRows, 'Indexing the file did not create a metadata record.');
+    }
+
+    /**
+     * Returns the `<figure>` element the image partial renders, so the assertions cannot be
+     * satisfied by markup coming from anywhere else on the page.
+     */
+    private function getRenderedFigure(): string
+    {
+        $showPage = $this->getProfileShowPage();
+        if (preg_match('@<figure>.*?</figure>@s', $showPage, $matches) !== 1) {
+            $this->fail('The profile detail view rendered no <figure> element for the profile image.');
+        }
+
+        return $matches[0];
+    }
+
+    private function fileMetadataTableHasColumn(string $columnName): bool
+    {
+        $columnNames = array_map(
+            static fn(string $name): string => strtolower($name),
+            array_keys(
+                $this->getConnectionPool()
+                    ->getConnectionForTable('sys_file_metadata')
+                    ->createSchemaManager()
+                    ->listTableColumns('sys_file_metadata'),
+            ),
+        );
+
+        return in_array(strtolower($columnName), $columnNames, true);
+    }
+
+    #[Test]
+    public function alternativeAndTitleOfTheImageAreRendered(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->setFileMetadata($fileUid, [
+            'alternative' => 'Portrait of the profile owner',
+            'title' => 'Profile portrait',
+        ]);
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringContainsString(
+            'alt="Portrait of the profile owner"',
+            $figure,
+            'The image is rendered without its alternative text.',
+        );
+        $this->assertStringContainsString(
+            'title="Profile portrait"',
+            $figure,
+            'The image is rendered without its title.',
+        );
+    }
+
+    #[Test]
+    public function descriptionOfTheImageIsRenderedAsCaption(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->setFileMetadata($fileUid, ['description' => 'Taken at the faculty building']);
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringContainsString(
+            '<figcaption class="visually-hidden">Taken at the faculty building</figcaption>',
+            $figure,
+            'The image description is not rendered as a caption.',
+        );
+    }
+
+    #[Test]
+    public function noCaptionIsRenderedForAnImageWithoutDescription(): void
+    {
+        $this->setUpTestCase();
+        $this->seedProfileImage();
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringNotContainsString(
+            '<figcaption',
+            $figure,
+            'An empty caption is rendered for an image without a description.',
+        );
+    }
+
+    /**
+     * A default installation has no `copyright` column at all, because the field comes with
+     * `EXT:filemetadata`. The partial used to reference it through a view variable that is
+     * never assigned, which is why it never rendered anything — the output was removed
+     * rather than repaired, see the changelog entry of ACE-343.
+     */
+    #[Test]
+    public function imageIsRenderedWithoutTheFileMetadataExtension(): void
+    {
+        $this->setUpTestCase();
+        $fileUid = $this->seedProfileImage();
+        $this->setFileMetadata($fileUid, ['description' => 'Taken at the faculty building']);
+
+        $this->assertFalse(
+            $this->fileMetadataTableHasColumn('copyright'),
+            'This test has to run without EXT:filemetadata, but the copyright column exists.',
+        );
+
+        $figure = $this->getRenderedFigure();
+
+        $this->assertStringNotContainsString(
+            'class="copyright"',
+            $figure,
+            'The profile image partial renders a copyright element.',
+        );
+        $this->assertStringContainsString(
+            '<figcaption class="visually-hidden">Taken at the faculty building</figcaption>',
+            $figure,
+            'The image description is not rendered as a caption.',
+        );
+    }
+}


### PR DESCRIPTION
Resolves ACE-343.

`Partials/Profile/Show/Image.html` read the caption from a view variable `image` that is never assigned, so it was dead markup. The `alt` and `title` attribute were broken the same way: they use `profile.image`, which carries an `Extbase\Domain\Model\FileReference`, and that class exposes nothing but `getOriginalResource()` — every other property path resolves to `null` and renders as an empty string. Verified on the running stack: with metadata present the image rendered as `alt="" title=""`.

All values are now read through `originalResource`.

### The copyright output is removed, not repaired

It has never rendered anything in any released version, for two independent reasons: the unassigned variable, and `show_copyright` — a field that exists

* in no TYPO3 system extension (`grep` over the installed tree; `show_copyright repo:TYPO3/typo3` → 0, with control queries confirming the index is live),
* in no `fgtclb` extension — `fgtclb/file-required-attributes` introduces `right_of_use`, not this, in any version of its full history,
* nowhere in this repository except that one condition.

The `copyright` field it would have printed is real but comes with `EXT:filemetadata`, which is no dependency here. Repairing the paths would have produced a second, differently broken condition. Rendering a file copyright is a feature and should be introduced as one, with a declared dependency and test coverage — documented that way in the collective breaking entry.

### Tests

* `AcademicPersonsEditProfileImageMetadataTest` — 4 tests without `EXT:filemetadata` (the default), asserting the column really is absent.
* `AcademicPersonsEditProfileImageFileMetadataTest` — 2 tests with `typo3/cms-filemetadata` loaded, holding the line that no copyright is rendered even when the field is filled.

`typo3/cms-filemetadata` was added to `packages-dev/monorepo-shared` so the second case can run, matching where every other system extension constraint lives.

Every assertion was mutation-checked: the naive `{profile.image.x}` form kills 5 tests, dropping either `f:if` guard or re-adding the copyright block kills exactly the tests that should catch it.

Local: v13/8.2 and v14/8.5, sqlite + postgres, cgl, phpstan on both core configs, lint, docs render.
