### PR TITLE
[TASK] ACE-344: Cover category types services with tests

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Registry/CategoryTypeRegistry.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Registry/CategoryTypeRegistry.php
@@ -17,7 +17,7 @@ class CategoryTypeRegistry implements \JsonSerializable
     /**
      * @var array<string, CategoryType[]>
      */
-    protected array $groupedRegistry;
+    protected array $groupedRegistry = [];
 
     /**
      * @param CategoryType ...$categoryTypes

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Important-CategoryTypeRegistryWithoutRegisteredTypes.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Important-CategoryTypeRegistryWithoutRegisteredTypes.rst
@@ -1,0 +1,62 @@
+.. _important-1785700800:
+
+=============================================================
+Important: Category type registry without any registered type
+=============================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\Registry\\CategoryTypeRegistry` kept its grouped
+registry in a typed property that was never initialised, and
+`CategoryTypeRegistry::attach()` returns early when it is called without a
+category type — which is what `CategoryTypeLoader::load()` does when no
+installed extension ships a `Configuration/CategoryTypes.yaml`.
+
+On such an installation the registry was left in a state where four of its
+methods raised a fatal error instead of answering:
+
+..  code-block:: text
+
+    Error: Typed property CategoryTypeRegistry::$groupedRegistry
+    must not be accessed before initialization
+
+That affected `getGroupedCategoryTypes()`, `toArray()`,
+`getCategoryTypesByGroup()` and `getCategoryTypeIdentifierByGroup()`. The last
+two are called by every method of
+`FGTCLB\\CategoryTypes\\Domain\\Repository\\CategoryRepository` and by
+`FGTCLB\\CategoryTypes\\Factory\\CategoryCollectionFactory`, so a category
+lookup on an installation without registered types brought the request down.
+
+The property is now initialised, so an empty registry answers like a registry
+whose groups simply do not match:
+
+*   `getCategoryTypes()`, `getGroupedCategoryTypes()` and `toArray()` return an
+    empty array,
+*   `getCategoryTypesByGroup()` and `getCategoryTypeIdentifierByGroup()` throw
+    the documented `\\InvalidArgumentException` (code `1683633304209`) for the
+    group that was asked for.
+
+Impact
+======
+
+A category lookup on an installation that has `EXT:category_types` installed
+but no extension registering category types no longer fails with a fatal error.
+
+Installations that already had registered category types are unaffected: the
+property was initialised by the first `attach()` call there.
+
+Affected Installations
+======================
+
+Installations using `EXT:category_types` without any extension shipping
+`Configuration/CategoryTypes.yaml`. Among the extensions of this repository
+those are `EXT:academic_partners`, `EXT:academic_programs` and
+`EXT:academic_projects`.
+
+Migration
+=========
+
+No configuration change is required.
+
+.. index:: PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Loader/CategoryTypeLoaderTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Loader/CategoryTypeLoaderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Loader;
+
+use FGTCLB\CategoryTypes\Loader\CategoryTypeLoader;
+use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Covers `CategoryTypeLoader::load()` against a real package manager and a real core
+ * cache — the wiring around the YAML handling, which is covered on its own in the unit
+ * counterpart.
+ *
+ * `EXT:category_types` registers no category type itself, so everything asserted here
+ * comes from the `test_category_types_group` fixture extension.
+ */
+final class CategoryTypeLoaderTest extends AbstractCategoryTypesTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension('tests/category-types-group');
+        parent::setUp();
+    }
+
+    private function coreCache(): PhpFrontend
+    {
+        $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('core');
+        $this->assertInstanceOf(PhpFrontend::class, $cache);
+
+        return $cache;
+    }
+
+    /**
+     * A loader that sees no package at all, so anything it returns can only come from
+     * the cache the previous loader wrote.
+     */
+    private function loaderWithoutPackages(): CategoryTypeLoader
+    {
+        $packageManager = $this->createMock(PackageManager::class);
+        $packageManager->method('getActivePackages')->willReturn([]);
+
+        return new CategoryTypeLoader($this->coreCache(), $packageManager);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function identifiersOf(CategoryTypeRegistry $registry): array
+    {
+        $identifiers = [];
+        foreach ($registry->getCategoryTypes() as $categoryType) {
+            $identifiers[] = $categoryType->getGroup() . '.' . $categoryType->getIdentifier();
+        }
+        sort($identifiers);
+
+        return $identifiers;
+    }
+
+    #[Test]
+    public function loadCollectsTheTypesOfTheActivePackages(): void
+    {
+        $registry = $this->get(CategoryTypeLoader::class)->load();
+
+        $this->assertSame(
+            ['testing.testing_first', 'testing.testing_second'],
+            $this->identifiersOf($registry),
+        );
+        $this->assertSame(
+            'test_category_types_group',
+            $registry->getCategoryType('testing', 'testing_first')?->getExtensionKey(),
+        );
+    }
+
+    /**
+     * The registry the container hands out is the one the loader built — `Services.yaml`
+     * registers `CategoryTypeRegistry` as a service produced by this factory method.
+     */
+    #[Test]
+    public function containerRegistryIsTheLoadedOne(): void
+    {
+        $this->assertSame(
+            $this->identifiersOf($this->get(CategoryTypeLoader::class)->load()),
+            $this->identifiersOf($this->get(CategoryTypeRegistry::class)),
+        );
+    }
+
+    #[Test]
+    public function repeatedLoadReturnsTheSameRegistryInstance(): void
+    {
+        $loader = $this->get(CategoryTypeLoader::class);
+
+        $this->assertSame($loader->load(), $loader->load());
+    }
+
+    /**
+     * The point of the cache: a second request does not read a single YAML file. The
+     * types are restored from the exported PHP through `CategoryType::__set_state()`,
+     * which is why that method has to keep working even though nothing calls it directly.
+     */
+    #[Test]
+    public function typesAreRestoredFromTheCacheWithoutReadingAnyPackage(): void
+    {
+        $this->get(CategoryTypeLoader::class)->load();
+
+        $cachedRegistry = $this->loaderWithoutPackages()->load();
+
+        $this->assertSame(
+            ['testing.testing_first', 'testing.testing_second'],
+            $this->identifiersOf($cachedRegistry),
+        );
+        $this->assertSame(
+            'Testing first',
+            $cachedRegistry->getCategoryType('testing', 'testing_first')?->getTitle(),
+        );
+    }
+
+    /**
+     * Without a cache entry the same loader finds nothing, which is what makes the test
+     * above evidence for the cache rather than for the fixture extension.
+     */
+    #[Test]
+    public function loaderWithoutPackagesFindsNothingWhenTheCacheIsEmpty(): void
+    {
+        $this->coreCache()->flush();
+
+        $this->assertSame([], $this->identifiersOf($this->loaderWithoutPackages()->load()));
+    }
+
+    /**
+     * An installation where no extension ships category types: the registry stays empty
+     * and usable. Its group lookups then report an unknown group rather than failing on
+     * an uninitialised property.
+     */
+    #[Test]
+    public function emptyRegistryStaysUsable(): void
+    {
+        $this->coreCache()->flush();
+
+        $registry = $this->loaderWithoutPackages()->load();
+
+        $this->assertSame([], $registry->getCategoryTypes());
+        $this->assertSame([], $registry->getGroupedCategoryTypes());
+        $this->assertSame([], $registry->toArray());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+        $registry->getCategoryTypesByGroup('testing');
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
@@ -5,15 +5,274 @@ declare(strict_types=1);
 namespace FGTCLB\CategoryTypes\Tests\Unit\Collection;
 
 use FGTCLB\CategoryTypes\Collection\CategoryCollection;
+use FGTCLB\CategoryTypes\Domain\Model\Category;
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use FGTCLB\CategoryTypes\Exception\CategoryExistException;
+use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
+/**
+ * The collection groups categories by their type identifier, and the identifiers it
+ * accepts are the ones `setTypeIdentifiers()` was given — normally from
+ * `CategoryCollectionFactory`, which takes them from the registry group.
+ *
+ * The categories carry their type as a plain string here: `Category::getType()` resolves
+ * through the registry and returns `null` for an unregistered type, while the collection
+ * groups by `(string)$category->getType()`, so an untyped category groups under `''`.
+ */
 final class CategoryCollectionTest extends UnitTestCase
 {
+    private function category(int $uid, string $title = 'Category'): Category
+    {
+        return new Category(uid: $uid, parentId: 0, title: $title);
+    }
+
+    /**
+     * Builds a category that carries the given type. `Category` resolves its type in the
+     * constructor through `GeneralUtility::makeInstance(CategoryTypeRegistry::class)`, so
+     * a matching registry is queued for exactly that call — see `CategoryTest` for why
+     * this is `addInstance()` rather than a singleton.
+     */
+    private function typedCategory(int $uid, string $typeIdentifier, string $group = 'testing'): Category
+    {
+        $registry = new CategoryTypeRegistry();
+        $registry->attach(new CategoryType(
+            identifier: $typeIdentifier,
+            extensionKey: 'test_extension',
+            title: ucfirst($typeIdentifier),
+            group: $group,
+            icon: '',
+            priority: 0,
+        ));
+        GeneralUtility::addInstance(CategoryTypeRegistry::class, $registry);
+
+        return new Category(
+            uid: $uid,
+            parentId: 0,
+            title: 'Category ' . $uid,
+            type: $typeIdentifier,
+            typeGroup: $group,
+        );
+    }
+
     #[Test]
-    public function canBeCreatedUsingNew(): void
+    public function freshCollectionIsEmpty(): void
     {
         $subject = new CategoryCollection();
-        $this->assertInstanceOf(CategoryCollection::class, $subject);
+
+        $this->assertCount(0, $subject);
+        $this->assertSame([], $subject->getAllCategoriesByType());
+        $this->assertSame(CategoryCollection::class, (string)$subject);
+    }
+
+    #[Test]
+    public function attachedCategoriesAreCounted(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->attach($this->category(1));
+        $subject->attach($this->category(2));
+
+        $this->assertCount(2, $subject);
+    }
+
+    #[Test]
+    public function attachingTheSameUidTwiceIsRejected(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->attach($this->category(1));
+
+        $this->expectException(CategoryExistException::class);
+        $this->expectExceptionCode(1739368562);
+
+        $subject->attach($this->category(1, 'Another title'));
+    }
+
+    #[Test]
+    public function attachedCategoryIsReportedAsExisting(): void
+    {
+        $category = $this->category(1);
+
+        $subject = new CategoryCollection();
+        $subject->attach($category);
+
+        $this->assertTrue($subject->exist($category));
+        $this->assertFalse($subject->exist($this->category(2)));
+    }
+
+    #[Test]
+    public function collectionIteratesOverItsCategoriesKeyedByUid(): void
+    {
+        $first = $this->category(11);
+        $second = $this->category(22);
+
+        $subject = new CategoryCollection();
+        $subject->attach($first);
+        $subject->attach($second);
+
+        $seen = [];
+        foreach ($subject as $key => $category) {
+            $seen[$key] = $category;
+        }
+
+        $this->assertSame([11 => $first, 22 => $second], $seen);
+    }
+
+    #[Test]
+    public function iterationCanBeRepeatedAfterRewind(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->attach($this->category(1));
+
+        $this->assertCount(1, iterator_to_array($subject));
+        $this->assertCount(1, iterator_to_array($subject));
+    }
+
+    /**
+     * Without registered type identifiers there is nothing to group by, so the grouped
+     * view stays empty even though the collection holds categories.
+     */
+    #[Test]
+    public function groupingIsEmptyWhileNoTypeIdentifiersAreKnown(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->attach($this->typedCategory(1, 'research_field'));
+
+        $this->assertSame([], $subject->getAllCategoriesByType());
+    }
+
+    #[Test]
+    public function everyKnownTypeGetsAnEntryEvenWithoutCategories(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field', 'country']);
+
+        $this->assertSame(['research_field' => [], 'country' => []], $subject->getAllCategoriesByType());
+    }
+
+    #[Test]
+    public function categoriesAreGroupedByTheirTypeIdentifier(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+        $otherField = $this->typedCategory(2, 'research_field');
+        $country = $this->typedCategory(3, 'country');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field', 'country']);
+        $subject->attach($field);
+        $subject->attach($otherField);
+        $subject->attach($country);
+
+        $this->assertSame(
+            [
+                'research_field' => [1 => $field, 2 => $otherField],
+                'country' => [3 => $country],
+            ],
+            $subject->getAllCategoriesByType(),
+        );
+    }
+
+    /**
+     * A category whose type is not part of the group is dropped from the grouped view
+     * rather than added under its own key — the same constraint `CategoryRepository`
+     * applies in SQL, here as a second line of defence.
+     */
+    #[Test]
+    public function categoryOfAnUnknownTypeIsNotGrouped(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $subject->attach($this->typedCategory(1, 'country'));
+
+        $this->assertSame(['research_field' => []], $subject->getAllCategoriesByType());
+    }
+
+    #[Test]
+    public function categoriesOfATypeAreLookedUpByName(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $subject->attach($field);
+
+        $this->assertSame([1 => $field], $subject->getCategoriesByTypeName('research_field'));
+    }
+
+    /**
+     * The lookup normalises camel case, which is what makes `{categories.researchField}`
+     * work in Fluid for a `research_field` type.
+     */
+    #[Test]
+    public function typeNameLookupAcceptsCamelCase(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $subject->attach($field);
+
+        $this->assertSame([1 => $field], $subject->getCategoriesByTypeName('researchField'));
+        $this->assertSame([1 => $field], $subject->offsetGet('researchField'));
+        // The magic accessor is what makes `{categories.researchField}` work in a
+        // template that calls it as a method rather than as an offset.
+        $this->assertSame([1 => $field], $subject->__call('researchField', []));
+    }
+
+    #[Test]
+    public function unknownTypeNameIsRejected(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1739372162);
+
+        $subject->getCategoriesByTypeName('country');
+    }
+
+    /**
+     * `@implements \ArrayAccess<string, Category[]>` declares string offsets, but PHP
+     * hands whatever the caller wrote to the methods, so both guard against it. The
+     * offset is produced as `mixed` here to exercise that guard rather than the
+     * annotation.
+     */
+    #[Test]
+    public function nonStringOffsetsAreRejectedByArrayAccess(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $offset = $this->numericOffset();
+
+        $this->assertFalse($subject->offsetExists($offset));
+        $this->assertFalse($subject->offsetGet($offset));
+    }
+
+    private function numericOffset(): mixed
+    {
+        return 1;
+    }
+
+    #[Test]
+    public function writingThroughArrayAccessIsRejected(): void
+    {
+        $subject = new CategoryCollection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683214236549);
+
+        $subject->offsetSet('research_field', []);
+    }
+
+    #[Test]
+    public function unsettingThroughArrayAccessIsRejected(): void
+    {
+        $subject = new CategoryCollection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683214246022);
+
+        $subject->offsetUnset('research_field');
     }
 }

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/FilterCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/FilterCollectionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Collection;
+
+use FGTCLB\CategoryTypes\Collection\CategoryCollection;
+use FGTCLB\CategoryTypes\Collection\FilterCollection;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The filter collection wraps a `CategoryCollection` and is what the demand objects of
+ * the consuming plugins carry — `{demand.filterCollection.filterCategories.<type>}` in
+ * the shipped `DemandCategories.html` partials.
+ *
+ * Unlike the wrapped collection it answers `offsetExists()` through the same lookup as
+ * `offsetGet()`, so both agree on what exists.
+ */
+final class FilterCollectionTest extends UnitTestCase
+{
+    private function categoryCollectionWithTypes(string ...$typeIdentifiers): CategoryCollection
+    {
+        $categoryCollection = new CategoryCollection();
+        $categoryCollection->setTypeIdentifiers($typeIdentifiers);
+
+        return $categoryCollection;
+    }
+
+    #[Test]
+    public function collectionIsCreatedEmptyWhenNoneIsGiven(): void
+    {
+        $subject = new FilterCollection();
+
+        $this->assertCount(0, $subject->getFilterCategories());
+    }
+
+    #[Test]
+    public function givenCollectionIsKept(): void
+    {
+        $categoryCollection = $this->categoryCollectionWithTypes('research_field');
+
+        $this->assertSame($categoryCollection, (new FilterCollection($categoryCollection))->getFilterCategories());
+    }
+
+    #[Test]
+    public function knownTypeIsReportedAsExisting(): void
+    {
+        $subject = new FilterCollection($this->categoryCollectionWithTypes('research_field'));
+
+        $this->assertTrue($subject->offsetExists('research_field'));
+        $this->assertTrue(isset($subject['research_field']));
+    }
+
+    /**
+     * Both accessors normalise camel case, which is what the partials rely on when they
+     * pass a type identifier straight into the template expression.
+     */
+    #[Test]
+    public function knownTypeIsReachableInCamelCase(): void
+    {
+        $subject = new FilterCollection($this->categoryCollectionWithTypes('research_field'));
+
+        $this->assertTrue($subject->offsetExists('researchField'));
+        $this->assertSame([], $subject->offsetGet('researchField'));
+    }
+
+    #[Test]
+    public function unknownTypeIsReportedAsMissing(): void
+    {
+        $subject = new FilterCollection($this->categoryCollectionWithTypes('research_field'));
+
+        $this->assertFalse($subject->offsetExists('country'));
+        $this->assertFalse($subject->offsetGet('country'));
+    }
+
+    /**
+     * Only the "unknown category type" exception is swallowed. Anything else has to
+     * travel, so a different defect in the wrapped collection cannot be mistaken for an
+     * absent filter.
+     */
+    #[Test]
+    public function unrelatedInvalidArgumentExceptionIsNotSwallowed(): void
+    {
+        $categoryCollection = new class () extends CategoryCollection {
+            public function getCategoriesByTypeName(string $typeIdentifier): array
+            {
+                throw new \InvalidArgumentException('Something else went wrong', 1234567890);
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1234567890);
+
+        (new FilterCollection($categoryCollection))->offsetExists('research_field');
+    }
+
+    #[Test]
+    public function writingThroughArrayAccessIsRejected(): void
+    {
+        $subject = new FilterCollection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633632593);
+
+        $subject->offsetSet('research_field', []);
+    }
+
+    #[Test]
+    public function unsettingThroughArrayAccessIsRejected(): void
+    {
+        $subject = new FilterCollection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633656658);
+
+        $subject->offsetUnset('research_field');
+    }
+
+    #[Test]
+    public function stringRepresentationIsTheClassName(): void
+    {
+        $this->assertSame(FilterCollection::class, (string)new FilterCollection());
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Domain\Model;
+
+use FGTCLB\CategoryTypes\Domain\Model\Category;
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Category` resolves its own type through
+ * `GeneralUtility::makeInstance(CategoryTypeRegistry::class)` in the constructor. In a
+ * request that registry comes from the container — `Services.yaml` registers it as a
+ * public service built by `CategoryTypeLoader::load()`. There is no container here, so
+ * the instance is queued with `GeneralUtility::addInstance()` instead, once per
+ * `Category` that is about to resolve a type. It is not a singleton, so
+ * `setSingletonInstance()` is not an option.
+ */
+final class CategoryTest extends UnitTestCase
+{
+    private function categoryType(string $identifier, string $group): CategoryType
+    {
+        return new CategoryType(
+            identifier: $identifier,
+            extensionKey: 'test_extension',
+            title: ucfirst($identifier),
+            group: $group,
+            icon: 'EXT:test_extension/Resources/Public/Icons/' . $identifier . '.svg',
+            priority: 0,
+        );
+    }
+
+    /**
+     * Queues one registry carrying the given types for the next `makeInstance()` call.
+     */
+    private function queueRegistryWith(CategoryType ...$categoryTypes): void
+    {
+        $registry = new CategoryTypeRegistry();
+        $registry->attach(...$categoryTypes);
+        GeneralUtility::addInstance(CategoryTypeRegistry::class, $registry);
+    }
+
+    #[Test]
+    public function everyConstructorArgumentIsExposedByItsGetter(): void
+    {
+        $subject = new Category(uid: 12, parentId: 7, title: 'Solar research', hidden: true);
+
+        $this->assertSame(12, $subject->getUid());
+        $this->assertSame(7, $subject->getParentId());
+        $this->assertSame('Solar research', $subject->getTitle());
+        $this->assertTrue($subject->getHidden());
+    }
+
+    #[Test]
+    public function stringRepresentationIsTheUid(): void
+    {
+        $this->assertSame('12', (string)new Category(12, 0, 'Solar research'));
+    }
+
+    /**
+     * The default `default` is not looked up at all — a category without an explicit type
+     * keeps a `null` type rather than resolving one, so nothing touches the registry.
+     */
+    #[Test]
+    public function defaultTypeIsNotResolvedFromTheRegistry(): void
+    {
+        $this->assertNull((new Category(1, 0, 'Untyped'))->getType());
+    }
+
+    #[Test]
+    public function typeIsResolvedFromTheRegistry(): void
+    {
+        $categoryType = $this->categoryType('research_field', 'programs');
+        $this->queueRegistryWith($categoryType);
+
+        $subject = new Category(1, 0, 'Solar research', 'research_field', 'programs');
+
+        $this->assertSame($categoryType, $subject->getType());
+    }
+
+    /**
+     * A type that no extension registered resolves to `null` instead of failing, so a
+     * category record referencing a removed type stays renderable. The same holds for a
+     * type that exists in a different group.
+     */
+    #[Test]
+    public function unregisteredTypeResolvesToNull(): void
+    {
+        $this->queueRegistryWith($this->categoryType('research_field', 'programs'));
+        $this->assertNull((new Category(1, 0, 'Solar research', 'gone', 'programs'))->getType());
+
+        $this->queueRegistryWith($this->categoryType('research_field', 'programs'));
+        $this->assertNull((new Category(1, 0, 'Solar research', 'research_field', 'partners'))->getType());
+    }
+
+    #[Test]
+    public function categoryWithoutAParentReportsSo(): void
+    {
+        $subject = new Category(1, 0, 'Root');
+
+        $this->assertFalse($subject->hasParent());
+        $this->assertNull($subject->getParent());
+    }
+
+    #[Test]
+    public function categoryWithAParentReportsSo(): void
+    {
+        $this->assertTrue((new Category(2, 1, 'Child'))->hasParent());
+    }
+
+    /**
+     * Without a parent there is nothing to compare against, so the category is its own
+     * root. This is the branch that answers without asking the repository.
+     */
+    #[Test]
+    public function categoryWithoutAParentIsARoot(): void
+    {
+        $this->assertTrue((new Category(1, 0, 'Root'))->isRoot());
+    }
+
+    #[Test]
+    public function childrenAreEmptyUntilTheyAreLoaded(): void
+    {
+        $this->assertNull((new Category(1, 0, 'Root'))->getChildren());
+    }
+
+    #[Test]
+    public function disabledStateCanBeToggled(): void
+    {
+        $subject = new Category(1, 0, 'Root');
+        $this->assertFalse($subject->isDisabled());
+
+        $subject->setDisabled(true);
+        $this->assertTrue($subject->isDisabled());
+
+        $subject->setDisabled(false);
+        $this->assertFalse($subject->isDisabled());
+    }
+
+    #[Test]
+    public function disabledStateCanBeSetThroughTheConstructor(): void
+    {
+        $this->assertTrue((new Category(1, 0, 'Root', 'default', 'default', false, true))->isDisabled());
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeGroupTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeGroupTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Domain\Model;
+
+use FGTCLB\CategoryTypes\Domain\Model\CategoryTypeGroup;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class CategoryTypeGroupTest extends UnitTestCase
+{
+    #[Test]
+    public function everyPropertyDefaultsToAnEmptyValue(): void
+    {
+        $subject = new CategoryTypeGroup();
+
+        $this->assertSame('', $subject->getIdentifier());
+        $this->assertSame('', $subject->getGroup());
+        $this->assertSame(0, $subject->getPriority());
+    }
+
+    #[Test]
+    public function everyConstructorArgumentIsExposedByItsGetter(): void
+    {
+        $subject = new CategoryTypeGroup('programs', 'academic', 20);
+
+        $this->assertSame('programs', $subject->getIdentifier());
+        $this->assertSame('academic', $subject->getGroup());
+        $this->assertSame(20, $subject->getPriority());
+    }
+
+    #[Test]
+    public function everyPropertyCanBeReplacedByItsSetter(): void
+    {
+        $subject = new CategoryTypeGroup();
+        $subject->setIdentifier('partners');
+        $subject->setGroup('academic');
+        $subject->setPriority(5);
+
+        $this->assertSame(
+            ['identifier' => 'partners', 'group' => 'academic', 'priority' => 5],
+            $subject->toArray(),
+        );
+    }
+
+    #[Test]
+    public function arrayRepresentationCarriesEveryProperty(): void
+    {
+        $subject = new CategoryTypeGroup('programs', 'academic', 20);
+
+        $this->assertSame(
+            ['identifier' => 'programs', 'group' => 'academic', 'priority' => 20],
+            $subject->toArray(),
+        );
+    }
+
+    /**
+     * Note that `fromArray()` is an instance method here, unlike the static counterpart
+     * on `CategoryType` — it still builds a new object rather than filling this one.
+     */
+    #[Test]
+    public function fromArrayBuildsANewGroupAndLeavesTheReceiverUntouched(): void
+    {
+        $subject = new CategoryTypeGroup('original', 'academic', 1);
+
+        $built = $subject->fromArray(['identifier' => 'built', 'group' => 'other', 'priority' => 9]);
+
+        $this->assertSame(['identifier' => 'built', 'group' => 'other', 'priority' => 9], $built->toArray());
+        $this->assertSame(['identifier' => 'original', 'group' => 'academic', 'priority' => 1], $subject->toArray());
+    }
+
+    #[Test]
+    public function fromArrayDefaultsMissingKeysAndCastsScalars(): void
+    {
+        $built = (new CategoryTypeGroup())->fromArray(['priority' => '7']);
+
+        $this->assertSame(['identifier' => '', 'group' => '', 'priority' => 7], $built->toArray());
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Domain\Model;
+
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class CategoryTypeTest extends UnitTestCase
+{
+    /**
+     * @return array{
+     *     identifier: string,
+     *     extensionKey: string,
+     *     title: string,
+     *     group: string,
+     *     icon: string,
+     *     priority: int,
+     * }
+     */
+    private function completeArray(): array
+    {
+        return [
+            'identifier' => 'field_of_study',
+            'extensionKey' => 'academic_programs',
+            'title' => 'Field of study',
+            'group' => 'programs',
+            'icon' => 'EXT:academic_programs/Resources/Public/Icons/field_of_study.svg',
+            'priority' => 30,
+        ];
+    }
+
+    #[Test]
+    public function everyConstructorArgumentIsExposedByItsGetter(): void
+    {
+        $values = $this->completeArray();
+        $subject = new CategoryType(...$values);
+
+        $this->assertSame($values['identifier'], $subject->getIdentifier());
+        $this->assertSame($values['extensionKey'], $subject->getExtensionKey());
+        $this->assertSame($values['title'], $subject->getTitle());
+        $this->assertSame($values['group'], $subject->getGroup());
+        $this->assertSame($values['icon'], $subject->getIcon());
+        $this->assertSame($values['priority'], $subject->getPriority());
+    }
+
+    /**
+     * The icon identifier is what `ServiceProvider::addIcons()` registers with the
+     * `IconRegistry` and what the backend then resolves an icon by, so its shape is
+     * public API rather than an implementation detail.
+     */
+    #[Test]
+    public function iconIdentifierIsComposedOfPrefixGroupAndIdentifier(): void
+    {
+        $subject = new CategoryType(...$this->completeArray());
+
+        $this->assertSame('category_types.programs.field_of_study', $subject->getIconIdentifier());
+    }
+
+    #[Test]
+    public function stringRepresentationIsTheIdentifier(): void
+    {
+        $subject = new CategoryType(...$this->completeArray());
+
+        $this->assertSame('field_of_study', (string)$subject);
+    }
+
+    #[Test]
+    public function arrayAndJsonRepresentationCarryEveryProperty(): void
+    {
+        $values = $this->completeArray();
+        $subject = new CategoryType(...$values);
+
+        $this->assertSame($values, $subject->toArray());
+        $this->assertSame($values, $subject->jsonSerialize());
+    }
+
+    /**
+     * @return \Generator<string, array{0: callable(array<string, mixed>): CategoryType}>
+     */
+    public static function factoryMethods(): \Generator
+    {
+        yield 'fromArray' => [static fn(array $array): CategoryType => CategoryType::fromArray($array)];
+        // `__set_state()` is what `var_export()` writes into the core cache, so the cached
+        // registry is rebuilt through it on every request that hits the cache.
+        yield '__set_state' => [static fn(array $array): CategoryType => CategoryType::__set_state($array)];
+    }
+
+    /**
+     * @param callable(array<string, mixed>): CategoryType $factory
+     */
+    #[DataProvider('factoryMethods')]
+    #[Test]
+    public function factoryMethodRestoresEveryProperty(callable $factory): void
+    {
+        $values = $this->completeArray();
+
+        $this->assertSame($values, $factory($values)->toArray());
+    }
+
+    /**
+     * A YAML file may leave any key out — the loader only insists on `identifier` and
+     * `group`. Everything else falls back rather than failing.
+     *
+     * @param callable(array<string, mixed>): CategoryType $factory
+     */
+    #[DataProvider('factoryMethods')]
+    #[Test]
+    public function factoryMethodDefaultsMissingKeys(callable $factory): void
+    {
+        $subject = $factory(['identifier' => 'minimal']);
+
+        $this->assertSame(
+            [
+                'identifier' => 'minimal',
+                'extensionKey' => '',
+                'title' => '',
+                'group' => '',
+                'icon' => '',
+                'priority' => 0,
+            ],
+            $subject->toArray(),
+        );
+    }
+
+    /**
+     * `priority` arrives as a string from YAML often enough to matter, and the cache
+     * round trip has to survive it as well.
+     *
+     * @param callable(array<string, mixed>): CategoryType $factory
+     */
+    #[DataProvider('factoryMethods')]
+    #[Test]
+    public function factoryMethodCastsScalarsToTheDeclaredTypes(callable $factory): void
+    {
+        $subject = $factory(['identifier' => 'cast', 'priority' => '42']);
+
+        $this->assertSame(42, $subject->getPriority());
+    }
+
+    #[Test]
+    public function exportedTypeCanBeRestoredFromItsVarExport(): void
+    {
+        $subject = new CategoryType(...$this->completeArray());
+
+        /** @var CategoryType $restored */
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(CategoryType::class, $restored);
+        $this->assertSame($subject->toArray(), $restored->toArray());
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Factory/CategoryCollectionFactoryTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Factory/CategoryCollectionFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Factory;
+
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use FGTCLB\CategoryTypes\Factory\CategoryCollectionFactory;
+use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class CategoryCollectionFactoryTest extends UnitTestCase
+{
+    private function registry(string $group, string ...$typeIdentifiers): CategoryTypeRegistry
+    {
+        $registry = new CategoryTypeRegistry();
+        foreach ($typeIdentifiers as $typeIdentifier) {
+            $registry->attach(new CategoryType(
+                identifier: $typeIdentifier,
+                extensionKey: 'test_extension',
+                title: ucfirst($typeIdentifier),
+                group: $group,
+                icon: '',
+                priority: 0,
+            ));
+        }
+
+        return $registry;
+    }
+
+    /**
+     * The factory is the only place that tells a collection which types it may hold, so
+     * the group of the registry decides what the collection can later be asked for.
+     */
+    #[Test]
+    public function createdCollectionKnowsTheTypesOfItsGroup(): void
+    {
+        $subject = new CategoryCollectionFactory($this->registry('programs', 'research_field', 'degree'));
+
+        $collection = $subject->createCategoryCollection('programs');
+
+        $this->assertCount(0, $collection);
+        $this->assertSame(
+            ['research_field' => [], 'degree' => []],
+            $collection->getAllCategoriesByType(),
+        );
+    }
+
+    #[Test]
+    public function everyCallCreatesItsOwnCollection(): void
+    {
+        $subject = new CategoryCollectionFactory($this->registry('programs', 'research_field'));
+
+        $this->assertNotSame(
+            $subject->createCategoryCollection('programs'),
+            $subject->createCategoryCollection('programs'),
+        );
+    }
+
+    /**
+     * An unknown group is the registry's `InvalidArgumentException`, not an empty
+     * collection — the caller asked for something that no extension registered.
+     */
+    #[Test]
+    public function unknownGroupIsRejected(): void
+    {
+        $subject = new CategoryCollectionFactory($this->registry('programs', 'research_field'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $subject->createCategoryCollection('partners');
+    }
+
+    /**
+     * The same on an installation where no extension ships category types at all. This
+     * used to be a fatal `Error` about an uninitialised property instead.
+     */
+    #[Test]
+    public function unknownGroupIsRejectedWithoutAnyRegisteredType(): void
+    {
+        $subject = new CategoryCollectionFactory(new CategoryTypeRegistry());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $subject->createCategoryCollection('programs');
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/base_types/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/base_types/Configuration/CategoryTypes.yaml
@@ -1,0 +1,10 @@
+types:
+  - identifier: research_field
+    title: 'Research field'
+    group: programs
+    icon: 'EXT:base_types/Resources/Public/Icons/research_field.svg'
+    priority: 10
+  - identifier: degree
+    title: 'Degree'
+    group: programs
+    icon: 'EXT:base_types/Resources/Public/Icons/degree.svg'

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/no_group/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/no_group/Configuration/CategoryTypes.yaml
@@ -1,0 +1,3 @@
+types:
+  - identifier: groupless
+    title: 'Groupless'

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/no_identifier/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/no_identifier/Configuration/CategoryTypes.yaml
@@ -1,0 +1,3 @@
+types:
+  - title: 'Nameless'
+    group: programs

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/orphan_override/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/orphan_override/Configuration/CategoryTypes.yaml
@@ -1,0 +1,5 @@
+types:
+  - identifier: never_defined
+    group: programs
+    title: 'Override without an original'
+    useExisting: true

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/overriding_extension/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/overriding_extension/Configuration/CategoryTypes.yaml
@@ -1,0 +1,5 @@
+types:
+  - identifier: research_field
+    group: programs
+    title: 'Subject area'
+    useExisting: true

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/removing_extension/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/removing_extension/Configuration/CategoryTypes.yaml
@@ -1,0 +1,4 @@
+types:
+  - identifier: degree
+    group: programs
+    remove: true

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/second_extension/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/second_extension/Configuration/CategoryTypes.yaml
@@ -1,0 +1,5 @@
+types:
+  - identifier: country
+    title: 'Country'
+    group: partners
+    icon: 'EXT:second_extension/Resources/Public/Icons/country.svg'

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/without_types/Configuration/CategoryTypes.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Fixtures/Packages/without_types/Configuration/CategoryTypes.yaml
@@ -1,0 +1,3 @@
+groups:
+  - identifier: programs
+    title: 'Programs'

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Loader/CategoryTypeLoaderTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Loader/CategoryTypeLoaderTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Loader;
+
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use FGTCLB\CategoryTypes\Loader\CategoryTypeLoader;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Covers how `CategoryTypeLoader::loadUncached()` reads
+ * `Configuration/CategoryTypes.yaml` of the active packages — the format handling the
+ * class asks for coverage of in its own `@todo`.
+ *
+ * The packages are stubbed, so the fixtures under `Tests/Unit/Fixtures/Packages/` are
+ * plain directories rather than installable extensions, and a test can put them in any
+ * order. Order matters: `remove` and `useExisting` act on what earlier packages defined.
+ *
+ * `load()` and the cache round trip are covered by the functional counterpart, which has
+ * a real cache backend.
+ */
+final class CategoryTypeLoaderTest extends UnitTestCase
+{
+    private function subject(string ...$packageNames): CategoryTypeLoader
+    {
+        $packages = [];
+        foreach ($packageNames as $packageName) {
+            $package = $this->createMock(PackageInterface::class);
+            $package->method('getPackageKey')->willReturn($packageName);
+            $package->method('getPackagePath')->willReturn(__DIR__ . '/../Fixtures/Packages/' . $packageName);
+            $packages[] = $package;
+        }
+
+        $packageManager = $this->createMock(PackageManager::class);
+        $packageManager->method('getActivePackages')->willReturn($packages);
+
+        return new CategoryTypeLoader($this->createMock(PhpFrontend::class), $packageManager);
+    }
+
+    #[Test]
+    public function noActivePackageYieldsNoTypes(): void
+    {
+        $this->assertSame([], $this->subject()->loadUncached());
+    }
+
+    #[Test]
+    public function packageWithoutAConfigurationFileIsSkipped(): void
+    {
+        $this->assertSame([], $this->subject('no_configuration')->loadUncached());
+    }
+
+    #[Test]
+    public function emptyConfigurationFileIsSkipped(): void
+    {
+        $this->assertSame([], $this->subject('empty_file')->loadUncached());
+    }
+
+    #[Test]
+    public function configurationWithoutATypesSectionIsSkipped(): void
+    {
+        $this->assertSame([], $this->subject('without_types')->loadUncached());
+    }
+
+    /**
+     * The key is `<group>.<identifier>`, which is what makes `remove` and `useExisting`
+     * of a later package address a type of an earlier one.
+     */
+    #[Test]
+    public function typesAreKeyedByGroupAndIdentifier(): void
+    {
+        $categoryTypes = $this->subject('base_types')->loadUncached();
+
+        $this->assertSame(['programs.research_field', 'programs.degree'], array_keys($categoryTypes));
+        $this->assertContainsOnlyInstancesOf(CategoryType::class, $categoryTypes);
+    }
+
+    /**
+     * The extension key is not part of the YAML — the loader stamps it onto every type,
+     * which is what tells an integrator where a type came from.
+     */
+    #[Test]
+    public function everyTypeCarriesTheDefiningExtensionKey(): void
+    {
+        $categoryTypes = $this->subject('base_types')->loadUncached();
+
+        $this->assertSame('base_types', $categoryTypes['programs.research_field']->getExtensionKey());
+        $this->assertSame('base_types', $categoryTypes['programs.degree']->getExtensionKey());
+    }
+
+    #[Test]
+    public function everyDeclaredValueIsCarriedOver(): void
+    {
+        $categoryTypes = $this->subject('base_types')->loadUncached();
+
+        $this->assertSame(
+            [
+                'identifier' => 'research_field',
+                'extensionKey' => 'base_types',
+                'title' => 'Research field',
+                'group' => 'programs',
+                'icon' => 'EXT:base_types/Resources/Public/Icons/research_field.svg',
+                'priority' => 10,
+            ],
+            $categoryTypes['programs.research_field']->toArray(),
+        );
+    }
+
+    #[Test]
+    public function omittedPriorityDefaultsToZero(): void
+    {
+        $categoryTypes = $this->subject('base_types')->loadUncached();
+
+        $this->assertSame(0, $categoryTypes['programs.degree']->getPriority());
+    }
+
+    #[Test]
+    public function typesOfSeveralPackagesAreCollected(): void
+    {
+        $categoryTypes = $this->subject('base_types', 'second_extension')->loadUncached();
+
+        $this->assertSame(
+            ['programs.research_field', 'programs.degree', 'partners.country'],
+            array_keys($categoryTypes),
+        );
+    }
+
+    #[Test]
+    public function laterPackageCanRemoveAnEarlierType(): void
+    {
+        $categoryTypes = $this->subject('base_types', 'removing_extension')->loadUncached();
+
+        $this->assertSame(['programs.research_field'], array_keys($categoryTypes));
+    }
+
+    /**
+     * `remove` on a type nobody defined is not an error — the removing extension may
+     * simply be installed without the one that would have defined it.
+     */
+    #[Test]
+    public function removingAnUndefinedTypeIsAccepted(): void
+    {
+        $this->assertSame([], $this->subject('removing_extension')->loadUncached());
+    }
+
+    /**
+     * Order decides: a `remove` before the definition removes nothing, because the type
+     * is added afterwards.
+     */
+    #[Test]
+    public function removalBeforeTheDefinitionHasNoEffect(): void
+    {
+        $categoryTypes = $this->subject('removing_extension', 'base_types')->loadUncached();
+
+        $this->assertSame(['programs.research_field', 'programs.degree'], array_keys($categoryTypes));
+    }
+
+    #[Test]
+    public function laterPackageCanOverrideSingleValuesOfAnEarlierType(): void
+    {
+        $categoryTypes = $this->subject('base_types', 'overriding_extension')->loadUncached();
+
+        $this->assertSame(
+            [
+                'identifier' => 'research_field',
+                // Reassigned to the overriding extension, so the origin stays traceable.
+                'extensionKey' => 'overriding_extension',
+                'title' => 'Subject area',
+                'group' => 'programs',
+                // Not restated by the override, so the original value survives.
+                'icon' => 'EXT:base_types/Resources/Public/Icons/research_field.svg',
+                'priority' => 10,
+            ],
+            $categoryTypes['programs.research_field']->toArray(),
+        );
+    }
+
+    #[Test]
+    public function overridingATypeThatWasNeverDefinedIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(1678979375330);
+        $this->expectExceptionMessage('Category type does not exist for override.');
+
+        $this->subject('orphan_override')->loadUncached();
+    }
+
+    #[Test]
+    public function typeWithoutAnIdentifierIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(1678979375330);
+        $this->expectExceptionMessage('Category type identifier has to be defined as a non-empty string.');
+
+        $this->subject('no_identifier')->loadUncached();
+    }
+
+    #[Test]
+    public function typeWithoutAGroupIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(1678979375330);
+        $this->expectExceptionMessage('Category type group has to be defined as a non-empty string.');
+
+        $this->subject('no_group')->loadUncached();
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Registry/CategoryTypeRegistryTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Registry/CategoryTypeRegistryTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Registry;
+
+use FGTCLB\CategoryTypes\Domain\Model\CategoryType;
+use FGTCLB\CategoryTypes\Exception\CategoryTypeExistException;
+use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class CategoryTypeRegistryTest extends UnitTestCase
+{
+    private function categoryType(
+        string $identifier,
+        string $group = 'testing',
+        string $extensionKey = 'test_extension',
+        int $priority = 0,
+    ): CategoryType {
+        return new CategoryType(
+            identifier: $identifier,
+            extensionKey: $extensionKey,
+            title: ucfirst($identifier),
+            group: $group,
+            icon: 'EXT:' . $extensionKey . '/Resources/Public/Icons/' . $identifier . '.svg',
+            priority: $priority,
+        );
+    }
+
+    /**
+     * A registry nobody attached anything to is a real state: only three extensions of
+     * this repository ship a `Configuration/CategoryTypes.yaml`, so an installation
+     * using `EXT:category_types` alone never fills it. `attach()` also returns early for
+     * an empty argument list, which is what the loader passes in that case.
+     */
+    #[Test]
+    public function freshRegistryReportsNoTypes(): void
+    {
+        $subject = new CategoryTypeRegistry();
+
+        $this->assertSame([], $subject->getCategoryTypes());
+        $this->assertSame([], $subject->getGroupedCategoryTypes());
+        $this->assertSame([], $subject->toArray());
+        $this->assertSame(['registry' => []], $subject->jsonSerialize());
+    }
+
+    #[Test]
+    public function attachWithoutArgumentsLeavesTheRegistryUsable(): void
+    {
+        $subject = new CategoryTypeRegistry();
+        $subject->attach();
+
+        $this->assertSame([], $subject->getGroupedCategoryTypes());
+    }
+
+    /**
+     * The documented failure mode of an unknown group. On a registry that never received
+     * a type this used to be a fatal `Error` about the uninitialised property instead.
+     */
+    #[Test]
+    public function unknownGroupIsReportedAsInvalidArgumentOnAFreshRegistry(): void
+    {
+        $subject = new CategoryTypeRegistry();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $subject->getCategoryTypesByGroup('testing');
+    }
+
+    #[Test]
+    public function attachedTypesAreReturnedInAttachmentOrder(): void
+    {
+        $first = $this->categoryType('first');
+        $second = $this->categoryType('second');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($first, $second);
+
+        $this->assertSame([$first, $second], $subject->getCategoryTypes());
+    }
+
+    #[Test]
+    public function typesAreGroupedByTheirGroupAndKeyedByIdentifier(): void
+    {
+        $programs = $this->categoryType('field_of_study', group: 'programs');
+        $partners = $this->categoryType('country', group: 'partners');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($programs, $partners);
+
+        $this->assertSame(
+            [
+                'programs' => ['field_of_study' => $programs],
+                'partners' => ['country' => $partners],
+            ],
+            $subject->getGroupedCategoryTypes(),
+        );
+    }
+
+    /**
+     * `CategoryType::$group` is a plain string with no default, so an empty one is what a
+     * YAML file without a group produces. The registry files those under `default`.
+     */
+    #[Test]
+    public function typeWithoutAGroupIsFiledUnderDefault(): void
+    {
+        $groupless = $this->categoryType('loose', group: '');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($groupless);
+
+        $this->assertSame(['default' => ['loose' => $groupless]], $subject->getGroupedCategoryTypes());
+    }
+
+    #[Test]
+    public function attachingTheSameIdentifierTwiceInOneGroupIsRejected(): void
+    {
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($this->categoryType('duplicate'));
+
+        $this->expectException(CategoryTypeExistException::class);
+        $this->expectExceptionCode(1678979375329);
+
+        $subject->attach($this->categoryType('duplicate'));
+    }
+
+    #[Test]
+    public function theSameIdentifierIsAllowedInDifferentGroups(): void
+    {
+        $programs = $this->categoryType('topic', group: 'programs');
+        $projects = $this->categoryType('topic', group: 'projects');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($programs, $projects);
+
+        $this->assertSame($programs, $subject->getCategoryType('programs', 'topic'));
+        $this->assertSame($projects, $subject->getCategoryType('projects', 'topic'));
+    }
+
+    #[Test]
+    public function unknownTypeResolvesToNull(): void
+    {
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($this->categoryType('known'));
+
+        $this->assertNull($subject->getCategoryType('testing', 'unknown'));
+        $this->assertNull($subject->getCategoryType('unknown', 'known'));
+        $this->assertNull((new CategoryTypeRegistry())->getCategoryType('testing', 'known'));
+    }
+
+    #[Test]
+    public function typesOfAGroupAreReturnedKeyedByIdentifier(): void
+    {
+        $first = $this->categoryType('first', group: 'programs');
+        $second = $this->categoryType('second', group: 'programs');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($first, $second, $this->categoryType('other', group: 'partners'));
+
+        $this->assertSame(['first' => $first, 'second' => $second], $subject->getCategoryTypesByGroup('programs'));
+        $this->assertSame(['first', 'second'], $subject->getCategoryTypeIdentifierByGroup('programs'));
+    }
+
+    #[Test]
+    public function unknownGroupIsRejectedWhenAskingForIdentifiers(): void
+    {
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($this->categoryType('known', group: 'programs'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $subject->getCategoryTypeIdentifierByGroup('partners');
+    }
+
+    #[Test]
+    public function attachedTypeIsReportedAsExisting(): void
+    {
+        $attached = $this->categoryType('attached');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($attached);
+
+        $this->assertTrue($subject->exists($attached));
+        $this->assertFalse($subject->exists($this->categoryType('different')));
+    }
+
+    #[Test]
+    public function toArraySerialisesEveryTypeGroupedByItsGroup(): void
+    {
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($this->categoryType('field_of_study', group: 'programs', priority: 10));
+
+        $this->assertSame(
+            [
+                'programs' => [
+                    [
+                        'identifier' => 'field_of_study',
+                        'extensionKey' => 'test_extension',
+                        'title' => 'Field_of_study',
+                        'group' => 'programs',
+                        'icon' => 'EXT:test_extension/Resources/Public/Icons/field_of_study.svg',
+                        'priority' => 10,
+                    ],
+                ],
+            ],
+            $subject->toArray(),
+        );
+    }
+
+    #[Test]
+    public function jsonSerializeReturnsTheFlatRegistry(): void
+    {
+        $first = $this->categoryType('first', group: 'programs');
+        $second = $this->categoryType('second', group: 'partners');
+
+        $subject = new CategoryTypeRegistry();
+        $subject->attach($first, $second);
+
+        $this->assertSame(['registry' => [$first, $second]], $subject->jsonSerialize());
+    }
+}


### PR DESCRIPTION
Resolves ACE-344 for branch `2`. Backport of #413.

`EXT:category_types` guarded roughly 1.700 lines of classes with **four** test methods. This adds tier 1 (registry, models, collections, factory) and tier 2 (the YAML loader) of that issue, plus the registry bugfix found while writing them.

**104 tests now, up from 4** — 89 unit, 15 functional.

### The bugfix commit

`CategoryTypeRegistry::$groupedRegistry` was declared without an initialiser, and `attach()` returns early when called without a type — which is what `CategoryTypeLoader::load()` does when no installed extension ships a `Configuration/CategoryTypes.yaml`. Four methods then raised `Error: Typed property ... must not be accessed before initialization`, two of which every `CategoryRepository` method and `CategoryCollectionFactory` call. A category lookup on such an installation brought the request down instead of reporting an unknown group.

Branch `2` carries this defect identically — `Classes/Registry/CategoryTypeRegistry.php` is byte-identical to `main`.

### What differs from #413

Only the changelog entry, which moves from `Documentation/Changelog/3.0/` to `2.4/`. Nothing else needed adapting: the covered classes are byte-identical between the branches, and the tests use no helper that `main` has and `2` lacks — `AbstractCategoryTypesTestCase::addTestExtension()` exists here since ACE-332.

Worth noting for once, given how rarely it holds on this repository: this really was a plain cherry-pick plus a moved file.

### Verification

Local, on this branch: v12/8.1 and v13/8.3, unit and functional, sqlite + postgres, cgl, phpstan on both core configs, lint, docs rendering. Mutation-checked here too — removing the registry initialiser or the `extensionKey` stamp kills exactly the tests that should catch it (2 errors + 5 failures).

### Follow-up

ACE-345 (`CategoryCollection::offsetExists()` hides a known type from Fluid) is fixed on both branches **after** this has landed, so its tests can build on this coverage. No assertion here locks in that behaviour.
