### PR TITLE
[BUGFIX] ACE-345: Resolve category types in Fluid

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
@@ -184,6 +184,13 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
 
     /**
      * ArrayAccess method offsetExists
+     *
+     * Answers from the registered type identifiers, which is what {@see offsetGet()}
+     * resolves against as well. Reading the lazily built `$typeSortedCollection` here
+     * instead made a type exist only after something had computed the grouping - and
+     * Fluid resolves `{collection.someType}` through this method, so a template that
+     * did not touch `allCategoriesByType` first rendered nothing.
+     *
      * @return bool
      */
     public function offsetExists(mixed $offset): bool
@@ -192,7 +199,7 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
             return false;
         }
         $lowerName = GeneralUtility::camelCaseToLowerCaseUnderscored($offset);
-        return array_key_exists($lowerName, $this->typeSortedCollection);
+        return in_array($lowerName, $this->typeIdentifiers, true);
     }
 
     /**

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryCollectionOffsetExists.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryCollectionOffsetExists.rst
@@ -1,0 +1,69 @@
+.. _important-1785704400:
+
+===========================================================
+Important: Category types resolve in templates on first use
+===========================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\Collection\\CategoryCollection::offsetExists()` answered
+from `$typeSortedCollection`, the grouped view the collection builds lazily. That
+array stays empty until `getAllCategoriesByType()` has been called once on the
+instance, so a category type was reported as absent although the collection
+accepted it — while `offsetGet()`, which resolves through
+`getCategoriesByTypeName()`, answered from the start:
+
+..  code-block:: php
+
+    $collection = new CategoryCollection();
+    $collection->setTypeIdentifiers(['research_field']);
+
+    $collection->offsetExists('researchField');   // false
+    $collection->offsetGet('researchField');      // array
+
+This reached the frontend. Fluid resolves a path segment on an `ArrayAccess`
+subject through `offsetExists()` and only reads the offset once that returned
+`true`, so `{categories.researchField}` produced nothing — no exception, no log
+entry — until something else had computed the grouping first.
+
+`offsetExists()` now answers from the registered type identifiers, the same
+source the lookup it guards resolves against. `FilterCollection::offsetExists()`
+already behaved that way.
+
+Impact
+======
+
+A template can access a category type by name without preparing the collection
+first:
+
+..  code-block:: html
+
+    <f:for each="{categories.researchField}" as="category">
+        {category.title}
+    </f:for>
+
+Previously that rendered nothing unless the template had accessed
+`{categories.allCategoriesByType}` — or anything else computing the grouping —
+beforehand.
+
+The Fluid files shipped by `EXT:academic_partners`, `EXT:academic_programs` and
+`EXT:academic_projects` were not affected: their `DemandCategories.html` partials
+iterate `{categories.allCategoriesByType}` before reaching a type by name, so the
+grouping was always computed in time.
+
+Affected Installations
+======================
+
+Installations with project templates or partials that read a category type by
+name from a `CategoryCollection`, and any code calling `offsetExists()` or
+`isset()` on one.
+
+Migration
+=========
+
+No configuration change is required. Workarounds that accessed
+`{categories.allCategoriesByType}` only to make a later expression resolve can be
+removed.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
@@ -12,6 +12,7 @@ use FGTCLB\CategoryTypes\Registry\CategoryTypeRegistry;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
 /**
  * The collection groups categories by their type identifier, and the identifiers it
@@ -230,6 +231,83 @@ final class CategoryCollectionTest extends UnitTestCase
         $this->expectExceptionCode(1739372162);
 
         $subject->getCategoriesByTypeName('country');
+    }
+
+    /**
+     * `offsetExists()` used to answer from the lazily built grouping, so a type only
+     * "existed" once something had called `getAllCategoriesByType()` on that instance,
+     * while `offsetGet()` answered all along. Both now read the registered type
+     * identifiers.
+     */
+    #[Test]
+    public function knownTypeExistsBeforeTheGroupingWasComputed(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $this->assertTrue($subject->offsetExists('research_field'));
+        $this->assertTrue($subject->offsetExists('researchField'));
+        $this->assertTrue(isset($subject['research_field']));
+    }
+
+    #[Test]
+    public function existenceAndLookupAgreeOnAnUntouchedCollection(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $this->assertSame(
+            $subject->offsetExists('research_field'),
+            $subject->offsetGet('research_field') !== false,
+        );
+    }
+
+    #[Test]
+    public function unknownTypeDoesNotExist(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $this->assertFalse($subject->offsetExists('country'));
+        $this->assertFalse($subject->offsetExists('countryOfOrigin'));
+    }
+
+    #[Test]
+    public function noTypeExistsWhileNoTypeIdentifiersAreKnown(): void
+    {
+        $this->assertFalse((new CategoryCollection())->offsetExists('research_field'));
+    }
+
+    /**
+     * Why the disagreement mattered: Fluid resolves a path segment on an `ArrayAccess`
+     * subject through `offsetExists()` and only reads the offset once that answered
+     * `true` (`StandardVariableProvider::getByPath()`). `{categories.researchField}`
+     * therefore rendered nothing — silently — until something else had computed the
+     * grouping first.
+     */
+    #[Test]
+    public function templateExpressionResolvesOnAnUntouchedCollection(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $subject->attach($field);
+
+        $variableProvider = new StandardVariableProvider(['categories' => $subject]);
+
+        $this->assertSame([1 => $field], $variableProvider->getByPath('categories.researchField'));
+    }
+
+    #[Test]
+    public function templateExpressionOfAnUnknownTypeResolvesToNull(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $variableProvider = new StandardVariableProvider(['categories' => $subject]);
+
+        $this->assertNull($variableProvider->getByPath('categories.country'));
     }
 
     /**


### PR DESCRIPTION
Resolves ACE-345 (subtask of ACE-10), which depended on the ACE-344 coverage landing first — the tests here build on `CategoryCollectionTest` from #413.

`CategoryCollection::offsetExists()` answered from `$typeSortedCollection`, the grouped view the collection builds lazily. That array stays empty until `getAllCategoriesByType()` has been called once on the instance, so a registered type was reported as absent while `offsetGet()` — which resolves through `getCategoriesByTypeName()` — answered from the start:

```php
$collection = new CategoryCollection();
$collection->setTypeIdentifiers(['research_field']);

$collection->offsetExists('researchField');   // false
$collection->offsetGet('researchField');      // array
```

### Why it reached the frontend

Fluid resolves a path segment on an `ArrayAccess` subject **through `offsetExists()`** and reads the offset only once that returned `true` (`StandardVariableProvider::getByPath()`). So `{categories.researchField}` produced nothing — no exception, no log entry — until something else had computed the grouping. Verified on both `typo3fluid/fluid` 4.6.1 (v13) and 5.3.1 (v14): not core-version specific.

The partials shipped by `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` were safe **by accident** — `DemandCategories.html` iterates `{categories.allCategoriesByType}` on line 8 and only reaches `{categories.{categoryKey}}` on line 19. A project template in the other order rendered nothing.

`offsetExists()` now answers from the registered type identifiers, the same source the lookup it guards resolves against — which is what `FilterCollection::offsetExists()` already did, and why the filter collection never had this defect.

### Tests

Six added to `CategoryCollectionTest`, three of which fail against the old implementation. One drives the template expression through Fluid's `StandardVariableProvider` and asserts it resolves, so the *reason* for the defect is covered rather than only its symptom.

Mutation-checked on both branches: restoring the old `array_key_exists()` line kills exactly those three.

### Verification

`main`: v13/8.2 and v14/8.5. `2`: v12/8.1 and v13/8.3. Both with unit + functional, cgl, phpstan per core config, lint and docs rendering.
