### PR TITLE
[TASK] ACE-346: Cover the category types repository and view helpers

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php
@@ -17,15 +17,15 @@ class CategoryViewHelper extends AbstractViewHelper
         parent::initializeArguments();
 
         $arguments = [
+            // A required argument must not carry a default value: Fluid 5, shipped with
+            // TYPO3 v14, rejects that combination when the argument is defined.
             'page' => [
                 'type' => 'int',
-                'defaultValue' => [],
                 'description' => 'The page ID for which the categories should be fetched',
                 'required' => true,
             ],
             'group' => [
                 'type' => 'string',
-                'defaultValue' => 'default',
                 'description' => 'The group identifier for the categories for this page type',
                 'required' => true,
             ],

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-BackendCategoryViewHelperArguments.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-BackendCategoryViewHelperArguments.rst
@@ -1,0 +1,81 @@
+.. _important-1785708000:
+
+==========================================================
+Important: Page categories render in the TYPO3 v14 backend
+==========================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Be\\CategoryViewHelper` registered its two
+required arguments with a default value:
+
+..  code-block:: php
+
+    'page' => [
+        'type' => 'int',
+        'defaultValue' => [],
+        'description' => 'The page ID for which the categories should be fetched',
+        'required' => true,
+    ],
+    'group' => [
+        'type' => 'string',
+        'defaultValue' => 'default',
+        'description' => 'The group identifier for the categories for this page type',
+        'required' => true,
+    ],
+
+Fluid 5, shipped with TYPO3 v14, rejects that combination while the template is
+being parsed:
+
+..  code-block:: text
+
+    TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentDefinitionException:
+    ArgumentDefinition "page" cannot have a default value while also being
+    required. Either remove the default or mark it as optional. (1754235900)
+
+The default value of a required argument can never be used, and Fluid now says
+so instead of accepting the definition. Both default values are dropped; the
+arguments stay required, which is what the registration meant. The one of `page`
+was wrong in its own right as well - an empty array for an argument typed `int`.
+
+References
+----------
+
+* Fluid pull request `#1157 - Disallow argument definitions with a default value
+  while also being required
+  <https://github.com/TYPO3/Fluid/pull/1157>`__, first released in
+  `Fluid 5.0.0 <https://github.com/TYPO3/Fluid/releases/tag/5.0.0>`__. The commit
+  message states that it "will not be backported to 4.x because it might break
+  existing ViewHelpers or components if they are not configured properly" -
+  which is why TYPO3 v13, running Fluid 4, accepts the same registration.
+* `Fluid changelog 5.x
+  <https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/Changelog/5.x.html>`__
+* TYPO3 v14 changelog `Breaking: #108148 - Strict Types in Fluid ViewHelpers
+  <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108148-StrictTypesInFluidViewHelpers.html>`__,
+  the wider move to stricter ViewHelper argument handling this belongs to.
+
+Impact
+======
+
+On TYPO3 v14 every template using `<ct:be.category>` threw while being parsed, so
+the backend page layout preview of `EXT:academic_partners`,
+`EXT:academic_programs` and `EXT:academic_projects` could not render at all. The
+exception came from the parser, before the view helper was invoked, so there was
+no partial output either.
+
+TYPO3 v13 was not affected.
+
+Affected Installations
+======================
+
+Installations on TYPO3 v14 using the backend page layout preview of one of the
+three extensions above, or a project template of their own calling
+`<ct:be.category>`.
+
+Migration
+=========
+
+None. Both arguments were required before and still are.
+
+.. index:: Backend, Fluid, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Model/CategoryTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Model/CategoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Domain\Model;
+
+use FGTCLB\CategoryTypes\Domain\Model\Category;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The two methods of `Category` that reach the database: `getParent()` looks the parent up
+ * through `CategoryRepository::findParent()`, and `isRoot()` builds on it.
+ *
+ * `isRoot()` decides where an option ends up in a grouped filter select
+ * (`ViewHelpers\Form\FilterSelectViewHelper`), and it does not mean "has no parent": a
+ * category whose parent belongs to a different type is a root as well, because the select
+ * only ever shows one type at a time.
+ *
+ * The remaining behaviour of the model is covered without a database in
+ * `Tests/Unit/Domain/Model/CategoryTest`.
+ */
+final class CategoryTest extends AbstractCategoryTypesTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTree.csv');
+    }
+
+    #[Test]
+    public function categoryWithoutAParentHasNone(): void
+    {
+        $category = $this->category(uid: 1, parentId: 0);
+
+        $this->assertFalse($category->hasParent());
+        $this->assertNull($category->getParent());
+        $this->assertTrue($category->isRoot());
+    }
+
+    #[Test]
+    public function parentIsLookedUpInTheDatabase(): void
+    {
+        $parent = $this->category(uid: 2, parentId: 1)->getParent();
+
+        $this->assertNotNull($parent);
+        $this->assertSame('Root Category', $parent->getTitle());
+    }
+
+    #[Test]
+    public function categoryBelowAParentOfTheSameTypeIsNotARoot(): void
+    {
+        $this->assertFalse($this->category(uid: 2, parentId: 1)->isRoot());
+        $this->assertFalse($this->category(uid: 3, parentId: 2)->isRoot());
+    }
+
+    #[Test]
+    public function categoryBelowAParentOfAnotherTypeIsARoot(): void
+    {
+        // Category 7 hangs below category 6, which carries `testing_second`.
+        $this->assertTrue($this->category(uid: 7, parentId: 6)->isRoot());
+    }
+
+    /**
+     * `findParent()` applies the default restrictions, so a hidden ancestor is invisible and
+     * its children move up to the root level rather than disappearing from the select.
+     */
+    #[Test]
+    public function categoryBelowAHiddenParentIsARoot(): void
+    {
+        $category = $this->category(uid: 5, parentId: 4);
+
+        $this->assertNull($category->getParent());
+        $this->assertTrue($category->isRoot());
+    }
+
+    /**
+     * The lookup uses the group of the resolved type, so a category built without one falls
+     * back to `default` - where the fixture group's types are not registered, and the parent
+     * comes back untyped instead of failing.
+     */
+    #[Test]
+    public function parentOfAnUntypedCategoryIsResolvedInTheDefaultGroup(): void
+    {
+        $parent = (new Category(uid: 2, parentId: 1, title: 'Child Category'))->getParent();
+
+        $this->assertNotNull($parent);
+        $this->assertNull($parent->getType());
+    }
+
+    private function category(int $uid, int $parentId, string $type = 'testing_first'): Category
+    {
+        return new Category(
+            uid: $uid,
+            parentId: $parentId,
+            title: 'Category ' . $uid,
+            type: $type,
+            typeGroup: 'testing',
+        );
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryGroupSelectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryGroupSelectionTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Domain\Repository;
+
+use FGTCLB\CategoryTypes\Collection\CategoryCollection;
+use FGTCLB\CategoryTypes\Collection\GetCategoryCollectionInterface;
+use FGTCLB\CategoryTypes\Domain\Model\Category;
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Direct coverage for the two methods selecting from a whole category group:
+ * `CategoryRepository::findAllApplicable()` and `findByGroupAndUidList()`.
+ *
+ * `findAllApplicable()` builds the filter offered on a list view: it returns every category
+ * of the group and marks the ones no listed record carries as disabled, so the select box
+ * keeps its shape while unusable options grey out. Its callers are the list actions of
+ * `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects`.
+ *
+ * `findByGroupAndUidList()` resolves the submitted filter back into categories, called from
+ * the `DemandFactory` of the same three extensions.
+ *
+ * `EXT:category_types` registers no category group of its own, so the group and the two
+ * types come from the `test_category_types_group` fixture extension.
+ */
+final class CategoryRepositoryGroupSelectionTest extends AbstractCategoryTypesTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/groupedCategories.csv');
+    }
+
+    #[Test]
+    public function everyCategoryOfTheGroupIsApplicable(): void
+    {
+        $collection = $this->subject()->findAllApplicable('testing', $this->entityWithCategories(1));
+
+        // Category 4 carries no registered type and category 5 is hidden, so neither is part
+        // of the group - the disabled marker is not what keeps them out.
+        $this->assertSame(['First Category', 'Second Category', 'Third Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function categoriesNoEntityCarriesAreDisabled(): void
+    {
+        $collection = $this->subject()->findAllApplicable('testing', $this->entityWithCategories(1, 3));
+
+        $this->assertSame(
+            ['First Category' => false, 'Second Category' => true, 'Third Category' => false],
+            $this->disabledStates($collection),
+        );
+    }
+
+    /**
+     * The entity list is variadic, and an empty one is what a list view without a single
+     * record hands over. Everything greys out, nothing disappears.
+     */
+    #[Test]
+    public function withoutAnyEntityEveryCategoryIsDisabled(): void
+    {
+        $collection = $this->subject()->findAllApplicable('testing');
+
+        $this->assertSame(
+            ['First Category' => true, 'Second Category' => true, 'Third Category' => true],
+            $this->disabledStates($collection),
+        );
+    }
+
+    #[Test]
+    public function categoriesOfAllEntitiesAreCombined(): void
+    {
+        $collection = $this->subject()->findAllApplicable(
+            'testing',
+            $this->entityWithCategories(1),
+            $this->entityWithCategories(2),
+        );
+
+        $this->assertSame(
+            ['First Category' => false, 'Second Category' => false, 'Third Category' => true],
+            $this->disabledStates($collection),
+        );
+    }
+
+    /**
+     * A category an entity carries but the group does not contain must not sneak into the
+     * result through the entity - the group defines the offered filter, the entities only
+     * decide which of its entries are usable.
+     */
+    #[Test]
+    public function categoryOutsideTheGroupStaysOutEvenWhenAnEntityCarriesIt(): void
+    {
+        $collection = $this->subject()->findAllApplicable('testing', $this->entityWithCategories(4, 5));
+
+        $this->assertSame(['First Category', 'Second Category', 'Third Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function applicableCategoriesOfAnUnknownGroupAreRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $this->subject()->findAllApplicable('unknown');
+    }
+
+    #[Test]
+    public function onlyTheRequestedCategoriesAreReturned(): void
+    {
+        $collection = $this->subject()->findByGroupAndUidList('testing', [1, 3]);
+
+        $this->assertSame(['First Category', 'Third Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function requestedCategoryOutsideTheGroupIsIgnored(): void
+    {
+        $collection = $this->subject()->findByGroupAndUidList('testing', [1, 4]);
+
+        $this->assertSame(['First Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function requestedHiddenCategoryIsIgnored(): void
+    {
+        $collection = $this->subject()->findByGroupAndUidList('testing', [1, 5]);
+
+        $this->assertSame(['First Category'], $this->titles($collection));
+    }
+
+    /**
+     * `DemandFactory` builds the list with `GeneralUtility::intExplode()`, so a submitted
+     * filter that was never chosen arrives as `[0]` rather than as an empty list.
+     */
+    #[Test]
+    public function unknownCategoryUidReturnsAnEmptyCollection(): void
+    {
+        $this->assertCount(0, $this->subject()->findByGroupAndUidList('testing', [0]));
+        $this->assertCount(0, $this->subject()->findByGroupAndUidList('testing', [999]));
+    }
+
+    #[Test]
+    public function requestedCategoriesOfAnUnknownGroupAreRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $this->subject()->findByGroupAndUidList('unknown', [1]);
+    }
+
+    private function subject(): CategoryRepository
+    {
+        return $this->get(CategoryRepository::class);
+    }
+
+    /**
+     * `findAllApplicable()` reads nothing but the uid from the categories of an entity, so
+     * the type they carry does not matter here.
+     */
+    private function entityWithCategories(int ...$uids): GetCategoryCollectionInterface
+    {
+        $collection = new CategoryCollection();
+        foreach ($uids as $uid) {
+            $collection->attach(new Category(uid: $uid, parentId: 0, title: 'Carried category ' . $uid));
+        }
+
+        return new class ($collection) implements GetCategoryCollectionInterface {
+            public function __construct(private readonly CategoryCollection $collection) {}
+
+            public function getAttributes(): CategoryCollection
+            {
+                return $this->collection;
+            }
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    private function titles(CategoryCollection $collection): array
+    {
+        $titles = [];
+        foreach ($collection as $category) {
+            $titles[] = $category->getTitle();
+        }
+        sort($titles);
+
+        return $titles;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function disabledStates(CategoryCollection $collection): array
+    {
+        $states = [];
+        foreach ($collection as $category) {
+            $states[$category->getTitle()] = $category->isDisabled();
+        }
+        ksort($states);
+
+        return $states;
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryPageTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryPageTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Domain\Repository;
+
+use FGTCLB\CategoryTypes\Collection\CategoryCollection;
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Direct coverage for `CategoryRepository::findByGroupAndPageId()`.
+ *
+ * The method reads the categories a page carries in its own `categories` field, and is the
+ * only consumer of the `$includeHidden` switch. Its single caller is the backend page
+ * layout view helper `ViewHelpers\Be\CategoryViewHelper`, which always passes `true` —
+ * hidden records have to show up in the backend module of `EXT:academic_partners`,
+ * `EXT:academic_programs` and `EXT:academic_projects`.
+ *
+ * Both directions of that switch are asserted here, and for the page as well as for the
+ * category: the query joins `pages`, so the restrictions apply to that table too, which is
+ * what the comment in the method refers to.
+ *
+ * `EXT:category_types` registers no category group of its own, so the group and the two
+ * types come from the `test_category_types_group` fixture extension.
+ */
+final class CategoryRepositoryPageTest extends AbstractCategoryTypesTestCase
+{
+    private const CATEGORISED_PAGE = 2;
+    private const HIDDEN_PAGE = 3;
+    private const UNCATEGORISED_PAGE = 4;
+
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categorisedPages.csv');
+    }
+
+    #[Test]
+    public function categoriesOfThePageAreReturned(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::CATEGORISED_PAGE);
+
+        $this->assertSame(['First Category', 'Second Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function categoryOutsideTheRequestedGroupIsIgnored(): void
+    {
+        // The page also carries category 4, whose `type` belongs to no registered type of
+        // the group, so the `sys_category.type IN (...)` constraint filters it out.
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::CATEGORISED_PAGE);
+
+        $this->assertNotContains('Untyped Category', $this->titles($collection));
+    }
+
+    #[Test]
+    public function pageWithoutCategoriesReturnsAnEmptyCollection(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::UNCATEGORISED_PAGE);
+
+        $this->assertCount(0, $collection);
+    }
+
+    #[Test]
+    public function hiddenCategoryIsOmittedByDefault(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::CATEGORISED_PAGE);
+
+        $this->assertNotContains('Hidden Category', $this->titles($collection));
+    }
+
+    #[Test]
+    public function hiddenCategoryIsReturnedWhenHiddenRecordsAreRequested(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::CATEGORISED_PAGE, true);
+
+        $this->assertSame(
+            ['First Category', 'Hidden Category', 'Second Category'],
+            $this->titles($collection),
+        );
+    }
+
+    /**
+     * The hidden state travels with the category, so a template can tell the two apart
+     * instead of only seeing more rows.
+     */
+    #[Test]
+    public function hiddenStateIsCarriedByTheCategory(): void
+    {
+        $hidden = [];
+        foreach ($this->subject()->findByGroupAndPageId('testing', self::CATEGORISED_PAGE, true) as $category) {
+            $hidden[$category->getTitle()] = $category->getHidden();
+        }
+        ksort($hidden);
+
+        $this->assertSame(
+            ['First Category' => false, 'Hidden Category' => true, 'Second Category' => false],
+            $hidden,
+        );
+    }
+
+    /**
+     * The restrictions cover the joined `pages` table as well, so a hidden page hides its
+     * categories - which is exactly what the backend caller lifts.
+     */
+    #[Test]
+    public function categoriesOfAHiddenPageAreOmittedByDefault(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::HIDDEN_PAGE);
+
+        $this->assertCount(0, $collection);
+    }
+
+    #[Test]
+    public function categoriesOfAHiddenPageAreReturnedWhenHiddenRecordsAreRequested(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::HIDDEN_PAGE, true);
+
+        $this->assertSame(['First Category'], $this->titles($collection));
+    }
+
+    #[Test]
+    public function collectionIsPreparedForTheRequestedGroup(): void
+    {
+        $collection = $this->subject()->findByGroupAndPageId('testing', self::UNCATEGORISED_PAGE);
+
+        // Even without a single row the collection knows the types of the group, so a
+        // template iterating them renders an empty group rather than nothing.
+        $this->assertSame(
+            ['testing_first' => [], 'testing_second' => []],
+            $collection->getAllCategoriesByType(),
+        );
+    }
+
+    #[Test]
+    public function unknownGroupIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $this->subject()->findByGroupAndPageId('unknown', self::CATEGORISED_PAGE);
+    }
+
+    private function subject(): CategoryRepository
+    {
+        return $this->get(CategoryRepository::class);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function titles(CategoryCollection $collection): array
+    {
+        $titles = [];
+        foreach ($collection as $category) {
+            $titles[] = $category->getTitle();
+        }
+        sort($titles);
+
+        return $titles;
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTreeTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTreeTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\Domain\Repository;
+
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Direct coverage for the two methods walking the category tree:
+ * `CategoryRepository::findParent()` and `getCategoryRootline()`.
+ *
+ * `findParent()` is reached from `Category::getParent()` and therefore from `isRoot()`,
+ * which decides where an option is placed in the grouped filter select - see
+ * `Tests/Functional/Domain/Model/CategoryTest`.
+ *
+ * `getCategoryRootline()` has no caller in this repository: the only one,
+ * `EXT:academic_programs` `Backend\Tca\Labels::category()`, is commented out. It is public
+ * API nonetheless, and the recursion is the part worth pinning down - the more so because
+ * the method returns raw database rows rather than `Category` objects, unlike every other
+ * method of the class.
+ *
+ * `EXT:category_types` registers no category group of its own, so the group and the two
+ * types come from the `test_category_types_group` fixture extension.
+ */
+final class CategoryRepositoryTreeTest extends AbstractCategoryTypesTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTree.csv');
+    }
+
+    /**
+     * The argument is the uid to look up, not the uid whose parent is wanted - the name
+     * describes the caller, `Category::getParent()`, which passes its own `parentId`.
+     */
+    #[Test]
+    public function categoryIsFoundByItsUid(): void
+    {
+        $category = $this->subject()->findParent('testing', 1);
+
+        $this->assertNotNull($category);
+        $this->assertSame('Root Category', $category->getTitle());
+        $this->assertSame(1, $category->getUid());
+    }
+
+    #[Test]
+    public function foundCategoryCarriesItsTypeOfTheRequestedGroup(): void
+    {
+        $category = $this->subject()->findParent('testing', 2);
+
+        $this->assertNotNull($category);
+        $this->assertSame('testing_first', (string)$category->getType());
+        $this->assertSame(1, $category->getParentId());
+    }
+
+    #[Test]
+    public function unknownCategoryIsNotFound(): void
+    {
+        $this->assertNull($this->subject()->findParent('testing', 999));
+    }
+
+    /**
+     * No restriction is lifted here, so a hidden category has no parent from the frontend's
+     * point of view - which makes `Category::isRoot()` report its children as roots.
+     */
+    #[Test]
+    public function hiddenCategoryIsNotFound(): void
+    {
+        $this->assertNull($this->subject()->findParent('testing', 4));
+    }
+
+    /**
+     * Unlike every other method of the repository this one does not check the group: the
+     * type of the found record is resolved against the group that was passed, so a category
+     * of a foreign group comes back without a type rather than not at all.
+     */
+    #[Test]
+    public function categoryOfAnotherGroupIsFoundWithoutItsType(): void
+    {
+        $category = $this->subject()->findParent('unknown', 1);
+
+        $this->assertNotNull($category);
+        $this->assertSame('Root Category', $category->getTitle());
+        $this->assertNull($category->getType());
+    }
+
+    #[Test]
+    public function rootlineOfANestedCategoryStartsAtTheRoot(): void
+    {
+        $rootline = $this->subject()->getCategoryRootline(3);
+
+        $this->assertSame(
+            ['Root Category', 'Child Category', 'Grandchild Category'],
+            array_column($rootline, 'title'),
+        );
+    }
+
+    #[Test]
+    public function rootlineCarriesTheFullDatabaseRows(): void
+    {
+        $rootline = $this->subject()->getCategoryRootline(2);
+
+        $this->assertSame([1, 2], array_map(intval(...), array_column($rootline, 'uid')));
+        $this->assertSame(['testing_first', 'testing_first'], array_column($rootline, 'type'));
+    }
+
+    #[Test]
+    public function rootlineOfARootCategoryHoldsThatCategoryOnly(): void
+    {
+        $rootline = $this->subject()->getCategoryRootline(1);
+
+        $this->assertCount(1, $rootline);
+        $this->assertSame('Root Category', $rootline[0]['title']);
+    }
+
+    /**
+     * The rootline is built from the raw records, so it does not stop at a hidden ancestor
+     * the way `findParent()` does.
+     */
+    #[Test]
+    public function rootlineIncludesHiddenAncestors(): void
+    {
+        $rootline = $this->subject()->getCategoryRootline(5);
+
+        $this->assertSame(['Hidden Root Category', 'Child Of Hidden Root'], array_column($rootline, 'title'));
+    }
+
+    /**
+     * Neither does it stop where the type changes, which is where `isRoot()` would.
+     */
+    #[Test]
+    public function rootlineCrossesATypeBoundary(): void
+    {
+        $rootline = $this->subject()->getCategoryRootline(7);
+
+        $this->assertSame(['Second Type Root', 'Child Of Another Type'], array_column($rootline, 'title'));
+    }
+
+    private function subject(): CategoryRepository
+    {
+        return $this->get(CategoryRepository::class);
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categorisedPages.csv
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categorisedPages.csv
@@ -1,0 +1,19 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,"/categorised","Categorised Page"
+,3,1,1,0,1,0,0,"/hidden","Hidden Page"
+,4,1,1,0,0,0,0,"/uncategorised","Uncategorised Page"
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,1,0,0,0,"testing_first","First Category",0,0
+,2,1,0,0,0,"testing_second","Second Category",0,0
+,3,1,0,1,0,"testing_first","Hidden Category",0,0
+,4,1,0,0,0,"","Untyped Category",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,2,"pages","categories",0,1
+,2,2,"pages","categories",0,2
+,3,2,"pages","categories",0,3
+,4,2,"pages","categories",0,4
+,1,3,"pages","categories",0,1

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categoryTree.csv
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categoryTree.csv
@@ -1,0 +1,12 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,1,0,0,0,"testing_first","Root Category",0,0
+,2,1,0,0,1,"testing_first","Child Category",0,0
+,3,1,0,0,2,"testing_first","Grandchild Category",0,0
+,4,1,0,1,0,"testing_first","Hidden Root Category",0,0
+,5,1,0,0,4,"testing_first","Child Of Hidden Root",0,0
+,6,1,0,0,0,"testing_second","Second Type Root",0,0
+,7,1,0,0,6,"testing_first","Child Of Another Type",0,0

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/groupedCategories.csv
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/groupedCategories.csv
@@ -1,0 +1,10 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,1,0,0,0,"testing_first","First Category",0,0
+,2,1,0,0,0,"testing_second","Second Category",0,0
+,3,1,0,0,0,"testing_first","Third Category",0,0
+,4,1,0,0,0,"","Untyped Category",0,0
+,5,1,0,1,0,"testing_first","Hidden Category",0,0

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Classes/ViewHelpers/TestSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Classes/ViewHelpers/TestSelectViewHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TESTS\CategoryTypesGroup\ViewHelpers;
+
+use FGTCLB\CategoryTypes\ViewHelpers\Form\AbstractSelectViewHelper;
+
+/**
+ * Minimal subclass turning the `options` argument into the option shape
+ * `AbstractSelectViewHelper::renderOptionTags()` expects, the way the
+ * `SortingSelectViewHelper` of `EXT:academic_partners`, `EXT:academic_programs` and
+ * `EXT:academic_projects` does.
+ *
+ * `ViewHelpers\Form\FilterSelectViewHelper` overrides both `getOptions()` and
+ * `renderOptionTags()`, so the ones of the base class cannot be reached through it.
+ */
+final class TestSelectViewHelper extends AbstractSelectViewHelper
+{
+    /**
+     * @return array<array<string, mixed>>
+     */
+    protected function getOptions(): array
+    {
+        $options = [];
+        foreach ((array)($this->arguments['options'] ?? []) as $value => $label) {
+            $options[] = [
+                'value' => $value,
+                'label' => $label,
+                'isSelected' => $this->isSelected((string)$value),
+            ];
+        }
+
+        return $options;
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Configuration/Services.yaml
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  TESTS\CategoryTypesGroup\:
+    resource: '../Classes/*'

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/composer.json
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Extensions/test_category_types_group/composer.json
@@ -10,6 +10,11 @@
             "role": "Maintainer"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "TESTS\\CategoryTypesGroup\\": "Classes/"
+        }
+    },
     "require": {
         "typo3/cms-core": "~13.4.0@dev || ~14.3.0@dev",
         "fgtclb/category-types": "~3.0.0@dev"

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategory.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategory.html
@@ -1,0 +1,5 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:be.category page="{page}" group="{group}"><f:for each="{category.allCategoriesByType}" as="categories" key="type">[{type}<f:for each="{categories}" as="category">:{category.title}</f:for>]</f:for></ct:be.category></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategoryVariableScope.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategoryVariableScope.html
@@ -1,0 +1,5 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>inside:<ct:be.category page="{page}" group="{group}"><f:if condition="{category}">yes</f:if></ct:be.category>|outside:<f:if condition="{category}">yes</f:if></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategoryWithAlias.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/BeCategoryWithAlias.html
@@ -1,0 +1,5 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:be.category page="{page}" group="{group}" as="pageCategories"><f:for each="{pageCategories.testingFirst}" as="category">[{category.title}]</f:for></ct:be.category></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelect.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelect.html
@@ -1,0 +1,13 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    value="{value}"
+    options="{options}"
+    required="{required}"
+    sortByOptionLabel="{sortByOptionLabel}"
+    groupByParent="{groupByParent}"
+    groupLevelClassPrefix="{groupLevelClassPrefix}"
+    class="form-select"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithContent.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithContent.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    options="{options}"
+    optionsAfterContent="{optionsAfterContent}"
+><option value="own">Own option</option></ct:form.filterSelect></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithOptionValueField.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithOptionValueField.html
@@ -1,0 +1,9 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    value="{value}"
+    options="{options}"
+    optionValueField="uid"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithPrependedOption.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithPrependedOption.html
@@ -1,0 +1,10 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    options="{options}"
+    prependOptionLabel="{prependOptionLabel}"
+    prependOptionValue="{prependOptionValue}"
+    class="form-select"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithoutRenderedOptions.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithoutRenderedOptions.html
@@ -1,0 +1,9 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    options="{options}"
+    renderOptions="false"
+><f:for each="{options}" as="option">[{option.uid}:{option.label}]</f:for></ct:form.filterSelect></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/TestSelect.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/TestSelect.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:test="http://typo3.org/ns/TESTS/CategoryTypesGroup/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><test:testSelect
+    name="{name}"
+    value="{value}"
+    options="{options}"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/AbstractViewHelperTestCase.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/AbstractViewHelperTestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers;
+
+use FGTCLB\CategoryTypes\Tests\Functional\AbstractCategoryTypesTestCase;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
+/**
+ * Renders a fixture template from `Tests/Functional/Fixtures/Templates/` and returns the
+ * markup, so the view helpers are asserted the way a template uses them rather than through
+ * their protected methods.
+ *
+ * That also keeps these tests independent of how a view helper is entered: on branch `2`
+ * `ViewHelpers\Be\CategoryViewHelper` implements `renderStatic()` with
+ * `CompileWithRenderStatic`, here it implements `render()` - a rendering test does not see
+ * the difference.
+ *
+ * Every call builds its own view. The views share the container, and
+ * `ViewHelpers\Form\AbstractSelectViewHelper` writes and then removes a template variable
+ * named `options` when `renderOptions` is `false`, which would otherwise take the assigned
+ * options of the next render with it.
+ */
+abstract class AbstractViewHelperTestCase extends AbstractCategoryTypesTestCase
+{
+    /**
+     * @param array<string, mixed> $variables
+     */
+    protected function render(string $template, array $variables = []): string
+    {
+        $view = $this->get(ViewFactoryInterface::class)->create(new ViewFactoryData(
+            templateRootPaths: [__DIR__ . '/../Fixtures/Templates/'],
+            request: $this->extbaseRequest(),
+        ));
+        $view->assignMultiple($variables);
+
+        return trim($view->render($template));
+    }
+
+    /**
+     * The form view helpers refuse to render without one, see
+     * `TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper::getRequest()`.
+     */
+    private function extbaseRequest(): Request
+    {
+        return new Request(
+            (new ServerRequest())
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+                ->withAttribute('extbase', new ExtbaseRequestParameters())
+        );
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Be/CategoryViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Be/CategoryViewHelperTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\Be;
+
+use FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `ViewHelpers\Be\CategoryViewHelper` provides the categories of a page to the backend page
+ * layout of `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` -
+ * their `PageLayout/Doktype*.html` partials are its only callers.
+ *
+ * It is the one class of this extension that differs between the branches: on `2` it renders
+ * through `renderStatic()` and `CompileWithRenderStatic`, here through `render()`. These
+ * tests go through a template and therefore describe both.
+ */
+final class CategoryViewHelperTest extends AbstractViewHelperTestCase
+{
+    private const CATEGORISED_PAGE = 2;
+    private const UNCATEGORISED_PAGE = 4;
+
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categorisedPages.csv');
+    }
+
+    #[Test]
+    public function categoriesOfThePageAreProvidedGroupedByType(): void
+    {
+        $output = $this->render('BeCategory', ['page' => self::CATEGORISED_PAGE, 'group' => 'testing']);
+
+        $this->assertSame(
+            '[testing_first:First Category:Hidden Category][testing_second:Second Category]',
+            $output,
+        );
+    }
+
+    /**
+     * The view helper always asks for hidden records: an editor has to see a category that is
+     * switched off, which is what the plain `findByGroupAndPageId()` call would hide.
+     */
+    #[Test]
+    public function hiddenCategoriesAreProvidedAsWell(): void
+    {
+        $output = $this->render('BeCategory', ['page' => self::CATEGORISED_PAGE, 'group' => 'testing']);
+
+        $this->assertStringContainsString('Hidden Category', $output);
+    }
+
+    /**
+     * Every type of the group gets an entry even when the page carries no category at all, so
+     * the backend module renders its rows instead of nothing.
+     */
+    #[Test]
+    public function pageWithoutCategoriesStillProvidesTheTypesOfTheGroup(): void
+    {
+        $output = $this->render('BeCategory', ['page' => self::UNCATEGORISED_PAGE, 'group' => 'testing']);
+
+        $this->assertSame('[testing_first][testing_second]', $output);
+    }
+
+    #[Test]
+    public function variableNameCanBeChosen(): void
+    {
+        $output = $this->render('BeCategoryWithAlias', ['page' => self::CATEGORISED_PAGE, 'group' => 'testing']);
+
+        $this->assertSame('[First Category][Hidden Category]', $output);
+    }
+
+    #[Test]
+    public function providedVariableIsRemovedAfterTheTag(): void
+    {
+        $output = $this->render('BeCategoryVariableScope', ['page' => self::CATEGORISED_PAGE, 'group' => 'testing']);
+
+        $this->assertSame('inside:yes|outside:', $output);
+    }
+
+    #[Test]
+    public function unknownGroupIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $this->render('BeCategory', ['page' => self::CATEGORISED_PAGE, 'group' => 'unknown']);
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/AbstractSelectViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/AbstractSelectViewHelperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\Form;
+
+use FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `ViewHelpers\Form\AbstractSelectViewHelper` renders an empty select on its own - its
+ * `getOptions()` returns `[]` - so everything it contributes around the options is asserted
+ * through `FilterSelectViewHelperTest`, which uses the subclass shipped here.
+ *
+ * What that leaves is `renderOptionTags()`, which the filter select overrides and therefore
+ * never reaches. The three `SortingSelectViewHelper` implementations of
+ * `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` do use it:
+ * they only fill `getOptions()` and let the base class write the markup. The
+ * `TestSelectViewHelper` of the `test_category_types_group` fixture extension is built the
+ * same way and stands in for them, so the contract stays covered inside this extension.
+ */
+final class AbstractSelectViewHelperTest extends AbstractViewHelperTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+    }
+
+    #[Test]
+    public function optionsAreRenderedInTheGivenOrder(): void
+    {
+        $output = $this->renderTestSelect(['options' => ['title' => 'By title', 'date' => 'By date']]);
+
+        $this->assertSame(
+            '<select name="sorting">'
+            . '<option value="title">By title</option>' . LF
+            . '<option value="date">By date</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function selectedOptionIsMarked(): void
+    {
+        $output = $this->renderTestSelect([
+            'value' => 'date',
+            'options' => ['title' => 'By title', 'date' => 'By date'],
+        ]);
+
+        $this->assertStringContainsString('<option value="title">By title</option>', $output);
+        $this->assertStringContainsString('<option value="date" selected="selected">By date</option>', $output);
+    }
+
+    #[Test]
+    public function optionLabelIsEscaped(): void
+    {
+        $output = $this->renderTestSelect(['options' => ['title' => 'Fluid & "Templating" <b>']]);
+
+        $this->assertStringContainsString(
+            '<option value="title">Fluid &amp; &quot;Templating&quot; &lt;b&gt;</option>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function withoutOptionsAnEmptySelectIsRendered(): void
+    {
+        $this->assertSame('<select name="sorting"></select>', $this->renderTestSelect());
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function renderTestSelect(array $variables = []): string
+    {
+        return $this->render('TestSelect', array_replace(
+            [
+                'name' => 'sorting',
+                'value' => '',
+                'options' => [],
+            ],
+            $variables,
+        ));
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\Form;
+
+use FGTCLB\CategoryTypes\Domain\Model\Category;
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `ViewHelpers\Form\FilterSelectViewHelper` renders the category filter of the list plugins
+ * of `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` - their
+ * `DemandCategories.html` partials are its only callers.
+ *
+ * Everything `ViewHelpers\Form\AbstractSelectViewHelper` contributes - the name, the
+ * prepended option, `required`, the child content, the `renderOptions` variable and the
+ * selected-value handling - is asserted here rather than in a test of its own: the class is
+ * not abstract, but on its own it renders an empty select, because its `getOptions()`
+ * returns `[]`. Its own `renderOptionTags()`, which the filter select overrides, is covered
+ * in `AbstractSelectViewHelperTest` - the three `SortingSelectViewHelper` implementations of
+ * `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` are its other
+ * subclasses and use it.
+ *
+ * The options are built as `Category` objects instead of being read from the database, which
+ * pins the order the assertions rely on: none of the repository methods sorts. `isRoot()`
+ * still queries, so the parents come from the `categoryTree.csv` fixture.
+ */
+final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
+{
+    protected function setUp(): void
+    {
+        $this->addTestExtension(...array_values([
+            'tests/category-types-group',
+        ]));
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTree.csv');
+    }
+
+    #[Test]
+    public function everyCategoryBecomesAnOption(): void
+    {
+        $output = $this->renderFilterSelect(['options' => [
+            $this->category(1, 0, 'Root Category'),
+            $this->category(6, 0, 'Second Type Root', 'testing_second'),
+        ]]);
+
+        $this->assertSame(
+            '<select class="form-select" name="filter[researchField]">'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '<option value="6" class="level-0">Second Type Root</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function optionsAreReadFromACategoryCollection(): void
+    {
+        // The production callers hand over the collection of a repository method, not an
+        // array - `getOptions()` accepts both.
+        $options = $this->get(CategoryRepository::class)->findByGroupAndUidList('testing', [1, 2]);
+
+        $output = $this->renderFilterSelect(['options' => $options]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
+        $this->assertStringContainsString('<option value="2" class="level-0">Child Category</option>', $output);
+    }
+
+    #[Test]
+    public function optionLabelIsEscaped(): void
+    {
+        $output = $this->renderFilterSelect(['options' => [
+            $this->category(1, 0, 'Fluid & "Templating" <b>'),
+        ]]);
+
+        $this->assertStringContainsString(
+            '<option value="1" class="level-0">Fluid &amp; &quot;Templating&quot; &lt;b&gt;</option>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function withoutOptionsAnEmptySelectIsRendered(): void
+    {
+        $this->assertSame(
+            '<select class="form-select" name="filter[researchField]"></select>',
+            $this->renderFilterSelect(),
+        );
+    }
+
+    #[Test]
+    public function selectedValueIsMarked(): void
+    {
+        $output = $this->renderFilterSelect([
+            'value' => '2',
+            'options' => [$this->category(1, 0, 'Root Category'), $this->category(2, 1, 'Child Category')],
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
+        $this->assertStringContainsString(
+            '<option value="2" class="level-0" selected="selected">Child Category</option>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function severalValuesCanBeSelected(): void
+    {
+        $output = $this->renderFilterSelect([
+            'value' => ['1', '2'],
+            'options' => [
+                $this->category(1, 0, 'Root Category'),
+                $this->category(2, 1, 'Child Category'),
+                $this->category(3, 2, 'Grandchild Category'),
+            ],
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0" selected="selected">', $output);
+        $this->assertStringContainsString('<option value="2" class="level-0" selected="selected">', $output);
+        $this->assertStringContainsString('<option value="3" class="level-0">Grandchild Category</option>', $output);
+    }
+
+    /**
+     * A category as the value is what `{demand.filterCollection.filterCategories.<type>}`
+     * hands over. `Category` is no Extbase entity, so the persistence manager has no
+     * identifier for it and the cast falls back to `__toString()`, which returns the uid.
+     */
+    #[Test]
+    public function selectedValueCanBeACategory(): void
+    {
+        $output = $this->renderFilterSelect([
+            'value' => $this->category(2, 1, 'Child Category'),
+            'options' => [$this->category(1, 0, 'Root Category'), $this->category(2, 1, 'Child Category')],
+        ]);
+
+        $this->assertStringContainsString(
+            '<option value="2" class="level-0" selected="selected">Child Category</option>',
+            $output,
+        );
+    }
+
+    /**
+     * `optionValueField` is not a registered argument of this view helper, it arrives through
+     * the additional-argument handling of the tag based base class - and the partials of the
+     * three consuming extensions pass it. It still reaches `getOptionValueScalar()`.
+     */
+    #[Test]
+    public function selectedValueCanBeReadFromAPropertyOfTheValueObject(): void
+    {
+        $output = $this->renderFilterSelect(
+            [
+                'value' => $this->category(2, 1, 'Child Category'),
+                'options' => [$this->category(2, 1, 'Child Category')],
+            ],
+            'FilterSelectWithOptionValueField',
+        );
+
+        $this->assertStringContainsString('selected="selected"', $output);
+    }
+
+    #[Test]
+    public function valueThatCannotBeCastToAStringIsRejected(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1742820065);
+
+        $this->renderFilterSelect(['value' => new \stdClass()]);
+    }
+
+    #[Test]
+    public function disabledCategoryIsRenderedAsADisabledOption(): void
+    {
+        $disabled = $this->category(2, 1, 'Child Category');
+        $disabled->setDisabled(true);
+
+        $output = $this->renderFilterSelect(['options' => [$this->category(1, 0, 'Root Category'), $disabled]]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
+        $this->assertStringContainsString(
+            '<option value="2" class="level-0" disabled="disabled">Child Category</option>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function prependedOptionComesFirst(): void
+    {
+        $output = $this->render('FilterSelectWithPrependedOption', [
+            'name' => 'filter[researchField]',
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'prependOptionLabel' => 'All categories',
+            'prependOptionValue' => '',
+        ]);
+
+        $this->assertSame(
+            '<select class="form-select" name="filter[researchField]">'
+            . '<option value="">All categories</option>' . LF
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function prependedOptionCanCarryAValue(): void
+    {
+        $output = $this->render('FilterSelectWithPrependedOption', [
+            'name' => 'filter[researchField]',
+            'options' => [],
+            'prependOptionLabel' => 'All categories',
+            'prependOptionValue' => 'all',
+        ]);
+
+        $this->assertStringContainsString('<option value="all">All categories</option>', $output);
+    }
+
+    /**
+     * The label is what decides whether the entry is rendered, and Fluid counts an empty
+     * string as a given argument - so a `prependOptionLabel` whose translation is missing
+     * adds an empty entry rather than none.
+     */
+    #[Test]
+    public function prependedOptionWithoutALabelStillAddsAnEntry(): void
+    {
+        $output = $this->render('FilterSelectWithPrependedOption', [
+            'name' => 'filter[researchField]',
+            'options' => [],
+            'prependOptionLabel' => '',
+            'prependOptionValue' => '',
+        ]);
+
+        $this->assertStringContainsString('<option value=""></option>', $output);
+    }
+
+    #[Test]
+    public function optionsAreSortedByLabelOnDemand(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [
+                $this->category(1, 0, 'Zeta'),
+                $this->category(6, 0, 'Alpha', 'testing_second'),
+            ],
+            'sortByOptionLabel' => true,
+        ]);
+
+        $this->assertSame(
+            '<select class="form-select" name="filter[researchField]">'
+            . '<option value="6" class="level-0">Alpha</option>' . LF
+            . '<option value="1" class="level-0">Zeta</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    /**
+     * Grouping does not nest the markup - it reorders the flat list so children follow their
+     * parent, and records the depth in a class name the stylesheet indents on.
+     */
+    #[Test]
+    public function optionsAreOrderedByTheirParentOnDemand(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [
+                $this->category(3, 2, 'Grandchild Category'),
+                $this->category(2, 1, 'Child Category'),
+                $this->category(1, 0, 'Root Category'),
+            ],
+            'groupByParent' => true,
+        ]);
+
+        $this->assertSame(
+            '<select class="form-select" name="filter[researchField]">'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '<option value="2" class="level-1">Child Category</option>' . LF
+            . '<option value="3" class="level-2">Grandchild Category</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    /**
+     * A category whose parent carries a different type is a root of its own, because the
+     * select only ever shows one type - see `Tests/Functional/Domain/Model/CategoryTest`.
+     */
+    #[Test]
+    public function categoryBelowAParentOfAnotherTypeIsGroupedAsARoot(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [$this->category(7, 6, 'Child Of Another Type')],
+            'groupByParent' => true,
+        ]);
+
+        $this->assertStringContainsString('<option value="7" class="level-0">', $output);
+    }
+
+    /**
+     * Grouping walks down from the roots, so an option whose root is not part of the list is
+     * dropped rather than rendered without a parent. The three consuming extensions always
+     * pass a whole category type, where that cannot happen.
+     */
+    #[Test]
+    public function groupedOptionWithoutItsRootIsDropped(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [$this->category(2, 1, 'Child Category'), $this->category(3, 2, 'Grandchild Category')],
+            'groupByParent' => true,
+        ]);
+
+        $this->assertSame('<select class="form-select" name="filter[researchField]"></select>', $output);
+    }
+
+    #[Test]
+    public function levelClassPrefixCanBeChanged(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [$this->category(2, 1, 'Child Category'), $this->category(1, 0, 'Root Category')],
+            'groupByParent' => true,
+            'groupLevelClassPrefix' => 'depth-',
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="depth-0">', $output);
+        $this->assertStringContainsString('<option value="2" class="depth-1">', $output);
+    }
+
+    #[Test]
+    public function requiredIsRenderedAsAnAttribute(): void
+    {
+        $output = $this->renderFilterSelect(['required' => true]);
+
+        $this->assertStringContainsString('required="required"', $output);
+    }
+
+    #[Test]
+    public function tagContentOfTheTemplateIsKept(): void
+    {
+        $output = $this->render('FilterSelectWithContent', [
+            'name' => 'filter[researchField]',
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'optionsAfterContent' => false,
+        ]);
+
+        $this->assertSame(
+            '<select name="filter[researchField]">'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '<option value="own">Own option</option>'
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function tagContentCanBePlacedBeforeTheGeneratedOptions(): void
+    {
+        $output = $this->render('FilterSelectWithContent', [
+            'name' => 'filter[researchField]',
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'optionsAfterContent' => true,
+        ]);
+
+        $this->assertSame(
+            '<select name="filter[researchField]">'
+            . '<option value="own">Own option</option>'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    /**
+     * With `renderOptions="false"` the prepared options are handed to the template as a
+     * variable named `options` instead of being rendered, which lets a project template mark
+     * up the entries itself. The variable is removed again afterwards.
+     */
+    #[Test]
+    public function optionsCanBeRenderedByTheTemplateItself(): void
+    {
+        $output = $this->render('FilterSelectWithoutRenderedOptions', [
+            'name' => 'filter[researchField]',
+            'options' => [$this->category(1, 0, 'Root Category'), $this->category(2, 1, 'Child Category')],
+        ]);
+
+        $this->assertSame(
+            '<select name="filter[researchField]">[1:Root Category][2:Child Category]</select>',
+            $output,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function renderFilterSelect(array $variables = [], string $template = 'FilterSelect'): string
+    {
+        return $this->render($template, array_replace(
+            [
+                'name' => 'filter[researchField]',
+                'value' => '',
+                'options' => [],
+                'required' => false,
+                'sortByOptionLabel' => false,
+                'groupByParent' => false,
+                'groupLevelClassPrefix' => 'level-',
+            ],
+            $variables,
+        ));
+    }
+
+    private function category(int $uid, int $parentId, string $title, string $type = 'testing_first'): Category
+    {
+        return new Category(
+            uid: $uid,
+            parentId: $parentId,
+            title: $title,
+            type: $type,
+            typeGroup: 'testing',
+        );
+    }
+}


### PR DESCRIPTION
Third and last tier of the `EXT:category_types` coverage round started with
ACE-344, which named this part as out of scope — plus the defect it turned up.

## ACE-347 — `<ct:be.category>` cannot render on TYPO3 v14

`ViewHelpers\Be\CategoryViewHelper` registered its two required arguments with a
default value. Fluid 5, shipped with TYPO3 v14, rejects that in
`ArgumentDefinition::__construct()`:

```
ArgumentDefinition "page" cannot have a default value while also being required.
Either remove the default or mark it as optional. (1754235900)
```

The exception comes from the parser, before the view helper is invoked, so the
backend page layout preview of `EXT:academic_partners`, `EXT:academic_programs`
and `EXT:academic_projects` could not render at all on TYPO3 v14. TYPO3 v13 runs
Fluid 4, which [deliberately never received the
check](https://github.com/TYPO3/Fluid/pull/1157), and is unaffected — so this is
`main` only.

Both defaults are dropped, the arguments stay required. `Important` changelog
entry with the references included; the `page` default was wrong in its own
right as well (an empty array for an argument typed `int`).

## ACE-346 — the coverage

Five of the six public methods of `CategoryRepository` and all three view
helpers had no test. 69 new functional test methods in seven test cases, taking
the extension's suite from 110 to 179.

| test case | what it pins |
|---|---|
| `Domain/Repository/CategoryRepositoryPageTest` | `findByGroupAndPageId()`, both directions of `$includeHidden` — for the page as well as for the category, since the query joins `pages` |
| `Domain/Repository/CategoryRepositoryGroupSelectionTest` | `findAllApplicable()` and `findByGroupAndUidList()` |
| `Domain/Repository/CategoryRepositoryTreeTest` | `findParent()` and `getCategoryRootline()` |
| `Domain/Model/CategoryTest` | `getParent()` and `isRoot()`, the two model methods reaching the database |
| `ViewHelpers/Form/FilterSelectViewHelperTest` | the filter select and everything `AbstractSelectViewHelper` contributes to it |
| `ViewHelpers/Form/AbstractSelectViewHelperTest` | the base class' own `renderOptionTags()`, which the filter select overrides |
| `ViewHelpers/Be/CategoryViewHelperTest` | the backend page layout view helper |

Putting the repository on the four-DBMS matrix is half the point — that is where
ACE-314 lived. Verified locally on SQLite, MariaDB, MySQL and PostgreSQL.

The view helpers are driven through fixture templates rather than by calling
their methods, so the assertions describe the markup the partials of the three
consuming extensions depend on. It also keeps the tests portable:
`Be\CategoryViewHelper` is the one class of this extension that differs between
the branches — `renderStatic()` plus `CompileWithRenderStatic` on `2` — and a
rendering test does not see that.

`AbstractSelectViewHelper` is covered through `FilterSelectViewHelper`, which is
how it runs in production. What that leaves is its own `renderOptionTags()`,
used by the three `SortingSelectViewHelper` implementations of the extensions
above; the fixture extension gained a subclass built the same way, so that
contract stays covered inside this extension.

Every assertion was checked by mutation: eight deliberate defects in the
repository and the three view helpers, each caught by the tests naming that
behaviour.

## Backport

The coverage backports to `2`. The ACE-347 fix does not — branch `2` supports
TYPO3 v12 and v13 only, where the registration is accepted.
