### PR TITLE
[BUGFIX] ACE-349: Quote the category uid list

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
@@ -135,7 +135,7 @@ class CategoryRepository
 
     /**
      * @param string $group
-     * @param array<int> $idList
+     * @param array<int> $idList A positive selection of categories, an empty list selects none
      */
     public function findByGroupAndUidList(
         string $group,
@@ -153,7 +153,10 @@ class CategoryRepository
                     ),
                 ),
                 $queryBuilder->expr()->in('sys_category.sys_language_uid', [0, -1]),
-                $queryBuilder->expr()->in('uid', $idList),
+                $queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->quoteArrayBasedValueListToIntegerList($idList),
+                ),
             )->executeQuery();
 
         $categoryCollection = $this->categoryCollectionFactory->createCategoryCollection($group);

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRepositoryEmptyUidList.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRepositoryEmptyUidList.rst
@@ -1,0 +1,100 @@
+.. _important-1785790800:
+
+==================================================================
+Important: Category selection with an empty uid list returns empty
+==================================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\Domain\\Repository\\CategoryRepository::findByGroupAndUidList()`
+passed its `$idList` argument as a plain array to the Doctrine DBAL expression
+builder:
+
+..  code-block:: php
+
+    $queryBuilder->expr()->in('uid', $idList)
+
+An empty array is not a valid value list there. TYPO3 v13 and v14 raise an
+`\InvalidArgumentException` (1701857902), *ExpressionBuilder::in() can not be
+used with an empty array value*. That validation was added for TYPO3 v13 only
+and never backported, so on TYPO3 v12 the same call produces `uid IN ()` and the
+outcome depends on the database: MariaDB, MySQL and PostgreSQL reject the
+statement with a syntax error, SQLite accepts it and returns no row.
+
+The uid list is now quoted with
+`TYPO3\\CMS\\Core\\Database\\Query\\QueryBuilder::quoteArrayBasedValueListToIntegerList()`,
+the API TYPO3 provides for exactly this case:
+
+..  code-block:: php
+
+    $queryBuilder->expr()->in(
+        'uid',
+        $queryBuilder->quoteArrayBasedValueListToIntegerList($idList),
+    )
+
+The helper returns the string `NULL` for an empty array, so the query becomes
+`uid IN (NULL)` — valid on every supported DBMS and matching no row. It is the
+same API the neighbouring condition on `sys_category.type` already used through
+`quoteArrayBasedValueListToStringList()`.
+
+Impact
+======
+
+`findByGroupAndUidList()` no longer fails for an empty uid list, on any
+supported TYPO3 version and any supported DBMS. It returns an empty category
+collection, which still carries the type identifiers of the group like the
+result of every other selection, so a template iterating the types keeps its
+shape.
+
+The uid list is a positive selection, so "nothing selected" means "no
+categories" — it is deliberately not read as "no restriction", which would
+return the whole group.
+
+An unknown group is still rejected with an `\InvalidArgumentException`
+(1683633304209).
+
+The frontend filters shipped by `EXT:academic_partners`,
+`EXT:academic_programs` and `EXT:academic_projects` were not affected: their
+`Factory\\DemandFactory` builds the list with
+`TYPO3\\CMS\\Core\\Utility\\GeneralUtility::intExplode()`, which returns `[0]`
+for an empty value, so a submitted but unselected filter never produced an empty
+list. Only a `filterCollection` that is an empty array reached the failing call.
+
+Affected Installations
+======================
+
+Installations calling `CategoryRepository::findByGroupAndUidList()` from own
+code with a uid list that can be empty, and installations that worked around the
+failure with a caller-side guard.
+
+Migration
+=========
+
+No configuration change is required. Caller-side guards of the shape
+
+..  code-block:: php
+
+    if ($uids !== []) {
+        $categories = $categoryRepository->findByGroupAndUidList($group, $uids);
+    }
+
+can be removed.
+
+References
+==========
+
+*   TYPO3 issue `#96434 <https://forge.typo3.org/issues/96434>`__,
+    *Provide quoted array to string-list implode support* — the change adding
+    `quoteArrayBasedValueListToIntegerList()` and
+    `quoteArrayBasedValueListToStringList()` to the query builder, released for
+    TYPO3 v11.5 and later
+    (`commit 4ec4b7e2f9 <https://github.com/TYPO3/typo3/commit/4ec4b7e2f9>`__).
+*   TYPO3 issue `#102612 <https://forge.typo3.org/issues/102612>`__,
+    *Validate arguments for ExpressionBuilder::in and notIn* — the change adding
+    the validation, released for TYPO3 v13 only
+    (`commit 7c6b5cc7ac <https://github.com/TYPO3/typo3/commit/7c6b5cc7ac>`__).
+*   `QueryBuilder <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html>`__
+    in the TYPO3 Explained manual.
+
+.. index:: Database, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryGroupSelectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryGroupSelectionTest.php
@@ -145,6 +145,37 @@ final class CategoryRepositoryGroupSelectionTest extends AbstractCategoryTypesTe
         $this->assertCount(0, $this->subject()->findByGroupAndUidList('testing', [999]));
     }
 
+    /**
+     * The uid list is a positive selection, so an empty one can only mean "no category" -
+     * reading it as "no restriction" would return the whole group instead.
+     *
+     * Handed to `ExpressionBuilder::in()` as a plain array, an empty list raises an
+     * `\InvalidArgumentException` (1701857902) on TYPO3 v13 and v14 and, on TYPO3 v12,
+     * produces `uid IN ()`, which every DBMS but SQLite rejects with a syntax error.
+     * `QueryBuilder::quoteArrayBasedValueListToIntegerList()` turns it into `NULL`.
+     */
+    #[Test]
+    public function emptyUidListReturnsAnEmptyCollection(): void
+    {
+        $this->assertCount(0, $this->subject()->findByGroupAndUidList('testing', []));
+    }
+
+    /**
+     * The returned collection carries the type identifiers of the group like the one of
+     * every other selection, so a template iterating the types keeps its shape instead of
+     * finding nothing at all. A collection built without the factory would answer `[]`.
+     */
+    #[Test]
+    public function collectionOfAnEmptyUidListStillKnowsTheGroupTypes(): void
+    {
+        $collection = $this->subject()->findByGroupAndUidList('testing', []);
+
+        $this->assertSame(
+            ['testing_first' => [], 'testing_second' => []],
+            $collection->getAllCategoriesByType(),
+        );
+    }
+
     #[Test]
     public function requestedCategoriesOfAnUnknownGroupAreRejected(): void
     {
@@ -152,6 +183,18 @@ final class CategoryRepositoryGroupSelectionTest extends AbstractCategoryTypesTe
         $this->expectExceptionCode(1683633304209);
 
         $this->subject()->findByGroupAndUidList('unknown', [1]);
+    }
+
+    /**
+     * An empty uid list does not change how an unknown group is answered.
+     */
+    #[Test]
+    public function emptyUidListOfAnUnknownGroupIsRejectedAsWell(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1683633304209);
+
+        $this->subject()->findByGroupAndUidList('unknown', []);
     }
 
     private function subject(): CategoryRepository


### PR DESCRIPTION
`CategoryRepository::findByGroupAndUidList()` passed its `$idList` argument as a
plain array to `$queryBuilder->expr()->in('uid', $idList)`. An empty array is not
a valid value list there, and what that produced depended on the core version:

* **TYPO3 v13 and v14** — `\InvalidArgumentException` (1701857902),
  *ExpressionBuilder::in() can not be used with an empty array value.*
* **TYPO3 v12** — no such validation exists, so the statement became `uid IN ()`
  and the outcome depended on the database: MariaDB, MySQL and PostgreSQL reject
  it with a `SyntaxErrorException`, SQLite accepts it and returns no row. The
  check was added for v13 only ([#102612](https://forge.typo3.org/issues/102612),
  [7c6b5cc7ac](https://github.com/TYPO3/typo3/commit/7c6b5cc7ac)) and never
  backported — verified against `v12.4.36`, `v13.4.33` and `main`.

The list is now quoted with the query builder API TYPO3 provides for exactly this
case:

```php
$queryBuilder->expr()->in(
    'uid',
    $queryBuilder->quoteArrayBasedValueListToIntegerList($idList),
)
```

`quoteArrayBasedValueListToIntegerList()` returns the string `NULL` for an empty
array, so the query becomes `uid IN (NULL)` — valid on every supported DBMS and
matching no row. It exists since TYPO3 v11.5
([#96434](https://forge.typo3.org/issues/96434),
[4ec4b7e2f9](https://github.com/TYPO3/typo3/commit/4ec4b7e2f9), `Releases: main,
11.5`), confirmed present in `v11.5.41`, `v12.4.36`, `v13.4.33` and `main`, so the
same call works on both branches. The neighbouring condition on
`sys_category.type` already used the string counterpart of the same API.

An empty uid list therefore returns an empty collection, still built through
`CategoryCollectionFactory`, so it carries the type identifiers of the group like
the result of every other selection and a template iterating the types keeps its
shape. An unknown group stays rejected with `\InvalidArgumentException`
(1683633304209).

**Reachability:** none through the shipped code. The three `DemandFactory`
callers build the list with `GeneralUtility::intExplode()`, which returns `[0]`
for an empty value, so a submitted but unselected filter never produced an empty
list — that case is covered by `unknownCategoryUidReturnsAnEmptyCollection()`
from #417. Only a `filterCollection` that is an empty array reached the failing
call, which is why this was never reported.

## Tests

Three methods added to `CategoryRepositoryGroupSelectionTest`, next to the
existing uid list coverage: the empty result, the type identifiers of the
returned collection, and the group validation on the same path.

Mutation checked: with the helper replaced by the plain `$idList`,
`emptyUidListReturnsAnEmptyCollection` and
`collectionOfAnEmptyUidListStillKnowsTheGroupTypes` error with 1701857902 on v13.
The same mutation on branch `2` is what established the v12 DBMS split — green on
SQLite, `SyntaxErrorException` on MariaDB and PostgreSQL.

Green locally: `cgl -n`, `lintPhp`, `phpstan`, `unit` and the full `functional`
suite for TYPO3 v13 and v14, the repository tests additionally on MariaDB, MySQL
and PostgreSQL, plus `checkRstRenderingSingle`.

## Documentation

`Documentation/Changelog/3.0/Important-CategoryRepositoryEmptyUidList.rst`
documents the behaviour change with the core references above.

Backport to branch `2`: #420

ACE-349
