### PR TITLE
[BUGFIX] ACE-356: Fix the FlexForm upgrade wizard

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/Upgrades/FlexFormUpgradeWizard.php
+++ b/packages/fgtclb/academic-projects/Classes/Upgrades/FlexFormUpgradeWizard.php
@@ -81,9 +81,11 @@ final class FlexFormUpgradeWizard implements UpgradeWizardInterface
             $updateQueryBuilder->update('tt_content')
                 ->set('pi_flexform', $this->array2xml($flexFormData))
                 ->where(
-                    $queryBuilder->expr()->in(
+                    // The constraint must be built on the builder that executes it: a named
+                    // parameter is bound to the query builder that created it.
+                    $updateQueryBuilder->expr()->eq(
                         'uid',
-                        $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
+                        $updateQueryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
                     )
                 )
                 ->executeStatement();

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-FlexFormUpgradeWizardMigratesRecords.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-FlexFormUpgradeWizardMigratesRecords.rst
@@ -1,0 +1,91 @@
+.. _important-1785796200:
+
+=======================================================
+Important: The FlexForm upgrade wizard migrates records
+=======================================================
+
+Description
+===========
+
+The upgrade wizard `academicProjects_flexFormUpgradeWizard`
+(`FGTCLB\\AcademicProjects\\Upgrades\\FlexFormUpgradeWizard`) never migrated a
+single content element. It built the `WHERE` constraint of its `UPDATE`
+statement on the query builder of the enclosing `SELECT`:
+
+..  code-block:: php
+
+    $updateQueryBuilder->update('tt_content')
+        ->set('pi_flexform', $this->array2xml($flexFormData))
+        ->where(
+            $queryBuilder->expr()->in(                                   // select builder
+                'uid',
+                $queryBuilder->createNamedParameter($record['uid'], …)   // select builder
+            )
+        )
+        ->executeStatement();
+
+A named parameter is bound to the query builder that created it, so the
+statement carried a placeholder whose value was never bound to it — while
+`set()` had created a placeholder of its own on the update builder, holding the
+new FlexForm XML. The first record therefore ran
+
+..  code-block:: sql
+
+    UPDATE tt_content SET pi_flexform = :dcValue1 WHERE uid IN (:dcValue1)
+
+comparing the XML against `uid`, and every following record referred to a
+placeholder that did not exist on the update builder at all.
+
+The constraint is now built on the builder that executes it, with `eq()` since
+the value is always a single uid:
+
+..  code-block:: php
+
+    ->where(
+        $updateQueryBuilder->expr()->eq(
+            'uid',
+            $updateQueryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
+        )
+    )
+
+Impact
+======
+
+The wizard now performs the FlexForm migration it announces:
+`settings.hideCompletedProjects` becomes `settings.activeState` (value `1` maps
+to `active`, anything else to `all`), `settings.filter.options` becomes
+`settings.hideFilter` and `settings.sorting.options` becomes
+`settings.hideSorting`, each keeping its value.
+
+Previously the outcome depended on the database:
+
+*   MySQL, MariaDB and SQLite reported success and changed nothing.
+*   PostgreSQL aborted with a
+    `Doctrine\\DBAL\\Exception\\DriverException`, *invalid input syntax for
+    integer*.
+
+Affected Installations
+======================
+
+Installations that ran the upgrade wizard of a previous version. The plugin
+FlexForm of `academicprojects_projectlist` and
+`academicprojects_projectlistsingle` content elements still carries the old
+setting names, and the plugins fall back to their default behaviour for those
+settings.
+
+Migration
+=========
+
+Run the upgrade wizard again. An installation that already executed it has it
+recorded as done, so it has to be marked undone first — in the Install Tool
+under :guilabel:`Upgrade > Upgrade Wizard`, or on the command line:
+
+..  code-block:: bash
+
+    vendor/bin/typo3 upgrade:mark:undone academicProjects_flexFormUpgradeWizard
+    vendor/bin/typo3 upgrade:run academicProjects_flexFormUpgradeWizard
+
+Running it again is safe: the wizard only rewrites a FlexForm that still
+contains one of the old setting names and leaves every other record untouched.
+
+.. index:: Database, FlexForm, Backend, NotScanned

--- a/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/FlexFormUpgradeWizardTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Upgrades/FlexFormUpgradeWizardTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Upgrades;
+
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use FGTCLB\AcademicProjects\Upgrades\FlexFormUpgradeWizard;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Coverage for the FlexForm migration of `EXT:academic_projects`.
+ *
+ * The wizard rewrites the plugin FlexForm of every already migrated content element, so each
+ * test seeds `tt_content` rows carrying the old setting names and reads the stored XML back.
+ *
+ * **More than one record per test on purpose.** The wizard builds one update statement per
+ * record; a defect in how that statement is parameterised shows up differently in the first
+ * iteration than in the following ones, so a single-record fixture can pass while the wizard
+ * is broken (ACE-356).
+ */
+final class FlexFormUpgradeWizardTest extends AbstractAcademicProjectsTestCase
+{
+    #[Test]
+    public function updateIsNotNecessaryWithoutContentElements(): void
+    {
+        $this->assertFalse($this->subject()->updateNecessary());
+    }
+
+    #[Test]
+    public function updateIsNecessaryForAMigratableContentElement(): void
+    {
+        $this->createContentElement(1, 'academicprojects_projectlist', $this->flexForm([
+            'settings.hideCompletedProjects' => '1',
+        ]));
+
+        $this->assertTrue($this->subject()->updateNecessary());
+    }
+
+    #[Test]
+    public function completedProjectsFlagBecomesTheActiveState(): void
+    {
+        $this->createContentElement(1, 'academicprojects_projectlist', $this->flexForm([
+            'settings.hideCompletedProjects' => '1',
+        ]));
+        $this->createContentElement(2, 'academicprojects_projectlistsingle', $this->flexForm([
+            'settings.hideCompletedProjects' => '0',
+        ]));
+
+        $this->assertTrue($this->subject()->executeUpdate());
+
+        // '1' meant "hide completed", which is the active-only listing.
+        $this->assertSame(['settings.activeState' => 'active'], $this->settingsOf(1));
+        $this->assertSame(['settings.activeState' => 'all'], $this->settingsOf(2));
+    }
+
+    #[Test]
+    public function filterAndSortingSettingsAreRenamedKeepingTheirValue(): void
+    {
+        $this->createContentElement(1, 'academicprojects_projectlist', $this->flexForm([
+            'settings.filter.options' => '1',
+            'settings.sorting.options' => '0',
+        ]));
+        $this->createContentElement(2, 'academicprojects_projectlist', $this->flexForm([
+            'settings.filter.options' => '0',
+            'settings.sorting.options' => '1',
+        ]));
+
+        $this->assertTrue($this->subject()->executeUpdate());
+
+        $this->assertSame(
+            ['settings.hideFilter' => '1', 'settings.hideSorting' => '0'],
+            $this->settingsOf(1),
+        );
+        $this->assertSame(
+            ['settings.hideFilter' => '0', 'settings.hideSorting' => '1'],
+            $this->settingsOf(2),
+        );
+    }
+
+    /**
+     * The third record is the one a per-record parameter defect loses: the first update may
+     * still work by accident, the ones after it never do.
+     */
+    #[Test]
+    public function everyContentElementIsMigratedNotOnlyTheFirst(): void
+    {
+        for ($uid = 1; $uid <= 3; $uid++) {
+            $this->createContentElement($uid, 'academicprojects_projectlist', $this->flexForm([
+                'settings.hideCompletedProjects' => '1',
+            ]));
+        }
+
+        $this->assertTrue($this->subject()->executeUpdate());
+
+        for ($uid = 1; $uid <= 3; $uid++) {
+            $this->assertSame(
+                ['settings.activeState' => 'active'],
+                $this->settingsOf($uid),
+                sprintf('content element %d migrated', $uid),
+            );
+        }
+    }
+
+    #[Test]
+    public function contentElementOfAnotherPluginStaysUntouched(): void
+    {
+        $unrelated = $this->flexForm(['settings.hideCompletedProjects' => '1']);
+        $this->createContentElement(1, 'academicprojects_projectlist', $this->flexForm([
+            'settings.hideCompletedProjects' => '1',
+        ]));
+        $this->createContentElement(2, 'unrelated_plugin', $unrelated);
+
+        $this->assertTrue($this->subject()->executeUpdate());
+
+        $this->assertSame(['settings.activeState' => 'active'], $this->settingsOf(1));
+        $this->assertSame($unrelated, $this->flexFormOf(2));
+    }
+
+    #[Test]
+    public function contentElementWithoutAFlexFormIsSkipped(): void
+    {
+        $this->createContentElement(1, 'academicprojects_projectlist', '');
+        $this->createContentElement(2, 'academicprojects_projectlist', $this->flexForm([
+            'settings.hideCompletedProjects' => '1',
+        ]));
+
+        $this->assertTrue($this->subject()->executeUpdate());
+
+        $this->assertSame('', $this->flexFormOf(1));
+        $this->assertSame(['settings.activeState' => 'active'], $this->settingsOf(2));
+    }
+
+    private function subject(): FlexFormUpgradeWizard
+    {
+        $subject = $this->get(FlexFormUpgradeWizard::class);
+        $this->assertInstanceOf(FlexFormUpgradeWizard::class, $subject);
+
+        return $subject;
+    }
+
+    /**
+     * @param array<string, string> $settings
+     */
+    private function flexForm(array $settings): string
+    {
+        $fields = '';
+        foreach ($settings as $name => $value) {
+            $fields .= sprintf(
+                '<field index="%s"><value index="vDEF">%s</value></field>',
+                $name,
+                $value,
+            );
+        }
+
+        return '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>'
+            . '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF">'
+            . $fields
+            . '</language></sheet></data></T3FlexForms>';
+    }
+
+    private function createContentElement(int $uid, string $cType, string $flexForm): void
+    {
+        $this->getConnectionPool()->getConnectionForTable('tt_content')->insert(
+            'tt_content',
+            [
+                'uid' => $uid,
+                'pid' => 1,
+                'CType' => $cType,
+                'pi_flexform' => $flexForm,
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function settingsOf(int $uid): array
+    {
+        $flexForm = GeneralUtility::xml2array($this->flexFormOf($uid));
+        $this->assertIsArray($flexForm);
+
+        $settings = [];
+        foreach ($flexForm['data']['sDEF']['lDEF'] ?? [] as $name => $field) {
+            $settings[$name] = $field['vDEF'];
+        }
+
+        return $settings;
+    }
+
+    private function flexFormOf(int $uid): string
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (string)$queryBuilder
+            ->select('pi_flexform')
+            ->from('tt_content')
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid)))
+            ->executeQuery()
+            ->fetchOne();
+    }
+}


### PR DESCRIPTION
`FGTCLB\AcademicProjects\Upgrades\FlexFormUpgradeWizard::executeUpdate()` never
migrated a single content element. It built the `WHERE` constraint of its
`UPDATE` on the query builder of the enclosing `SELECT`:

```php
$updateQueryBuilder->update('tt_content')
    ->set('pi_flexform', $this->array2xml($flexFormData))
    ->where(
        $queryBuilder->expr()->in(                                   // select builder
            'uid',
            $queryBuilder->createNamedParameter($record['uid'], …)   // select builder
        )
    )
    ->executeStatement();
```

A named parameter is bound to the query builder that created it, so the
statement carried a placeholder whose value was never bound to it — while
`set()` had created a placeholder of its own on the update builder, holding the
new FlexForm XML. The select builder's counter is still at zero at that point
(`quoteArrayBasedValueListToStringList()` quotes inline and creates no
parameter), so the first record ran

```sql
UPDATE tt_content SET pi_flexform = :dcValue1 WHERE uid IN (:dcValue1)
```

comparing the XML against `uid`, and every record after it referred to a
placeholder the update builder does not know at all.

**Observed**, with a probe seeding one `tt_content` record carrying
`settings.hideCompletedProjects` and calling `executeUpdate()` on TYPO3 v13.4:

* **SQLite** and **MariaDB 10.4** — returns `true`, no exception, `pi_flexform`
  unchanged. The XML casts to integer `0` and no record has `uid = 0`. A silent
  no-op.
* **PostgreSQL 10** — `Doctrine\DBAL\Exception\DriverException`, *SQLSTATE[22P02]:
  Invalid text representation: invalid input syntax for integer: "<?xml version=…"*.
  The error text shows the XML being compared against `uid`, which pins the
  mechanism exactly.

So the migration of `settings.hideCompletedProjects` → `settings.activeState`,
`settings.filter.options` → `settings.hideFilter` and `settings.sorting.options`
→ `settings.hideSorting` has never run anywhere, and on PostgreSQL the wizard
aborts.

The constraint is now built on the builder that executes it, with `eq()` since
`$record['uid']` is always a single uid from `fetchAssociative()` — which is how
every other upgrade wizard in this repository writes the same condition.

## Tests

`FlexFormUpgradeWizard` was the only upgrade wizard here without a functional
test; the other six have one. It has one now, 7 methods: the two `updateNecessary()`
directions, the `activeState` mapping in both values, the two renamed settings
keeping their value, an unrelated plugin staying untouched, and a record without
a FlexForm being skipped.

**Every case seeds more than one content element on purpose** — the first record
and the ones after it fail differently, so a single-record fixture can pass while
the wizard is broken.

Mutation checked: with the old `$queryBuilder->expr()->in(…)` put back, 5 of the
7 fail (3 errors, 2 failures) on SQLite; the two that still pass are the ones not
asserting a migration.

Green locally: `cgl -n`, `lintPhp`, `phpstan`, `unit` and the full `functional`
suite for TYPO3 v12 and v13, the wizard tests additionally on MariaDB and
PostgreSQL, plus `checkRstRenderingSingle`.

## Documentation

`Documentation/Changelog/2.4/Important-FlexFormUpgradeWizardMigratesRecords.rst`
describes the defect and tells affected installations how to re-run the wizard —
`upgrade:mark:undone` first, since an installation that already ran it has it
recorded as done.

Backport of #421, cherry-picked. The three files are identical to the ones on
`main`; only the changelog folder differs — note git did **not** apply its
directory-rename detection this time, the entry was moved to `2.4/` by hand.

ACE-356
