### PR TITLE
[TASK] ACE-355: Document the query builder rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,40 @@ consolidated into `ci.yml`.
 artifact per extension with `typo3/tailor`. **The tag version must match each
 extension's `ext_emconf.php` version or the artifact step fails.**
 
+## Database queries
+
+Two rules, both learned from defects that reached a release (ACE-349, ACE-356).
+
+**Never hand a raw array to `in()` or `notIn()`.** Quote it with the query
+builder helper meant for it:
+
+```php
+$queryBuilder->expr()->in('uid', $queryBuilder->quoteArrayBasedValueListToIntegerList($uids));
+$queryBuilder->expr()->in('CType', $queryBuilder->quoteArrayBasedValueListToStringList($types));
+```
+
+Both return the string `NULL` for an empty array, so the condition becomes
+`field IN (NULL)`: valid on every DBMS and matching no row. They exist since
+TYPO3 v11.5 and are therefore available on both core versions of this branch.
+A raw `[]` instead reaches the database as `IN ()` on TYPO3 v12 — MariaDB, MySQL
+and PostgreSQL reject it, **SQLite accepts it**, so the default `-d sqlite` run
+does not show the defect — while TYPO3 v13 raises `\InvalidArgumentException`
+1701857902 before the query is built. A
+`createNamedParameter($values, PARAM_*_ARRAY)` is equally safe; Doctrine renders
+an empty array as `NULL` too. Do not write a caller-side `if ($values === [])`
+guard instead.
+
+**Build a constraint on the query builder that executes it.** A named parameter
+is bound to the builder that created it, so a `WHERE` assembled on one builder
+and passed to another references a placeholder that was never bound — and may
+collide with a placeholder the target builder created itself, e.g. through
+`set()`. That silently updated nothing on MySQL, MariaDB and SQLite and threw on
+PostgreSQL. When a loop builds one statement per record, keep expression and
+execution on the same object.
+
+This is the **decorated TYPO3 `QueryBuilder`** (`TYPO3\CMS\Core\Database\Query`),
+not the Extbase one.
+
 ## Core-version-aware code (v12 vs v13)
 
 The reference pattern lives in `academic-base`. Where v12 and v13 APIs diverge,


### PR DESCRIPTION
Closes the audit of ACE-355 with the option that fits its result: the codebase
already follows both rules everywhere except the one place ACE-356 fixed, so a
note in the agent guidance is enough — no phpstan rule.

Adds a `## Database queries` section to this branch's `CLAUDE.md` — branch `2`
has no `AGENT.md`, it carries its own real guidance file — placed before
`Core-version-aware code`:

* **Never hand a raw array to `in()`/`notIn()`.** Use
  `quoteArrayBasedValueListToIntegerList()` or `…ToStringList()`, which return
  the string `NULL` for an empty array — `field IN (NULL)`, valid everywhere and
  matching no row. They exist since TYPO3 v11.5, so they are available on every
  core version any branch here supports. A raw `[]` throws
  `\InvalidArgumentException` 1701857902 from TYPO3 v13 on and reaches the
  database as `IN ()` on v12 — the core version this branch still supports —
  which MariaDB, MySQL and PostgreSQL reject while **SQLite accepts it**, the
  trap that makes the default `-d sqlite` run look green. `createNamedParameter($values, PARAM_*_ARRAY)` is equally safe.
  Explicitly: no caller-side `if ($values === [])` guard.
* **Build a constraint on the query builder that executes it.** A named
  parameter is bound to the builder that created it; a `WHERE` assembled on one
  builder and handed to another references an unbound placeholder and can
  collide with one the target builder created itself through `set()`.
* Both refer to the **decorated TYPO3 `QueryBuilder`**, not the Extbase one.

Documentation only — no production code, so no changelog entry and no test.
`lintPhp` run for completeness.

The rules are not theoretical: the first is ACE-349, the second ACE-356, and
both shipped in releases before this round.

Backport of #423. The section is identical apart from the file it lives in and
the version wording: here v12 is the primary case, since that is where an empty
`IN ()` actually reaches the database.

ACE-355
