### PR TITLE
[BUGFIX] ACE-350: Harden the category rootline walk

### DIFF
--- a/Build/phpstan/Core14/phpstan-baseline.neon
+++ b/Build/phpstan/Core14/phpstan-baseline.neon
@@ -206,16 +206,6 @@ parameters:
 			path: ../../../packages/fgtclb/academic-study-plan/Tests/Functional/ExtensionLoadedTest.php
 
 		-
-			message: "#^Cannot access offset 'l10n_parent' on array\\|false\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
-
-		-
-			message: "#^Method FGTCLB\\\\CategoryTypes\\\\Domain\\\\Repository\\\\CategoryRepository\\:\\:getCategoryArray\\(\\) should return array\\<string, mixed\\> but returns array\\|null\\.$#"
-			count: 1
-			path: ../../../packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
-
-		-
 			message: "#^Cannot call method getVariableProvider\\(\\) on TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContextInterface\\|null\\.$#"
 			count: 1
 			path: ../../../packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Be/CategoryViewHelper.php

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php
@@ -264,27 +264,42 @@ class CategoryRepository
     }
 
     /**
-     * @param array<int, mixed> $rootline
-     * @return array<int, mixed>
+     * Returns the raw database rows of a category and all its ancestors, root first.
+     *
+     * A category that cannot be resolved - unknown, deleted, or removed in the current
+     * workspace - ends the walk instead of failing. For the requested uid that means an
+     * empty rootline; for an ancestor it means the part that could be resolved, because
+     * deleting a category leaves its children in place.
+     *
+     * @param array<int, array<string, mixed>> $rootline
+     * @return array<int, array<string, mixed>>
      */
     public function getCategoryRootline(int $uid, array $rootline = []): array
     {
+        // A category referencing itself or one of its own descendants would recurse until
+        // the memory limit is reached, which is a fatal error no caller can catch.
+        if (in_array($uid, array_map(intval(...), array_column($rootline, 'uid')), true)) {
+            return array_reverse($rootline);
+        }
         $category = $this->getCategoryArray($uid);
+        if ($category === null) {
+            return array_reverse($rootline);
+        }
         $rootline[] = $category;
 
-        if ($category['parent'] !== 0) {
-            $rootline = $this->getCategoryRootline($category['parent'], $rootline);
-        } else {
-            $rootline = array_reverse($rootline);
+        // The parent is cast because a string '0' would recurse into uid 0 rather than
+        // end the walk at the root.
+        if ((int)$category['parent'] !== 0) {
+            return $this->getCategoryRootline((int)$category['parent'], $rootline);
         }
 
-        return $rootline;
+        return array_reverse($rootline);
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, mixed>|null
      */
-    private function getCategoryArray(int $uid): array
+    private function getCategoryArray(int $uid): ?array
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
@@ -306,7 +321,14 @@ class CategoryRepository
             )
             ->executeQuery()
             ->fetchAssociative();
+        if ($category === false) {
+            return null;
+        }
+        // Sets the record to `false` when the workspace deleted or moved it away.
         $pageRepository->versionOL('sys_category', $category, false, true);
+        if (!is_array($category)) {
+            return null;
+        }
         if ($category['l10n_parent'] > 0) {
             $category = $pageRepository->getLanguageOverlay('sys_category', $category);
         }

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRootlineOfUnresolvableCategory.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRootlineOfUnresolvableCategory.rst
@@ -1,0 +1,92 @@
+.. _important-1785874800:
+
+============================================================
+Important: Category rootline no longer fails on broken trees
+============================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\Domain\\Repository\\CategoryRepository::getCategoryRootline()`
+walks from a category up to its root through the private `getCategoryArray()`,
+which returned the result of `fetchAssociative()` and was typed `array`. For a
+uid without a row that result is `false`:
+
+..  code-block:: text
+
+    TypeError: FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository::getCategoryArray():
+    Return value must be of type array, bool returned
+
+Three inputs produced it, on every supported TYPO3 version and every supported
+DBMS: an unknown uid, the uid `0`, and a **deleted** category — the restrictions
+are lifted except for the deleted one. The last case is the reachable one:
+deleting a category leaves its children in place, so `sys_category.parent` can
+point at a deleted record in ordinary editorial data, and the rootline of every
+descendant failed with it.
+
+A category referencing itself, or two categories referencing each other, made
+the method recurse until the memory limit was reached — a fatal error, which
+unlike the `TypeError` no caller can catch.
+
+`getCategoryArray()` now returns `null` for a record it cannot resolve, which
+also covers the two cases where TYPO3 drops the record afterwards: a workspace
+that deleted or moved it, and a language overlay that yields nothing.
+`getCategoryRootline()` ends the walk instead of failing, and it stops when it
+reaches a uid it has already collected.
+
+The comparison ending the recursion at the root was `$category['parent'] !== 0`,
+a strict comparison against an integer. All four supported DBMS return `parent`
+as an integer, so this was not a defect, but a string `'0'` would have recursed
+into uid `0`. The value is cast now.
+
+Impact
+======
+
+`getCategoryRootline()` no longer throws for a category it cannot resolve.
+
+*   The requested uid cannot be resolved — an empty rootline.
+*   An ancestor cannot be resolved — the part of the rootline that could be
+    resolved, root first, rather than nothing. A category whose parent was
+    deleted still yields its own record.
+*   A cycle — the walk ends at the uid it has already seen, so the result holds
+    each category once.
+
+An intact tree is unchanged.
+
+Affected Installations
+======================
+
+Installations calling `CategoryRepository::getCategoryRootline()` from own code.
+The only call site inside these extensions,
+`EXT:academic_programs` `FGTCLB\\AcademicPrograms\\Backend\\Tca\\Labels::category()`,
+is not active, so no shipped feature changes behaviour.
+
+Migration
+=========
+
+No configuration change is required. A caller-side guard of the shape
+
+..  code-block:: php
+
+    if ($categoryRepository->findParent($group, $uid) !== null) {
+        $rootline = $categoryRepository->getCategoryRootline($uid);
+    }
+
+can be removed, and a `try`/`catch` around the call can be dropped. Callers that
+have to tell "no such category" from "a broken chain" apart should check the
+result for an empty array, which now means the requested category itself could
+not be resolved.
+
+References
+==========
+
+*   `PageRepository::versionOL()
+    <https://api.typo3.org/main/classes/TYPO3-CMS-Core-Domain-Repository-PageRepository.html>`__
+    — it sets the record to `false` when the workspace deleted or moved it away,
+    which is why that case is checked after the call and not only after the
+    query. See `Workspaces
+    <https://docs.typo3.org/permalink/t3coreapi:workspaces>`__.
+*   `Categories <https://docs.typo3.org/permalink/t3coreapi:categories>`__ in
+    the TYPO3 Explained manual — `sys_category` and its `parent` field.
+
+.. index:: Database, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTreeTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryTreeTest.php
@@ -143,6 +143,71 @@ final class CategoryRepositoryTreeTest extends AbstractCategoryTypesTestCase
         $this->assertSame(['Second Type Root', 'Child Of Another Type'], array_column($rootline, 'title'));
     }
 
+    #[Test]
+    public function rootlineOfAnUnknownCategoryIsEmpty(): void
+    {
+        $this->assertSame([], $this->subject()->getCategoryRootline(999));
+    }
+
+    /**
+     * Reached from `Category::getParentId()` of a root category, which is `0`.
+     */
+    #[Test]
+    public function rootlineOfUidZeroIsEmpty(): void
+    {
+        $this->assertSame([], $this->subject()->getCategoryRootline(0));
+    }
+
+    /**
+     * `getCategoryArray()` lifts every restriction except the deleted one, so a deleted
+     * category is as unresolvable as an unknown one.
+     */
+    #[Test]
+    public function rootlineOfADeletedCategoryIsEmpty(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTreeBroken.csv');
+
+        $this->assertSame([], $this->subject()->getCategoryRootline(8));
+    }
+
+    /**
+     * Deleting a category leaves its children in place, so an ancestor going missing is
+     * ordinary editorial data. What could be resolved is returned rather than nothing.
+     */
+    #[Test]
+    public function rootlineStopsWhereAnAncestorWasDeleted(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTreeBroken.csv');
+
+        $rootline = $this->subject()->getCategoryRootline(9);
+
+        $this->assertSame(['Child Of Deleted Root'], array_column($rootline, 'title'));
+    }
+
+    #[Test]
+    public function rootlineOfASelfReferencingCategoryHoldsThatCategoryOnly(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTreeBroken.csv');
+
+        $rootline = $this->subject()->getCategoryRootline(10);
+
+        $this->assertSame(['Self Referencing Category'], array_column($rootline, 'title'));
+    }
+
+    /**
+     * Two categories pointing at each other: the walk ends when it reaches a uid it has
+     * already collected, so the entry category is the last element of the reversed result.
+     */
+    #[Test]
+    public function rootlineOfACycleEndsWhereItStarted(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/CategoryRepository/categoryTreeBroken.csv');
+
+        $rootline = $this->subject()->getCategoryRootline(11);
+
+        $this->assertSame(['Cycle Second', 'Cycle First'], array_column($rootline, 'title'));
+    }
+
     private function subject(): CategoryRepository
     {
         return $this->get(CategoryRepository::class);

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categoryTreeBroken.csv
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/CategoryRepository/categoryTreeBroken.csv
@@ -1,0 +1,7 @@
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,8,1,1,0,0,"testing_first","Deleted Root Category",0,0
+,9,1,0,0,8,"testing_first","Child Of Deleted Root",0,0
+,10,1,0,0,10,"testing_first","Self Referencing Category",0,0
+,11,1,0,0,12,"testing_first","Cycle First",0,0
+,12,1,0,0,11,"testing_first","Cycle Second",0,0


### PR DESCRIPTION
`CategoryRepository::getCategoryRootline()` walked up the category tree through
`getCategoryArray()`, which returned the result of `fetchAssociative()` and was
typed `array`. A uid without a row made it a `TypeError`:

```
TypeError: CategoryRepository::getCategoryArray():
Return value must be of type array, bool returned
```

Probed on all four DBMS and both core versions: identical everywhere, unlike
the last two issues of this chain. The `false` also reaches
`$category['l10n_parent']` first and raises a PHP warning there — red twice
over in a suite running with `failOnWarning`.

## What the probe added to the issue

**The reachable case is a deleted ancestor, not an unknown uid.** Deleting a
category does not touch its children, so `sys_category.parent` pointing at a
deleted record is ordinary editorial data — and the rootline of every
descendant failed with it, discarding the records that *were* resolvable.
That is why an unresolvable ancestor now yields the resolved part rather than
nothing, while an unresolvable requested uid yields an empty rootline.

**A cycle was a hard fatal, and not in the issue.** A category referencing
itself, or two referencing each other:

```
PHP Fatal error: Allowed memory size of 3221225472 bytes exhausted
```

Unlike the `TypeError`, that is not catchable — it takes the request down. The
accumulated rootline already carries every uid visited, so the guard is one
`in_array`.

**`parent` is an `int` on all four DBMS** (v14 / DBAL 4.4.4), so the strict
`!== 0` was not a defect. It is cast anyway, since a string `'0'` would recurse
into uid 0 and land in the failure above.

## The change

* `getCategoryArray()` returns `?array`. Besides the missing row it now also
  covers the two places where TYPO3 drops the record afterwards:
  `versionOL()` sets it to `false` for a workspace `DELETE_PLACEHOLDER`, and
  `getLanguageOverlay()` returns `null`. Both were **baselined phpstan
  findings** — `Build/phpstan/Core14/phpstan-baseline.neon` loses two entries.
* `getCategoryRootline()` ends the walk instead of failing, and stops at a uid
  it has already collected.

## Verification

Six functional tests in `CategoryRepositoryTreeTest`, against a second fixture
so the shared `categoryTree.csv` keeps its shape for `CategoryTest` and
`FilterSelectViewHelperTest`. With the production change reverted, four of them
error and the fifth takes the process down with the memory fatal.

`cgl`, `lintPhp`, `phpstan`, `unit` on TYPO3 v13 and v14; `EXT:category_types`
functional on sqlite + postgres (v14) and sqlite + mariadb (v13);
`checkRstRenderingSingle`.

## Reachability

Unchanged: the only caller, `EXT:academic_programs`
`Backend\Tca\Labels::category()`, is commented out pending exactly this method.
Nothing shipped changes behaviour — this is the prerequisite for reviving that
label callback, which is why the quiet variant was chosen over an exception.

Backport to branch `2`: #426

ACE-350
