### PR TITLE
[BUGFIX] ACE-351: Register four select arguments

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -34,10 +34,23 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
                 'defaultValue' => false,
                 'description' => 'If true, places auto-generated option tags after those rendered in the tag content. If false, automatic options come first.',
             ],
+            'optionValueField' => [
+                'type' => 'string',
+                'description' => 'If specified, will call the appropriate getter on each object to determine the value.',
+            ],
+            'optionLabelField' => [
+                'type' => 'string',
+                'description' => 'If specified, will call the appropriate getter on each object to determine the label.',
+            ],
             'sortByOptionLabel' => [
                 'type' => 'boolean',
                 'defaultValue' => false,
                 'description' => 'If true, List will be sorted by label.',
+            ],
+            'selectAllByDefault' => [
+                'type' => 'boolean',
+                'defaultValue' => false,
+                'description' => 'If specified options are selected if none was set before.',
             ],
             'errorClass' => [
                 'type' => 'string',
@@ -51,6 +64,11 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
             'prependOptionValue' => [
                 'type' => 'string',
                 'description' => 'If specified, will provide an option at first position with the specified value.',
+            ],
+            'multiple' => [
+                'type' => 'boolean',
+                'defaultValue' => false,
+                'description' => 'If set multiple options may be selected.',
             ],
             'required' => [
                 'type' => 'boolean',
@@ -74,6 +92,12 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
         }
 
         $name = $this->getName();
+        if ($this->arguments['multiple'] === true) {
+            $this->tag->addAttribute('multiple', 'multiple');
+            // Without the suffix the browser submits one of the selected values instead of
+            // all of them, the same way the core select view helper builds the name.
+            $name .= '[]';
+        }
         $this->tag->addAttribute('name', $name);
 
         $this->initSelectedValues();
@@ -93,6 +117,19 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
 
         // Register field name for token generation.
         $this->registerFieldNameForFormTokenGeneration($name);
+        if ($this->arguments['multiple'] === true) {
+            $content .= $this->renderHiddenFieldForEmptyValue();
+            // A multi select submits one value per selected option, so the field name has to
+            // be registered as often as there are options. It is registered once above.
+            for ($i = 1; $i < count($options); $i++) {
+                $this->registerFieldNameForFormTokenGeneration($name);
+            }
+            $viewHelperVariableContainer->addOrUpdate(
+                self::class,
+                'registerFieldNameForFormTokenGeneration',
+                $name
+            );
+        }
 
         $prependContent = $this->renderPrependOptionTag();
 
@@ -188,7 +225,9 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     {
         if (is_object($valueElement)) {
             if ($this->hasArgument('optionValueField')) {
-                return ObjectAccess::getPropertyPath($valueElement, $this->arguments['optionValueField']);
+                // Cast: `ObjectAccess` hands back the property as it is typed, an `uid` as an
+                // integer - and the selected values are compared as strings.
+                return (string)ObjectAccess::getPropertyPath($valueElement, $this->arguments['optionValueField']);
             }
             // @todo use $this->persistenceManager->isNewObject() once it is implemented
             if ($this->persistenceManager->getIdentifierByObject($valueElement) !== null) {
@@ -222,6 +261,24 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     {
         if (in_array((string)$value, $this->selectedValues)) {
             return true;
+        }
+
+        // Only a multi select can preselect every option, and only while nothing is selected.
+        return $this->arguments['multiple'] === true
+            && $this->arguments['selectAllByDefault'] === true
+            && $this->hasSelectedValue() === false;
+    }
+
+    /**
+     * An unselected select still carries one empty selected value, which is what the value
+     * attribute of a form without submitted data resolves to.
+     */
+    private function hasSelectedValue(): bool
+    {
+        foreach ($this->selectedValues as $selectedValue) {
+            if ($selectedValue !== '') {
+                return true;
+            }
         }
 
         return false;

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace FGTCLB\CategoryTypes\ViewHelpers\Form;
 
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
 class FilterSelectViewHelper extends AbstractSelectViewHelper
 {
     public function initializeArguments(): void
@@ -28,13 +30,15 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
         $optionsFromArgument = $this->arguments['options'];
 
         foreach ($optionsFromArgument as $option) {
+            $value = $this->optionProperty($option, 'optionValueField') ?? (string)$option->getUid();
             $options[] = [
-                'label' => $option->getTitle(),
+                'label' => $this->optionProperty($option, 'optionLabelField') ?? (string)$option->getTitle(),
+                'value' => $value,
                 'uid' => $option->getUid(),
                 'parentId' => $option->getParentId(),
                 'isRoot' => $option->isRoot(),
                 'type' => (string)$option->getType(),
-                'isSelected' => $this->isSelected((string)$option->getUid()),
+                'isSelected' => $this->isSelected($value),
                 'isDisabled' => $option->isDisabled(),
                 'level' => 0,
                 'children' => [],
@@ -59,6 +63,33 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
         }
 
         return $options;
+    }
+
+    /**
+     * Resolves `optionValueField` or `optionLabelField` on a single option, and returns
+     * `null` when the argument was not given so the caller can fall back to the getter the
+     * category filter uses by default.
+     */
+    private function optionProperty(mixed $option, string $argumentName): ?string
+    {
+        if (!$this->hasArgument($argumentName)) {
+            return null;
+        }
+
+        $property = ObjectAccess::getPropertyPath($option, (string)$this->arguments[$argumentName]);
+        if (!is_scalar($property) && !$property instanceof \Stringable && $property !== null) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Property "%s" of "%s", read through "%s", cannot be cast to string.',
+                    (string)$this->arguments[$argumentName],
+                    get_debug_type($option),
+                    $argumentName,
+                ),
+                1785706600,
+            );
+        }
+
+        return (string)$property;
     }
 
     /**
@@ -113,8 +144,8 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
     protected function renderOptionTags($options): string
     {
         $output = '';
-        foreach ($options as $value => $option) {
-            $output .= '<option value="' . $option['uid'] . '"';
+        foreach ($options as $option) {
+            $output .= '<option value="' . $option['value'] . '"';
             $output .= ' class="' . $this->arguments['groupLevelClassPrefix'] . $option['level'] . '"';
             if ($option['isSelected']) {
                 $output .= ' selected="selected"';

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Breaking-CategoryFilterSelectOptionArray.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Breaking-CategoryFilterSelectOptionArray.rst
@@ -1,0 +1,91 @@
+.. _breaking-1785706800:
+
+==============================================================
+Breaking: Category filter select options carry their own value
+==============================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\FilterSelectViewHelper::getOptions()`
+built one array per category with a `uid` key, and `renderOptionTags()` rendered
+that uid as the value of the option:
+
+..  code-block:: php
+
+    $options[] = [
+        'label' => $option->getTitle(),
+        'uid' => $option->getUid(),
+        // ...
+    ];
+
+Now that `optionValueField` and `optionLabelField` are registered arguments, the
+value of an option is no longer necessarily the uid. Every option carries an
+additional `value` key holding the resolved value, and `renderOptionTags()`
+renders that key:
+
+..  code-block:: php
+
+    $options[] = [
+        'label' => $this->optionProperty($option, 'optionLabelField') ?? (string)$option->getTitle(),
+        'value' => $value,
+        'uid' => $option->getUid(),
+        // ...
+    ];
+
+The `uid` key is kept. It is what the grouping by parent matches on, and what the
+`renderOptions="false"` template variable is read with.
+
+Impact
+======
+
+Two things change for own code.
+
+*   A class extending `FilterSelectViewHelper` and overriding `getOptions()`
+    without adding the `value` key renders an option without a value, because
+    `renderOptionTags()` reads a key that is not there.
+*   `optionValueField` used to affect only the value an object handed over as
+    `value` was compared against, never the rendered option value. It determines
+    both now. A template passing `optionValueField` with anything but `uid` gets
+    different option values than before — and a selection that finally matches
+    them, which it could not before.
+
+Nothing changes for a template that does not pass `optionValueField`, and
+nothing changes for the three `DemandCategories.html` partials of
+`EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects`,
+which pass `optionValueField="uid"`.
+
+Affected Installations
+======================
+
+Installations with an own subclass of `FilterSelectViewHelper` that overrides
+`getOptions()`, and installations whose templates pass `optionValueField` to
+`ct:form.filterSelect`.
+
+Migration
+=========
+
+Add the `value` key to an overridden `getOptions()`:
+
+..  code-block:: php
+
+    $options[] = [
+        'label' => $category->getTitle(),
+        'value' => (string)$category->getUid(),
+        'uid' => $category->getUid(),
+        // ...
+    ];
+
+An override of `renderOptionTags()` that reads `$option['uid']` keeps working,
+since the key is still there — but it ignores `optionValueField`. Read
+`$option['value']` instead.
+
+References
+==========
+
+*   :ref:`feature-1785706700` — the four arguments this change comes with.
+*   `SelectViewHelper
+    <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-select>`__ —
+    the core view helper whose behaviour `optionValueField` now follows.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Feature-CategoryFilterSelectArguments.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Feature-CategoryFilterSelectArguments.rst
@@ -1,0 +1,83 @@
+.. _feature-1785706700:
+
+=================================================================
+Feature: Category filter select accepts the core select arguments
+=================================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper` registers the
+argument list of the TYPO3 core `<f:form.select>` view helper, apart from four
+arguments it never registered: `optionValueField`, `optionLabelField`,
+`multiple` and `selectAllByDefault`.
+
+Unregistered arguments are not rejected. `AbstractTagBasedViewHelper` turns them
+into attributes of the rendered tag, so a template passing them produced
+
+..  code-block:: html
+
+    <select optionValueField="uid" optionLabelField="title" name="filter[researchField]">
+
+None of these is a valid attribute of a `select` element. The four arguments are
+registered now and do what their core counterparts do.
+
+`optionValueField`
+------------------
+
+Determines the value of every option, and the value an object handed over as
+`value` is compared against. It defaulted to the category uid and still does
+when the argument is not given.
+
+`optionLabelField`
+------------------
+
+Determines the label of every option. Without the argument the label is the
+category title, as before.
+
+Both are resolved with
+`TYPO3\\CMS\\Extbase\\Reflection\\ObjectAccess::getPropertyPath()`, so a property
+path such as `type.title` is allowed. A property that is neither a scalar nor
+`\\Stringable` is rejected with a `\\RuntimeException` (1785706600).
+
+`multiple`
+----------
+
+Renders the `multiple` attribute and appends `[]` to the field name, registers
+the field name once per option for the form token, and adds the hidden field
+that lets an empty selection reach the controller — all of it the way
+`TYPO3\\CMS\\Fluid\\ViewHelpers\\Form\\SelectViewHelper` does.
+
+`selectAllByDefault`
+--------------------
+
+Selects every option of a multiple select while nothing else is selected.
+
+Impact
+======
+
+A template can use the four arguments, and none of them reaches the markup as an
+attribute any more.
+
+The three `DemandCategories.html` partials of `EXT:academic_partners`,
+`EXT:academic_programs` and `EXT:academic_projects` pass `optionValueField="uid"`
+and `optionLabelField="title"`. Their rendered options are unchanged — both
+fields resolve to what the filter select used by default — but the two invalid
+attributes are gone from the `select` element.
+
+The arguments are registered on `AbstractSelectViewHelper`, so they also apply to
+the `SortingSelectViewHelper` of those three extensions. Their options are label
+strings rather than objects, where `optionValueField` and `optionLabelField` have
+nothing to resolve; `multiple` and `selectAllByDefault` work there as well.
+
+References
+==========
+
+*   `SelectViewHelper
+    <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-select>`__ —
+    the core view helper this argument list follows.
+*   `ObjectAccess
+    <https://docs.typo3.org/permalink/t3coreapi:extbase>`__ — the property path
+    resolution used for the two option fields.
+
+.. index:: Fluid, Frontend, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectMultiple.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectMultiple.html
@@ -1,0 +1,10 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    value="{value}"
+    options="{options}"
+    multiple="{multiple}"
+    selectAllByDefault="{selectAllByDefault}"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithOptionFields.html
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/Fixtures/Templates/FilterSelectWithOptionFields.html
@@ -1,0 +1,10 @@
+<html
+    xmlns:ct="http://typo3.org/ns/FGTCLB/CategoryTypes/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ct:form.filterSelect
+    name="{name}"
+    value="{value}"
+    options="{options}"
+    optionValueField="{optionValueField}"
+    optionLabelField="{optionLabelField}"
+/></html>

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
@@ -123,9 +123,10 @@ final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
     }
 
     /**
-     * A category as the value is what `{demand.filterCollection.filterCategories.<type>}`
-     * hands over. `Category` is no Extbase entity, so the persistence manager has no
-     * identifier for it and the cast falls back to `__toString()`, which returns the uid.
+     * `{demand.filterCollection.filterCategories.<type>}` hands over a list of categories,
+     * and every element goes through the same cast - so a single one covers it. `Category`
+     * is no Extbase entity, so the persistence manager has no identifier for it and the cast
+     * falls back to `__toString()`, which returns the uid.
      */
     #[Test]
     public function selectedValueCanBeACategory(): void
@@ -142,9 +143,9 @@ final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
     }
 
     /**
-     * `optionValueField` is not a registered argument of this view helper, it arrives through
-     * the additional-argument handling of the tag based base class - and the partials of the
-     * three consuming extensions pass it. It still reaches `getOptionValueScalar()`.
+     * `optionValueField` decides how an object handed over as the value is turned into the
+     * string the options are compared against - the case the three `DemandCategories.html`
+     * partials pass it for.
      */
     #[Test]
     public function selectedValueCanBeReadFromAPropertyOfTheValueObject(): void
@@ -385,6 +386,200 @@ final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
             '<select name="filter[researchField]">[1:Root Category][2:Child Category]</select>',
             $output,
         );
+    }
+
+    /**
+     * The three `DemandCategories.html` partials pass both fields. Before they were
+     * registered they reached the markup as attributes of the `select` element, where
+     * neither of them is valid HTML.
+     */
+    #[Test]
+    public function optionFieldsAreNotRenderedAsAttributes(): void
+    {
+        $output = $this->renderWithOptionFields(['options' => [$this->category(1, 0, 'Root Category')]]);
+
+        $this->assertSame(
+            '<select name="filter[researchField]">'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function optionLabelIsReadFromTheConfiguredField(): void
+    {
+        $output = $this->renderWithOptionFields([
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'optionLabelField' => 'type',
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">testing_first</option>', $output);
+    }
+
+    #[Test]
+    public function optionValueIsReadFromTheConfiguredField(): void
+    {
+        $output = $this->renderWithOptionFields([
+            'options' => [$this->category(2, 1, 'Child Category')],
+            'optionValueField' => 'parentId',
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Child Category</option>', $output);
+    }
+
+    /**
+     * The value the selection is compared against comes from the same field, so a value
+     * field other than the uid stays consistent between option and selection.
+     */
+    #[Test]
+    public function selectionIsComparedAgainstTheConfiguredValueField(): void
+    {
+        $output = $this->renderWithOptionFields([
+            'value' => '1',
+            'options' => [$this->category(2, 1, 'Child Category'), $this->category(3, 2, 'Grandchild Category')],
+            'optionValueField' => 'parentId',
+        ]);
+
+        $this->assertStringContainsString(
+            '<option value="1" class="level-0" selected="selected">Child Category</option>',
+            $output,
+        );
+        $this->assertStringContainsString('<option value="2" class="level-0">Grandchild Category</option>', $output);
+    }
+
+    /**
+     * Every property a `Category` exposes is a scalar or `Stringable`, so the rejection
+     * needs an option of its own kind - which is what an `options` argument holding
+     * anything but categories amounts to.
+     */
+    #[Test]
+    public function optionFieldThatCannotBeCastToAStringIsRejected(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1785706600);
+
+        $this->renderWithOptionFields(['options' => [new class () {
+            public function getUid(): int
+            {
+                return 1;
+            }
+
+            /**
+             * @return array<int, string>
+             */
+            public function getTitle(): array
+            {
+                return ['not', 'a', 'string'];
+            }
+        }]]);
+    }
+
+    /**
+     * `multiple` is a valid attribute of a `select`, so before it was registered a template
+     * passing it got a real multi select - but the name kept its single-value shape and the
+     * browser submitted one of the selected options. The name carries the suffix now, the
+     * way the core select view helper builds it, and the hidden field lets an empty
+     * selection reach the controller.
+     */
+    #[Test]
+    public function multipleSelectSubmitsAnArray(): void
+    {
+        $output = $this->renderMultiple(['options' => [$this->category(1, 0, 'Root Category')]]);
+
+        $this->assertSame(
+            '<input type="hidden" name="filter[researchField]" value="" />'
+            . '<select multiple="multiple" name="filter[researchField][]">'
+            . '<option value="1" class="level-0">Root Category</option>' . LF
+            . '</select>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function singleSelectKeepsItsName(): void
+    {
+        $output = $this->renderMultiple(['multiple' => false]);
+
+        $this->assertStringContainsString('<select name="filter[researchField]">', $output);
+    }
+
+    #[Test]
+    public function everyOptionOfAMultipleSelectIsSelectedByDefaultOnDemand(): void
+    {
+        $output = $this->renderMultiple([
+            'options' => [$this->category(1, 0, 'Root Category'), $this->category(2, 1, 'Child Category')],
+            'selectAllByDefault' => true,
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0" selected="selected">', $output);
+        $this->assertStringContainsString('<option value="2" class="level-0" selected="selected">', $output);
+    }
+
+    /**
+     * A selection replaces the default - "if none was set before" is what the argument
+     * promises.
+     */
+    #[Test]
+    public function selectAllByDefaultStepsBackForASelection(): void
+    {
+        $output = $this->renderMultiple([
+            'value' => ['2'],
+            'options' => [$this->category(1, 0, 'Root Category'), $this->category(2, 1, 'Child Category')],
+            'selectAllByDefault' => true,
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
+        $this->assertStringContainsString(
+            '<option value="2" class="level-0" selected="selected">Child Category</option>',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function selectAllByDefaultIsIgnoredForASingleSelect(): void
+    {
+        $output = $this->renderMultiple([
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'multiple' => false,
+            'selectAllByDefault' => true,
+        ]);
+
+        $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function renderWithOptionFields(array $variables = []): string
+    {
+        return $this->render('FilterSelectWithOptionFields', array_replace(
+            [
+                'name' => 'filter[researchField]',
+                'value' => '',
+                'options' => [],
+                'optionValueField' => 'uid',
+                'optionLabelField' => 'title',
+            ],
+            $variables,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function renderMultiple(array $variables = []): string
+    {
+        return $this->render('FilterSelectMultiple', array_replace(
+            [
+                'name' => 'filter[researchField]',
+                'value' => '',
+                'options' => [],
+                'multiple' => true,
+                'selectAllByDefault' => false,
+            ],
+            $variables,
+        ));
     }
 
     /**


### PR DESCRIPTION
Backport of #427 to branch `2`.

The three `DemandCategories.html` partials of `EXT:academic_partners`,
`EXT:academic_programs` and `EXT:academic_projects` pass `optionValueField` and
`optionLabelField` to `ct:form.filterSelect`, which registered neither. An
unregistered argument is not rejected — the tag based base class turns it into
an attribute:

```html
<select optionValueField="uid" optionLabelField="title" name="filter[researchField]">
```

Neither is valid HTML on a `select`.

Two more arguments of core's `SelectViewHelper` were unregistered as well, and
one of them is worse than an invalid attribute: **`multiple` is a valid
attribute**, so a template passing it got a real multi-select — while core's
`SelectViewHelper::getName()` appends `[]` to the field name and this class did
not, so the browser submitted one value out of several.

All four are registered now and behave like their core counterparts:

* `optionValueField` — the value of an option, and the value an object handed
  over as `value` is compared against.
* `optionLabelField` — the label. Both resolve through
  `ObjectAccess::getPropertyPath()`; a property that is neither scalar nor
  `Stringable` is rejected with `\RuntimeException` 1785706600.
* `multiple` — attribute, `[]` name suffix, hidden field for the empty value,
  one token registration per option.
* `selectAllByDefault` — preselects a multi-select while nothing is selected.

The filter select's option array gains a **`value`** key, which the option tags
render; `uid` stays, because the grouping by parent matches on it and the
`renderOptions="false"` template variable reads it. That is the breaking part
and has its own changelog entry next to the feature one.

## Differences to #427

Only the changelog folder — the entries land in `Documentation/Changelog/2.4/`.
The two view helpers and the test file were identical on both branches before
this, so everything else is the cherry-pick unchanged.

`AbstractFormFieldViewHelper::renderHiddenFieldForEmptyValue()`, which the
`multiple` handling needs, was checked against the TYPO3 v12 vendor tree — it is
present there.

## Verification

`cgl`, `lintPhp`, `phpstan`, `unit` and the **full** functional suite on TYPO3
v12 and v13 — full rather than scoped because the three `SortingSelectViewHelper`
subclasses live in the other extensions. Plus `checkRstRenderingSingle`. With
the two view helpers reverted, seven of the ten new tests fail; the other three
assert unchanged behaviour.

ACE-351
