### PR TITLE
[BUGFIX] ACE-357: Read the category filter safely

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-partners/Classes/Factory/DemandFactory.php
@@ -7,12 +7,14 @@ namespace FGTCLB\AcademicPartners\Factory;
 use FGTCLB\AcademicPartners\Domain\Model\Dto\PartnerDemand;
 use FGTCLB\CategoryTypes\Collection\FilterCollection;
 use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Filter\CategoryFilterNormalizer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DemandFactory
 {
     public function __construct(
         private readonly CategoryRepository $categoryRepository,
+        private readonly CategoryFilterNormalizer $categoryFilterNormalizer,
     ) {}
 
     /**
@@ -55,14 +57,9 @@ class DemandFactory
             }
 
             if (isset($demandFromForm['filterCollection'])) {
-                $categoryUids = [];
-                foreach ($demandFromForm['filterCollection'] as $uids) {
-                    $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
-                }
-
                 $categoryCollection = $this->categoryRepository->findByGroupAndUidList(
                     'partners',
-                    $categoryUids,
+                    $this->categoryFilterNormalizer->toUidList($demandFromForm['filterCollection']),
                 );
             }
         }

--- a/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
+++ b/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
@@ -1,0 +1,70 @@
+.. _important-1785709800:
+
+=====================================================
+Important: The category filter accepts a list of uids
+=====================================================
+
+Description
+===========
+
+`Factory\\DemandFactory::createDemandObject()` read the submitted category
+filter itself:
+
+..  code-block:: php
+
+    foreach ($demandFromForm['filterCollection'] as $uids) {
+        $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
+    }
+
+`GeneralUtility::intExplode()` takes a **string**, so a filter value that is a
+list ended in a `TypeError`:
+
+..  code-block:: text
+
+    TypeError: GeneralUtility::intExplode(): Argument #2 ($string) must be of
+    type string, array given
+
+That is exactly what a filter select with `multiple` submits — the argument the
+category filter select gained in the same release. A `filterCollection` that is
+not an array at all did not raise, but emitted a PHP warning
+*foreach() argument must be of type array|object* and silently dropped the
+filter.
+
+Both shapes are reachable from a crafted request without any template being
+involved, because the controller action takes the demand as a plain
+`?array $demand = null` and validates nothing.
+
+The filter is read through
+`FGTCLB\\CategoryTypes\\Filter\\CategoryFilterNormalizer` now, which accepts a
+single value, a list and a comma separated string, and treats anything it cannot
+read as no filter.
+
+Impact
+======
+
+*   A category filter select with `multiple` works.
+*   A request with an unreadable filter renders the list unfiltered instead of
+    failing.
+*   An unselected filter no longer contributes uid `0` to the query. The
+    prepended "all options" entry carries an empty value, and every unselected
+    category type added one `0` to the uid list. The rendered result is
+    unchanged — no category has uid `0` — but the list handed to
+    `CategoryRepository::findByGroupAndUidList()` is empty now, which it accepts
+    since the same release.
+*   A uid submitted twice is used once.
+
+Affected Installations
+======================
+
+None have to act. Own code calling `createDemandObject()` with a hand built
+demand array keeps working, and gains the list shape.
+
+References
+==========
+
+*   `CategoryFilterNormalizer
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` — the class the filter is read with, and where its
+    behaviour is documented.
+
+.. index:: Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-partners/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional\Factory;
+
+use FGTCLB\AcademicPartners\Domain\Model\Dto\PartnerDemand;
+use FGTCLB\AcademicPartners\Factory\DemandFactory;
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The category filter of the list plugin reaches `createDemandObject()` as the raw request
+ * array of `listAction(?array $demand = null)`, which validates nothing. Reading it is
+ * `EXT:category_types` `Filter\CategoryFilterNormalizer`, covered on its own in
+ * `Tests/Unit/Filter/CategoryFilterNormalizerTest` - what is asserted here is that this
+ * factory hands the filter over to it and turns the result into a demand.
+ */
+final class DemandFactoryCategoryFilterTest extends AbstractAcademicPartnersTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactory/categories.csv');
+    }
+
+    #[Test]
+    public function aSingleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['region' => '1']);
+
+        $this->assertSame([1], $this->filteredUids($demand));
+    }
+
+    /**
+     * What a filter select with `multiple` submits. It was a `TypeError` before, because
+     * the value was handed to `GeneralUtility::intExplode()`, which takes a string.
+     */
+    #[Test]
+    public function aMultipleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['region' => ['1', '2']]);
+
+        $this->assertSame([1, 2], $this->filteredUids($demand));
+    }
+
+    #[Test]
+    public function filtersOfSeveralCategoryTypesAreCombined(): void
+    {
+        $demand = $this->createDemand(['region' => '1', 'partner_type' => ['3']]);
+
+        $this->assertSame([1, 3], $this->filteredUids($demand));
+    }
+
+    /**
+     * The prepended "all options" entry carries an empty value, so every unselected filter
+     * used to add uid 0 to the list.
+     */
+    #[Test]
+    public function unselectedFiltersSelectNoCategory(): void
+    {
+        $demand = $this->createDemand(['region' => '', 'partner_type' => '']);
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    /**
+     * A crafted request must drop the filter rather than take the plugin down.
+     */
+    #[Test]
+    public function anUnreadableFilterSelectsNoCategory(): void
+    {
+        $demand = $this->createDemand('nonsense');
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    private function createDemand(mixed $filterCollection): PartnerDemand
+    {
+        return $this->get(DemandFactory::class)->createDemandObject(
+            ['filterCollection' => $filterCollection],
+            [],
+            [],
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function filteredUids(PartnerDemand $demand): array
+    {
+        $uids = [];
+        foreach ($demand->getFilterCollection()?->getFilterCategories() ?? [] as $category) {
+            $uids[] = $category->getUid();
+        }
+        sort($uids);
+
+        return $uids;
+    }
+}

--- a/packages/fgtclb/academic-partners/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
@@ -1,0 +1,5 @@
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,0,0,0,0,"region","First Category",0,0
+,2,0,0,0,0,"region","Second Category",0,0
+,3,0,0,0,0,"partner_type","Third Category",0,0

--- a/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-programs/Classes/Factory/DemandFactory.php
@@ -8,6 +8,7 @@ use FGTCLB\AcademicPrograms\Domain\Model\Dto\ProgramDemand;
 use FGTCLB\AcademicPrograms\Utility\PagesUtility;
 use FGTCLB\CategoryTypes\Collection\FilterCollection;
 use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Filter\CategoryFilterNormalizer;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -16,6 +17,7 @@ class DemandFactory
 {
     public function __construct(
         private readonly CategoryRepository $categoryRepository,
+        private readonly CategoryFilterNormalizer $categoryFilterNormalizer,
     ) {}
 
     /**
@@ -58,14 +60,9 @@ class DemandFactory
             }
 
             if (isset($demandFromForm['filterCollection'])) {
-                $categoryUids = [];
-                foreach ($demandFromForm['filterCollection'] as $uids) {
-                    $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
-                }
-
                 $categoryCollection = $this->categoryRepository->findByGroupAndUidList(
                     'programs',
-                    $categoryUids,
+                    $this->categoryFilterNormalizer->toUidList($demandFromForm['filterCollection']),
                 );
             }
         }

--- a/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
+++ b/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
@@ -1,0 +1,70 @@
+.. _important-1785709800:
+
+=====================================================
+Important: The category filter accepts a list of uids
+=====================================================
+
+Description
+===========
+
+`Factory\\DemandFactory::createDemandObject()` read the submitted category
+filter itself:
+
+..  code-block:: php
+
+    foreach ($demandFromForm['filterCollection'] as $uids) {
+        $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
+    }
+
+`GeneralUtility::intExplode()` takes a **string**, so a filter value that is a
+list ended in a `TypeError`:
+
+..  code-block:: text
+
+    TypeError: GeneralUtility::intExplode(): Argument #2 ($string) must be of
+    type string, array given
+
+That is exactly what a filter select with `multiple` submits — the argument the
+category filter select gained in the same release. A `filterCollection` that is
+not an array at all did not raise, but emitted a PHP warning
+*foreach() argument must be of type array|object* and silently dropped the
+filter.
+
+Both shapes are reachable from a crafted request without any template being
+involved, because the controller action takes the demand as a plain
+`?array $demand = null` and validates nothing.
+
+The filter is read through
+`FGTCLB\\CategoryTypes\\Filter\\CategoryFilterNormalizer` now, which accepts a
+single value, a list and a comma separated string, and treats anything it cannot
+read as no filter.
+
+Impact
+======
+
+*   A category filter select with `multiple` works.
+*   A request with an unreadable filter renders the list unfiltered instead of
+    failing.
+*   An unselected filter no longer contributes uid `0` to the query. The
+    prepended "all options" entry carries an empty value, and every unselected
+    category type added one `0` to the uid list. The rendered result is
+    unchanged — no category has uid `0` — but the list handed to
+    `CategoryRepository::findByGroupAndUidList()` is empty now, which it accepts
+    since the same release.
+*   A uid submitted twice is used once.
+
+Affected Installations
+======================
+
+None have to act. Own code calling `createDemandObject()` with a hand built
+demand array keeps working, and gains the list shape.
+
+References
+==========
+
+*   `CategoryFilterNormalizer
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` — the class the filter is read with, and where its
+    behaviour is documented.
+
+.. index:: Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-programs/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Factory;
+
+use FGTCLB\AcademicPrograms\Domain\Model\Dto\ProgramDemand;
+use FGTCLB\AcademicPrograms\Factory\DemandFactory;
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The category filter of the list plugin reaches `createDemandObject()` as the raw request
+ * array of `listAction(?array $demand = null)`, which validates nothing. Reading it is
+ * `EXT:category_types` `Filter\CategoryFilterNormalizer`, covered on its own in
+ * `Tests/Unit/Filter/CategoryFilterNormalizerTest` - what is asserted here is that this
+ * factory hands the filter over to it and turns the result into a demand.
+ */
+final class DemandFactoryCategoryFilterTest extends AbstractAcademicProgramsTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactory/categories.csv');
+    }
+
+    #[Test]
+    public function aSingleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['admission_restriction' => '1']);
+
+        $this->assertSame([1], $this->filteredUids($demand));
+    }
+
+    /**
+     * What a filter select with `multiple` submits. It was a `TypeError` before, because
+     * the value was handed to `GeneralUtility::intExplode()`, which takes a string.
+     */
+    #[Test]
+    public function aMultipleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['admission_restriction' => ['1', '2']]);
+
+        $this->assertSame([1, 2], $this->filteredUids($demand));
+    }
+
+    #[Test]
+    public function filtersOfSeveralCategoryTypesAreCombined(): void
+    {
+        $demand = $this->createDemand(['admission_restriction' => '1', 'application_period' => ['3']]);
+
+        $this->assertSame([1, 3], $this->filteredUids($demand));
+    }
+
+    /**
+     * The prepended "all options" entry carries an empty value, so every unselected filter
+     * used to add uid 0 to the list.
+     */
+    #[Test]
+    public function unselectedFiltersSelectNoCategory(): void
+    {
+        $demand = $this->createDemand(['admission_restriction' => '', 'application_period' => '']);
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    /**
+     * A crafted request must drop the filter rather than take the plugin down.
+     */
+    #[Test]
+    public function anUnreadableFilterSelectsNoCategory(): void
+    {
+        $demand = $this->createDemand('nonsense');
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    private function createDemand(mixed $filterCollection): ProgramDemand
+    {
+        return $this->get(DemandFactory::class)->createDemandObject(
+            ['filterCollection' => $filterCollection],
+            [],
+            [],
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function filteredUids(ProgramDemand $demand): array
+    {
+        $uids = [];
+        foreach ($demand->getFilterCollection()?->getFilterCategories() ?? [] as $category) {
+            $uids[] = $category->getUid();
+        }
+        sort($uids);
+
+        return $uids;
+    }
+}

--- a/packages/fgtclb/academic-programs/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
@@ -1,0 +1,5 @@
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,0,0,0,0,"admission_restriction","First Category",0,0
+,2,0,0,0,0,"admission_restriction","Second Category",0,0
+,3,0,0,0,0,"application_period","Third Category",0,0

--- a/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
+++ b/packages/fgtclb/academic-projects/Classes/Factory/DemandFactory.php
@@ -8,12 +8,14 @@ use FGTCLB\AcademicProjects\Domain\Model\Dto\ActiveState;
 use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
 use FGTCLB\CategoryTypes\Collection\FilterCollection;
 use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use FGTCLB\CategoryTypes\Filter\CategoryFilterNormalizer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DemandFactory
 {
     public function __construct(
-        private readonly CategoryRepository $categoryRepository
+        private readonly CategoryRepository $categoryRepository,
+        private readonly CategoryFilterNormalizer $categoryFilterNormalizer,
     ) {}
 
     /**
@@ -57,15 +59,9 @@ class DemandFactory
                 $demand->setSortingDirection($demandFromForm['sortingDirection']);
             }
             if (isset($demandFromForm['filterCollection'])) {
-                // @todo Does this really make sense combined with the intExplode() ?
-                $categoryUids = [];
-                foreach ($demandFromForm['filterCollection'] as $uids) {
-                    $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
-                }
-
                 $categoryCollection = $this->categoryRepository->findByGroupAndUidList(
                     'projects',
-                    $categoryUids,
+                    $this->categoryFilterNormalizer->toUidList($demandFromForm['filterCollection']),
                 );
             }
         }

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-CategoryFilterAcceptsAList.rst
@@ -1,0 +1,70 @@
+.. _important-1785709800:
+
+=====================================================
+Important: The category filter accepts a list of uids
+=====================================================
+
+Description
+===========
+
+`Factory\\DemandFactory::createDemandObject()` read the submitted category
+filter itself:
+
+..  code-block:: php
+
+    foreach ($demandFromForm['filterCollection'] as $uids) {
+        $categoryUids = array_merge($categoryUids, GeneralUtility::intExplode(',', $uids));
+    }
+
+`GeneralUtility::intExplode()` takes a **string**, so a filter value that is a
+list ended in a `TypeError`:
+
+..  code-block:: text
+
+    TypeError: GeneralUtility::intExplode(): Argument #2 ($string) must be of
+    type string, array given
+
+That is exactly what a filter select with `multiple` submits — the argument the
+category filter select gained in the same release. A `filterCollection` that is
+not an array at all did not raise, but emitted a PHP warning
+*foreach() argument must be of type array|object* and silently dropped the
+filter.
+
+Both shapes are reachable from a crafted request without any template being
+involved, because the controller action takes the demand as a plain
+`?array $demand = null` and validates nothing.
+
+The filter is read through
+`FGTCLB\\CategoryTypes\\Filter\\CategoryFilterNormalizer` now, which accepts a
+single value, a list and a comma separated string, and treats anything it cannot
+read as no filter.
+
+Impact
+======
+
+*   A category filter select with `multiple` works.
+*   A request with an unreadable filter renders the list unfiltered instead of
+    failing.
+*   An unselected filter no longer contributes uid `0` to the query. The
+    prepended "all options" entry carries an empty value, and every unselected
+    category type added one `0` to the uid list. The rendered result is
+    unchanged — no category has uid `0` — but the list handed to
+    `CategoryRepository::findByGroupAndUidList()` is empty now, which it accepts
+    since the same release.
+*   A uid submitted twice is used once.
+
+Affected Installations
+======================
+
+None have to act. Own code calling `createDemandObject()` with a hand built
+demand array keeps working, and gains the list shape.
+
+References
+==========
+
+*   `CategoryFilterNormalizer
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` — the class the filter is read with, and where its
+    behaviour is documented.
+
+.. index:: Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/DemandFactoryCategoryFilterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Factory;
+
+use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
+use FGTCLB\AcademicProjects\Factory\DemandFactory;
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The category filter of the list plugin reaches `createDemandObject()` as the raw request
+ * array of `listAction(?array $demand = null)`, which validates nothing. Reading it is
+ * `EXT:category_types` `Filter\CategoryFilterNormalizer`, covered on its own in
+ * `Tests/Unit/Filter/CategoryFilterNormalizerTest` - what is asserted here is that this
+ * factory hands the filter over to it and turns the result into a demand.
+ */
+final class DemandFactoryCategoryFilterTest extends AbstractAcademicProjectsTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactory/categories.csv');
+    }
+
+    #[Test]
+    public function aSingleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['competence_field' => '1']);
+
+        $this->assertSame([1], $this->filteredUids($demand));
+    }
+
+    /**
+     * What a filter select with `multiple` submits. It was a `TypeError` before, because
+     * the value was handed to `GeneralUtility::intExplode()`, which takes a string.
+     */
+    #[Test]
+    public function aMultipleSelectionIsAccepted(): void
+    {
+        $demand = $this->createDemand(['competence_field' => ['1', '2']]);
+
+        $this->assertSame([1, 2], $this->filteredUids($demand));
+    }
+
+    #[Test]
+    public function filtersOfSeveralCategoryTypesAreCombined(): void
+    {
+        $demand = $this->createDemand(['competence_field' => '1', 'cooperation' => ['3']]);
+
+        $this->assertSame([1, 3], $this->filteredUids($demand));
+    }
+
+    /**
+     * The prepended "all options" entry carries an empty value, so every unselected filter
+     * used to add uid 0 to the list.
+     */
+    #[Test]
+    public function unselectedFiltersSelectNoCategory(): void
+    {
+        $demand = $this->createDemand(['competence_field' => '', 'cooperation' => '']);
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    /**
+     * A crafted request must drop the filter rather than take the plugin down.
+     */
+    #[Test]
+    public function anUnreadableFilterSelectsNoCategory(): void
+    {
+        $demand = $this->createDemand('nonsense');
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    private function createDemand(mixed $filterCollection): ProjectDemand
+    {
+        return $this->get(DemandFactory::class)->createDemandObject(
+            ['filterCollection' => $filterCollection],
+            [],
+            [],
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function filteredUids(ProjectDemand $demand): array
+    {
+        $uids = [];
+        foreach ($demand->getFilterCollection()?->getFilterCategories() ?? [] as $category) {
+            $uids[] = $category->getUid();
+        }
+        sort($uids);
+
+        return $uids;
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/DemandFactory/categories.csv
@@ -1,0 +1,5 @@
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,0,0,0,0,"competence_field","First Category",0,0
+,2,0,0,0,0,"competence_field","Second Category",0,0
+,3,0,0,0,0,"cooperation","Third Category",0,0

--- a/packages/fgtclb/typo3-category-types/Classes/Filter/CategoryFilterNormalizer.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Filter/CategoryFilterNormalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Filter;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Turns the category filter of a submitted demand form into a list of category uids.
+ *
+ * The filter reaches a controller action as a plain array taken from the request, without
+ * any validation on the way, so every shape has to be survivable. A value that cannot be
+ * read is treated as no filter rather than as an error - a crafted request must not be
+ * able to take a list plugin down.
+ *
+ * The shapes that do carry a selection:
+ *
+ * - a single select submits one uid per category type,
+ * - a select with `multiple` submits one value per selected option,
+ * - a value assembled by a template may be a comma separated list.
+ *
+ * The category type the values were submitted under is not part of the result. The
+ * consumers pass the list to
+ * {@see \FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository::findByGroupAndUidList()},
+ * which resolves the types of the whole group anyway.
+ */
+class CategoryFilterNormalizer
+{
+    /**
+     * @return array<int, int>
+     */
+    public function toUidList(mixed $filter): array
+    {
+        if (!is_array($filter)) {
+            return [];
+        }
+
+        $uids = [];
+        foreach ($filter as $filterValue) {
+            foreach ($this->toStringList($filterValue) as $value) {
+                $uids = array_merge($uids, GeneralUtility::intExplode(',', $value, true));
+            }
+        }
+
+        return array_values(array_unique($uids));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function toStringList(mixed $filterValue): array
+    {
+        if (!is_array($filterValue)) {
+            return $this->toStringOrNull($filterValue) === null ? [] : [(string)$filterValue];
+        }
+
+        $values = [];
+        foreach ($filterValue as $value) {
+            $stringValue = $this->toStringOrNull($value);
+            if ($stringValue !== null) {
+                $values[] = $stringValue;
+            }
+        }
+
+        return $values;
+    }
+
+    private function toStringOrNull(mixed $value): ?string
+    {
+        if (is_bool($value) || $value === null) {
+            return null;
+        }
+        if (is_scalar($value) || $value instanceof \Stringable) {
+            return (string)$value;
+        }
+
+        return null;
+    }
+}

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Feature-CategoryFilterNormalizer.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Feature-CategoryFilterNormalizer.rst
@@ -1,0 +1,68 @@
+.. _feature-1785709700:
+
+====================================================
+Feature: Category filter normalizer for demand forms
+====================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\Filter\\CategoryFilterNormalizer` turns the category
+filter of a submitted demand form into a list of category uids:
+
+..  code-block:: php
+
+    public function toUidList(mixed $filter): array
+
+The filter reaches a plugin as the raw request array of an action such as
+`listAction(?array $demand = null)`, which validates nothing, so every shape has
+to be survivable. The shapes that carry a selection:
+
+*   a single select submits one uid per category type,
+*   a select with `multiple` submits one value per selected option,
+*   a value assembled by a template may be a comma separated list.
+
+Anything that cannot be read is treated as **no filter** rather than as an
+error — a crafted request must not be able to take a list plugin down. That
+covers a filter that is not an array at all, a value nested deeper than one
+level, an object, a boolean and `null`.
+
+Two more properties worth knowing:
+
+*   The category type the values were submitted under is **not** part of the
+    result. The consumers pass the list to
+    `CategoryRepository::findByGroupAndUidList()`, which resolves the types of
+    the whole group anyway.
+*   Empty values are dropped, so the prepended "all options" entry of a filter
+    select no longer contributes uid `0`, and a uid submitted twice is collected
+    once.
+
+The class is stateless and autowired, so it can be injected wherever a submitted
+category filter has to be read:
+
+..  code-block:: php
+
+    public function __construct(
+        private readonly CategoryRepository $categoryRepository,
+        private readonly CategoryFilterNormalizer $categoryFilterNormalizer,
+    ) {}
+
+Impact
+======
+
+The demand factories of `EXT:academic_partners`, `EXT:academic_programs` and
+`EXT:academic_projects` read their category filter through it, which is what
+lets them accept the `multiple` filter select added in the same release. Own
+code that reads a submitted category filter can use the same class instead of
+splitting the request value itself.
+
+References
+==========
+
+*   :ref:`feature-1785706700` — the `multiple` argument of the category filter
+    select, whose submitted shape this class exists to read.
+*   :ref:`important-1785790800` — the empty uid list
+    `findByGroupAndUidList()` accepts, which is what makes dropping the empty
+    values safe.
+
+.. index:: Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Filter/CategoryFilterNormalizerTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Filter/CategoryFilterNormalizerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\CategoryTypes\Tests\Unit\Filter;
+
+use FGTCLB\CategoryTypes\Filter\CategoryFilterNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The category filter of a demand form reaches a controller action as a plain request
+ * array - `listAction(?array $demand = null)` validates nothing - so this class is what
+ * stands between an arbitrary request and the category query.
+ *
+ * The three `Factory\DemandFactory` implementations of `EXT:academic_partners`,
+ * `EXT:academic_programs` and `EXT:academic_projects` are its callers.
+ */
+final class CategoryFilterNormalizerTest extends UnitTestCase
+{
+    /**
+     * What a single select of `ViewHelpers\Form\FilterSelectViewHelper` submits: one uid
+     * per category type.
+     */
+    #[Test]
+    public function oneValuePerCategoryTypeIsCollected(): void
+    {
+        $this->assertSame(
+            [5, 8],
+            $this->subject()->toUidList(['research_field' => '5', 'degree' => '8']),
+        );
+    }
+
+    /**
+     * What a select with `multiple` submits.
+     */
+    #[Test]
+    public function aListOfValuesIsCollected(): void
+    {
+        $this->assertSame(
+            [5, 8, 13],
+            $this->subject()->toUidList(['research_field' => ['5', '8'], 'degree' => ['13']]),
+        );
+    }
+
+    /**
+     * No select can submit this, but a template assembling the value itself can.
+     */
+    #[Test]
+    public function aCommaSeparatedValueIsSplit(): void
+    {
+        $this->assertSame([5, 8], $this->subject()->toUidList(['research_field' => '5,8']));
+    }
+
+    /**
+     * The prepended "all options" entry carries an empty value, so an unselected filter
+     * used to contribute uid 0 - one per category type. An empty list is what the
+     * repository is handed now, which it takes since ACE-349.
+     */
+    #[Test]
+    public function unselectedFiltersContributeNothing(): void
+    {
+        $this->assertSame([], $this->subject()->toUidList(['research_field' => '', 'degree' => '']));
+    }
+
+    #[Test]
+    public function theSameUidIsCollectedOnce(): void
+    {
+        $this->assertSame([5], $this->subject()->toUidList(['research_field' => '5', 'degree' => ['5']]));
+    }
+
+    /**
+     * The category type the values were submitted under is not part of the result: the
+     * repository resolves the types of the whole group anyway.
+     */
+    #[Test]
+    public function theCategoryTypeKeyIsNotEvaluated(): void
+    {
+        $this->assertSame([5], $this->subject()->toUidList(['anything at all' => '5']));
+    }
+
+    /**
+     * @param array<int, int> $expected
+     */
+    #[Test]
+    #[DataProvider('unreadableFilters')]
+    public function anUnreadableFilterIsNoFilter(mixed $filter, array $expected): void
+    {
+        $this->assertSame($expected, $this->subject()->toUidList($filter));
+    }
+
+    /**
+     * A crafted request may put anything in there. None of it may raise, because that
+     * would take the whole list plugin down instead of dropping the filter.
+     *
+     * @return array<string, array{0: mixed, 1: array<int, int>}>
+     */
+    public static function unreadableFilters(): array
+    {
+        return [
+            'not an array' => ['nonsense', []],
+            'null' => [null, []],
+            'an integer' => [42, []],
+            'an empty array' => [[], []],
+            'nested deeper than one level' => [['research_field' => [['5']]], []],
+            'an object' => [['research_field' => new \stdClass()], []],
+            'a boolean' => [['research_field' => true], []],
+            'readable next to unreadable' => [['research_field' => ['5', ['8']], 'degree' => '13'], [5, 13]],
+        ];
+    }
+
+    /**
+     * Not a uid any category can have, but the repository is the place that decides that -
+     * quoting the list is what makes an arbitrary value safe there.
+     */
+    #[Test]
+    public function aNegativeValueIsKept(): void
+    {
+        $this->assertSame([-1], $this->subject()->toUidList(['research_field' => '-1']));
+    }
+
+    #[Test]
+    public function aNonNumericValueBecomesZero(): void
+    {
+        $this->assertSame([0], $this->subject()->toUidList(['research_field' => 'drop table']));
+    }
+
+    private function subject(): CategoryFilterNormalizer
+    {
+        return new CategoryFilterNormalizer();
+    }
+}


### PR DESCRIPTION
Backport of #429 to branch `2`.

All three `Factory\DemandFactory` implementations read the submitted category
filter themselves and handed every value to `GeneralUtility::intExplode()`,
which takes a **string**. Verified from a functional test:

| `filterCollection` | before |
|---|---|
| `['research_field' => '1']` | OK |
| `['research_field' => ['1', '2']]` | `TypeError: intExplode(): Argument #2 ($string) must be of type string, array given` |
| `'nonsense'` | PHP warning *foreach() argument must be of type array\|object*, filter silently dropped |

Both bad rows are reachable from a crafted URL with no template involved — the
controller action takes the demand as a plain `?array $demand = null` and
validates nothing. The list shape is additionally what a filter select submits
since `multiple` became a registered argument in #428.

## Decisions

1. **Accept `string|array`** — a scalar stays a comma list, a list is flattened
   per element.
2. **An unreadable filter is no filter** — no exception; a crafted request
   renders the list unfiltered instead of returning a 500.
3. **One shared helper** in `EXT:category_types`, already a hard dependency of
   all three.

`FGTCLB\CategoryTypes\Filter\CategoryFilterNormalizer::toUidList(mixed $filter)`
— stateless, autowired, constructor-injected into the three factories.

Empty values are dropped, which answers the `@todo Does this really make sense
combined with the intExplode() ?` in `EXT:academic_projects`: the prepended
"all options" entry no longer contributes uid `0` per unselected category type.
The empty list that leaves behind is what `findByGroupAndUidList()` accepts
since ACE-349. The rendered result is unchanged either way, since no category
has uid 0.

## Differences to #429

Only the changelog folder — all four entries land in
`Documentation/Changelog/2.4/`. Git's rename detection moved two of them by
itself and left the other two in a fresh `3.0/`; both were moved by hand and the
empty directories removed. Everything else is the cherry-pick unchanged.

## Verification

16 unit tests for the normalizer, including a data provider of eight unreadable
shapes; 5 functional tests per extension for the wiring. `cgl`, `lintPhp`,
`phpstan`, `unit` and the **full** functional suite on TYPO3 v12 and v13, plus
`checkRstRenderingSingle` for all four changed extensions. With the three
factories reverted on `main`, each extension reports 2 errors and 1 warning.

ACE-357
