### PR TITLE
[BUGFIX] ACE-352: Escape the select option values

### DIFF
--- a/packages/fgtclb/academic-partners/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-partners/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -109,23 +109,6 @@ final class SortingSelectViewHelper extends AbstractSelectViewHelper
         return $options;
     }
 
-    /**
-     * @param array<int|string, array{value: int|string, label: string, isSelected: bool}> $options
-     * @return string
-     */
-    protected function renderOptionTags($options): string
-    {
-        $output = '';
-        foreach ($options as $option) {
-            $output .= '<option value="' . $option['value'] . '"';
-            if ($option['isSelected']) {
-                $output .= ' selected="selected"';
-            }
-            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
-        }
-        return $output;
-    }
-
     protected function translateLabel(
         string $labelKey,
         ?string $l10nPrefix = 'sorting'

--- a/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
+++ b/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
@@ -1,0 +1,37 @@
+.. _important-1785882200:
+
+=========================================================
+Important: The sorting select shares the option rendering
+=========================================================
+
+Description
+===========
+
+`ViewHelpers\\Form\\SortingSelectViewHelper::renderOptionTags()` was removed. It
+was identical to the method it inherits from
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper`, down to the
+last character - the class only ever needed its own `getOptions()`.
+
+That base class writes every option through a single method now, which escapes
+the option value. It used to concatenate the value unchanged while escaping the
+label.
+
+Impact
+======
+
+The rendered markup is unchanged. The options of this select carry the values of
+`Enumeration\\SortingOptions` - `title`, `asc`, `desc` and their siblings - and
+none of them needs escaping.
+
+An own subclass overriding `renderOptionTags()` keeps working, and one calling
+`parent::renderOptionTags()` reaches the inherited implementation.
+
+References
+==========
+
+*   `AbstractSelectViewHelper
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` - the class writing the option markup, and where the
+    change is documented.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-programs/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -87,23 +87,6 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         return $options;
     }
 
-    /**
-     * @param array<int, mixed> $options
-     * @return string
-     */
-    protected function renderOptionTags($options): string
-    {
-        $output = '';
-        foreach ($options as $option) {
-            $output .= '<option value="' . $option['value'] . '"';
-            if ($option['isSelected']) {
-                $output .= ' selected="selected"';
-            }
-            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
-        }
-        return $output;
-    }
-
     protected function translateLabel(
         string $labelKey,
         ?string $l10nPrefix = 'sorting'

--- a/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
+++ b/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
@@ -1,0 +1,37 @@
+.. _important-1785882200:
+
+=========================================================
+Important: The sorting select shares the option rendering
+=========================================================
+
+Description
+===========
+
+`ViewHelpers\\Form\\SortingSelectViewHelper::renderOptionTags()` was removed. It
+was identical to the method it inherits from
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper`, down to the
+last character - the class only ever needed its own `getOptions()`.
+
+That base class writes every option through a single method now, which escapes
+the option value. It used to concatenate the value unchanged while escaping the
+label.
+
+Impact
+======
+
+The rendered markup is unchanged. The options of this select carry the values of
+`Enumeration\\SortingOptions` - `title`, `asc`, `desc` and their siblings - and
+none of them needs escaping.
+
+An own subclass overriding `renderOptionTags()` keeps working, and one calling
+`parent::renderOptionTags()` reaches the inherited implementation.
+
+References
+==========
+
+*   `AbstractSelectViewHelper
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` - the class writing the option markup, and where the
+    change is documented.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Form/SortingSelectViewHelper.php
@@ -87,23 +87,6 @@ class SortingSelectViewHelper extends AbstractSelectViewHelper
         return $options;
     }
 
-    /**
-     * @param array<int, mixed> $options
-     * @return string
-     */
-    protected function renderOptionTags($options): string
-    {
-        $output = '';
-        foreach ($options as $option) {
-            $output .= '<option value="' . $option['value'] . '"';
-            if ($option['isSelected']) {
-                $output .= ' selected="selected"';
-            }
-            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
-        }
-        return $output;
-    }
-
     protected function translateLabel(
         string $labelKey,
         ?string $l10nPrefix = 'sorting'

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-SortingSelectSharesOptionRendering.rst
@@ -1,0 +1,37 @@
+.. _important-1785882200:
+
+=========================================================
+Important: The sorting select shares the option rendering
+=========================================================
+
+Description
+===========
+
+`ViewHelpers\\Form\\SortingSelectViewHelper::renderOptionTags()` was removed. It
+was identical to the method it inherits from
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper`, down to the
+last character - the class only ever needed its own `getOptions()`.
+
+That base class writes every option through a single method now, which escapes
+the option value. It used to concatenate the value unchanged while escaping the
+label.
+
+Impact
+======
+
+The rendered markup is unchanged. The options of this select carry the values of
+`Enumeration\\SortingOptions` - `title`, `asc`, `desc` and their siblings - and
+none of them needs escaping.
+
+An own subclass overriding `renderOptionTags()` keeps working, and one calling
+`parent::renderOptionTags()` reaches the inherited implementation.
+
+References
+==========
+
+*   `AbstractSelectViewHelper
+    <https://github.com/fgtclb/typo3-category-types>`__ in
+    `EXT:category_types` - the class writing the option markup, and where the
+    change is documented.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -287,6 +287,11 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     /**
      * Render the option tags.
      *
+     * Every option goes through `renderOptionTag()`, the way the core select view helper
+     * does it - so there is one place writing an option, and one place escaping it. An
+     * option that needs more than the value, the label and the selected state carries the
+     * additional attributes in an `attributes` key.
+     *
      * @param array<array<string, mixed>> $options the options for the form.
      * @return string rendered tags.
      */
@@ -294,11 +299,13 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
     {
         $output = '';
         foreach ($options as $option) {
-            $output .= '<option value="' . $option['value'] . '"';
-            if ($option['isSelected']) {
-                $output .= ' selected="selected"';
-            }
-            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
+            $attributes = $option['attributes'] ?? [];
+            $output .= $this->renderOptionTag(
+                (string)$option['value'],
+                (string)$option['label'],
+                (bool)$option['isSelected'],
+                is_array($attributes) ? $attributes : [],
+            ) . LF;
         }
         return $output;
     }
@@ -309,11 +316,15 @@ class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
      * @param string $value value attribute of the option tag (will be escaped)
      * @param string $label content of the option tag (will be escaped)
      * @param bool $isSelected specifies whether or not to add selected attribute
+     * @param array<string, mixed> $attributes additional attributes, keyed by name (values will be escaped)
      * @return string the rendered option tag
      */
-    protected function renderOptionTag($value, $label, $isSelected)
+    protected function renderOptionTag($value, $label, $isSelected, array $attributes = [])
     {
         $output = '<option value="' . htmlspecialchars((string)$value) . '"';
+        foreach ($attributes as $attributeName => $attributeValue) {
+            $output .= ' ' . $attributeName . '="' . htmlspecialchars((string)$attributeValue) . '"';
+        }
         if ($isSelected) {
             $output .= ' selected="selected"';
         }

--- a/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/packages/fgtclb/typo3-category-types/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -62,6 +62,16 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
             $options = $this->linearizeOptionsTree($options, $optionsTree);
         }
 
+        // Added last: the level is only known once the options were grouped, and the base
+        // class writes the markup from this array.
+        foreach ($options as $key => $option) {
+            $attributes = ['class' => $this->arguments['groupLevelClassPrefix'] . $option['level']];
+            if ($option['isDisabled'] === true) {
+                $attributes['disabled'] = 'disabled';
+            }
+            $options[$key]['attributes'] = $attributes;
+        }
+
         return $options;
     }
 
@@ -135,26 +145,5 @@ class FilterSelectViewHelper extends AbstractSelectViewHelper
             }
         }
         return $options;
-    }
-
-    /**
-     * @param array<int, mixed> $options
-     * @return string
-     */
-    protected function renderOptionTags($options): string
-    {
-        $output = '';
-        foreach ($options as $option) {
-            $output .= '<option value="' . $option['value'] . '"';
-            $output .= ' class="' . $this->arguments['groupLevelClassPrefix'] . $option['level'] . '"';
-            if ($option['isSelected']) {
-                $output .= ' selected="selected"';
-            }
-            if ($option['isDisabled']) {
-                $output .= ' disabled="disabled"';
-            }
-            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
-        }
-        return $output;
     }
 }

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Breaking-SelectOptionTagRendering.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Breaking-SelectOptionTagRendering.rst
@@ -1,0 +1,113 @@
+.. _breaking-1785882000:
+
+===================================================
+Breaking: Select options are rendered by one method
+===================================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper` had two
+methods writing an `<option>` element: `renderOptionTag()` for the entry
+`prependOptionLabel` adds, and `renderOptionTags()` for the generated ones. Both
+built the markup themselves, and every subclass that needed one more attribute
+copied the whole loop - `FilterSelectViewHelper` for the level class and the
+disabled state, the three `SortingSelectViewHelper` implementations of
+`EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects`
+without changing anything at all.
+
+`renderOptionTags()` now writes no markup of its own. It hands every option to
+`renderOptionTag()`, the way `TYPO3\\CMS\\Fluid\\ViewHelpers\\Form\\SelectViewHelper`
+does it:
+
+..  code-block:: php
+
+    protected function renderOptionTags(array $options)
+    {
+        $output = '';
+        foreach ($options as $option) {
+            $attributes = $option['attributes'] ?? [];
+            $output .= $this->renderOptionTag(
+                (string)$option['value'],
+                (string)$option['label'],
+                (bool)$option['isSelected'],
+                is_array($attributes) ? $attributes : [],
+            ) . LF;
+        }
+        return $output;
+    }
+
+`renderOptionTag()` takes a fourth parameter for that, an array of additional
+attributes keyed by name:
+
+..  code-block:: php
+
+    protected function renderOptionTag($value, $label, $isSelected, array $attributes = [])
+
+An option carries those attributes in an `attributes` key.
+`FilterSelectViewHelper::getOptions()` fills it with the level class and, where
+applicable, `disabled`; its `renderOptionTags()` override and the three of the
+sorting selects were removed.
+
+Impact
+======
+
+*   A subclass overriding `renderOptionTag()` with the previous three-parameter
+    signature is a fatal error - PHP rejects an override with fewer parameters
+    than the parent declares.
+*   A subclass overriding `FilterSelectViewHelper::getOptions()` without adding
+    an `attributes` key renders its options without the level class and without
+    the disabled attribute. Both used to be added while the markup was written.
+*   `disabled` precedes `selected` in the markup of the category filter now,
+    because it comes from the option array while `selected` is appended last.
+    The two only ever appear together on a disabled category that is the
+    selected one.
+*   Removing the three `SortingSelectViewHelper::renderOptionTags()` methods
+    changes no markup. They were identical to the one they inherit, and a
+    subclass overriding or calling them keeps working.
+
+Affected Installations
+======================
+
+Installations with an own subclass of `AbstractSelectViewHelper`,
+`FilterSelectViewHelper` or one of the three `SortingSelectViewHelper`
+implementations that overrides `renderOptionTag()`, `renderOptionTags()` or
+`FilterSelectViewHelper::getOptions()`.
+
+Migration
+=========
+
+Add the parameter to an overridden `renderOptionTag()`:
+
+..  code-block:: php
+
+    protected function renderOptionTag($value, $label, $isSelected, array $attributes = [])
+
+Add the attributes to an overridden `getOptions()`:
+
+..  code-block:: php
+
+    $options[] = [
+        'label' => $category->getTitle(),
+        'value' => (string)$category->getUid(),
+        'isSelected' => $this->isSelected((string)$category->getUid()),
+        'attributes' => ['class' => 'level-0'],
+        // ...
+    ];
+
+An override of `renderOptionTags()` that writes its own markup keeps working,
+but it escapes nothing unless it does so itself - see
+:ref:`important-1785882100`.
+
+References
+==========
+
+*   :ref:`important-1785882100` - the escaping this change makes possible in one
+    place.
+*   :ref:`breaking-1785706800` - the `value` key of an option, which this builds
+    on.
+*   `SelectViewHelper
+    <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-select>`__ -
+    the core view helper whose structure the base class now follows.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Important-SelectOptionValueEscaping.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/2.4/Important-SelectOptionValueEscaping.rst
@@ -1,0 +1,60 @@
+.. _important-1785882100:
+
+===========================================
+Important: Select option values are escaped
+===========================================
+
+Description
+===========
+
+`FGTCLB\\CategoryTypes\\ViewHelpers\\Form\\AbstractSelectViewHelper` escaped the
+label of a generated option and concatenated its value unchanged:
+
+..  code-block:: php
+
+    $output .= '<option value="' . $option['value'] . '"';
+    // ...
+    $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
+
+`FilterSelectViewHelper` did the same, and additionally wrote the
+`groupLevelClassPrefix` argument into the `class` attribute unchanged. The entry
+`prependOptionLabel` adds was never affected - it goes through
+`renderOptionTag()`, which escaped both from the start.
+
+A value that contains a quotation mark ended the attribute and everything after
+it became markup:
+
+..  code-block:: html
+
+    <option value="" autofocus onfocus="alert(1)">A category</option>
+
+Every option value and every additional attribute is escaped with
+`htmlspecialchars()` now, in the one method that writes an option.
+
+Impact
+======
+
+The rendered markup is unchanged for every value that needs no escaping, which
+is what the shipped templates produce: the three `DemandCategories.html`
+partials of `EXT:academic_partners`, `EXT:academic_programs` and
+`EXT:academic_projects` pass `optionValueField="uid"`, and the sorting selects
+of those extensions render their own constants.
+
+It matters for a template that points `optionValueField` at a text property -
+supported since :ref:`feature-1785706700` - because a category title is free
+text entered in the backend. A title carrying a quotation mark used to reach the
+`value` attribute unchanged.
+
+An own subclass that overrides `renderOptionTags()` and writes its own markup is
+not covered by this. Let it render through `renderOptionTag()` instead, see
+:ref:`breaking-1785882000`.
+
+References
+==========
+
+*   :ref:`breaking-1785882000` - the single option writer this relies on.
+*   :ref:`feature-1785706700` - `optionValueField`, which decides what the value
+    of an option is.
+*   `htmlspecialchars <https://www.php.net/manual/en/function.htmlspecialchars.php>`__
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/AbstractSelectViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/AbstractSelectViewHelperTest.php
@@ -12,12 +12,12 @@ use PHPUnit\Framework\Attributes\Test;
  * `getOptions()` returns `[]` - so everything it contributes around the options is asserted
  * through `FilterSelectViewHelperTest`, which uses the subclass shipped here.
  *
- * What that leaves is `renderOptionTags()`, which the filter select overrides and therefore
- * never reaches. The three `SortingSelectViewHelper` implementations of
- * `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` do use it:
- * they only fill `getOptions()` and let the base class write the markup. The
- * `TestSelectViewHelper` of the `test_category_types_group` fixture extension is built the
- * same way and stands in for them, so the contract stays covered inside this extension.
+ * What that leaves is `renderOptionTags()` and `renderOptionTag()`, which every subclass
+ * shares: `ViewHelpers\Form\FilterSelectViewHelper` and the three `SortingSelectViewHelper`
+ * implementations of `EXT:academic_partners`, `EXT:academic_programs` and
+ * `EXT:academic_projects` only fill `getOptions()` and let the base class write the markup.
+ * The `TestSelectViewHelper` of the `test_category_types_group` fixture extension is built
+ * the same way and stands in for them, so the contract stays covered inside this extension.
  */
 final class AbstractSelectViewHelperTest extends AbstractViewHelperTestCase
 {
@@ -62,6 +62,22 @@ final class AbstractSelectViewHelperTest extends AbstractViewHelperTestCase
 
         $this->assertStringContainsString(
             '<option value="title">Fluid &amp; &quot;Templating&quot; &lt;b&gt;</option>',
+            $output,
+        );
+    }
+
+    /**
+     * The label was escaped and the value was not, although both are written by the same
+     * method. A value reaches the markup unchanged from `getOptions()`, which a subclass
+     * fills - for the category filter from a property the template names.
+     */
+    #[Test]
+    public function optionValueIsEscaped(): void
+    {
+        $output = $this->renderTestSelect(['options' => ['" autofocus onfocus="alert(1)' => 'By title']]);
+
+        $this->assertStringContainsString(
+            '<option value="&quot; autofocus onfocus=&quot;alert(1)">By title</option>',
             $output,
         );
     }

--- a/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Functional/ViewHelpers/Form/FilterSelectViewHelperTest.php
@@ -18,10 +18,10 @@ use PHPUnit\Framework\Attributes\Test;
  * prepended option, `required`, the child content, the `renderOptions` variable and the
  * selected-value handling - is asserted here rather than in a test of its own: the class is
  * not abstract, but on its own it renders an empty select, because its `getOptions()`
- * returns `[]`. Its own `renderOptionTags()`, which the filter select overrides, is covered
- * in `AbstractSelectViewHelperTest` - the three `SortingSelectViewHelper` implementations of
- * `EXT:academic_partners`, `EXT:academic_programs` and `EXT:academic_projects` are its other
- * subclasses and use it.
+ * returns `[]`. Its `renderOptionTags()` writes the markup for this class as well and is
+ * covered in `AbstractSelectViewHelperTest` - the three `SortingSelectViewHelper`
+ * implementations of `EXT:academic_partners`, `EXT:academic_programs` and
+ * `EXT:academic_projects` are its other subclasses and share it too.
  *
  * The options are built as `Category` objects instead of being read from the database, which
  * pins the order the assertions rely on: none of the repository methods sorts. `isRoot()`
@@ -77,6 +77,39 @@ final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
 
         $this->assertStringContainsString(
             '<option value="1" class="level-0">Fluid &amp; &quot;Templating&quot; &lt;b&gt;</option>',
+            $output,
+        );
+    }
+
+    /**
+     * A category title is free text an editor types, and `optionValueField` may name any
+     * property since the four select arguments were registered - so the value is as
+     * uncontrolled as the label, which was escaped from the start.
+     */
+    #[Test]
+    public function optionValueIsEscaped(): void
+    {
+        $output = $this->renderWithOptionFields([
+            'options' => [$this->category(1, 0, '" autofocus onfocus="alert(1)')],
+            'optionValueField' => 'title',
+        ]);
+
+        $this->assertStringContainsString(
+            '<option value="&quot; autofocus onfocus=&quot;alert(1)" class="level-0">',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function levelClassPrefixIsEscaped(): void
+    {
+        $output = $this->renderFilterSelect([
+            'options' => [$this->category(1, 0, 'Root Category')],
+            'groupLevelClassPrefix' => '" autofocus onfocus="alert(1)',
+        ]);
+
+        $this->assertStringContainsString(
+            '<option value="1" class="&quot; autofocus onfocus=&quot;alert(1)0">',
             $output,
         );
     }
@@ -181,6 +214,25 @@ final class FilterSelectViewHelperTest extends AbstractViewHelperTestCase
         $this->assertStringContainsString('<option value="1" class="level-0">Root Category</option>', $output);
         $this->assertStringContainsString(
             '<option value="2" class="level-0" disabled="disabled">Child Category</option>',
+            $output,
+        );
+    }
+
+    /**
+     * A disabled category can be the selected one, and both attributes are written by the
+     * same option. `disabled` comes from the option array now and therefore precedes
+     * `selected`, which the base class appends last.
+     */
+    #[Test]
+    public function disabledCategoryCanBeTheSelectedOne(): void
+    {
+        $disabled = $this->category(2, 1, 'Child Category');
+        $disabled->setDisabled(true);
+
+        $output = $this->renderFilterSelect(['value' => '2', 'options' => [$disabled]]);
+
+        $this->assertStringContainsString(
+            '<option value="2" class="level-0" disabled="disabled" selected="selected">Child Category</option>',
             $output,
         );
     }


### PR DESCRIPTION
Backport of #431.

`AbstractSelectViewHelper` escaped the label of a generated option and
concatenated its value unchanged, although `renderOptionTag()` two methods
further down escaped both. A value carrying a quotation mark ended the
attribute, and everything after it became markup:

```html
<option value="" autofocus onfocus="alert(1)">A category</option>
```

**The issue's premise needed correcting.** It states that the three
`SortingSelectViewHelper` implementations use the inherited method — they do
not, all three override it with a byte-identical copy, and so does
`FilterSelectViewHelper`. The base method has no production caller at all, so
escaping it alone (the fix the issue proposes) would have changed nothing that
runs.

`renderOptionTags()` hands every option to `renderOptionTag()` now, the way
`TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelper` does it, and that method
takes the additional attributes of an option as a fourth parameter. The four
overrides are removed, `groupLevelClassPrefix` is escaped along with the rest,
and one place is left that writes an option.

**Nothing exploitable ships today.** The three `DemandCategories.html` partials
pass `optionValueField="uid"` and the sorting values are enumeration constants.
A template pointing `optionValueField` at a category title — supported since
ACE-351 — put backend entered text into the value attribute unchanged.

### Breaking

Adding the fourth parameter to the protected `renderOptionTag()` is a fatal
error for a subclass overriding it with the old signature, and an overridden
`FilterSelectViewHelper::getOptions()` has to add the `attributes` key. Both are
documented, together with the one markup change: `disabled` now precedes
`selected` on a disabled category that is also the selected one.

### Difference to #431

The plugin tests of `EXT:academic_partners`, `EXT:academic_programs` and
`EXT:academic_projects` do not exist on this branch, so the three assertions
added there are not part of this backport. What they cover on `main` is the
inherited method, which the four functional tests in `EXT:category_types` cover
here as well — the removed overrides were identical to it.

Verified on TYPO3 v12 (PHP 8.1) and v13 (PHP 8.2): `cgl -n`, `lintPhp`,
`phpstan`, `unit`, `functional` and `checkRstRenderingAll`.

ACE-352
