### PR TITLE
[TASK] ACE-353: Migrate the replace view helper

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
@@ -2,49 +2,42 @@
 
 namespace FGTCLB\AcademicProjects\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 class ReplaceViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
         $this->registerArgument('substring', 'string', 'Substring to replace. Array supported.', true);
         $this->registerArgument('replacement', 'string', 'Replacement to insert. Array supported.', false, '');
         $this->registerArgument('caseSensitive', 'boolean', 'If true, perform case-sensitive replacement', false, true);
+        $this->registerArgument('returnCount', 'boolean', 'If true, return the number of replacements instead of the replaced content.', false, false);
     }
 
     /**
-     * @param array<string, mixed> $arguments
      * @return mixed
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
-    ): mixed {
-        $content = $renderChildrenClosure();
+    public function render(): mixed
+    {
+        $content = $this->arguments['content'] ?? $this->renderChildren();
         /** @var string|array<string, mixed> $content */
         $content = is_scalar($content) || $content === null ? (string)$content : (array)$content;
 
-        $substring = $arguments['substring'];
+        $substring = $this->arguments['substring'];
         /** @var string|array<string, mixed> $substring */
         $substring = is_scalar($substring) ? (string)$substring : (array)$substring;
 
-        $replacement = $arguments['replacement'];
+        $replacement = $this->arguments['replacement'];
         /** @var string|array<string, mixed> $replacement */
         $replacement = is_scalar($replacement) ? (string)$replacement : (array)$replacement;
 
         $count = 0;
-        $caseSensitive = (bool)$arguments['caseSensitive'];
+        $caseSensitive = (bool)$this->arguments['caseSensitive'];
         $function = $caseSensitive ? 'str_replace' : 'str_ireplace';
         $replaced = $function($substring, $replacement, $content, $count);
 
-        if ($arguments['returnCount'] ?? false) {
+        if ((bool)$this->arguments['returnCount'] === true) {
             return $count;
         }
 

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Feature-ReplaceViewHelperReturnCount.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Feature-ReplaceViewHelperReturnCount.rst
@@ -1,0 +1,60 @@
+.. _feature-1785882300:
+
+===============================================================
+Feature: The replace view helper can return the number of edits
+===============================================================
+
+Description
+===========
+
+`FGTCLB\\AcademicProjects\\ViewHelpers\\Format\\ReplaceViewHelper` counted its
+replacements and returned the count instead of the replaced content when a
+`returnCount` argument was set:
+
+..  code-block:: php
+
+    if ($this->arguments['returnCount'] ?? false) {
+        return $count;
+    }
+
+That argument was never registered, and Fluid rejects an argument a view helper
+does not declare while it parses the template - so no template could reach the
+branch:
+
+..  code-block:: text
+
+    Undeclared arguments passed to ViewHelper
+    FGTCLB\AcademicProjects\ViewHelpers\Format\ReplaceViewHelper: returnCount.
+    Valid arguments are: content, substring, replacement, caseSensitive
+
+`returnCount` is a registered boolean argument now, defaulting to `false`:
+
+..  code-block:: html
+
+    <ap:format.replace
+        content="A research project of the research group"
+        substring="research"
+        replacement="teaching"
+        returnCount="true"
+    />
+
+renders `2`.
+
+Impact
+======
+
+Nothing changes for a template that does not pass the argument - the default
+returns the replaced content, as before. A template that passed `returnCount`
+used to raise the parse error above and renders the count now.
+
+The count is the one `str_replace()` and `str_ireplace()` report, so it counts
+occurrences rather than distinct substrings, and it is `0` for a substring that
+does not occur.
+
+References
+==========
+
+*   `str_replace <https://www.php.net/manual/en/function.str-replace.php>`__ -
+    the `$count` parameter this returns.
+
+.. index:: Fluid, Frontend, NotScanned

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/Replace.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/Replace.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    content="{content}"
+    substring="{substring}"
+    replacement="{replacement}"
+/></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceCaseSensitive.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceCaseSensitive.html
@@ -1,0 +1,9 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    content="{content}"
+    substring="{substring}"
+    replacement="{replacement}"
+    caseSensitive="{caseSensitive}"
+/></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceChildren.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceChildren.html
@@ -1,0 +1,7 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    substring="{substring}"
+    replacement="{replacement}"
+>{content}</ap:format.replace></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceChildrenAndContent.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceChildrenAndContent.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    content="From the argument"
+    substring="{substring}"
+    replacement="{replacement}"
+>{content}</ap:format.replace></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceReturnCount.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceReturnCount.html
@@ -1,0 +1,9 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    content="{content}"
+    substring="{substring}"
+    replacement="{replacement}"
+    returnCount="{returnCount}"
+/></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceWithoutReplacement.html
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Fixtures/Templates/ReplaceWithoutReplacement.html
@@ -1,0 +1,7 @@
+<html
+    xmlns:ap="http://typo3.org/ns/FGTCLB/AcademicProjects/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+><ap:format.replace
+    content="{content}"
+    substring="{substring}"
+/></html>

--- a/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/AbstractViewHelperTestCase.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/AbstractViewHelperTestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers;
+
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+/**
+ * Renders a fixture template from `Tests/Functional/Fixtures/Templates/` and returns the
+ * result, so a view helper is asserted the way a template uses it rather than by calling
+ * its methods.
+ *
+ * That also keeps the tests independent of how a view helper is entered - `render()` or
+ * the deprecated `renderStatic()` - which is what makes them usable as the safety net of a
+ * migration between the two.
+ *
+ * The view is built from a rendering context rather than through `ViewFactoryInterface`,
+ * which does not exist on TYPO3 v12.
+ */
+abstract class AbstractViewHelperTestCase extends AbstractAcademicProjectsTestCase
+{
+    /**
+     * @param array<string, mixed> $variables
+     */
+    protected function render(string $template, array $variables = []): string
+    {
+        $renderingContext = $this->get(RenderingContextFactory::class)->create([
+            'templateRootPaths' => [__DIR__ . '/../Fixtures/Templates/'],
+        ]);
+
+        $view = new TemplateView($renderingContext);
+        $view->assignMultiple($variables);
+
+        return trim($view->render($template));
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\Format;
+
+use FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `ViewHelpers\Format\ReplaceViewHelper` had no test when it was migrated from the
+ * deprecated `renderStatic()` to `render()`, and it is used by no template of this
+ * repository - only by project templates, which is why the deprecation stayed unnoticed.
+ *
+ * The cases below pin what the view helper promised before that migration: the content
+ * comes from the argument or from the children, `substring` and `replacement` accept a
+ * list, and `caseSensitive` decides between `str_replace()` and `str_ireplace()`. They pass
+ * against the removed `renderStatic()` implementation as well, which is what makes them the
+ * safety net of the migration rather than a description of its result.
+ *
+ * `returnCount` is the exception - it is asserted here for the first time, having been
+ * unreachable until it was registered.
+ */
+final class ReplaceViewHelperTest extends AbstractViewHelperTestCase
+{
+    #[Test]
+    public function substringOfTheContentArgumentIsReplaced(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'A research project',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+        ]);
+
+        $this->assertSame('A teaching project', $output);
+    }
+
+    /**
+     * The content argument is the first optional one, which is what the removed
+     * `CompileWithContentArgumentAndRenderStatic` trait resolved it as - so the children
+     * are rendered only while it is not given.
+     */
+    #[Test]
+    public function childrenAreUsedWithoutAContentArgument(): void
+    {
+        $output = $this->render('ReplaceChildren', [
+            'content' => 'A research project',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+        ]);
+
+        $this->assertSame('A teaching project', $output);
+    }
+
+    #[Test]
+    public function contentArgumentTakesPrecedenceOverTheChildren(): void
+    {
+        $output = $this->render('ReplaceChildrenAndContent', [
+            'content' => 'From the children',
+            'substring' => 'the',
+            'replacement' => 'THE',
+        ]);
+
+        $this->assertSame('From THE argument', $output);
+    }
+
+    /**
+     * An empty content argument counts as given. `isset()` is what the trait used to decide
+     * it with, and `??` is what the migrated `render()` uses - both step aside for `null`
+     * only.
+     */
+    #[Test]
+    public function emptyContentArgumentIsNotFilledFromTheChildren(): void
+    {
+        $output = $this->render('ReplaceChildren', [
+            'content' => '',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+        ]);
+
+        $this->assertSame('', $output);
+    }
+
+    /**
+     * TYPO3 v14 rejects the list. `content`, `substring` and `replacement` are registered
+     * as `string` while the class documents and implements array support, and Fluid 5
+     * validates the registered type with `StrictArgumentProcessor`, where Fluid 4 was
+     * lenient:
+     *
+     * `The argument "substring" was registered with type "string", but is of type "array"`
+     *
+     * Tracked as ACE-359 - the registered types have to widen before this can run there.
+     */
+    #[Group('not-core-14')]
+    #[Test]
+    public function substringAndReplacementCanBeLists(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'A research project',
+            'substring' => ['A', 'research'],
+            'replacement' => ['One', 'teaching'],
+        ]);
+
+        $this->assertSame('One teaching project', $output);
+    }
+
+    #[Test]
+    public function replacementIsCaseSensitiveByDefault(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'A Research project',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+        ]);
+
+        $this->assertSame('A Research project', $output);
+    }
+
+    #[Test]
+    public function replacementIgnoresTheCaseOnDemand(): void
+    {
+        $output = $this->render('ReplaceCaseSensitive', [
+            'content' => 'A Research project',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+            'caseSensitive' => false,
+        ]);
+
+        $this->assertSame('A teaching project', $output);
+    }
+
+    /**
+     * Without a `replacement` the substring is dropped rather than kept - the argument
+     * defaults to an empty string.
+     */
+    #[Test]
+    public function substringIsRemovedWithoutAReplacement(): void
+    {
+        $output = $this->render('ReplaceWithoutReplacement', [
+            'content' => 'A research project',
+            'substring' => 'research ',
+        ]);
+
+        $this->assertSame('A project', $output);
+    }
+
+    /**
+     * The count was computed and returned from the start, but the argument deciding it was
+     * never registered - and Fluid rejects an undeclared argument while parsing, so no
+     * template could ask for it:
+     *
+     * `Undeclared arguments passed to ViewHelper [...]: returnCount. Valid arguments are:
+     * content, substring, replacement, caseSensitive`
+     */
+    #[Test]
+    public function numberOfReplacementsIsReturnedOnDemand(): void
+    {
+        $output = $this->render('ReplaceReturnCount', [
+            'content' => 'A research project of the research group',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+            'returnCount' => true,
+        ]);
+
+        $this->assertSame('2', $output);
+    }
+
+    #[Test]
+    public function contentIsReturnedWithoutReturnCount(): void
+    {
+        $output = $this->render('ReplaceReturnCount', [
+            'content' => 'A research project',
+            'substring' => 'research',
+            'replacement' => 'teaching',
+            'returnCount' => false,
+        ]);
+
+        $this->assertSame('A teaching project', $output);
+    }
+
+    /**
+     * A substring that does not occur is counted as well - as zero, rather than as no
+     * result at all.
+     */
+    #[Test]
+    public function countIsZeroWithoutAMatch(): void
+    {
+        $output = $this->render('ReplaceReturnCount', [
+            'content' => 'A research project',
+            'substring' => 'teaching',
+            'replacement' => 'learning',
+            'returnCount' => true,
+        ]);
+
+        $this->assertSame('0', $output);
+    }
+
+    #[Test]
+    public function outputIsEscaped(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'A <b>research</b> project',
+            'substring' => 'research',
+            'replacement' => 'teaching & learning',
+        ]);
+
+        $this->assertSame('A &lt;b&gt;teaching &amp; learning&lt;/b&gt; project', $output);
+    }
+}


### PR DESCRIPTION
`Format\ReplaceViewHelper` rendered through a static `renderStatic()` and the
`CompileWithContentArgumentAndRenderStatic` trait. Fluid 4, shipped with TYPO3
v13, raises an `E_USER_DEPRECATED` from that trait on every render, and Fluid 5
will not call `renderStatic()` at all.

It was the last one on this branch — `git grep` over `packages/*/Classes/**`
finds it and nothing else. `main` migrated it with 95088475, and the class here
is byte-identical to `main`'s again.

### The migration is behaviour-identical, and that is measured

The trait resolves the content argument as the first *optional* registered
argument — here `content` — and `AbstractViewHelper::buildRenderChildrenClosure()`
gates it with `isset()`. The migrated `render()` uses
`$this->arguments['content'] ?? $this->renderChildren()`; `isset()` and `??` both
step aside for `null` only, so an empty string counts as given in either version.

Nine functional tests were written first and run against **both**
implementations:

| implementation | v12 / PHP 8.1 | v13 / PHP 8.2 |
|---|---|---|
| old, `renderStatic()` | 9/9 pass | **FAILURE** — 2 deprecations across 5 tests |
| new, `render()` | 9/9 pass | 9/9 pass |

The v12 column is what proves the migration changes no behaviour; the v13 column
is what proves the tests catch the defect rather than merely accompanying the
fix. They are the first tests this class ever had — which is also why the
deprecation stayed quiet: the view helper is used by no template in this
repository, only by project templates.

### `returnCount` is registered along the way

The argument was read but never declared:

```php
if ($this->arguments['returnCount'] ?? false) {
    return $count;
}
```

Fluid rejects an undeclared argument while parsing, so no template could reach
that branch — probed, not deduced:

```
TYPO3Fluid\Fluid\Core\ViewHelper\Exception (1773227091): Undeclared arguments
passed to ViewHelper ...ReplaceViewHelper: returnCount.
Valid arguments are: content, substring, replacement, caseSensitive
```

It is a registered boolean argument now, defaulting to `false`, with three tests
and a feature changelog entry.

Verified on TYPO3 v12 (PHP 8.1) and v13 (PHP 8.2): `cgl`, `lintPhp`, `phpstan`,
`unit`, `functional` and `checkRstRenderingAll`.

### Kept in step with `main`

`substringAndReplacementCanBeLists()` carries `#[Group('not-core-14')]`, which is
**inert on this branch** — TYPO3 v12 and v13 never exclude that group, so all
twelve tests run on both. It is there so the test file is byte-identical with
the one forward-ported to `main` in #434, where Fluid 5 rejects the array
because the three value arguments are registered as `string`. Filed as ACE-359.

The feature changelog entry sits in `Documentation/Changelog/2.4/` on both
branches, so it lands at the same path in both trees.

ACE-353
