### PR TITLE
[BUGFIX] ACE-359: Accept the replace arrays on v14

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
@@ -8,9 +8,9 @@ class ReplaceViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {
-        $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
-        $this->registerArgument('substring', 'string', 'Substring to replace. Array supported.', true);
-        $this->registerArgument('replacement', 'string', 'Replacement to insert. Array supported.', false, '');
+        $this->registerArgument('content', 'mixed', 'Content in which to perform replacement. Array supported.');
+        $this->registerArgument('substring', 'mixed', 'Substring to replace. Array supported.', true);
+        $this->registerArgument('replacement', 'mixed', 'Replacement to insert. Array supported.', false, '');
         $this->registerArgument('caseSensitive', 'boolean', 'If true, perform case-sensitive replacement', false, true);
         $this->registerArgument('returnCount', 'boolean', 'If true, return the number of replacements instead of the replaced content.', false, false);
     }

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/3.0/Important-ReplaceViewHelperArgumentTypes.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/3.0/Important-ReplaceViewHelperArgumentTypes.rst
@@ -1,0 +1,63 @@
+.. _important-1785882400:
+
+==================================================================
+Important: The replace view helper accepts its arrays again on v14
+==================================================================
+
+Description
+===========
+
+`FGTCLB\\AcademicProjects\\ViewHelpers\\Format\\ReplaceViewHelper` documents and
+implements array support for three of its arguments, but registered all three as
+`string`:
+
+..  code-block:: php
+
+    $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
+    $this->registerArgument('substring', 'string', 'Substring to replace. Array supported.', true);
+    $this->registerArgument('replacement', 'string', 'Replacement to insert. Array supported.', false, '');
+
+TYPO3 v14 rejects that. Fluid 5 validates a registered argument type with
+`StrictArgumentProcessor`, where Fluid 4 used `LenientArgumentProcessor` and let
+anything through:
+
+..  code-block:: text
+
+    InvalidArgumentValueException (1256475113): The argument "substring" was
+    registered with type "string", but is of type "array" in view helper
+    "FGTCLB\AcademicProjects\ViewHelpers\Format\ReplaceViewHelper".
+
+The three arguments are registered as `mixed` now, which is the type the view
+helper always behaved as: it branches on `is_scalar()` and casts to `(array)`
+otherwise, before handing the values to `str_replace()` or `str_ireplace()`.
+
+Impact
+======
+
+A template passing a list to `content`, `substring` or `replacement` works on
+TYPO3 v14 again. Nothing changes for a template passing strings.
+
+`caseSensitive` and `returnCount` keep their `boolean` type - they rely on the
+coercion `StrictArgumentProcessor` performs for it.
+
+A `string|array` union was tried first and **is not equivalent**. Fluid 5 matches
+its scalar coercion on the whole registered type string, so a union falls through
+uncoerced and is then validated against each member. An integer is neither a
+string nor an array, and the previous `string` type used to cast it - so the
+union would have exchanged one rejected value type for another. With `mixed` the
+view helper performs that cast itself, as it always did.
+
+Affected Installations
+======================
+
+Installations on TYPO3 v14 whose templates pass an array or a non-string scalar
+to this view helper. It is used by no template shipped here.
+
+References
+==========
+
+*   `Deprecation: #104789 - renderStatic() for Fluid ViewHelpers
+    <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Deprecation-104789-RenderStaticForFluidViewHelpers.html>`__ -
+    the migration that brought the tests uncovering this.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\Format;
 
 use FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -83,16 +82,10 @@ final class ReplaceViewHelperTest extends AbstractViewHelperTestCase
     }
 
     /**
-     * TYPO3 v14 rejects the list. `content`, `substring` and `replacement` are registered
-     * as `string` while the class documents and implements array support, and Fluid 5
-     * validates the registered type with `StrictArgumentProcessor`, where Fluid 4 was
-     * lenient:
-     *
-     * `The argument "substring" was registered with type "string", but is of type "array"`
-     *
-     * Tracked as ACE-359 - the registered types have to widen before this can run there.
+     * The three value arguments are registered as `mixed`, because TYPO3 v14 rejected the
+     * list while they were registered as `string`: Fluid 5 validates a registered type with
+     * `StrictArgumentProcessor`, where Fluid 4 is lenient and lets anything through.
      */
-    #[Group('not-core-14')]
     #[Test]
     public function substringAndReplacementCanBeLists(): void
     {
@@ -103,6 +96,24 @@ final class ReplaceViewHelperTest extends AbstractViewHelperTestCase
         ]);
 
         $this->assertSame('One teaching project', $output);
+    }
+
+    /**
+     * `mixed` rather than a `string|array` union, and this is the case that decides it.
+     * Fluid 5 matches its scalar coercion on the whole registered type string, so a union
+     * falls through uncoerced and is then validated against both members - an integer is
+     * neither, and `string` used to cast it. The view helper casts it itself.
+     */
+    #[Test]
+    public function nonStringScalarsAreAccepted(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'Project 2025 report',
+            'substring' => 2025,
+            'replacement' => 2026,
+        ]);
+
+        $this->assertSame('Project 2026 report', $output);
     }
 
     #[Test]


### PR DESCRIPTION
`Format\ReplaceViewHelper` documents and implements array support for `content`,
`substring` and `replacement`, but registered all three as `string`. TYPO3 v14
rejects that — Fluid 5 validates a registered argument type with
`StrictArgumentProcessor`, where Fluid 4 used `LenientArgumentProcessor` and let
anything through:

```
InvalidArgumentValueException (1256475113): The argument "substring" was
registered with type "string", but is of type "array" in view helper
FGTCLB\AcademicProjects\ViewHelpers\Format\ReplaceViewHelper
```

The three are registered as `mixed` now — the type the class always behaved as:
it branches on `is_scalar()` and casts to `(array)` otherwise before handing the
values to `str_replace()` / `str_ireplace()`.

### Why not the `string|array` union

It was tried first, and it is **not equivalent**. Fluid 5 matches its scalar
coercion on the *whole* registered type string, so a union falls through
uncoerced and is then validated against each member. An integer is neither a
string nor an array, and the previous `string` type used to cast it — so the
union exchanges one rejected value type for another. Measured on v14, same
template, same values:

| registered type | `substring` = `2025` (int) | `substring` = `['a']` |
|---|---|---|
| `string` (before) | `Project 2026 report` | **throws** |
| `string\|array` | **throws** | `c b c` |
| `mixed` | `Project 2026 report` | `c b c` |

`nonStringScalarsAreAccepted()` pins the integer case so the union cannot be
reintroduced silently.

`caseSensitive` and `returnCount` keep `boolean` — they rely on the coercion the
strict processor performs for that type.

### Coverage

`substringAndReplacementCanBeLists()` loses its `#[Group('not-core-14')]` and
runs on both core versions again: 13 tests on v13 and 13 on v14, where it was
12 and 11 before.

Verified on TYPO3 v13 and v14 with PHP 8.2: `cgl`, `lintPhp`, `phpstan`, `unit`,
`functional` and `checkRstRenderingAll`.

ACE-359
