### PR TITLE
[BUGFIX] ACE-359: Declare the replace argument types

### DIFF
--- a/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
+++ b/packages/fgtclb/academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php
@@ -8,9 +8,9 @@ class ReplaceViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {
-        $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
-        $this->registerArgument('substring', 'string', 'Substring to replace. Array supported.', true);
-        $this->registerArgument('replacement', 'string', 'Replacement to insert. Array supported.', false, '');
+        $this->registerArgument('content', 'mixed', 'Content in which to perform replacement. Array supported.');
+        $this->registerArgument('substring', 'mixed', 'Substring to replace. Array supported.', true);
+        $this->registerArgument('replacement', 'mixed', 'Replacement to insert. Array supported.', false, '');
         $this->registerArgument('caseSensitive', 'boolean', 'If true, perform case-sensitive replacement', false, true);
         $this->registerArgument('returnCount', 'boolean', 'If true, return the number of replacements instead of the replaced content.', false, false);
     }

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-ReplaceViewHelperArgumentTypes.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-ReplaceViewHelperArgumentTypes.rst
@@ -1,0 +1,47 @@
+.. _important-1785882400:
+
+==============================================================
+Important: The replace view helper declares its argument types
+==============================================================
+
+Description
+===========
+
+`FGTCLB\\AcademicProjects\\ViewHelpers\\Format\\ReplaceViewHelper` documents and
+implements array support for three of its arguments, but registered all three as
+`string`:
+
+..  code-block:: php
+
+    $this->registerArgument('content', 'string', 'Content in which to perform replacement. Array supported.');
+    $this->registerArgument('substring', 'string', 'Substring to replace. Array supported.', true);
+    $this->registerArgument('replacement', 'string', 'Replacement to insert. Array supported.', false, '');
+
+They are registered as `mixed` now, which is the type the view helper always
+behaved as: it branches on `is_scalar()` and casts to `(array)` otherwise,
+before handing the values to `str_replace()` or `str_ireplace()`.
+
+Impact
+======
+
+**Nothing changes on TYPO3 v12 and v13.** Both let any value through - Fluid 2
+does not validate a registered argument type, and Fluid 4 validates it with
+`LenientArgumentProcessor`, which accepts everything that is not an object of a
+wrong class. The arrays this view helper documents worked on both from the
+start.
+
+The declaration is corrected because TYPO3 v14 does reject it. Fluid 5 validates
+with `StrictArgumentProcessor`, and an array handed to a `string` argument raises
+`InvalidArgumentValueException` there. The `3.x` branch carries the same change
+for that reason, and this branch follows it so the class and its tests stay
+identical in both.
+
+`caseSensitive` and `returnCount` keep their `boolean` type.
+
+References
+==========
+
+*   `str_replace <https://www.php.net/manual/en/function.str-replace.php>`__ -
+    the function the values are handed to, which accepts arrays.
+
+.. index:: Fluid, Frontend, PHP-API, NotScanned

--- a/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/ViewHelpers/Format/ReplaceViewHelperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\Format;
 
 use FGTCLB\AcademicProjects\Tests\Functional\ViewHelpers\AbstractViewHelperTestCase;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -83,16 +82,10 @@ final class ReplaceViewHelperTest extends AbstractViewHelperTestCase
     }
 
     /**
-     * TYPO3 v14 rejects the list. `content`, `substring` and `replacement` are registered
-     * as `string` while the class documents and implements array support, and Fluid 5
-     * validates the registered type with `StrictArgumentProcessor`, where Fluid 4 was
-     * lenient:
-     *
-     * `The argument "substring" was registered with type "string", but is of type "array"`
-     *
-     * Tracked as ACE-359 - the registered types have to widen before this can run there.
+     * The three value arguments are registered as `mixed`, because TYPO3 v14 rejected the
+     * list while they were registered as `string`: Fluid 5 validates a registered type with
+     * `StrictArgumentProcessor`, where Fluid 4 is lenient and lets anything through.
      */
-    #[Group('not-core-14')]
     #[Test]
     public function substringAndReplacementCanBeLists(): void
     {
@@ -103,6 +96,24 @@ final class ReplaceViewHelperTest extends AbstractViewHelperTestCase
         ]);
 
         $this->assertSame('One teaching project', $output);
+    }
+
+    /**
+     * `mixed` rather than a `string|array` union, and this is the case that decides it.
+     * Fluid 5 matches its scalar coercion on the whole registered type string, so a union
+     * falls through uncoerced and is then validated against both members - an integer is
+     * neither, and `string` used to cast it. The view helper casts it itself.
+     */
+    #[Test]
+    public function nonStringScalarsAreAccepted(): void
+    {
+        $output = $this->render('Replace', [
+            'content' => 'Project 2025 report',
+            'substring' => 2025,
+            'replacement' => 2026,
+        ]);
+
+        $this->assertSame('Project 2026 report', $output);
     }
 
     #[Test]


### PR DESCRIPTION
Sync of #435, so the class and its tests stay identical on both branches.

`Format\ReplaceViewHelper` documents and implements array support for `content`,
`substring` and `replacement`, but registered all three as `string`. They are
registered as `mixed` now — the type the class always behaved as: it branches on
`is_scalar()` and casts to `(array)` otherwise before handing the values to
`str_replace()` / `str_ireplace()`.

### Nothing changes on this branch

TYPO3 v12 and v13 let any value through. Fluid 2 does not validate a registered
argument type, and Fluid 4 validates it with `LenientArgumentProcessor`, which
accepts everything that is not an object of a wrong class — so the documented
arrays worked on both from the start. Verified: all 13 view-helper tests pass on
v12 and on v13, before and after.

The declaration is corrected because **TYPO3 v14 does reject it**, where Fluid 5
validates with `StrictArgumentProcessor`. That is #435 on `main`, and this
follows it for two reasons:

* the test file was byte-identical across the branches after ACE-353, and #435
  removes the `#[Group('not-core-14')]` that only existed to keep it that way —
  without this it would diverge again;
* the class file was byte-identical too, which is what keeps future cherry-picks
  of it clean.

`caseSensitive` and `returnCount` keep their `boolean` type.

The changelog entry is worded for this branch — it states that v12 and v13 are
unaffected, rather than describing a v14 failure that cannot occur here.

Verified on TYPO3 v12 (PHP 8.1) and v13 (PHP 8.2): `cgl -n`, `lintPhp`,
`phpstan`, `unit`, `functional` and `checkRstRenderingAll`.

ACE-359
