### PR TITLE
[TASK] ACE-354: Drop the foreign service definition

### DIFF
--- a/packages/fgtclb/academic-programs/Tests/Functional/Domain/Repository/ProgramRepositoryTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Domain/Repository/ProgramRepositoryTest.php
@@ -785,18 +785,4 @@ ENDOFCONFIG,
         $this->assertArrays($expectedRecords, $resultRecords, '_localizedUid');
     }
 
-    /**
-     * @todo debug helper, must be removed before merge
-     * @return array<int, array<string, mixed>>
-     */
-    public function debugGetPageRecords(): array
-    {
-        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('pages');
-        $queryBuilder->getRestrictions()->removeAll();
-        return $queryBuilder
-            ->select('uid', 'pid', 'doktype', 'title', 'subtitle', 'sys_language_uid')
-            ->from('pages')
-            ->executeQuery()
-            ->fetchAllAssociative();
-    }
 }

--- a/packages/fgtclb/typo3-category-types/Configuration/Services.yaml
+++ b/packages/fgtclb/typo3-category-types/Configuration/Services.yaml
@@ -8,9 +8,6 @@ services:
     resource: '../Classes/*'
     exclude: '../Classes/Domain/Model/*.php'
 
-  FGTCLB\AcademicPrograms\Factory\DemandFactory:
-    public: true
-
   FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository:
     public: true
 


### PR DESCRIPTION
Backport of #437.

`EXT:category_types` `Configuration/Services.yaml` declared a service of another
extension:

```yaml
  FGTCLB\AcademicPrograms\Factory\DemandFactory:
    public: true
```

`EXT:academic_programs` is not a dependency of `EXT:category_types` and may not
be installed at all. Symfony tolerated it, so nothing was broken — the
declaration was simply in the wrong place, and the only cross-extension one in
the repository.

### It is deleted, not moved

The issue states the line "cannot simply be deleted — it has to move". That is
not the case: `Factory\DemandFactory` already carries
`#[Autoconfigure(public: true)]` on the class, **on both branches**, so the entry
only repeated what the attribute says. Three probes against the full
`academic_programs` suite:

| probe | change | result |
|---|---|---|
| 1 | yaml entry removed, attribute kept | **39 tests green** |
| 2 | yaml entry *and* attribute removed | `ArgumentCountError: Too few arguments to ...DemandFactory::__construct(), 0 passed in GeneralUtility.php:2906` |
| 3 | both removed, the caller switched to `$this->get()` | 39 tests green |

Probe 2 is what shows the attribute — not the entry — carries the
`GeneralUtility::makeInstance(DemandFactory::class)` in
`ProgramRepositoryTest:780`: `makeInstance()` consults the container only for a
public service and otherwise falls back to `new`.

Moving the entry would have duplicated the attribute, which the repository
guidance explicitly steers away from ("prefer PHP attribute usage … over
`Services.yaml` entries").

**Nothing changes for consumers.** The class stays public, and every production
caller — `ProgramController`, `DetailsController` — uses constructor injection.
No changelog entry: there is no behaviour to describe.

### Also removed

`ProgramRepositoryTest::debugGetPageRecords()`, marked
`@todo debug helper, must be removed before merge`, querying `pages` with all
restrictions removed and called by nothing.

Verified on TYPO3 v12 (PHP 8.1) and v13 (PHP 8.2): `cgl -n`, `lintPhp`,
`phpstan`, `unit` and `functional`.

ACE-354
