### PR TITLE
[TASK] ACE-363: Fix three category type leftovers

### DIFF
--- a/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Collection/CategoryCollection.php
@@ -21,11 +21,6 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
     protected array $collection = [];
 
     /**
-     * @var array<string, Category[]>
-     */
-    protected array $typeSortedCollection = [];
-
-    /**
      * @var array<string>
      */
     protected array $typeIdentifiers = [];
@@ -56,29 +51,35 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
     }
 
     /**
+     * Built on every call. Keeping the result in a property made the empty entries
+     * of {@see $typeIdentifiers} stale as soon as the identifiers were replaced: the
+     * seeding below ran only while that property was still empty, so an identifier
+     * added later never got its entry and {@see getCategoriesByTypeName()} returned
+     * `null` against its `array` return type. The loop over the categories re-ran on
+     * every call regardless, so nothing was actually cached.
+     *
      * @return array<string, Category[]>
      */
     public function getAllCategoriesByType(): array
     {
-        if (empty($this->typeIdentifiers)) {
+        if ($this->typeIdentifiers === []) {
             return [];
         }
 
-        if (empty($this->typeSortedCollection)) {
-            foreach ($this->typeIdentifiers as $typeIdentifier) {
-                $this->typeSortedCollection[$typeIdentifier] = [];
-            }
+        $typeSortedCollection = [];
+        foreach ($this->typeIdentifiers as $typeIdentifier) {
+            $typeSortedCollection[$typeIdentifier] = [];
         }
 
         foreach ($this->collection as $category) {
             $categoryIdentifier = $category->getUid();
             $typeIdentifier = (string)$category->getType();
             if (in_array($typeIdentifier, $this->typeIdentifiers, true)) {
-                $this->typeSortedCollection[$typeIdentifier][$categoryIdentifier] = $category;
+                $typeSortedCollection[$typeIdentifier][$categoryIdentifier] = $category;
             }
         }
 
-        return $this->typeSortedCollection;
+        return $typeSortedCollection;
     }
 
     /**
@@ -122,12 +123,17 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
     }
 
     /**
+     * Answers on the uid, which is what {@see attach()} guards on. Comparing the
+     * objects instead made the two disagree for the case that matters: the same
+     * record read a second time after an edit is a different object with equal uid,
+     * which `attach()` rejects as already present while this reported it as absent.
+     *
      * @param Category $category
      * @return bool
      */
     public function exist(Category $category): bool
     {
-        return in_array($category, $this->collection, false);
+        return array_key_exists($category->getUid(), $this->collection);
     }
 
     /**
@@ -186,10 +192,11 @@ class CategoryCollection implements \Countable, \Iterator, \ArrayAccess, \String
      * ArrayAccess method offsetExists
      *
      * Answers from the registered type identifiers, which is what {@see offsetGet()}
-     * resolves against as well. Reading the lazily built `$typeSortedCollection` here
-     * instead made a type exist only after something had computed the grouping - and
-     * Fluid resolves `{collection.someType}` through this method, so a template that
-     * did not touch `allCategoriesByType` first rendered nothing.
+     * resolves against as well. Reading the grouped view of
+     * {@see getAllCategoriesByType()} here instead made a type exist only after
+     * something had computed the grouping - and Fluid resolves `{collection.someType}`
+     * through this method, so a template that did not touch `allCategoriesByType` first
+     * rendered nothing.
      *
      * @return bool
      */

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryType.php
@@ -39,6 +39,11 @@ class CategoryType implements \JsonSerializable, \Stringable
     }
 
     /**
+     * Used by {@see CategoryTypeLoader} on the uncached path, together with
+     * {@see CategoryType::toArray()}. {@see CategoryType::__set_state()} serves the
+     * cached path, where the loader requires a var_exported file - it did not replace
+     * these two.
+     *
      * @param array{
      *     identifier?: string,
      *     extensionKey?: string,
@@ -48,9 +53,6 @@ class CategoryType implements \JsonSerializable, \Stringable
      *     priority?: int,
      * }|array<string, mixed> $array
      * @return CategoryType
-     * @todo Original used within {@see CategoryTypeLoader}, but replaced with {@see CategoryType::__set_state()}. Check
-     *       if other usages are usefill or remove this method along with {@see CategoryType::toArray()}. Other usage
-     *       may be to encode/decode from json and methods are use-full in that context.
      */
     public static function fromArray(array $array): CategoryType
     {
@@ -65,6 +67,11 @@ class CategoryType implements \JsonSerializable, \Stringable
     }
 
     /**
+     * Used by {@see CategoryTypeLoader} on the uncached path, together with
+     * {@see CategoryType::fromArray()}. {@see CategoryType::__set_state()} serves the
+     * cached path, where the loader requires a var_exported file - it did not replace
+     * these two.
+     *
      * @return array{
      *     identifier: string,
      *     extensionKey: string,
@@ -73,9 +80,6 @@ class CategoryType implements \JsonSerializable, \Stringable
      *     icon: string,
      *     priority: int,
      * }
-     * @todo Original used within {@see CategoryTypeLoader}, but replaced with {@see CategoryType::__set_state()}. Check
-     *       if other usages are usefill or remove this method along with {@see CategoryType::fromArray()}. Other usage
-     *       may be to encode/decode from json and methods are use-full in that context.
      */
     public function toArray(): array
     {

--- a/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryTypeGroup.php
+++ b/packages/fgtclb/typo3-category-types/Classes/Domain/Model/CategoryTypeGroup.php
@@ -66,7 +66,7 @@ class CategoryTypeGroup
      * }|array<string, mixed> $array
      * @return self
      */
-    public function fromArray(array $array): self
+    public static function fromArray(array $array): self
     {
         return new self(
             identifier: (string)($array['identifier'] ?? ''),

--- a/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryCollectionAndTypeGroupConsistency.rst
+++ b/packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryCollectionAndTypeGroupConsistency.rst
@@ -1,0 +1,69 @@
+.. _important-1785968400:
+
+============================================================
+Important: Collection and type group answer consistently now
+============================================================
+
+Description
+===========
+
+Three leftovers of the original category type handling are corrected. All three
+were unreachable through the callers this extension ships, so nothing an
+installation does changes; they matter to code that uses these classes directly.
+
+`CategoryCollection::getAllCategoriesByType()` builds the grouped view on every
+call. It used to keep the result in a `$typeSortedCollection` property whose
+empty entries were seeded only while that property was still empty. Identifiers
+passed to `setTypeIdentifiers()` *after* a first grouping therefore never got an
+entry, and `getCategoriesByTypeName()` then read a missing key and returned
+:php:`null` against its :php:`array` return type:
+
+..  code-block:: text
+
+    Undefined array key "country"
+    TypeError: …::getCategoriesByTypeName(): Return value must be of type array,
+    null returned
+
+The property is gone. Nothing was cached by it — the loop over the categories
+re-ran on every call regardless.
+
+`CategoryCollection::exist()` answers on the uid now:
+
+..  code-block:: php
+
+    // before
+    return in_array($category, $this->collection, false);
+    // after
+    return array_key_exists($category->getUid(), $this->collection);
+
+`attach()` has always guarded on the uid, so the two disagreed on the case that
+matters: the same record read a second time after an edit is a different object
+with an equal uid, which `attach()` rejects as already present while `exist()`
+reported it as absent.
+
+`CategoryTypeGroup::fromArray()` is :php:`static`, like its counterpart
+`CategoryType::fromArray()` has always been.
+
+Impact
+======
+
+`CategoryCollection::exist()` now returns :php:`true` for a category whose uid is
+in the collection, even when the object differs in any other property. It
+returned :php:`false` in that case before, and :php:`true` only for an object all
+of whose properties were equal.
+
+Calling `CategoryTypeGroup::fromArray()` on an instance keeps working — PHP
+permits an arrow call to a static method — so no call site has to change. Only a
+subclass overriding the method non-statically is a fatal error and has to follow.
+
+The removed `$typeSortedCollection` property was :php:`protected`; a subclass
+reading it has to build the grouping itself.
+
+Affected Installations
+======================
+
+None through the plugins and view helpers this extension ships. Only projects
+calling `CategoryCollection::exist()`, overriding `CategoryTypeGroup::fromArray()`
+or extending `CategoryCollection` are affected.
+
+.. index:: PHP, ext:category_types

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Collection/CategoryCollectionTest.php
@@ -102,6 +102,26 @@ final class CategoryCollectionTest extends UnitTestCase
         $this->assertFalse($subject->exist($this->category(2)));
     }
 
+    /**
+     * `exist()` and `attach()` have to answer the same question. They did not while
+     * `exist()` compared the objects: the same record read a second time after an edit
+     * is a different object with an equal uid, which `attach()` rejects as already
+     * present while `exist()` reported it as absent.
+     */
+    #[Test]
+    public function existAnswersOnTheUidJustAsAttachDoes(): void
+    {
+        $subject = new CategoryCollection();
+        $subject->attach($this->category(1, 'Original'));
+
+        $sameUidDifferentTitle = $this->category(1, 'Renamed');
+
+        $this->assertTrue($subject->exist($sameUidDifferentTitle));
+
+        $this->expectException(CategoryExistException::class);
+        $subject->attach($sameUidDifferentTitle);
+    }
+
     #[Test]
     public function collectionIteratesOverItsCategoriesKeyedByUid(): void
     {
@@ -150,6 +170,52 @@ final class CategoryCollectionTest extends UnitTestCase
         $subject->setTypeIdentifiers(['research_field', 'country']);
 
         $this->assertSame(['research_field' => [], 'country' => []], $subject->getAllCategoriesByType());
+    }
+
+    /**
+     * The grouped view is built on every call. It used to be kept in a property whose
+     * empty entries were seeded only while that property was still empty, so identifiers
+     * set after a first grouping never got one: `getCategoriesByTypeName()` then read a
+     * missing key and returned `null` against its `array` return type.
+     */
+    #[Test]
+    public function typeIdentifiersSetAfterAFirstGroupingAreHonoured(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field']);
+        $subject->attach($field);
+        $subject->getAllCategoriesByType();
+
+        $subject->setTypeIdentifiers(['research_field', 'country']);
+
+        $this->assertSame(
+            ['research_field' => [1 => $field], 'country' => []],
+            $subject->getAllCategoriesByType(),
+        );
+        $this->assertSame([], $subject->getCategoriesByTypeName('country'));
+    }
+
+    /**
+     * The counterpart: an identifier dropped after a first grouping disappears from the
+     * grouped view instead of lingering as a stale entry.
+     */
+    #[Test]
+    public function typeIdentifiersRemovedAfterAFirstGroupingAreDropped(): void
+    {
+        $field = $this->typedCategory(1, 'research_field');
+        $country = $this->typedCategory(2, 'country');
+
+        $subject = new CategoryCollection();
+        $subject->setTypeIdentifiers(['research_field', 'country']);
+        $subject->attach($field);
+        $subject->attach($country);
+        $subject->getAllCategoriesByType();
+
+        $subject->setTypeIdentifiers(['research_field']);
+
+        $this->assertSame(['research_field' => [1 => $field]], $subject->getAllCategoriesByType());
     }
 
     #[Test]

--- a/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeGroupTest.php
+++ b/packages/fgtclb/typo3-category-types/Tests/Unit/Domain/Model/CategoryTypeGroupTest.php
@@ -55,12 +55,29 @@ final class CategoryTypeGroupTest extends UnitTestCase
         );
     }
 
+    #[Test]
+    public function fromArrayBuildsANewGroup(): void
+    {
+        $built = CategoryTypeGroup::fromArray(['identifier' => 'built', 'group' => 'other', 'priority' => 9]);
+
+        $this->assertSame(['identifier' => 'built', 'group' => 'other', 'priority' => 9], $built->toArray());
+    }
+
+    #[Test]
+    public function fromArrayDefaultsMissingKeysAndCastsScalars(): void
+    {
+        $built = CategoryTypeGroup::fromArray(['priority' => '7']);
+
+        $this->assertSame(['identifier' => '', 'group' => '', 'priority' => 7], $built->toArray());
+    }
+
     /**
-     * Note that `fromArray()` is an instance method here, unlike the static counterpart
-     * on `CategoryType` — it still builds a new object rather than filling this one.
+     * The method was an instance method until it was aligned with the static counterpart
+     * on `CategoryType`. PHP allows an arrow call to a static method, so the previous
+     * calling convention keeps working and the receiver is still left untouched.
      */
     #[Test]
-    public function fromArrayBuildsANewGroupAndLeavesTheReceiverUntouched(): void
+    public function fromArrayCanStillBeCalledOnAnInstance(): void
     {
         $subject = new CategoryTypeGroup('original', 'academic', 1);
 
@@ -68,13 +85,5 @@ final class CategoryTypeGroupTest extends UnitTestCase
 
         $this->assertSame(['identifier' => 'built', 'group' => 'other', 'priority' => 9], $built->toArray());
         $this->assertSame(['identifier' => 'original', 'group' => 'academic', 'priority' => 1], $subject->toArray());
-    }
-
-    #[Test]
-    public function fromArrayDefaultsMissingKeysAndCastsScalars(): void
-    {
-        $built = (new CategoryTypeGroup())->fromArray(['priority' => '7']);
-
-        $this->assertSame(['identifier' => '', 'group' => '', 'priority' => 7], $built->toArray());
     }
 }


### PR DESCRIPTION
Resolves ACE-363 on `main`.

Three leftovers of the original category type handling in `EXT:category_types`. All three entered with the same commit — `ccef425d [!!!][FEATURE] Introduce new category type handlinging` — and none is reachable through a caller this repository ships, which is why they were filed as a tidy-up rather than fixed silently during the ACE-344/345 coverage round.

## 1. The grouped view was stale after `setTypeIdentifiers()`

`getAllCategoriesByType()` kept its result in a `$typeSortedCollection` property whose empty entries were seeded only while that property was still empty. Identifiers passed to `setTypeIdentifiers()` *after* a first grouping never got an entry, so `getCategoriesByTypeName()` read a missing key and returned `null` against its `array` return type:

```
Undefined array key "country"
TypeError: …::getCategoriesByTypeName(): Return value must be of type array, null returned
```

**The property was not a cache.** The loop over the categories re-ran on every call and re-assigned every entry; the `empty()` guard only skipped re-seeding the *empty* buckets. So its sole effect was this defect. It is removed and the view is built per call.

Related, and the reason this is worth fixing despite being unreachable today: `offsetGet()` delegates to `getCategoriesByTypeName()`, so Fluid's `{collection.someType}` reaches the same path, while `offsetExists()` answers from `$typeIdentifiers`. A type could therefore report as existing and then fail on read.

## 2. `exist()` and `attach()` disagreed

```php
- return in_array($category, $this->collection, false);
+ return array_key_exists($category->getUid(), $this->collection);
```

`attach()` has always guarded on `array_key_exists($category->getUid(), …)`. Measured before the change, with the same uid and a different title: **`exist()` returned `false` while `attach()` rejected the record as already present.** That is the case that matters — the same record read a second time after an edit.

## 3. `CategoryTypeGroup::fromArray()` is static

Aligned with `CategoryType::fromArray()`, which has always been static. **No call site has to change**: PHP permits an arrow call to a static method, verified on 8.5.9, so `(new CategoryTypeGroup())->fromArray(…)` keeps working. Only a subclass overriding it non-statically is a fatal error.

## 4. A stale `@todo`, corrected rather than acted on

The `@todo` on `CategoryType::fromArray()` and `::toArray()` claims both were "replaced with `__set_state()`". They were not: `CategoryTypeLoader` calls `toArray()` at the `useExisting` override merge and `fromArray()` at the end of the same loop; `__set_state()` serves the *cached* path, where the loader `require`s a `var_export`ed file. Following that note as written would have deleted two methods that are in use.

## Tests

Five unit tests, and **all five fail against the implementation as it stood** — two errors for the static call, three failures for the collection — with nothing else moving in the suite.

## Noted, not acted on

`CategoryTypeGroup` has **no production caller at all**, on either branch, since it was introduced; only its own unit test references it. Removing a public class is a `3.0` decision rather than a tidy-up, so it is left in place.

## Verified locally

| | v13 / PHP 8.2 | v14 / PHP 8.2 |
|---|---|---|
| `cgl`, `lintPhp`, `phpstan`, `unit` | green | green |
| `functional` sqlite | green | green |
| `checkRstRenderingAll` | green | |
