### PR TITLE
[TASK] ACE-377: Document the ddev branch switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@
 /rector.php
 *.diff
 
+# Composer writes its cache relative to the directory given with "-d", so
+# "bin/set-version" and any manual "composer -d <package>" leaves one behind.
+/packages-dev/*/.cache/
+/packages/*/*/.cache/
+
 # Development instances. "config/" and "composer.lock" are tracked now: the
 # instance ships its own system configuration and a locked dependency set, and
 # is seeded from "sqlite-databases/". Only generated trees are ignored, plus the

--- a/AGENT.md
+++ b/AGENT.md
@@ -25,6 +25,7 @@ together.
 - `.Build/` — generated composer install target (`vendor-dir`, `bin-dir`, `Web/`). Not committed.
 - `core-13/`, `core-14/` — ready-to-start development instances, one per core version. SQLite only, no database container; seeded on first start from `sqlite-databases/core-*.sqlite` by `config/system/additional.php`. Their `config/` and `composer.lock` are **tracked**; `public/`, `var/`, `vendor/` and `config/system/additional/*.php` are not. They are not part of any test run — `runTests.sh` never touches them.
 - `sqlite-databases/` — committed database templates for those instances. `core-*/patches` symlinks into the shared `patches/` pool consumed by `vaimo/composer-patches`.
+- Switching branches in one checkout collides in DDEV: the instance folders have the same path on every branch but the project names differ per version line (`core13-academics-v3` on `main`, `core13-academics-v2` on `2`), and DDEV refuses a second name for a known path. `ddev stop --unlist <other-name>` clears it; it removes only the registration. The instance database in the git-ignored `core-*/var/` survives the switch, so reset it with `ddev composer sqlite:apply`.
 
 The extension directory name does not always equal the extension key: e.g.
 `packages/fgtclb/academic-contact4pages/` ships extension key

--- a/README.md
+++ b/README.md
@@ -140,6 +140,32 @@ so commit it when the demo content genuinely changed, not on every run.
 cd core-13 && ddev stop -ROU && git clean -xdf -e '.idea'
 ```
 
+### Switching branches in the same checkout
+
+The instance folders sit at the repository root on every branch, but each branch
+names its DDEV projects after the version line it carries — `core13-academics-v3`
+here on `main`, `core13-academics-v2` on `2`. Two different project names for the
+same directory is a state DDEV refuses:
+
+```
+Failed to start app core13-academics-v2: this project root '…/core-13'
+already contains a project named 'core13-academics-v3'.
+```
+
+That is not a broken checkout. DDEV remembers the project by path, and the name
+changed underneath it. Unregister the one belonging to the other branch and start
+again:
+
+```shell
+ddev stop --unlist core13-academics-v2
+ddev start
+```
+
+`--unlist` only removes the registration; it touches neither the containers nor
+any data. The instance database lives in the git-ignored `core-*/var/`, so it
+survives the switch and keeps whatever the *other* branch left there — run
+`ddev composer sqlite:apply` to reset it to this branch's committed template.
+
 ### Without DDEV
 
 The instances do not depend on DDEV. `config/system/additional.php` recomputes the


### PR DESCRIPTION
Follow-up to #444, two small things it did not cover.

## The DDEV branch-switch collision

The instance folders sit at the repository root on every branch, but each branch names its DDEV projects after the version line it carries — `core13-academics-v3` on `main`, `core13-academics-v2` on `2`. Two names for the same directory is a state DDEV refuses, so a plain branch switch inside one checkout makes `ddev start` fail with:

```
Failed to start app core13-academics-v2: this project root '…/core-13'
already contains a project named 'core13-academics-v3'.
```

That reads like a broken checkout and is not one — DDEV remembers the project by path and the name changed underneath it. `README.md` now carries the error, the `ddev stop --unlist` fix, and the part that is easy to miss: the instance database lives in the git-ignored `core-*/var/`, so it **survives the switch and still holds whatever the other branch left there** until `ddev composer sqlite:apply` resets it. `AGENT.md` gets the same as a Layout bullet.

Hit for real while backporting to branch `2` (#446).

## Composer caches in package folders

Composer writes its cache relative to the directory passed with `-d`, and `bin/set-version` runs `composer -d <package>` against every package — so each run leaves a `.cache/` behind in `packages/*/*` and `packages-dev/*`. Now ignored.

Documentation and ignore rules only; no code, no test, no dependency change.