### PR TITLE
[TASK] ACE-377: Require the released plugin version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
         "fgtclb/academics-monorepo-shared": "~3.0.0@dev",
-        "sbuerk/extended-path-repository": "^1.0.1"
+        "sbuerk/extended-path-repository": "^1.1.0"
     },
     "config": {
         "allow-plugins": {

--- a/core-13/composer.json
+++ b/core-13/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2 || ^8.3 || ^8.4",
         "bk2k/bootstrap-package": "^15.0@dev",
         "fgtclb/academics-monorepo-shared": "~3.0.0@dev",
-        "sbuerk/extended-path-repository": "^1.0.1",
+        "sbuerk/extended-path-repository": "^1.1.0",
         "typo3/cms-adminpanel": "~13.4.0@dev",
         "typo3/cms-dashboard": "~13.4.0@dev",
         "typo3/cms-form": "~13.4.0@dev",

--- a/core-14/composer.json
+++ b/core-14/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2 || ^8.3 || ^8.4",
         "bk2k/bootstrap-package": "^16.0@dev",
         "fgtclb/academics-monorepo-shared": "~3.0.0@dev",
-        "sbuerk/extended-path-repository": "^1.0.1",
+        "sbuerk/extended-path-repository": "^1.1.0",
         "typo3/cms-adminpanel": "~14.3.6@dev",
         "typo3/cms-dashboard": "~14.3.6@dev",
         "typo3/cms-form": "~14.3.6@dev",

--- a/packages-dev/monorepo-shared/composer.json
+++ b/packages-dev/monorepo-shared/composer.json
@@ -23,7 +23,7 @@
         "fgtclb/academic-study-plan": "~3.0.0@dev",
         "fgtclb/category-types": "~3.0.0@dev",
         "fgtclb/environment-state-manager": "^2.0.1@dev",
-        "sbuerk/extended-path-repository": "^1.0.1",
+        "sbuerk/extended-path-repository": "^1.1.0",
         "typo3/cms-backend": "~13.4.0@dev || ~14.3.6@dev",
         "typo3/cms-belog": "~13.4.0@dev || ~14.3.6@dev",
         "typo3/cms-beuser": "~13.4.0@dev || ~14.3.6@dev",


### PR DESCRIPTION
Aligns `main` with branch `2`, which pins `sbuerk/extended-path-repository: ^1.1.0`.

The split was never intentional. The constraint was relaxed to `^1.0.1` mid-review of #444 because packagist served stale metadata to the CI runners and `^1.1.0` could not be resolved there; it was left that way once the metadata caught up.

## It also repairs a stale lock

Not purely cosmetic, as I first assumed. The two instance `composer.lock` files were generated against `^1.1.0` and never regenerated after the constraint was relaxed, so on `main` as merged:

```
$ composer install -d core-13 --dry-run
Warning: The lock file is not up to date with the latest changes in composer.json.
```

Raising the constraint restores the match. Verified: with `^1.1.0` both `core-13` and `core-14` install from their committed lock with no warning.

## No locked version changes

`^1.0.1` already permitted 1.1.0, so the plugin resolved to **1.1.0** either way — before and after. The root install still yields 14 path packages at `3.0.0.x-dev` on `typo3/cms-core v13.4.34`.

Both branches now state the same requirement, which is also the honest one: 1.0.1 requires PHP 8.2 and cannot serve branch `2`.

## Verification

`lintPhp`, `cgl -n`, `phpstan`, `unit` green on v13/8.2; `composer install` from the committed lock clean in `core-13` and `core-14`. Constraint-only change — no source, no test, no locked version moved.