### PR TITLE
[TASK] ACE-381: Fix the language overlay test names

### DIFF
--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedContractsPluginTest.php
@@ -114,7 +114,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
             ),
         ]);
 
@@ -213,18 +213,18 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
     /**
      * Same core defect as the strict-mode test above, reached over a different route.
      *
-     * Note: "content_fallback" is not a fallback type core knows -
-     * {@see \TYPO3\CMS\Core\Context\LanguageAspectFactory::createFromSiteLanguage()} maps anything
-     * unknown to `OVERLAYS_OFF`, which {@see \FGTCLB\AcademicPersons\Domain\Repository\ContractRepository::findByUids()}
-     * lifts to `OVERLAYS_ON_WITH_FLOATING` (ACE-341). This case therefore exercises the same overlay
-     * path as the test above rather than a real "fallback" mode, and moves with it.
+     * "free" maps to `OVERLAYS_OFF`, which
+     * {@see \FGTCLB\AcademicPersons\Domain\Repository\ContractRepository::findByUids()} lifts to
+     * `OVERLAYS_ON_WITH_FLOATING` (ACE-341) - so this exercises the same overlay decision as the
+     * strict test above, reached from a different site configuration. Genuine fallback mode is
+     * covered separately below and behaves differently: it keeps the untranslated contracts.
      *
      * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694
      * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935
      * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
-    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode(): void
+    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_freeMode(): void
     {
         if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
             $this->markTestSkipped(
@@ -245,7 +245,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
             ),
         ]);
 
@@ -264,7 +264,7 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
      * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
-    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode_beforeCoreFix(): void
+    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_freeMode_beforeCoreFix(): void
     {
         if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '>=')) {
             $this->markTestSkipped(
@@ -282,7 +282,45 @@ final class AcademicPersonsSelectedContractsPluginTest extends AbstractAcademicP
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
+            ),
+        ]);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
+        $this->assertStringContainsString('<h2>Selected Contracts</h2>', $content);
+        $this->assertStringContainsString('#0(3): [EN] Manager', $content);
+        $this->assertStringContainsString('#1(1): [DE] Arbeiter', $content);
+        $this->assertStringNotContainsString('[DE] Manager', $content);
+        $this->assertStringNotContainsString('[EN] Worker', $content);
+    }
+
+    /**
+     * Genuine fallback mode, which no test covered before: "fallback" maps to `OVERLAYS_MIXED`, and
+     * unlike `OVERLAYS_OFF` the repositories leave that untouched - {@see \FGTCLB\AcademicPersons\Domain\Repository\ContractRepository::findByUids()}
+     * only lifts `OVERLAYS_OFF`. The untranslated selected contract is therefore *kept* and rendered in
+     * the default language.
+     *
+     * This holds before and after the core fix for forge #88886: that change made the overlay honour
+     * the requested type, and the requested type here is already `OVERLAYS_MIXED`. So unlike the
+     * free-mode tests above, this one needs no core version guard.
+     *
+     * @see https://forge.typo3.org/issues/88886
+     */
+    #[Test]
+    public function fullyLocalized_SelectedContracts_notAllContractsLocalized_fallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedContractsPlugin/fullyLocalized_allContractsSelected_notAllContractsLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
             ),
         ]);
 

--- a/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php
@@ -114,7 +114,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
             ),
         ]);
 
@@ -213,18 +213,18 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
     /**
      * Same core defect as the strict-mode test above, reached over a different route.
      *
-     * Note: "content_fallback" is not a fallback type core knows -
-     * {@see \TYPO3\CMS\Core\Context\LanguageAspectFactory::createFromSiteLanguage()} maps anything
-     * unknown to `OVERLAYS_OFF`, which {@see \FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository::matchSelectedUidsAcrossLanguages()}
-     * lifts to `OVERLAYS_ON_WITH_FLOATING` (ACE-341). This case therefore exercises the same overlay
-     * path as the test above rather than a real "fallback" mode, and moves with it.
+     * "free" maps to `OVERLAYS_OFF`, which
+     * {@see \FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository::matchSelectedUidsAcrossLanguages()} lifts to
+     * `OVERLAYS_ON_WITH_FLOATING` (ACE-341) - so this exercises the same overlay decision as the
+     * strict test above, reached from a different site configuration. Genuine fallback mode is
+     * covered separately below and behaves differently: it keeps the untranslated profiles.
      *
      * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/66694
      * @see https://review.typo3.org/c/Packages/TYPO3.CMS/+/94935
      * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
-    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode(): void
+    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_freeMode(): void
     {
         if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
             $this->markTestSkipped(
@@ -245,7 +245,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
             ),
         ]);
 
@@ -264,7 +264,7 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
      * @see https://forge.typo3.org/issues/88886
      */
     #[Test]
-    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode_beforeCoreFix(): void
+    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_freeMode_beforeCoreFix(): void
     {
         if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '>=')) {
             $this->markTestSkipped(
@@ -282,7 +282,45 @@ final class AcademicPersonsSelectedProfilesPluginTest extends AbstractAcademicPe
                 identifier: 'DE',
                 base: '/de/',
                 fallbackIdentifiers: ['EN'],
-                fallbackType: 'content_fallback',
+                fallbackType: 'free',
+            ),
+        ]);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/de/home');
+        $this->assertStringContainsString('<h2>Selected Profiles</h2>', $content);
+        $this->assertStringContainsString('#0(3): [EN] Horst Huber', $content);
+        $this->assertStringContainsString('#1(1): [DE] Max Müllermann', $content);
+        $this->assertStringNotContainsString('[DE] Horst Huber', $content);
+        $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * Genuine fallback mode, which no test covered before: "fallback" maps to `OVERLAYS_MIXED`, and
+     * unlike `OVERLAYS_OFF` the repositories leave that untouched - {@see \FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository::matchSelectedUidsAcrossLanguages()}
+     * only lifts `OVERLAYS_OFF`. The untranslated selected profile is therefore *kept* and rendered in
+     * the default language.
+     *
+     * This holds before and after the core fix for forge #88886: that change made the overlay honour
+     * the requested type, and the requested type here is already `OVERLAYS_MIXED`. So unlike the
+     * free-mode tests above, this one needs no core version guard.
+     *
+     * @see https://forge.typo3.org/issues/88886
+     */
+    #[Test]
+    public function fullyLocalized_selectedProfiles_notAllProfilesLocalized_fallbackMode(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicPersonsSelectedProfilesPlugin/fullyLocalized_allProfilesSelected_notAllProfilesLocalized.csv');
+        $this->setUpFrontendRootPageForTestCase();
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(
+                identifier: 'EN',
+                base: '/',
+            ),
+            $this->buildLanguageConfiguration(
+                identifier: 'DE',
+                base: '/de/',
+                fallbackIdentifiers: ['EN'],
+                fallbackType: 'fallback',
             ),
         ]);
 


### PR DESCRIPTION
Resolves ACE-381.

Four functional tests were named `…_fallbackMode` but configured `fallbackType: 'content_fallback'` — **not a fallback type TYPO3 knows.**

## What it actually did

`LanguageAspectFactory::createFromSiteLanguage()` lands anything unknown in its `default:` branch, which means `OVERLAYS_OFF` **and**, less obviously, throws the configured `fallbackIdentifiers: ['EN']` away and replaces it with `[0]`. The repositories then lift `OVERLAYS_OFF` → `OVERLAYS_ON_WITH_FLOATING` (ACE-341).

So these tests ran **strict overlay semantics under a name promising the opposite** — which is exactly why they failed next to the strict ones when v14.3.6 started honouring the requested overlay type (ACE-378).

## The rename is behaviour-preserving, and that is proven

They now configure `free` — the real type producing the same `OVERLAYS_OFF` — and are named `_freeMode`. Both repositories build the aspect with three arguments, so `LanguageAspect::$fallbackChain` defaults to `[]` and the site's chain never reaches the query. That chain was the *only* thing separating the two values.

Measured on 14.3.6, both classes:

| configuration | result |
|---|---|
| `content_fallback` (before) | 7 tests, 26 assertions, 2 skipped |
| `free` (after) | 7 tests, 26 assertions, 2 skipped — **identical** |

## Why not just switch them to `fallback`

That was the obvious-looking option and it is wrong: it would delete the only coverage of `OVERLAYS_OFF` **with an untranslated selected record**. That combination is reachable in production through `fallbackType: free`, and the sole other `free` test — `AcademicPersonsListPluginTest::fullyLocalizedListDisplaysLocalizedSelectedProfilesForRequestedLanguageWithFallbackTypeFree` — uses a *fullyLocalized* fixture whose overlay never has to decide anything.

## Genuine fallback mode is now covered

Two new tests, one per class. `fallback` maps to `OVERLAYS_MIXED`, which the repositories leave alone, so the untranslated selected record is **kept** and rendered in the default language:

```
#0(3): [EN] Manager
#1(1): [DE] Arbeiter
```

That holds before *and* after the fix for forge #88886 — the requested type is already the one the fix honours — so these two need **no core version guard**. This closes a real gap: fallback mode with selected uids and an untranslated record was untested in both classes.

## Verification

| gate | v13.4.34 | v14.3.6 |
|---|---|---|
| the two classes | 8 tests, 32 assertions, 2 skipped | 8 tests, 32 assertions, 2 skipped |
| `functional` (full) | ✅ | ✅ |
| `unit` · `phpstan` | ✅ | ✅ |
| `cgl -n` · `lintPhp` | ✅ | — |

Up from 7 tests / 26 assertions per class. Test-only change; no production code touched. Backport to branch `2` follows.
