### PR TITLE
[TASK] ACE-382: Cache only composer's dist archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-
@@ -123,7 +131,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-
@@ -171,7 +187,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-
@@ -203,7 +227,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-
@@ -239,7 +271,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-


### PR DESCRIPTION
Resolves ACE-382.

The workflow cached the whole composer cache directory. That directory holds two things with **opposite risk**:

| | size (measured) | nature |
|---|---|---|
| `files/` | **153 MB** | dist archives, `files/<vendor>/<package>/<sha>.zip` — **content addressed**, so a restored entry can never be wrong |
| `repo/` | 18 MB | packagist metadata — **stale the moment anything is published** |
| `vcs/` | 172 KB | VCS clones |

The cache key hashes only *our* manifests, so when a dependency publishes a version and ours don't change, the `restore-keys` fallback still matches an older cache — and hands composer a package list from whenever that cache was written.

## The change

`path: ".cache/composer"` → `path: ".cache/composer/files"`, in all five cache steps, with a comment recording why.

This keeps the entire practical benefit — not re-downloading ~150 packages per job — and makes a stale-metadata restore *structurally impossible*, because composer refetches the small provider files every run. The broad restore keys stop mattering: an over-broad key is harmless for immutable content and only dangerous for mutable metadata.

## Verified

Deleted `repo/` from a warm cache (simulating a `files/`-only restore) and ran `composerUpdate`:

- install **succeeds**
- `files/` untouched at 153 MB — nothing re-downloaded
- only the 18 MB of metadata fetched again

Every job carrying the cache step runs `composerUpdate`, so the path always exists when the cache is saved; `lint` and `documentation` have no cache step.

> [!NOTE]
> This was **not** the cause of the stale metadata seen while releasing `sbuerk/extended-path-repository` 1.1.0 during ACE-377 — that was upstream, and deleting these caches demonstrably did not help. This is the weakness found while investigating it.

Backport to branch `2` follows.