### PR TITLE
[TASK] ACE-382: Cache only composer's dist archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php-version }}-v${{ matrix.typo3 }}-
@@ -127,7 +135,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-
@@ -178,7 +194,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-
@@ -213,7 +237,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-
@@ -252,7 +284,15 @@ jobs:
       - name: "Cache composer downloads"
         uses: actions/cache@v6
         with:
-          path: ".cache/composer"
+          # Only "files/", never the whole composer cache. That subdirectory holds
+          # dist archives at "files/<vendor>/<package>/<sha>.zip" - content
+          # addressed, so a restored entry can never be wrong, and it is where the
+          # entire benefit sits (~150 packages per job). Its sibling "repo/" holds
+          # packagist metadata, which is stale the moment anything is published;
+          # caching that lets the "restore-keys" fallback below resolve against a
+          # package list from whenever the cache was written. Composer refetches
+          # the small provider files every run instead, which costs seconds.
+          path: ".cache/composer/files"
           key: "composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-${{ hashFiles('composer.json', 'packages-dev/*/composer.json', 'packages/fgtclb/*/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.combo.php }}-v${{ matrix.combo.typo3 }}-


### PR DESCRIPTION
Backport of ACE-382 to branch `2` (companion of #451 on `main`). Identical change — this branch carries the same five cache steps.

The workflow cached the whole composer cache directory, which holds two things with **opposite risk**:

| | size (measured) | nature |
|---|---|---|
| `files/` | **153 MB** | dist archives, `files/<vendor>/<package>/<sha>.zip` — **content addressed**, a restored entry can never be wrong |
| `repo/` | 18 MB | packagist metadata — **stale the moment anything is published** |

The cache key hashes only *our* manifests, so when a dependency publishes a version and ours don't change, the `restore-keys` fallback still matches an older cache and hands composer a package list from whenever that cache was written.

`path: ".cache/composer"` → `path: ".cache/composer/files"` keeps the entire practical benefit (not re-downloading ~150 packages per job) and makes a stale-metadata restore structurally impossible.

## Verified

Deleting `repo/` from a warm cache and running `composerUpdate`: install succeeds, `files/` untouched at 153 MB, only the 18 MB of metadata refetched. Every job with the cache step runs `composerUpdate`, so the path always exists when the cache is saved; `lint` and `documentation` have none.

Workflow-only change.