### PR TITLE
[FEATURE] ACE-236: Select the displayed address records

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Classes/Backend/FormEngine/AddressRecordItems.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Backend/FormEngine/AddressRecordItems.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Backend\FormEngine;
+
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use FGTCLB\AcademicContacts4pages\Exception\InvalidAddressRecordTableException;
+use FGTCLB\AcademicPersons\Types\EmailAddressTypes;
+use FGTCLB\AcademicPersons\Types\PhoneNumberTypes;
+use FGTCLB\AcademicPersons\Types\PhysicalAddressTypes;
+use FGTCLB\AcademicPersons\Types\TypesInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * `itemsProcFunc` handlers for the dedicated address record selects of a contact record.
+ *
+ * They offer the email addresses, phone numbers and physical addresses of the contract the
+ * contact points at, on top of the two static items the TCA already defines: display all
+ * records of that kind (the default) and display none of them.
+ *
+ * Hidden records are offered as well, with a prefix marking them as such: whether they
+ * reach the frontend is decided by the "Show hidden records" option of the contacts list
+ * plugin, not here. Deleted records are left out. Only default language records are
+ * offered: the selection is shared by all translations of a contact, and the frontend
+ * resolves the language overlay itself.
+ *
+ * Dispatches {@see ModifyTcaSelectFieldItemsEvent} to allow projects or other extensions
+ * to modify the available select items.
+ *
+ * @phpstan-type ItemsProcFuncParameters array{
+ *      items: array<int, array{
+ *       label?: string|null,
+ *       value?: mixed,
+ *       icon?: string|null,
+ *       group?: string|null,
+ *      }>,
+ *      config: array<string, mixed>,
+ *      TSconfig: array<string, mixed>,
+ *      table: string,
+ *      row: array<string, mixed>,
+ *      field: string,
+ *      effectivePid: int,
+ *      site: \TYPO3\CMS\Core\Site\Entity\Site|null,
+ *      flexParentDatabaseRow?: array<string, mixed>|null,
+ *      inlineParentUid?: int,
+ *      inlineParentTableName?: string,
+ *      inlineParentFieldName?: string,
+ *      inlineParentConfig?: array<string, mixed>,
+ *      inlineTopMostParentUid?: int,
+ *      inlineTopMostParentTableName?: string,
+ *      inlineTopMostParentFieldName?: string,
+ *  }
+ */
+final class AddressRecordItems
+{
+    private const TABLE_EMAIL_ADDRESS = 'tx_academicpersons_domain_model_email';
+    private const TABLE_PHONE_NUMBER = 'tx_academicpersons_domain_model_phone_number';
+    private const TABLE_PHYSICAL_ADDRESS = 'tx_academicpersons_domain_model_address';
+
+    /**
+     * @var array<string, class-string<TypesInterface>>
+     */
+    private const TYPES_CLASS_NAMES = [
+        self::TABLE_EMAIL_ADDRESS => EmailAddressTypes::class,
+        self::TABLE_PHONE_NUMBER => PhoneNumberTypes::class,
+        self::TABLE_PHYSICAL_ADDRESS => PhysicalAddressTypes::class,
+    ];
+
+    /**
+     * @param ItemsProcFuncParameters $parameters
+     */
+    public function emailAddressItems(array &$parameters): void
+    {
+        $this->addAddressRecordItems($parameters, self::TABLE_EMAIL_ADDRESS);
+    }
+
+    /**
+     * @param ItemsProcFuncParameters $parameters
+     */
+    public function phoneNumberItems(array &$parameters): void
+    {
+        $this->addAddressRecordItems($parameters, self::TABLE_PHONE_NUMBER);
+    }
+
+    /**
+     * @param ItemsProcFuncParameters $parameters
+     */
+    public function physicalAddressItems(array &$parameters): void
+    {
+        $this->addAddressRecordItems($parameters, self::TABLE_PHYSICAL_ADDRESS);
+    }
+
+    /**
+     * @param ItemsProcFuncParameters $parameters
+     */
+    private function addAddressRecordItems(array &$parameters, string $tableName): void
+    {
+        $contractUid = $this->resolveContractUid($parameters);
+        if ($contractUid > 0) {
+            foreach ($this->getAddressRecords($tableName, $contractUid) as $addressRecord) {
+                $parameters['items'][] = [
+                    'label' => $this->buildLabel($tableName, $addressRecord),
+                    'value' => (int)$addressRecord['uid'],
+                ];
+            }
+        }
+
+        /** @var ModifyTcaSelectFieldItemsEvent $event */
+        $event = GeneralUtility::makeInstance(EventDispatcherInterface::class)->dispatch(new ModifyTcaSelectFieldItemsEvent(parameters: $parameters));
+        $parameters = $event->getParameters();
+    }
+
+    /**
+     * @param ItemsProcFuncParameters $parameters
+     */
+    private function resolveContractUid(array $parameters): int
+    {
+        $contract = $parameters['row']['contract'] ?? 0;
+        if (is_array($contract)) {
+            $contract = $contract[0] ?? 0;
+        }
+        $contractUid = (int)$contract;
+        if ($contractUid > 0) {
+            return $contractUid;
+        }
+
+        if (($parameters['inlineParentTableName'] ?? '') === 'tx_academicpersons_domain_model_contract') {
+            return (int)($parameters['inlineParentUid'] ?? 0);
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getAddressRecords(string $tableName, int $contractUid): array
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($tableName);
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        return $queryBuilder
+            ->select('*')
+            ->from($tableName)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'contract',
+                    $queryBuilder->createNamedParameter($contractUid, Connection::PARAM_INT)
+                ),
+                $queryBuilder->expr()->in(
+                    'sys_language_uid',
+                    $queryBuilder->quoteArrayBasedValueListToIntegerList([-1, 0])
+                ),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->addOrderBy('uid', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    /**
+     * @param array<string, mixed> $addressRecord
+     */
+    private function buildLabel(string $tableName, array $addressRecord): string
+    {
+        $label = match ($tableName) {
+            self::TABLE_EMAIL_ADDRESS => trim((string)($addressRecord['email'] ?? '')),
+            self::TABLE_PHONE_NUMBER => trim((string)($addressRecord['phone_number'] ?? '')),
+            self::TABLE_PHYSICAL_ADDRESS => $this->buildPhysicalAddressLabel($addressRecord),
+            default => throw new InvalidAddressRecordTableException(
+                sprintf('Table "%s" does not hold address records of a contract.', $tableName),
+                1786579200
+            ),
+        };
+
+        $typeLabel = $this->getTypeLabel($tableName, trim((string)($addressRecord['type'] ?? '')));
+        if ($typeLabel !== '' && $label !== '') {
+            $label = $typeLabel . ': ' . $label;
+        } elseif ($label === '' && $typeLabel === '') {
+            $label = '#' . (int)($addressRecord['uid'] ?? 0);
+        } else {
+            $label = $label ?: $typeLabel;
+        }
+
+        return $this->markHiddenLabel($label, (bool)($addressRecord['hidden'] ?? false));
+    }
+
+    private function markHiddenLabel(string $label, bool $isHidden): string
+    {
+        if (!$isHidden) {
+            return $label;
+        }
+
+        $labelPattern = $this->getLanguageService()->sL('LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.addressRecord.hidden');
+        // A translation that lost the placeholder must not swallow the address itself and
+        // leave the editor with a select of identical entries. Precautionary measure for overrides.
+        if (!str_contains($labelPattern, '%s')) {
+            return $label;
+        }
+
+        return sprintf($labelPattern, $label);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+
+    /**
+     * @param array<string, mixed> $addressRecord
+     */
+    private function buildPhysicalAddressLabel(array $addressRecord): string
+    {
+        $labelParts = [
+            trim(sprintf(
+                '%s %s',
+                (string)($addressRecord['street'] ?? ''),
+                (string)($addressRecord['street_number'] ?? '')
+            )),
+            trim((string)($addressRecord['additional'] ?? '')),
+            trim(sprintf(
+                '%s %s',
+                (string)($addressRecord['zip'] ?? ''),
+                (string)($addressRecord['city'] ?? '')
+            )),
+            trim((string)($addressRecord['country'] ?? '')),
+        ];
+
+        return implode(', ', array_filter($labelParts, static fn(string $labelPart): bool => $labelPart !== ''));
+    }
+
+    private function getTypeLabel(string $tableName, string $type): string
+    {
+        if ($type === '') {
+            return '';
+        }
+
+        $typesClassName = self::TYPES_CLASS_NAMES[$tableName] ?? throw new InvalidAddressRecordTableException(
+            sprintf('Table "%s" does not hold address records of a contract.', $tableName),
+            1786579203
+        );
+        /** @var TypesInterface $types */
+        $types = GeneralUtility::makeInstance($typesClassName);
+
+        return (string)($types->getAll()[$type] ?? $type);
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Controller/ContactsController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicContacts4pages\Controller;
 
 use FGTCLB\AcademicContacts4pages\Domain\Repository\ContactRepository;
+use FGTCLB\AcademicContacts4pages\Service\AddressRecordProvider;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -28,6 +30,13 @@ final class ContactsController extends ActionController
             $showHiddenRecords
         );
 
+        // Hidden address records are missing from the contract relation no matter what the
+        // query above ignores, see AddressRecordProvider. Handing the provider over is what
+        // lets a contact display them, so it only happens while the option is on.
+        $addressRecordProvider = $showHiddenRecords
+            ? GeneralUtility::makeInstance(AddressRecordProvider::class)
+            : null;
+
         // Contacts without a role are collected here rather than filtered in the
         // template: the grouped branch can only render a contact that belongs to one of
         // the roles, so without this list they were dropped from the output entirely as
@@ -37,6 +46,7 @@ final class ContactsController extends ActionController
         $roles = [];
         $contactsWithoutRole = [];
         foreach ($contacts as $contact) {
+            $contact->setAddressRecordProvider($addressRecordProvider);
             $role = $contact->getRole();
             if ($role !== null) {
                 $roles[$role->getUid()] = $role;

--- a/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Contact.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Domain/Model/Contact.php
@@ -4,14 +4,32 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicContacts4pages\Domain\Model;
 
+use FGTCLB\AcademicContacts4pages\Service\AddressRecordProvider;
 use FGTCLB\AcademicPersons\Domain\Model\Contract;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class Contact extends AbstractEntity
 {
+    public const DISPLAY_ALL = 0;
+    public const DISPLAY_NONE = -1;
+
     protected int $page = 0;
     protected ?Contract $contract = null;
     protected ?Role $role = null;
+    protected int $emailAddress = self::DISPLAY_ALL;
+    protected int $phoneNumber = self::DISPLAY_ALL;
+    protected int $physicalAddress = self::DISPLAY_ALL;
+
+    /**
+     * Contract copy carrying the address records to display, built on first access. Not
+     * persisted: the Extbase data map is built from the TCA columns of the table, so a
+     * property without a column is never mapped.
+     */
+    private ?Contract $displayContract = null;
+
+    private ?AddressRecordProvider $addressRecordProvider = null;
 
     public function __construct()
     {
@@ -30,12 +48,53 @@ class Contact extends AbstractEntity
 
     public function getContract(): ?Contract
     {
+        if ($this->contract === null) {
+            return $this->contract;
+        }
+
+        if (!$this->hasAddressRecordSelection() && $this->addressRecordProvider === null) {
+            return $this->contract;
+        }
+        return $this->displayContract ??= $this->createDisplayContract($this->contract);
+    }
+
+    public function setAddressRecordProvider(?AddressRecordProvider $addressRecordProvider): void
+    {
+        $this->addressRecordProvider = $addressRecordProvider;
+        // A contract narrowed before this point was narrowed without the provider.
+        $this->displayContract = null;
+    }
+
+    public function getUnfilteredContract(): ?Contract
+    {
         return $this->contract;
     }
 
     public function getRole(): ?Role
     {
         return $this->role;
+    }
+
+    public function getEmailAddress(): int
+    {
+        return $this->emailAddress;
+    }
+
+    public function getPhoneNumber(): int
+    {
+        return $this->phoneNumber;
+    }
+
+    public function getPhysicalAddress(): int
+    {
+        return $this->physicalAddress;
+    }
+
+    public function hasAddressRecordSelection(): bool
+    {
+        return $this->emailAddress !== self::DISPLAY_ALL
+            || $this->phoneNumber !== self::DISPLAY_ALL
+            || $this->physicalAddress !== self::DISPLAY_ALL;
     }
 
     public function getLabel(): string
@@ -48,5 +107,70 @@ class Contact extends AbstractEntity
             $labelParts[] = $this->contract->getLabel();
         }
         return implode(' - ', $labelParts);
+    }
+
+    private function createDisplayContract(Contract $contract): Contract
+    {
+        $contractUid = $contract->getUid() ?? 0;
+        $provider = $this->addressRecordProvider;
+
+        $displayContract = clone $contract;
+        $displayContract->setEmailAddresses(
+            $this->selectAddressRecords(
+                $contract->getEmailAddresses(),
+                $this->emailAddress,
+                static fn(): ?ObjectStorage => $provider?->findEmailAddresses($contractUid)
+            )
+        );
+        $displayContract->setPhoneNumbers(
+            $this->selectAddressRecords(
+                $contract->getPhoneNumbers(),
+                $this->phoneNumber,
+                static fn(): ?ObjectStorage => $provider?->findPhoneNumbers($contractUid)
+            )
+        );
+        $displayContract->setPhysicalAddresses(
+            $this->selectAddressRecords(
+                $contract->getPhysicalAddresses(),
+                $this->physicalAddress,
+                static fn(): ?ObjectStorage => $provider?->findPhysicalAddresses($contractUid)
+            )
+        );
+        return $displayContract;
+    }
+
+    /**
+     * @template T of DomainObjectInterface
+     * @param ObjectStorage<T> $addressRecords the records the frontend loaded, hidden ones missing
+     * @param \Closure(): ?ObjectStorage<T> $resolveAllAddressRecords
+     * @return ObjectStorage<T>
+     */
+    private function selectAddressRecords(
+        ObjectStorage $addressRecords,
+        int $selectedUid,
+        \Closure $resolveAllAddressRecords
+    ): ObjectStorage {
+        /** @var ObjectStorage<T> $selectedAddressRecords */
+        $selectedAddressRecords = new ObjectStorage();
+        if ($selectedUid === self::DISPLAY_NONE) {
+            return $selectedAddressRecords;
+        }
+
+        $addressRecords = $resolveAllAddressRecords() ?? $addressRecords;
+        if ($selectedUid === self::DISPLAY_ALL) {
+            return $addressRecords;
+        }
+
+        foreach ($addressRecords as $addressRecord) {
+            if ($addressRecord->getUid() === $selectedUid) {
+                $selectedAddressRecords->attach($addressRecord);
+                return $selectedAddressRecords;
+            }
+        }
+
+        // The selection cannot be resolved: the contract was switched after it was made,
+        // the record was deleted, or it is hidden and hidden ones are not asked for.
+        // Deliberately no fallback to all records.
+        return $selectedAddressRecords;
     }
 }

--- a/packages/fgtclb/academic-contact4pages/Classes/Exception/InvalidAddressRecordTableException.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Exception/InvalidAddressRecordTableException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Exception;
+
+final class InvalidAddressRecordTableException extends \LogicException {}

--- a/packages/fgtclb/academic-contact4pages/Classes/Service/AddressRecordProvider.php
+++ b/packages/fgtclb/academic-contact4pages/Classes/Service/AddressRecordProvider.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Service;
+
+use FGTCLB\AcademicPersons\Domain\Model\Address;
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use FGTCLB\AcademicPersons\Domain\Repository\AddressRepository;
+use FGTCLB\AcademicPersons\Domain\Repository\EmailRepository;
+use FGTCLB\AcademicPersons\Domain\Repository\PhoneNumberRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Loads the address records of a contract, hidden ones included.
+ *
+ * The relations of a contract never carry hidden records: Extbase builds the query for a
+ * relation from fresh query settings, so the "ignore disabled" of the contact query does
+ * not reach them. The contacts list plugin hands this provider to its contacts when its
+ * "Show hidden records" option is set, and only then a hidden address record is rendered
+ * at all - both as part of the complete list and as a dedicated selection.
+ *
+ * Records are always looked up through the contract, never by uid alone: a selection can
+ * outlive the contract it was made for, and such a record must not surface below a
+ * contract it does not belong to.
+ */
+final class AddressRecordProvider
+{
+    /**
+     * @return ObjectStorage<Email>
+     */
+    public function findEmailAddresses(int $contractUid): ObjectStorage
+    {
+        if ($contractUid <= 0) {
+            /** @var ObjectStorage<Email> $emailAddresses */
+            $emailAddresses = new ObjectStorage();
+            return $emailAddresses;
+        }
+
+        return $this->toObjectStorage(
+            GeneralUtility::makeInstance(EmailRepository::class)->findByContractIncludingHidden($contractUid)
+        );
+    }
+
+    /**
+     * @return ObjectStorage<PhoneNumber>
+     */
+    public function findPhoneNumbers(int $contractUid): ObjectStorage
+    {
+        if ($contractUid <= 0) {
+            /** @var ObjectStorage<PhoneNumber> $phoneNumbers */
+            $phoneNumbers = new ObjectStorage();
+            return $phoneNumbers;
+        }
+
+        return $this->toObjectStorage(
+            GeneralUtility::makeInstance(PhoneNumberRepository::class)->findByContractIncludingHidden($contractUid)
+        );
+    }
+
+    /**
+     * @return ObjectStorage<Address>
+     */
+    public function findPhysicalAddresses(int $contractUid): ObjectStorage
+    {
+        if ($contractUid <= 0) {
+            /** @var ObjectStorage<Address> $physicalAddresses */
+            $physicalAddresses = new ObjectStorage();
+            return $physicalAddresses;
+        }
+
+        return $this->toObjectStorage(
+            GeneralUtility::makeInstance(AddressRepository::class)->findByContractIncludingHidden($contractUid)
+        );
+    }
+
+    /**
+     * @template T of DomainObjectInterface
+     * @param QueryResultInterface<int, T> $addressRecords
+     * @return ObjectStorage<T>
+     */
+    private function toObjectStorage(QueryResultInterface $addressRecords): ObjectStorage
+    {
+        /** @var ObjectStorage<T> $addressRecordStorage */
+        $addressRecordStorage = new ObjectStorage();
+        foreach ($addressRecords as $addressRecord) {
+            $addressRecordStorage->attach($addressRecord);
+        }
+
+        return $addressRecordStorage;
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
+++ b/packages/fgtclb/academic-contact4pages/Configuration/TCA/tx_academiccontacts4pages_domain_model_contact.php
@@ -1,11 +1,24 @@
 <?php
 
+use FGTCLB\AcademicContacts4pages\Backend\FormEngine\AddressRecordItems;
 use FGTCLB\AcademicContacts4pages\Backend\FormEngine\ContactLabels;
+use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
 use FGTCLB\AcademicPersons\Backend\FormEngine\ContractItems;
 
 if (!defined('TYPO3')) {
     die('Not authorized');
 }
+
+$defaultAddressRecordItems = [
+    [
+        'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.addressRecord.all',
+        'value' => Contact::DISPLAY_ALL,
+    ],
+    [
+        'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.addressRecord.none',
+        'value' => Contact::DISPLAY_NONE,
+    ],
+];
 
 return [
     'ctrl' => [
@@ -33,12 +46,25 @@ return [
             'ignorePageTypeRestriction' => true,
         ],
     ],
+    'palettes' => [
+        'addressRecords' => [
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.palette.addressRecords',
+            'description' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.palette.addressRecords.description',
+            'showitem' => implode(',', [
+                'email_address',
+                'phone_number',
+                '--linebreak--',
+                'physical_address',
+            ]),
+        ],
+    ],
     'types' => [
         0 => [
             'showitem' => implode(',', [
                 'page',
                 'contract',
                 'role',
+                '--palette--;;addressRecords',
                 'hidden',
                 '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language',
                 'sys_language_uid',
@@ -72,6 +98,7 @@ return [
             'exclude' => true,
             'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.contract',
+            'onChange' => 'reload',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -105,6 +132,45 @@ return [
                 'foreign_table_where' => 'AND {#tx_academiccontacts4pages_domain_model_role}.{#sys_language_uid} = 0 ORDER BY tx_academiccontacts4pages_domain_model_role.name ASC',
                 'minitems' => 1,
                 'default' => 0,
+            ],
+        ],
+        'email_address' => [
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'displayCond' => 'FIELD:contract:>:0',
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.email_address',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => $defaultAddressRecordItems,
+                'itemsProcFunc' => AddressRecordItems::class . '->emailAddressItems',
+                'default' => Contact::DISPLAY_ALL,
+            ],
+        ],
+        'phone_number' => [
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'displayCond' => 'FIELD:contract:>:0',
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.phone_number',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => $defaultAddressRecordItems,
+                'itemsProcFunc' => AddressRecordItems::class . '->phoneNumberItems',
+                'default' => Contact::DISPLAY_ALL,
+            ],
+        ],
+        'physical_address' => [
+            'exclude' => true,
+            'l10n_mode' => 'exclude',
+            'displayCond' => 'FIELD:contract:>:0',
+            'label' => 'LLL:EXT:academic_contacts4pages/Resources/Private/Language/locallang_db.xlf:tx_academiccontacts4pages_domain_model_contact.physical_address',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => $defaultAddressRecordItems,
+                'itemsProcFunc' => AddressRecordItems::class . '->physicalAddressItems',
+                'default' => Contact::DISPLAY_ALL,
             ],
         ],
     ],

--- a/packages/fgtclb/academic-contact4pages/Documentation/Changelog/2.4/Feature-DedicatedAddressRecordSelection.rst
+++ b/packages/fgtclb/academic-contact4pages/Documentation/Changelog/2.4/Feature-DedicatedAddressRecordSelection.rst
@@ -1,0 +1,79 @@
+..  _feature-dedicated-address-record-selection:
+
+===============================================
+Feature: Dedicated selection of address records
+===============================================
+
+Description
+===========
+
+A contact record (:sql:`tx_academiccontacts4pages_domain_model_contact`) now
+carries three additional selects, grouped in the palette
+:guilabel:`Displayed address records`:
+
+*   :guilabel:`E-mail address` (:sql:`email_address`)
+*   :guilabel:`Phone number` (:sql:`phone_number`)
+*   :guilabel:`Physical address` (:sql:`physical_address`)
+
+They are offered as soon as a contract is selected and list the email
+addresses, phone numbers and physical addresses of exactly that contract. The
+contract field reloads the form on change, so the selects always match the
+contract that is currently selected.
+
+Each select offers two options besides the address records themselves:
+
+:guilabel:`Display all`
+    The default. All address records of that kind are rendered, the behaviour
+    of every contact record created so far.
+
+:guilabel:`Do not display`
+    The address record kind is left out of the frontend output for this
+    contact entirely.
+
+The narrowing is applied by the contact record itself, so it takes effect in
+the :guilabel:`Contacts for this page` plugin, in the page based rendering
+through :php:`ContactsProcessor` and in project templates built on either of
+them - they all reach the address records through
+:php:`Contact::getContract()`. :php:`Contact::getUnfilteredContract()` returns
+the contract with all of its address records.
+
+Only default language records are offered: the selection is shared by all
+translations of a contact, and the frontend resolves the language overlay of
+the address records itself. Deleted records are not offered. Hidden ones are,
+marked with a :guilabel:`[Hidden]` prefix - whether they reach the frontend is
+decided by the plugin, see below.
+
+Impact
+======
+
+Editors can restrict a page contact to a single email address, phone number
+and physical address of the contract, or suppress a kind completely - for
+example to publish the office phone number of a person on one page and the
+private one on another, from the same contract.
+
+Hidden address records reach the frontend only through the
+:guilabel:`Contacts for this page` plugin and only while its
+:guilabel:`Show hidden records` option (:typoscript:`settings.showHiddenRecords`)
+is enabled, the same option that decides about hidden contacts. That covers both
+ways of displaying them: with the option enabled a hidden record is part of
+:guilabel:`Display all` and can be selected as the single one to display.
+Everywhere else - the page based rendering through :php:`ContactsProcessor`
+included - hidden records are left out, and a selection pointing at one behaves
+like :guilabel:`Do not display`.
+
+A selection that cannot be resolved at all behaves the same way and renders
+nothing. This happens when the contract of a contact is switched after the
+selection was made, or when the selected address record is deleted afterwards.
+There is deliberately no fallback to :guilabel:`Display all`: publishing the
+private phone number of a person because a record was removed is worse than
+publishing nothing.
+
+Affected Installations
+======================
+
+All installations using the `EXT:academic_contacts4pages` extension starting
+with version 2.4. The three new columns default to :guilabel:`Display all`, so
+existing contact records keep their current frontend output and no migration
+is required. A database compare has to be applied for the new columns.
+
+.. index:: Backend, Frontend, Database, ext:academic_contacts4pages

--- a/packages/fgtclb/academic-contact4pages/Documentation/Introduction/Index.rst
+++ b/packages/fgtclb/academic-contact4pages/Documentation/Introduction/Index.rst
@@ -3,4 +3,52 @@
 What does it do?
 ================
 
-...
+This TYPO3 extension assigns people to pages and displays them in the frontend,
+for example the dean's office of a faculty page, the participants of a research
+page or the contact persons of a study programme.
+
+A person is not maintained here: the extension builds on `EXT:academic_persons`
+and points at one of the contracts of a profile. Everything that is displayed -
+the name, the position, the location, the email addresses, the phone numbers and
+the physical addresses - comes from that contract, so a change to the person has
+to be made once and reaches every page the person is a contact of.
+
+..  _introduction-contact-records:
+
+Contact records
+---------------
+
+A contact is a record of its own, maintained either in the :guilabel:`Contacts`
+tab of a page or in the :guilabel:`Linked pages` tab of a contract. Both edit
+the same record, so a person can be added from the page it belongs on as well
+as from the person itself.
+
+A contact record consists of:
+
+:guilabel:`Page`
+    The page the person is a contact of. Filled automatically when the record
+    is created from a page.
+
+:guilabel:`Contract`
+    The contract of the person to display. Filled automatically when the record
+    is created from a contract.
+
+:guilabel:`Role`
+    An optional role, for example :guilabel:`Dean's office` or
+    :guilabel:`Student advisors`. Contacts sharing a role are rendered as a
+    group below the name of that role, contacts without a role are rendered
+    below the grouped ones. Roles are records of their own and are usually kept
+    in a storage folder.
+
+..  _introduction-frontend:
+
+Frontend output
+---------------
+
+The contacts of a page are rendered either with the content element
+:guilabel:`Contacts for this page`, which can be placed anywhere on the page,
+or directly in a page template through the data processor
+:php:`FGTCLB\AcademicContacts4pages\DataProcessing\ContactsProcessor`, which
+adds the contacts and their roles to the page rendering. Both display the person
+through the :file:`Profile/Item` partial of `EXT:academic_persons`, so contacts
+look like the profiles rendered by that extension.

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_db.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/de.locallang_db.xlf
@@ -39,6 +39,38 @@
 				<source>Role</source>
 				<target>Rolle</target>
 			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.palette.addressRecords">
+				<source>Displayed address records</source>
+				<target>Angezeigte Adress-Datensätze</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.palette.addressRecords.description">
+				<source>Without a dedicated selection all address records of the contract are displayed.</source>
+				<target>Ohne dedizierte Auswahl werden alle Adress-Datensätze des Vertrags angezeigt.</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.email_address">
+				<source>E-mail address</source>
+				<target>E-Mail-Adresse</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.phone_number">
+				<source>Phone number</source>
+				<target>Telefonnummer</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.physical_address">
+				<source>Physical address</source>
+				<target>Physikalische Adresse</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.all">
+				<source>Display all</source>
+				<target>Alle anzeigen</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.none">
+				<source>Do not display</source>
+				<target>Nicht anzeigen</target>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.hidden">
+				<source>[Hidden] %s</source>
+				<target>[Verborgen] %s</target>
+			</trans-unit>
 
 			<trans-unit id="tx_academiccontacts4pages_domain_model_role">
 				<source>Role</source>

--- a/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_db.xlf
+++ b/packages/fgtclb/academic-contact4pages/Resources/Private/Language/locallang_db.xlf
@@ -31,6 +31,30 @@
 			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.role">
 				<source>Role</source>
 			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.palette.addressRecords">
+				<source>Displayed address records</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.palette.addressRecords.description">
+				<source>Without a dedicated selection all address records of the contract are displayed.</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.email_address">
+				<source>E-mail address</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.phone_number">
+				<source>Phone number</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.physical_address">
+				<source>Physical address</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.all">
+				<source>Display all</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.none">
+				<source>Do not display</source>
+			</trans-unit>
+			<trans-unit id="tx_academiccontacts4pages_domain_model_contact.addressRecord.hidden">
+				<source>[Hidden] %s</source>
+			</trans-unit>
 
 			<trans-unit id="tx_academiccontacts4pages_domain_model_role">
 				<source>Role</source>

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Backend/FormEngine/AddressRecordItemsTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Backend/FormEngine/AddressRecordItemsTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Backend\FormEngine;
+
+use FGTCLB\AcademicBase\Event\ModifyTcaSelectFieldItemsEvent;
+use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The three address record selects of a contact record are filled from the contract the
+ * contact points at. The fixture gives contract 1 a hidden record, which is offered with a
+ * marker, and records that must not be offered at all - a deleted one and a translation -
+ * plus records of a second contract, so the assertions on the full item list cover the
+ * exclusions as well.
+ */
+final class AddressRecordItemsTest extends AbstractAcademicContacts4PagesTestCase
+{
+    private const TABLE_NAME = 'tx_academiccontacts4pages_domain_model_contact';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AddressRecordItems/addressRecords.csv');
+        // The item labels of hidden records are composed and therefore translated by the
+        // itemsProcFunc itself, which FormEngine only ever calls with a language service.
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
+    }
+
+    /**
+     * The hidden record stays selectable and is marked as such - whether it reaches the
+     * frontend is decided by the "Show hidden records" option of the plugin.
+     */
+    #[Test]
+    public function emailAddressItemsAreBuiltFromTheAddressRecordsOfTheContract(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('email_address'),
+                ['label' => 'plain@example.org', 'value' => 2],
+                ['label' => 'Business: office@example.org', 'value' => 1],
+                ['label' => '[Hidden] Private: hidden@example.org', 'value' => 3],
+            ],
+            $this->callItemsProcFunc('email_address', ['uid' => 1, 'contract' => 1]),
+        );
+    }
+
+    #[Test]
+    public function phoneNumberItemsAreBuiltFromTheAddressRecordsOfTheContract(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('phone_number'),
+                ['label' => 'Mobile: +49 170 1234567', 'value' => 1],
+                ['label' => '+49 30 1234567', 'value' => 2],
+            ],
+            $this->callItemsProcFunc('phone_number', ['uid' => 1, 'contract' => 1]),
+        );
+    }
+
+    /**
+     * An address record without a single filled field falls back to its uid, so it stays
+     * selectable instead of showing up as an empty option.
+     */
+    #[Test]
+    public function physicalAddressItemsAreBuiltFromTheAddressRecordsOfTheContract(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('physical_address'),
+                ['label' => 'Business: Musterstraße 1, Building A, 10115 Berlin, Germany', 'value' => 1],
+                ['label' => '#2', 'value' => 2],
+            ],
+            $this->callItemsProcFunc('physical_address', ['uid' => 1, 'contract' => 1]),
+        );
+    }
+
+    #[Test]
+    public function itemsOfTheSecondContractAreBuiltFromItsOwnAddressRecords(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('email_address'),
+                ['label' => 'Business: other-contract@example.org', 'value' => 6],
+            ],
+            $this->callItemsProcFunc('email_address', ['uid' => 1, 'contract' => 2]),
+        );
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<string, mixed>}>
+     */
+    public static function contractIsNotResolvableDataProvider(): \Generator
+    {
+        yield 'contract not selected' => [['uid' => 1, 'contract' => 0]];
+        yield 'contract missing in row' => [['uid' => 1]];
+        yield 'contract of a deleted record' => [['uid' => 1, 'contract' => 99]];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    #[DataProvider('contractIsNotResolvableDataProvider')]
+    #[Test]
+    public function onlyTheStaticItemsRemainWithoutAContract(array $row): void
+    {
+        $this->assertSame(
+            $this->getStaticItems('email_address'),
+            $this->callItemsProcFunc('email_address', $row),
+        );
+    }
+
+    /**
+     * FormEngine hands over select values as an array once they went through the data
+     * providers of the form.
+     */
+    #[Test]
+    public function contractIsResolvedFromAnArrayValue(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('email_address'),
+                ['label' => 'plain@example.org', 'value' => 2],
+                ['label' => 'Business: office@example.org', 'value' => 1],
+                ['label' => '[Hidden] Private: hidden@example.org', 'value' => 3],
+            ],
+            $this->callItemsProcFunc('email_address', ['uid' => 1, 'contract' => ['1']]),
+        );
+    }
+
+    /**
+     * A contact created inline below a contract does not carry the relation in its row
+     * before it is saved for the first time.
+     */
+    #[Test]
+    public function contractIsResolvedFromTheInlineParent(): void
+    {
+        $this->assertSame(
+            [
+                ...$this->getStaticItems('email_address'),
+                ['label' => 'plain@example.org', 'value' => 2],
+                ['label' => 'Business: office@example.org', 'value' => 1],
+                ['label' => '[Hidden] Private: hidden@example.org', 'value' => 3],
+            ],
+            $this->callItemsProcFunc(
+                'email_address',
+                ['uid' => 0, 'contract' => 0],
+                [
+                    'inlineParentTableName' => 'tx_academicpersons_domain_model_contract',
+                    'inlineParentUid' => 1,
+                ],
+            ),
+        );
+    }
+
+    #[Test]
+    public function inlineParentOfAnotherTableIsNotUsedAsContract(): void
+    {
+        $this->assertSame(
+            $this->getStaticItems('email_address'),
+            $this->callItemsProcFunc(
+                'email_address',
+                ['uid' => 0, 'contract' => 0],
+                [
+                    'inlineParentTableName' => 'pages',
+                    'inlineParentUid' => 1,
+                ],
+            ),
+        );
+    }
+
+    #[Test]
+    public function itemsCanBeModifiedWithAnEventListener(): void
+    {
+        $itemsToSet = [
+            0 => [
+                'label' => 'some label',
+                'value' => 123,
+            ],
+        ];
+
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'event-dispatch-modification-checker',
+            static function (ModifyTcaSelectFieldItemsEvent $event) use ($itemsToSet): void {
+                $parameters = $event->getParameters();
+                if ($parameters['table'] === self::TABLE_NAME && $parameters['field'] === 'email_address') {
+                    $parameters['items'] = $itemsToSet;
+                    $event->setParameters($parameters);
+                }
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyTcaSelectFieldItemsEvent::class, 'event-dispatch-modification-checker');
+
+        $this->assertSame($itemsToSet, $this->callItemsProcFunc('email_address', ['uid' => 1, 'contract' => 1]));
+    }
+
+    #[Test]
+    public function staticItemsCarryTheDisplayMarkersOfTheModel(): void
+    {
+        foreach (['email_address', 'phone_number', 'physical_address'] as $fieldName) {
+            $this->assertSame(
+                [Contact::DISPLAY_ALL, Contact::DISPLAY_NONE],
+                array_column($this->getStaticItems($fieldName), 'value'),
+                sprintf('Static items of "%s" do not match the display markers.', $fieldName),
+            );
+        }
+    }
+
+    /**
+     * The items the TCA itself defines, which FormEngine passes into the `itemsProcFunc`.
+     * Their labels are still the untranslated `LLL:` references at that point, the
+     * translation of the whole item list happens afterwards.
+     *
+     * @return array<int, array{label?: string|null, value?: mixed, icon?: string|null, group?: string|null}>
+     */
+    private function getStaticItems(string $fieldName): array
+    {
+        return $GLOBALS['TCA'][self::TABLE_NAME]['columns'][$fieldName]['config']['items'] ?? [];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, mixed> $additionalParameters
+     * @return array<int, array{label?: string|null, value?: mixed, icon?: string|null, group?: string|null}>
+     */
+    private function callItemsProcFunc(string $fieldName, array $row, array $additionalParameters = []): array
+    {
+        $itemsProcFunc = (string)($GLOBALS['TCA'][self::TABLE_NAME]['columns'][$fieldName]['config']['itemsProcFunc'] ?? '');
+        if ($itemsProcFunc === '') {
+            throw new \RuntimeException(
+                sprintf('No itemsProcFunc configured for "%s.%s".', self::TABLE_NAME, $fieldName),
+                1786579202,
+            );
+        }
+
+        $items = $this->getStaticItems($fieldName);
+        $parameters = [
+            'items' => &$items,
+            'config' => $GLOBALS['TCA'][self::TABLE_NAME]['columns'][$fieldName]['config'],
+            'TSconfig' => [],
+            'table' => self::TABLE_NAME,
+            'row' => $row,
+            'field' => $fieldName,
+            'effectivePid' => 100,
+            'site' => null,
+            ...$additionalParameters,
+        ];
+        GeneralUtility::callUserFunction($itemsProcFunc, $parameters, $this);
+
+        return $parameters['items'];
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Backend/FormEngine/Fixtures/AddressRecordItems/addressRecords.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Backend/FormEngine/Fixtures/AddressRecordItems/addressRecords.csv
@@ -1,0 +1,29 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,100,1,254,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position"
+,1,100,0,0,0,0,1,"Professor"
+,2,100,0,0,0,0,1,"Lecturer"
+"tx_academicpersons_domain_model_email",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","email","type"
+,1,100,0,0,0,0,2,1,"office@example.org","business"
+,2,100,0,0,0,0,1,1,"plain@example.org",""
+,3,100,0,1,0,0,3,1,"hidden@example.org","private"
+,4,100,1,0,0,0,4,1,"deleted@example.org","private"
+,5,100,0,0,1,1,2,1,"translated@example.org","business"
+,6,100,0,0,0,0,1,2,"other-contract@example.org","business"
+"tx_academicpersons_domain_model_phone_number",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","phone_number","type"
+,1,100,0,0,0,0,1,1,"+49 170 1234567","mobile"
+,2,100,0,0,0,0,2,1,"+49 30 1234567",""
+,3,100,0,0,0,0,1,2,"+49 40 7654321","business"
+"tx_academicpersons_domain_model_address",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","street","street_number","additional","zip","city","country","type"
+,1,100,0,0,0,0,1,1,"Musterstraße","1","Building A","10115","Berlin","Germany","business"
+,2,100,0,0,0,0,2,1,"","","","","","",""
+,3,100,0,0,0,0,1,2,"Anderstraße","2","","20095","Hamburg","Germany","private"

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/DataHandling/AddressRecordSelectionTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/DataHandling/AddressRecordSelectionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\DataHandling;
+
+use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The address record selects hold two markers besides the uid of an address record:
+ * {@see Contact::DISPLAY_ALL} and the negative {@see Contact::DISPLAY_NONE}. They are
+ * plain values of a select without a `foreign_table`, so they have to survive a backend
+ * save unchanged - a dropped `-1` would turn "do not display" back into "display all"
+ * without the editor noticing.
+ */
+final class AddressRecordSelectionTest extends AbstractAcademicContacts4PagesTestCase
+{
+    private const TABLE_NAME = 'tx_academiccontacts4pages_domain_model_contact';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AddressRecordSelection/contacts.csv');
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
+    }
+
+    #[Test]
+    public function selectionIsStoredWhenAnExistingContactIsSaved(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::TABLE_NAME => [
+                    1 => [
+                        'email_address' => 1,
+                        'phone_number' => Contact::DISPLAY_NONE,
+                        'physical_address' => Contact::DISPLAY_ALL,
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $this->assertSame(
+            [
+                'email_address' => 1,
+                'phone_number' => Contact::DISPLAY_NONE,
+                'physical_address' => Contact::DISPLAY_ALL,
+            ],
+            $this->getSelectionOfContact(1)
+        );
+    }
+
+    #[Test]
+    public function selectionIsStoredWhenAContactIsCreated(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::TABLE_NAME => [
+                    'NEW1' => [
+                        'pid' => 100,
+                        'page' => 2,
+                        'contract' => 1,
+                        'email_address' => Contact::DISPLAY_NONE,
+                        'phone_number' => 1,
+                        'physical_address' => 1,
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $createdUid = (int)($dataHandler->substNEWwithIDs['NEW1'] ?? 0);
+        $this->assertGreaterThan(0, $createdUid);
+        $this->assertSame(
+            [
+                'email_address' => Contact::DISPLAY_NONE,
+                'phone_number' => 1,
+                'physical_address' => 1,
+            ],
+            $this->getSelectionOfContact($createdUid)
+        );
+    }
+
+    /**
+     * A new contact record keeps the default of the three selects, so contact records
+     * created without touching them render as they did before the selects existed.
+     */
+    #[Test]
+    public function contactWithoutSelectionKeepsTheDisplayAllDefault(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::TABLE_NAME => [
+                    'NEW1' => [
+                        'pid' => 100,
+                        'page' => 2,
+                        'contract' => 1,
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $this->assertSame(
+            [
+                'email_address' => Contact::DISPLAY_ALL,
+                'phone_number' => Contact::DISPLAY_ALL,
+                'physical_address' => Contact::DISPLAY_ALL,
+            ],
+            $this->getSelectionOfContact((int)($dataHandler->substNEWwithIDs['NEW1'] ?? 0))
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getSelectionOfContact(int $uid): array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        $row = $queryBuilder
+            ->select('email_address', 'phone_number', 'physical_address')
+            ->from(self::TABLE_NAME)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchAssociative();
+        $this->assertIsArray($row, sprintf('Contact record "%d" does not exist.', $uid));
+
+        return array_map(intval(...), $row);
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/DataHandling/Fixtures/AddressRecordSelection/contacts.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/DataHandling/Fixtures/AddressRecordSelection/contacts.csv
@@ -1,0 +1,26 @@
+"be_users",,,,
+,"uid","pid","username","password","admin"
+,1,0,"admin","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,"/home","Home"
+,100,1,254,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position"
+,1,100,0,0,0,0,1,"Professor"
+"tx_academicpersons_domain_model_email",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","email","type"
+,1,100,0,0,0,0,1,1,"office@example.org","business"
+"tx_academicpersons_domain_model_phone_number",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","phone_number","type"
+,1,100,0,0,0,0,1,1,"+4930123456","business"
+"tx_academicpersons_domain_model_address",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","street","street_number","zip","city","type"
+,1,100,0,0,0,0,1,1,"Musterstraße","1","10115","Berlin","business"
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","sorting","page","contract","role","email_address","phone_number","physical_address"
+,1,100,0,0,0,1,2,1,0,0,0,0

--- a/packages/fgtclb/academic-contact4pages/Tests/Unit/Domain/Model/ContactTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Unit/Domain/Model/ContactTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
+use FGTCLB\AcademicPersons\Domain\Model\Address;
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Covers the dedicated address record selection: {@see Contact::getContract()} hands out
+ * a contract carrying only the selected email address, phone number and physical address.
+ */
+final class ContactTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeCreated(): void
+    {
+        new Contact();
+    }
+
+    #[Test]
+    public function getContractReturnsNullForNewModel(): void
+    {
+        $this->assertNull((new Contact())->getContract());
+    }
+
+    #[Test]
+    public function hasAddressRecordSelectionIsFalseForNewModel(): void
+    {
+        $this->assertFalse((new Contact())->hasAddressRecordSelection());
+    }
+
+    #[Test]
+    public function getContractReturnsTheContractItselfWithoutDedicatedSelection(): void
+    {
+        $contract = $this->createContract();
+        $contact = $this->createContact($contract);
+
+        $this->assertSame($contract, $contact->getContract());
+    }
+
+    /**
+     * @return \Generator<string, array{0: non-empty-string, 1: int, 2: array<int, int>}>
+     */
+    public static function addressRecordSelectionDataProvider(): \Generator
+    {
+        yield 'no selection displays all email addresses' => ['emailAddress', Contact::DISPLAY_ALL, [11, 12]];
+        yield 'selected email address is displayed alone' => ['emailAddress', 12, [12]];
+        yield 'no email address is displayed' => ['emailAddress', Contact::DISPLAY_NONE, []];
+        yield 'unresolvable email address displays none' => ['emailAddress', 99, []];
+        yield 'no selection displays all phone numbers' => ['phoneNumber', Contact::DISPLAY_ALL, [21, 22]];
+        yield 'selected phone number is displayed alone' => ['phoneNumber', 21, [21]];
+        yield 'no phone number is displayed' => ['phoneNumber', Contact::DISPLAY_NONE, []];
+        yield 'unresolvable phone number displays none' => ['phoneNumber', 99, []];
+        yield 'no selection displays all physical addresses' => ['physicalAddress', Contact::DISPLAY_ALL, [31, 32]];
+        yield 'selected physical address is displayed alone' => ['physicalAddress', 32, [32]];
+        yield 'no physical address is displayed' => ['physicalAddress', Contact::DISPLAY_NONE, []];
+        yield 'unresolvable physical address displays none' => ['physicalAddress', 99, []];
+    }
+
+    /**
+     * @param non-empty-string $propertyName
+     * @param array<int, int> $expectedUids
+     */
+    #[DataProvider('addressRecordSelectionDataProvider')]
+    #[Test]
+    public function getContractNarrowsTheSelectedAddressRecordKind(
+        string $propertyName,
+        int $selectedUid,
+        array $expectedUids
+    ): void {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty($propertyName, $selectedUid);
+
+        $displayContract = $contact->getContract();
+        $this->assertInstanceOf(Contract::class, $displayContract);
+        $addressRecords = match ($propertyName) {
+            'emailAddress' => $displayContract->getEmailAddresses(),
+            'phoneNumber' => $displayContract->getPhoneNumbers(),
+            'physicalAddress' => $displayContract->getPhysicalAddresses(),
+            default => throw new \LogicException(sprintf('Unknown address record kind "%s".', $propertyName), 1786579201),
+        };
+
+        $this->assertSame($expectedUids, $this->getUids($addressRecords));
+    }
+
+    #[Test]
+    public function getContractKeepsTheOtherAddressRecordKindsUntouched(): void
+    {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty('emailAddress', 11);
+
+        $displayContract = $contact->getContract();
+        $this->assertInstanceOf(Contract::class, $displayContract);
+        $this->assertSame([11], $this->getUids($displayContract->getEmailAddresses()));
+        $this->assertSame([21, 22], $this->getUids($displayContract->getPhoneNumbers()));
+        $this->assertSame([31, 32], $this->getUids($displayContract->getPhysicalAddresses()));
+    }
+
+    #[Test]
+    public function getContractNarrowsAllThreeAddressRecordKindsAtOnce(): void
+    {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty('emailAddress', 12);
+        $contact->_setProperty('phoneNumber', Contact::DISPLAY_NONE);
+        $contact->_setProperty('physicalAddress', 31);
+
+        $displayContract = $contact->getContract();
+        $this->assertInstanceOf(Contract::class, $displayContract);
+        $this->assertSame([12], $this->getUids($displayContract->getEmailAddresses()));
+        $this->assertSame([], $this->getUids($displayContract->getPhoneNumbers()));
+        $this->assertSame([31], $this->getUids($displayContract->getPhysicalAddresses()));
+    }
+
+    /**
+     * The contract is a persisted entity shared with everything else that resolves it, so
+     * the narrowing must not reach it.
+     */
+    #[Test]
+    public function getContractLeavesTheContractRecordItselfUntouched(): void
+    {
+        $contract = $this->createContract();
+        $contact = $this->createContact($contract);
+        $contact->_setProperty('emailAddress', 11);
+        $contact->_setProperty('phoneNumber', Contact::DISPLAY_NONE);
+
+        $contact->getContract();
+
+        $this->assertSame([11, 12], $this->getUids($contract->getEmailAddresses()));
+        $this->assertSame([21, 22], $this->getUids($contract->getPhoneNumbers()));
+        $this->assertSame($contract, $contact->getUnfilteredContract());
+    }
+
+    /**
+     * Two contacts on different pages can point at the same contract, and Extbase hands
+     * out one instance for it, so one narrowing must not reach the other contact.
+     */
+    #[Test]
+    public function contactsSharingAContractNarrowItIndependently(): void
+    {
+        $contract = $this->createContract();
+        $firstContact = $this->createContact($contract);
+        $firstContact->_setProperty('emailAddress', 11);
+        $secondContact = $this->createContact($contract);
+        $secondContact->_setProperty('emailAddress', Contact::DISPLAY_NONE);
+
+        $firstDisplayContract = $firstContact->getContract();
+        $secondDisplayContract = $secondContact->getContract();
+        $this->assertInstanceOf(Contract::class, $firstDisplayContract);
+        $this->assertInstanceOf(Contract::class, $secondDisplayContract);
+        $this->assertSame([11], $this->getUids($firstDisplayContract->getEmailAddresses()));
+        $this->assertSame([], $this->getUids($secondDisplayContract->getEmailAddresses()));
+        $this->assertSame([11, 12], $this->getUids($contract->getEmailAddresses()));
+    }
+
+    #[Test]
+    public function getContractReturnsTheSameNarrowedContractOnEveryCall(): void
+    {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty('emailAddress', 11);
+
+        $this->assertSame($contact->getContract(), $contact->getContract());
+    }
+
+    /**
+     * The plugin sets the provider after the contact was mapped, so a contract narrowed
+     * before that must not be handed out afterwards.
+     */
+    #[Test]
+    public function settingTheAddressRecordProviderDiscardsTheNarrowedContract(): void
+    {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty('emailAddress', 11);
+        $narrowedContract = $contact->getContract();
+
+        $contact->setAddressRecordProvider(null);
+
+        $this->assertNotSame($narrowedContract, $contact->getContract());
+    }
+
+    private function createContact(Contract $contract): Contact
+    {
+        $contact = new Contact();
+        $contact->_setProperty('uid', 1);
+        $contact->_setProperty('contract', $contract);
+        return $contact;
+    }
+
+    private function createContract(): Contract
+    {
+        $contract = new Contract();
+        $contract->_setProperty('uid', 1);
+        foreach ([11, 12] as $uid) {
+            $emailAddress = new Email();
+            $emailAddress->_setProperty('uid', $uid);
+            $emailAddress->setEmail(sprintf('contact-%d@example.org', $uid));
+            $contract->addEmailAddress($emailAddress);
+        }
+        foreach ([21, 22] as $uid) {
+            $phoneNumber = new PhoneNumber();
+            $phoneNumber->_setProperty('uid', $uid);
+            $phoneNumber->setPhoneNumber(sprintf('+49 30 %d', $uid));
+            $contract->addPhoneNumber($phoneNumber);
+        }
+        foreach ([31, 32] as $uid) {
+            $physicalAddress = new Address();
+            $physicalAddress->_setProperty('uid', $uid);
+            $physicalAddress->setCity(sprintf('City %d', $uid));
+            $contract->addPhysicalAddress($physicalAddress);
+        }
+        return $contract;
+    }
+
+    /**
+     * @param iterable<DomainObjectInterface> $addressRecords
+     * @return array<int, int|null>
+     */
+    private function getUids(iterable $addressRecords): array
+    {
+        $uids = [];
+        foreach ($addressRecords as $addressRecord) {
+            $uids[] = $addressRecord->getUid();
+        }
+        return $uids;
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/ext_tables.sql
+++ b/packages/fgtclb/academic-contact4pages/ext_tables.sql
@@ -16,4 +16,9 @@ CREATE TABLE tx_academiccontacts4pages_domain_model_contact (
     page int(11) unsigned DEFAULT '0' NOT NULL,
     contract int(11) unsigned DEFAULT '0' NOT NULL,
     role int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Signed, due to `-1` option
+    email_address int(11) DEFAULT '0' NOT NULL,
+    phone_number int(11) DEFAULT '0' NOT NULL,
+    physical_address int(11) DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
Backport of #453 to branch `2`.

A contact rendered every email address, phone number and physical address of
the contract it points at. Contact records now carry three selects, one per
kind of address record, offering "display all" (the default, and the previous
behaviour), "do not display" and the individual records of the contract that
is currently selected.

## What was adopted for the v12 + v13 line

The production code is **byte identical** to the one on `main` - the four files
the feature touches (`ContactsController`, `Contact`, the contact TCA and
`ext_tables.sql`) do not differ between the branches, and every API the feature
uses is available on TYPO3 v12 and already in use here:

* the associative TCA item form (`label` / `value`)
* `onChange => 'reload'` on the contract field
* the `itemsProcFunc` signature and its associative `items`
* `Connection::PARAM_INT` and `quoteArrayBasedValueListToIntegerList()`
* `ModifyTcaSelectFieldItemsEvent`, the `Types` classes and
  `findByContractIncludingHidden()` on the three address record repositories

No version switch is needed anywhere, and neither the plugin registration nor a
flexform is touched, so the CType handling that differs between the branches
does not come into play.

Two things were adapted:

* **The language files** keep this branch's tab indentation. The eight new
  translation units are otherwise identical to `main`, verified by parsing both
  files and comparing every unit's id, source and target.
* **The frontend plugin rendering tests are left out.** This branch has no
  `Tests/Functional/Plugins` suite for the extension, and the testing helper it
  builds on carries no `FrontendPluginRenderingTrait` yet. Backend behaviour is
  covered by the same tests as on `main`: the `itemsProcFunc` test, the
  DataHandler round trip of the two marker values, and the unit tests of the
  narrowing itself.

## Verified locally

| | v12 / PHP 8.1 | v13 / PHP 8.2 |
|---|---|---|
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | no errors | no errors |
| `unit` | 24 tests, 119 assertions | 24 tests, 119 assertions |
| `functional` sqlite | 25 tests, 34 assertions | 25 tests, 34 assertions |
| `functional` postgres | 25 tests, 34 assertions | 25 tests, 34 assertions |

Postgres was run as well because the DataHandler test writes.
