### PR TITLE
[BUGFIX] ACE-387: Register FlexForms on v13 (#454)

### DIFF
--- a/docs/testing/testing-helper.md
+++ b/docs/testing/testing-helper.md
@@ -220,28 +220,47 @@ registration.
 
 ### The defect
 
-A plugin's FlexForm data structure is attached to the content type as
-`$GLOBALS['TCA']['tt_content']['types'][<CType>]['columnsOverrides']['pi_flexform']['config']['ds']`.
-**TYPO3 v13 and v14 want different shapes there, and neither tolerates the
-other's:**
+The two core versions do not disagree about the *shape* of a plugin's FlexForm
+registration. They disagree about **where it has to live**, and getting that
+wrong failed twice, in two different ways, before it was understood.
 
-| Core version | Required shape                            | What the other shape does                                                                                                        |
-|--------------|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| v13          | array, e.g. `['default' => 'FILE:EXT:…']` | A string throws in `FlexFormTools` (code 1463826960). **The record cannot be opened.**                                           |
-| v14          | plain string, `'FILE:EXT:…'`              | An array throws `InvalidTcaException`, which `TcaFlexPrepare` catches — the backend renders an **empty FlexForm tab**, silently. |
+| Core version | Where the data structure belongs                                                                              | How it is written                                                                       |
+|--------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| v14          | on the record type — `…['types'][<CType>]['columnsOverrides']['pi_flexform']['config']['ds']`, a plain string | assigned directly                                                                       |
+| v13          | in the **global** column configuration, under the key `ds_pointerField` matches                               | `ExtensionManagementUtility::addPiFlexFormValue('*', $ds, $cType)`, writing `*,<CType>` |
 
-The v14-shaped registration was introduced when `addPiFlexFormValue()` was
-dropped for its v14 deprecation, and it made all fifteen academic plugin content
-elements unopenable in the TYPO3 v13 backend. Every gate stayed green on both
-core versions, because nothing in the suite compiled a backend form. The commit
-message of `c2e8f84de` states the lesson plainly:
+**ACE-293, the visible failure.** The v14-shaped registration was introduced
+when `addPiFlexFormValue()` was dropped for its v14 deprecation. A plain string
+in `columnsOverrides` throws in `FlexFormTools` on v13 (code 1463826960), which
+made all fifteen academic plugin content elements unopenable in the v13 backend.
+Every gate stayed green, because nothing in the suite compiled a backend form.
+The commit message of `c2e8f84de` states the lesson plainly:
 
 > That no test caught this is the point worth keeping: nothing in the suite
 > renders or compiles a backend form, so TCA that is fatal in the v13 backend
 > passes every gate on both core versions.
 
-The production side of the fix is the single version switch in
-[`academic-base/Classes/TcaManipulator.php:165-168`](../../packages/fgtclb/academic-base/Classes/TcaManipulator.php#L165-L168);
+**ACE-387, the silent one.** Putting an *array* in `columnsOverrides` stopped the
+throw, so v13 records opened again — and still showed the wrong form. Core
+resolves a data structure there in two steps:
+`getDataStructureIdentifier()` is handed the field TCA with `columnsOverrides`
+already merged in and does pick the key from it, but the identifier it builds
+carries nothing but that key, and `parseDataStructureByIdentifier()` then reads
+the structure back from `$GLOBALS['TCA']` — where the override never was. The
+lookup landed on core's own `default` entry, a single field `xmlTitle` labelled
+"The Title:", and the plugin options were unreachable. `FlexFormTools` says so
+in its own docblock: the TCA for data structure definitions must not be
+overridden by `columnsOverrides`.
+
+So `columnsOverrides` is a v14 mechanism, not a shared one with two spellings.
+On v13 the registration goes into the global column configuration, under the key
+the `ds_pointerField` `list_type,CType` matches. A plugin registered as a
+content element has an empty `list_type`, so that key is `*,<CType>` — exactly
+what `addPiFlexFormValue()` writes.
+
+The production side of both fixes is the version switch in
+`addContentElementPluginFlexForm()` of
+[`academic-base/Classes/TcaManipulator.php`](../../packages/fgtclb/academic-base/Classes/TcaManipulator.php);
 its unit-level counterpart is the `not-core-13`/`not-core-14` pair described in
 [Unit tests](unit-tests.md#core-version-aware-unit-tests).
 
@@ -289,11 +308,12 @@ construct as a v14 gate and do not reuse it as one.** A genuine gate is
 ### The assertion
 
 `assertPluginFlexFormIsResolved(string $cType, string $sheetName = 'sDEF')` makes
-**two** assertions, and the second one is the load-bearing one:
+**three** assertions, one per way this has already gone wrong:
 
 ```php
 self::assertArrayHasKey($sheetName, $dataStructure['sheets'] ?? [], …);
-self::assertNotEmpty($dataStructure['sheets'][$sheetName]['ROOT']['el'] ?? [], …);
+self::assertNotEmpty($resolvedFields, …);
+self::assertNotSame($coreDefaultFields, $resolvedFields, …);
 ```
 
 Asserting the sheet alone would pass on v14 against the empty fallback: when
@@ -302,10 +322,29 @@ left with `['sheets' => ['sDEF' => []]]` — a sheet that exists and contains
 nothing. Only the assertion on `ROOT.el` distinguishes "resolved" from
 "silently empty".
 
+The third one exists because the first two are not enough. On v13 an
+unresolvable structure does not come back empty, it comes back as **core's
+default** — and core's default has a field, so "resolved to something" is
+satisfied. Seven extensions carried this test and all seven were green while
+every one of them rendered the wrong form. The field names it compares against
+are parsed out of
+`$GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']['default']`
+rather than hard coded, so a changed core default cannot quietly turn the guard
+into a no-op. TYPO3 v14 has no such fallback entry, so on v14 the third
+assertion returns early and the first two carry the check.
+
 **When to use it.** One `Tests/Functional/Tca/PluginFlexFormTest.php` per
 extension that registers plugins, listing every CType in a data provider. Seven
 extensions have one. Add the CType to the provider in the same change that
 registers the plugin.
+
+**Prove it can fail.** A test of this kind is worth exactly as much as its last
+failed run, and both defects above passed a test that existed. Break the
+registration on purpose — put the v14 assignment back on both branches of
+`addContentElementPluginFlexForm()` — watch the suite go red on v13, and
+restore. Done while writing this: **15 data sets across the seven extensions**
+fail with *"resolved to the TYPO3 core default data structure instead of the one
+the extension registers"*.
 
 ---
 

--- a/packages-dev/testing-helper/Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php
+++ b/packages-dev/testing-helper/Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php
@@ -7,6 +7,7 @@ namespace FGTCLB\TestingHelper\FunctionalTestCase;
 use TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsOverrides;
 use TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Resolves the FlexForm data structure of a plugin content type the way
@@ -65,12 +66,19 @@ trait PluginFlexFormDataStructureTrait
     }
 
     /**
-     * Asserts that the plugin's FlexForm is resolved to actual fields.
+     * Asserts that the plugin's own FlexForm is resolved to actual fields.
      *
-     * An empty sheet is the failure mode to watch on TYPO3 v14: `TcaFlexPrepare`
-     * swallows an unresolvable data structure there and leaves the caller with
-     * `['sheets' => ['sDEF' => []]]`, so the backend renders an empty tab
-     * instead of raising anything.
+     * Two failure modes, one per core version, and the assertion has to cover
+     * both because each one is silent in the backend:
+     *
+     * * TYPO3 v14 leaves an unresolvable data structure as
+     *   `['sheets' => ['sDEF' => []]]` — `TcaFlexPrepare` swallows the exception
+     *   and the backend renders an empty tab.
+     * * TYPO3 v13 falls back to **core's own default** data structure when the
+     *   extension's one is registered where core does not look for it. The
+     *   backend then shows a foreign field instead of the plugin options, which
+     *   a "did anything resolve at all" assertion happily accepts — that is how
+     *   the defect behind ACE-387 passed CI for seven extensions.
      */
     private function assertPluginFlexFormIsResolved(string $cType, string $sheetName = 'sDEF'): void
     {
@@ -81,13 +89,48 @@ trait PluginFlexFormDataStructureTrait
             $dataStructure['sheets'] ?? [],
             sprintf('FlexForm of content type "%s" has no sheet "%s".', $cType, $sheetName),
         );
+        $resolvedFields = array_keys($dataStructure['sheets'][$sheetName]['ROOT']['el'] ?? []);
         self::assertNotEmpty(
-            $dataStructure['sheets'][$sheetName]['ROOT']['el'] ?? [],
+            $resolvedFields,
             sprintf(
                 'FlexForm sheet "%s" of content type "%s" resolved to no fields at all.',
                 $sheetName,
                 $cType,
             ),
         );
+
+        $coreDefaultFields = $this->getCoreDefaultFlexFormFields();
+        if ($coreDefaultFields !== []) {
+            self::assertNotSame(
+                $coreDefaultFields,
+                $resolvedFields,
+                sprintf(
+                    'FlexForm of content type "%s" resolved to the TYPO3 core default data structure'
+                    . ' instead of the one the extension registers.',
+                    $cType,
+                ),
+            );
+        }
+    }
+
+    /**
+     * The field names of the data structure core ships in
+     * `tt_content.pi_flexform`, which is what a plugin falls back to when its
+     * own one is not found. Read from the TCA rather than hard coded, so a
+     * changed core default cannot turn this guard into a no-op.
+     *
+     * @return list<string>
+     */
+    private function getCoreDefaultFlexFormFields(): array
+    {
+        $coreDefault = $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']['default'] ?? null;
+        if (!is_string($coreDefault) || $coreDefault === '') {
+            // TYPO3 v14 has no such fallback.
+            return [];
+        }
+
+        $parsed = GeneralUtility::xml2array($coreDefault);
+
+        return is_array($parsed) ? array_keys($parsed['ROOT']['el'] ?? []) : [];
     }
 }

--- a/packages/fgtclb/academic-base/Classes/TcaManipulator.php
+++ b/packages/fgtclb/academic-base/Classes/TcaManipulator.php
@@ -145,17 +145,29 @@ final class TcaManipulator
      * Assign the FlexForm data structure of a plugin content element in a way
      * that works on both TYPO3 v13 and v14.
      *
-     * The two core versions want a different shape and neither tolerates the
-     * other, which makes this the one place a version switch is unavoidable:
+     * The two core versions want it in a different place and neither tolerates
+     * the other, which makes this the one place a version switch is unavoidable:
      *
-     * * TYPO3 v13 resolves `ds` through `ds_pointerField` and requires an array.
-     *   Given a string it throws, and the whole content element can no longer be
-     *   opened in the backend (`FlexFormTools`, code 1463826960).
      * * TYPO3 v14 resolves the data structure through the record type of the TCA
-     *   schema and requires the string. Given an array it throws
-     *   `InvalidTcaException` (code 1751796940) — which `TcaFlexPrepare` catches,
-     *   so the backend silently renders an **empty** FlexForm tab instead of
-     *   failing visibly.
+     *   schema, so it belongs to the record type as a plain string. Given an
+     *   array it throws `InvalidTcaException` (code 1751796940) — which
+     *   `TcaFlexPrepare` catches, so the backend silently renders an **empty**
+     *   FlexForm tab instead of failing visibly.
+     * * TYPO3 v13 resolves it through `ds_pointerField`, which is
+     *   `list_type,CType` for `pi_flexform`, and it must live in the **global**
+     *   column configuration. Putting it on the record type does not work:
+     *   `FlexFormTools::getDataStructureIdentifier()` does see the merged
+     *   `columnsOverrides` and picks a key from it, but the identifier carries
+     *   only that key, and `parseDataStructureByIdentifier()` then reads the
+     *   structure back from `$GLOBALS['TCA']` — where the override never was.
+     *   Core states this in its own docblock: "The TCA for data structure
+     *   definitions MUST NOT be overridden by 'columnsOverrides'". The record
+     *   would silently render core's default data structure, a single field
+     *   named `xmlTitle`, instead of the one the extension ships.
+     *
+     * A plugin registered through {@see self::addContentElementPlugin()} is a
+     * CType with an empty `list_type`, so `*,<CType>` is the key that matches —
+     * which is exactly what `addPiFlexFormValue()` writes.
      *
      * FOR USE IN files in `Configuration/TCA/Overrides/*.php`.
      *
@@ -164,10 +176,12 @@ final class TcaManipulator
      */
     public function addContentElementPluginFlexForm(string $cType, string $dataStructure): void
     {
-        $GLOBALS['TCA']['tt_content']['types'][$cType]['columnsOverrides']['pi_flexform']['config']['ds']
-            = (new Typo3Version())->getMajorVersion() >= 14
-                ? $dataStructure
-                : ['default' => $dataStructure];
+        if ((new Typo3Version())->getMajorVersion() >= 14) {
+            $GLOBALS['TCA']['tt_content']['types'][$cType]['columnsOverrides']['pi_flexform']['config']['ds']
+                = $dataStructure;
+            return;
+        }
+        ExtensionManagementUtility::addPiFlexFormValue('*', $dataStructure, $cType);
     }
 
     /**

--- a/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php
@@ -559,22 +559,30 @@ final class TcaManipulatorTest extends UnitTestCase
     }
 
     /**
-     * TYPO3 v13 resolves `ds` through `ds_pointerField` and requires an array;
-     * a string makes the content element unopenable in the backend.
+     * TYPO3 v13 resolves the data structure through `ds_pointerField`, which is
+     * `list_type,CType`, and reads it back from the global column configuration.
+     * A plugin content element has no `list_type`, so `*,<CType>` is the key.
+     * Assigning it to the record type instead is what left the backend showing
+     * core's own default data structure.
      */
     #[Group('not-core-14')]
     #[Test]
-    public function pluginFlexFormIsAssignedAsArrayOnCoreV13(): void
+    public function pluginFlexFormIsAssignedToTheGlobalColumnOnCoreV13(): void
     {
-        unset($GLOBALS['TCA']['tt_content']);
+        $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'] = ['default' => 'core default'];
+        unset($GLOBALS['TCA']['tt_content']['types']);
         (new TcaManipulator())->addContentElementPluginFlexForm(
             'academicexample_list',
             'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
         );
         $this->assertSame(
-            ['default' => 'FILE:EXT:academic_example/Configuration/FlexForms/List.xml'],
-            $GLOBALS['TCA']['tt_content']['types']['academicexample_list']['columnsOverrides']['pi_flexform']['config']['ds'],
+            [
+                'default' => 'core default',
+                '*,academicexample_list' => 'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
+            ],
+            $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'],
         );
+        $this->assertArrayNotHasKey('types', $GLOBALS['TCA']['tt_content']);
     }
 
     /**
@@ -586,6 +594,7 @@ final class TcaManipulatorTest extends UnitTestCase
     public function pluginFlexFormIsAssignedAsStringOnCoreV14(): void
     {
         unset($GLOBALS['TCA']['tt_content']);
+        $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'] = [];
         (new TcaManipulator())->addContentElementPluginFlexForm(
             'academicexample_list',
             'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
@@ -594,5 +603,6 @@ final class TcaManipulatorTest extends UnitTestCase
             'FILE:EXT:academic_example/Configuration/FlexForms/List.xml',
             $GLOBALS['TCA']['tt_content']['types']['academicexample_list']['columnsOverrides']['pi_flexform']['config']['ds'],
         );
+        $this->assertSame([], $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']);
     }
 }


### PR DESCRIPTION
Fixes #454.

On TYPO3 v13 every plugin of the 3.0.0 line renders the FlexForm **TYPO3 itself
ships** for `tt_content.pi_flexform` — a single field `xmlTitle` labelled
"The Title:" — instead of the data structure the extension provides. The plugin
options are unreachable, which is what the screenshot in #454 shows.

## Root cause

`TcaManipulator::addContentElementPluginFlexForm()` assigned the data structure
to the record type for both core versions. That is right on v14 and cannot work
on v13, where core resolves a data structure in two steps:

1. `FlexFormTools::getDataStructureIdentifier()` is handed the field TCA with
   `columnsOverrides` already merged in, so it *does* pick the key from the
   override, and
2. the identifier it builds carries nothing but that key, so
   `parseDataStructureByIdentifier()` reads the structure back from
   `$GLOBALS['TCA']` — where the override never was.

The lookup therefore landed on core's own `default` entry. `FlexFormTools` says
as much in its own docblock:

> Important: The TCA for data structure definitions MUST NOT be overridden by
> 'columnsOverrides' or by parent TCA in an inline relation!

## Fix

On v13 the data structure is registered in the global column configuration
instead, under the key the `ds_pointerField` `list_type,CType` matches. A plugin
registered as a content element has an empty `list_type`, so that key is
`*,<CType>` — exactly what `ExtensionManagementUtility::addPiFlexFormValue()`
writes. The v14 branch is unchanged.

## Why CI did not catch it

Seven extensions ship plugin FlexForms through this method and every one of them
carries a `PluginFlexFormTest`, yet all were green: the shared assertion in
`PluginFlexFormDataStructureTrait` only demanded that the sheet resolve to a
non-empty field list, and core's default data structure has a field.

It now also rejects a structure that *is* core's default, reading the field
names out of the TCA rather than hard coding them, so a changed core default
cannot turn the guard into a no-op. **Reverting the fix turns all seven tests
red** — verified.

## Verified locally

| | v13 / PHP 8.2 | v14 / PHP 8.2 |
|---|---|---|
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | no errors | no errors |
| `unit` | 225 tests, 319 assertions | 225 tests, 319 assertions |
| `functional` (full suite) | 769 tests, 8 skipped | 777 tests, 6 skipped |

The v13 resolution was additionally probed through `TcaColumnsOverrides` and
`TcaFlexPrepare` before and after the change: `['xmlTitle']` before, the plugin's
own `settings.*` fields after.

## Scope

`main` only. Branch `2` has no `TcaManipulator::addContentElementPluginFlexForm()`
and registers plugin FlexForms the classic way, so it is not affected.

Introduced by `c2e8f84d` (ACE-293), not by `737fd63c`, which added the sibling
`addContentElementPlugin()`.


---

## Rebased, and a documentation commit added

Rebased onto `main` (`fb95b0bbe`) so the required `all checks` context exists for this head — the branch predated the job and was `BLOCKED` on a status that could never be reported. Clean rebase; nothing that landed in between touches these files.

A second commit corrects `docs/testing/testing-helper.md`, which this change makes wrong in three places. It described the registration as **one place with two shapes** — which is exactly the assumption that failed here. It is one mechanism per core version: v14 on the record type, v13 in the global column configuration, and `columnsOverrides` is a v14 mechanism rather than a shared one spelled two ways.

The page now tells both failures, because only the second explains the current code:

* **ACE-293** was visible — a string in `columnsOverrides` throws on v13, the record cannot be opened.
* **ACE-387** was not — an array there stops the throw and silently resolves core's own `default` structure, because `parseDataStructureByIdentifier()` reads it back from `$GLOBALS['TCA']` where the override never was.

The assertion section claimed two assertions. There are three, and the third is why this survived: on v13 an unresolvable structure comes back as core's default, which *has* a field, so "resolved to something" was satisfied for seven extensions at once.

The `TcaManipulator.php:165-168` line reference is replaced by the method name, per ACE-400.

## Verification

Both core versions, full sequence, each after its own `composerUpdate`:

| Suite | v13 / PHP 8.2 | v14 / PHP 8.5 |
|---|---|---|
| `lintPhp`, `cgl -n` | SUCCESS | core independent |
| `phpstan` | SUCCESS | SUCCESS |
| `unit` | SUCCESS | SUCCESS |
| `functional` | SUCCESS — 769 tests, 4167 assertions | SUCCESS — 777 tests, 4232 assertions |

And the guard was shown to fail, not merely observed passing. Putting the v14 assignment back on both branches of `addContentElementPluginFlexForm()`:

```
15 data sets across the seven extensions fail with
"resolved to the TYPO3 core default data structure instead of the one the extension registers"
```

Restored, and the suite is green again at 769/4167. That instruction is now in the page as well, since both defects passed a test that already existed.
