### PR TITLE
[TASK] ACE-389: Add developer documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,29 @@ This file is the entry point for AI coding agents working in this repository.
 `CLAUDE.md`, `GEMINI.md` and `.github/copilot-instructions.md` are symlinks to
 it — there is one set of instructions, not four. Edit `AGENTS.md`.
 
+It does **not** repeat the developer documentation. Everything about how this
+repository is built lives in [`docs/`](docs/Index.md) and
+[`CONTRIBUTING.md`](CONTRIBUTING.md), and is linked from here. What this file
+adds are the rules that apply *specifically* to working as an agent, and the
+handful of things that are easy to get wrong and expensive to discover later.
+
+## Read this before changing code
+
+| Topic                                                | Page                                                                    |
+|------------------------------------------------------|-------------------------------------------------------------------------|
+| Container based tooling, every suite and option      | [Development environment](docs/development/environment.md)              |
+| What lives where, extension keys, split repositories | [Monorepo layout](docs/development/monorepo-layout.md)                  |
+| **Dual core setup — read this first**                | [Dual core setup](docs/development/dual-core-setup.md)                  |
+| The gates and what they check                        | [Quality gates](docs/development/quality-gates.md)                      |
+| Version differences, and the v15 blockers            | [Core version aware code](docs/architecture/core-version-aware-code.md) |
+| Service configuration and stateless services         | [Dependency injection](docs/architecture/dependency-injection.md)       |
+| `final`, `readonly`, injection, data objects         | [Class design](docs/architecture/class-design.md)                       |
+| **Quoting value lists and binding parameters**       | [Database queries](docs/architecture/database-queries.md)               |
+| Both suites, their strictness and their conventions  | [Testing](docs/testing/Index.md)                                        |
+| The shared functional test traits                    | [Testing helper](docs/testing/testing-helper.md)                        |
+| Commit message conventions                           | [Commit messages](docs/workflow/commit-messages.md)                     |
+| Analysing a backport instead of cherry-picking it    | [Backporting](docs/workflow/backporting.md)                             |
+
 ## Local additions and overrides
 
 A machine-local `AGENTS.local.md` may sit next to this file. It is git-ignored
@@ -80,7 +103,7 @@ together.
 
 - `packages/fgtclb/<name>/` — the real extensions (one composer `typo3-cms-extension` each). Edit code here.
 - `packages-dev/monorepo-shared/` — `fgtclb/academics-monorepo-shared`: a meta-package centralizing the TYPO3 core dependency constraints for all extensions, root, and DDEV instances. Change TYPO3 version constraints here, not per-extension where avoidable.
-- `packages-dev/testing-helper/` — `fgtclb/academics-monorepo-testing-helper`: shared functional-test traits (`ExtensionsLoadedTestsTrait`, `TcaHelperMethodsTrait`, `ExtensionCoreVersionCompatTestsTrait`, `EnsureTtContentListTypeColumnTrait`, `PluginFlexFormDataStructureTrait`).
+- `packages-dev/testing-helper/` — `fgtclb/academics-monorepo-testing-helper`: shared functional-test traits. Seven of them; see [Testing helper](docs/testing/testing-helper.md) rather than a list here that goes stale.
 - `Build/` — test harness, phpunit/phpstan/php-cs-fixer configs, docs build.
 - `.Build/` — generated composer install target (`vendor-dir`, `bin-dir`, `Web/`). Not committed.
 - `core-13/`, `core-14/` — ready-to-start development instances, one per core version. SQLite only, no database container; seeded on first start from `sqlite-databases/core-*.sqlite` by `config/system/additional.php`. Their `config/` and `composer.lock` are **tracked**; `public/`, `var/`, `vendor/` and `config/system/additional/*.php` are not. They are not part of any test run — `runTests.sh` never touches them.
@@ -125,8 +148,10 @@ override with `-b docker|podman`). It mirrors the TYPO3 Core `runTests.sh`. Key 
 - `-u` — update the `typo3/core-testing-*` container images.
 - Trailing `[file]` — restrict phpunit to a path.
 
-There is **no option to pass extra arguments through to phpunit** — no `-e`, and
-no `--` passthrough. Restrict a run with the trailing path only.
+There is **no `-e` option**. Everything after a `--` separator is appended to the
+suite's command, so `-s unit -- --filter Foo` does reach phpunit — but that is
+undocumented in the script's own help, so prefer restricting a run with the
+trailing path.
 
 Typical workflow — **always prepare deps first** for the target core version:
 
@@ -339,8 +364,12 @@ usage for symfony dependency injection configuration over `Services.yaml` entrie
 Not every TYPO3 attribute exists in every supported version, so check before using
 one — and never use Symfony's own `#[AsEventListener]`, always TYPO3's.
 
-`phpstan` core-version aware configurations require the related core version folder
-in the `paths` of `Build/phpstan/Core13|Core14`.
+`Build/phpstan/Core13/phpstan.neon` and `Core14/phpstan.neon` are byte-identical
+and their `paths` is `../../../packages` wholesale, so a new `Core13/`/`Core14/`
+folder is analysed without any change — what such a split would need instead is
+an `excludePaths` entry for the folder that does not match the analysed version.
+The real per-version difference is `phpstan-constants.php` and the two baselines.
+Note that `packages-dev/` is not analysed at all.
 
 Core-version aware **tests** come in two shapes:
 
@@ -355,9 +384,14 @@ runs on v14 only. Examples:
 `academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php`
 (class level) and `academic-base/Tests/Unit/TcaManipulatorTest.php` (method level).
 
-Note: extensions here still use `Configuration/Services.php` (PHP-form) for DI
-rather than Symfony attributes. Match the surrounding extension's existing DI
-style when editing it.
+Note: the DI style here is **not** what a fresh extension would use. Eleven of
+the twelve extensions configure services in `Configuration/Services.yaml`; only
+`academic-persons` also has a `Configuration/Services.php`, and that file holds
+nothing but `registerForAutoconfiguration()` calls. TYPO3's DI attributes are
+already in use in production code — `#[Autoconfigure]`, `#[Autowire]`,
+`#[AsAlias]`, `#[Exclude]` — so the two styles coexist. Match the surrounding
+extension when editing it, and see
+[Dependency injection](docs/architecture/dependency-injection.md).
 
 ## TYPO3 v15 blockers — do not migrate these yet
 
@@ -365,11 +399,11 @@ Three APIs on `main` are deprecated in TYPO3 v14 and removed in v15. **None of
 them can be migrated while the branch still supports TYPO3 v13**, because the
 replacement does not exist there. Verified against both vendor trees:
 
-| API | Replacement | Present on v13.4.33? | Call sites |
-|---|---|---|---|
-| `Extbase\Annotation\*` | `Extbase\Attribute\*` | no — `cms-extbase/Classes/Attribute/` absent | 10 in 6 files |
-| `Install\Updates\*`, `Install\Attribute\UpgradeWizard` | `Core\Upgrades\*`, `Core\Attribute\UpgradeWizard` | no — `cms-core/Classes/Upgrades/` absent | 8 wizards in 5 extensions |
-| `Core\Service\FlexFormService` | `Core\Configuration\FlexForm\FlexFormTools` | class exists on v13, but without `convertFlexFormContentToArray()` on `FlexFormTools` | 1 file |
+| API                                                    | Replacement                                       | Present on v13.4.33?                                                                  | Call sites                |
+|--------------------------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------------------|---------------------------|
+| `Extbase\Annotation\*`                                 | `Extbase\Attribute\*`                             | no — `cms-extbase/Classes/Attribute/` absent                                          | 10 in 6 files             |
+| `Install\Updates\*`, `Install\Attribute\UpgradeWizard` | `Core\Upgrades\*`, `Core\Attribute\UpgradeWizard` | no — `cms-core/Classes/Upgrades/` absent                                              | 8 wizards in 5 extensions |
+| `Core\Service\FlexFormService`                         | `Core\Configuration\FlexForm\FlexFormTools`       | class exists on v13, but without `convertFlexFormContentToArray()` on `FlexFormTools` | 1 file                    |
 
 They are tracked as **ACE-294** (epic) with ACE-295, ACE-296 and ACE-297.
 Static analysis and IDE inspections will keep suggesting the replacements —
@@ -411,6 +445,8 @@ Before reporting a change as complete:
       runtime behaviour.
 - [ ] New behaviour has a test, and the test was shown to fail without the
       change.
+- [ ] [`docs/`](docs/Index.md) updated in the same change — a new concept gets a
+      page or a section, and it is linked from the section `Index.md`.
 - [ ] The affected extension's `Documentation/` updated when the change is user
       or integrator facing, with a `Documentation/Changelog/<version>/` entry —
       `Breaking-*.rst`, `Deprecation-*.rst`, `Feature-*.rst` or

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -1,0 +1,82 @@
+# Developer documentation
+
+Technical documentation for developers working **on** these extensions: how the
+mono repository is structured, which rules apply to it, how to run the tooling
+and how changes get released.
+
+Documentation for people **using** an extension lives in that extension's own
+`Documentation/` directory — for example
+[`packages/fgtclb/academic-persons/Documentation/`](../packages/fgtclb/academic-persons/Documentation)
+— is written in reStructuredText and is rendered to docs.typo3.org. There is one
+such manual per extension; this tree is the single, repository-wide counterpart.
+
+[`README.md`](../README.md) is the short overview,
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) the entry point that links here, and
+[`AGENTS.md`](../AGENTS.md) the instruction file for AI coding agents.
+
+## [Development](development/Index.md)
+
+| Page                                                  | Contents                                                                                                  |
+|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [Development environment](development/environment.md) | `runTests.sh`, container runtimes, every suite and option.                                                |
+| [Monorepo layout](development/monorepo-layout.md)     | What each directory is, the packages and their split repositories, extension keys, path package versions. |
+| [Dual core setup](development/dual-core-setup.md)     | Running against TYPO3 v13 and v14, and the rule that avoids false positives.                              |
+| [Quality gates](development/quality-gates.md)         | Every gate and its configuration, PHPStan per core version, continuous integration.                       |
+
+## [Architecture](architecture/Index.md)
+
+| Page                                                               | Contents                                                                                             |
+|--------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| [Core version aware code](architecture/core-version-aware-code.md) | Version switches, when to split a class per core version, and the APIs that block a v15 migration.   |
+| [Dependency injection](architecture/dependency-injection.md)       | Service configuration, stateless services, the TYPO3 attributes that are safe on both core versions. |
+| [Class design](architecture/class-design.md)                       | What the code base actually does with `final`, `readonly`, injection and data objects.               |
+| [Database queries](architecture/database-queries.md)               | The two query builder rules that were learned from released defects.                                 |
+
+## [Testing](testing/Index.md)
+
+| Page                                                      | Contents                                                                              |
+|-----------------------------------------------------------|---------------------------------------------------------------------------------------|
+| [PHPUnit configuration](testing/phpunit-configuration.md) | Where the configuration comes from, the deliberate deviations, the strictness policy. |
+| [Unit tests](testing/unit-tests.md)                       | Running them, discovery across all extensions, core version aware tests.              |
+| [Functional tests](testing/functional-tests.md)           | Databases, why SQLite alone is not enough, loading extensions.                        |
+| [Fixture extensions](testing/fixture-extensions.md)       | Test-only extensions and how they are wired.                                          |
+| [Testing helper](testing/testing-helper.md)               | The shared traits in `packages-dev/testing-helper/` and the trap each one exists for. |
+
+## [Workflow](workflow/Index.md)
+
+| Page                                                                   | Contents                                                                       |
+|------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| [Commit messages](workflow/commit-messages.md)                         | The TYPO3 Core conventions as this repository applies them.                    |
+| [Pull requests](workflow/pull-requests.md)                             | Branch naming, the rebase merge model, the pre-flight checklist.               |
+| [Backporting](workflow/backporting.md)                                 | The maintained targets, and analysing a backport instead of cherry-picking it. |
+| [Changelog and documentation](workflow/changelog-and-documentation.md) | The two audiences, rendering the manual, changelog entries per extension.      |
+| [Releasing](workflow/releasing.md)                                     | Versions across twelve packages, the release scripts, the publishing chain.    |
+
+## Conventions of this documentation
+
+- Every directory has an `Index.md` linking its pages; every page ends with a
+  *See also* section.
+- Pages document **why**, not just **what** — the reasoning is the part that does
+  not survive in code.
+- A change updates the page covering it in the same commit.
+- Statements are verified against the repository rather than recalled. Where a
+  page states something it could not verify, it says so.
+- **Tables are always formatted.** Every cell is padded so the pipes line up, and
+  the separator row is as wide as the widest cell in its column:
+
+  ```markdown
+  <!-- no -->
+  | Header 1 | Header 2 |
+  |----------|----------|
+  | Value 1 with long text | Value 2 |
+
+  <!-- yes -->
+  | Header 1               | Header 2 |
+  |------------------------|----------|
+  | Value 1 with long text | Value 2  |
+  ```
+
+  Both render identically, which is exactly the problem: an unaligned table is
+  invisible until someone edits it, and then the reflow touches every row and
+  buries the actual change in the diff. Alignment markers (`:---`, `---:`,
+  `:---:`) are kept and padded the same way.

--- a/docs/architecture/Index.md
+++ b/docs/architecture/Index.md
@@ -1,0 +1,33 @@
+# Architecture
+
+The rules the code follows, and the reasoning behind them. Where the code base
+does not yet follow a rule consistently, the page says so rather than
+describing an intention as if it were the state.
+
+## The short version
+
+- A difference between core versions is a **switch** while it is one or two
+  lines, and a **class split** only when a whole class has to differ.
+- Services are **stateless**. New services must be; existing ones must not gain
+  state.
+- Never hand a raw array to `in()` or `notIn()`, and build a constraint on the
+  query builder that executes it. Both rules come from defects that reached a
+  release.
+
+## Pages
+
+| Page                                                  | Contents                                                                                                                                              |
+|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Core version aware code](core-version-aware-code.md) | The version switches that exist today, what a `Core13/`/`Core14/` split would look like, and the APIs that cannot be migrated while v13 is supported. |
+| [Dependency injection](dependency-injection.md)       | How services are configured across the extensions, why they must be stateless, and which TYPO3 attributes are safe on both core versions.             |
+| [Class design](class-design.md)                       | `final`, `readonly`, constructor versus method injection, data objects, and the traps in Extbase models.                                              |
+| [Database queries](database-queries.md)               | Quoting value lists, and keeping a constraint on the builder that executes it.                                                                        |
+
+## See also
+
+- [Dual core setup](../development/dual-core-setup.md) — running against both
+  core versions.
+- [Quality gates](../development/quality-gates.md) — PHPStan is configured per
+  core version.
+- [Testing](../testing/Index.md) — how core version differences are covered by
+  tests.

--- a/docs/architecture/class-design.md
+++ b/docs/architecture/class-design.md
@@ -1,0 +1,289 @@
+# Class design
+
+Conventions for classes under `packages/fgtclb/*/Classes/` and
+`packages-dev/*/Classes/`. Where the codebase is inconsistent this page says so
+rather than describing an intention as a rule — 234 PHP files declaring 211
+classes, 9 interfaces, 10 traits and 4 enums do not follow one style yet.
+
+## `final` by default, and where it is impossible
+
+89 of the 211 classes are `final` (42 %). The distribution is not random: it
+tracks whether the framework instantiates the class or the container does.
+
+| Directory                                  | final  | plain   | abstract | % final  |
+|--------------------------------------------|--------|---------|----------|----------|
+| `Classes/Upgrades/`                        | 9      | 0       | 0        | 100 %    |
+| `Classes/Service/` and `Classes/Services/` | 9      | 3       | 0        | 75 %     |
+| `Classes/EventListener/`                   | 2      | 1       | 0        | 67 %     |
+| `Classes/Controller/`                      | 9      | 5       | 1        | 60 %     |
+| `Classes/Domain/Model/Dto/`                | 5      | 10      | 1        | 31 %     |
+| `Classes/ViewHelpers/`                     | 2      | 8       | 0        | 20 %     |
+| `Classes/Domain/Model/` (excluding `Dto/`) | 0      | 23      | 0        | 0 %      |
+| `Classes/Domain/Repository/`               | 0      | 16      | 0        | 0 %      |
+| Everything else                            | 53     | 50      | 4        | 49 %     |
+| **Total**                                  | **89** | **116** | **6**    | **42 %** |
+
+Make a new class `final` unless something concrete prevents it. Services are
+replaced through the container, not through inheritance, so extensibility is
+provided by swapping the implementation behind an interface — not by leaving
+the class open.
+
+**Extbase domain models cannot be final in practice.** All 19 classes extending
+`AbstractEntity` are plain `class`, and this is the framework's shape rather
+than an oversight: the data mapper hydrates an instance it creates without
+calling the constructor, and projects routinely extend a shipped model to add
+fields. The same applies to the 16 repositories, none of which is `final`.
+
+There is no `AbstractValueObject` subclass anywhere in the repository.
+
+When `final` has to be dropped for a reason that is not structural, record the
+reason. `academic-persons/Classes/Service/RecordSynchronizer.php` line 19 does
+this and is the pattern to copy:
+
+```php
+* @final not marked as final for functional testing reasons (for now). Class should not be extended otherwise.
+```
+
+## `readonly` on properties, not on classes
+
+**There is not a single `readonly class` declaration in this repository.**
+`readonly` is used heavily, but always on individual properties: 161 modifiers,
+of which 160 are constructor-promoted. The one non-promoted declaration is
+`typo3-category-types/Classes/Collection/FilterCollection.php` line 15.
+
+The split by visibility says what each is for:
+
+| Modifier             | Count | Means                                             |
+|----------------------|-------|---------------------------------------------------|
+| `private readonly`   | 99    | An injected collaborator                          |
+| `public readonly`    | 41    | A field of an immutable data object               |
+| `protected readonly` | 21    | Either, in classes with subclasses or older style |
+
+Use `private readonly` for every constructor-injected dependency. It states that
+the service does not rebind it, which is the property half of the stateless rule
+in [Dependency injection](dependency-injection.md#services-are-stateless).
+
+`readonly class` is not used, and adopting it is not a small change: a
+`readonly` class cannot extend a non-`readonly` one and vice versa, so the whole
+hierarchy has to agree. With Extbase base classes in the picture that decision
+is not available for models, repositories, controllers or validators. Property
+level `readonly` gives the same guarantee where it matters without that
+constraint.
+
+Extbase domain models use mutable `protected` properties with getters and
+setters throughout, because the data mapper assigns by reflection. That is
+required, not a deviation.
+
+## Constructor injection, and the abstract class exception
+
+Constructor injection with promoted properties is the default: 64 files declare
+159 promoted `readonly` parameters. The fullest example is
+`academic-persons-edit/Classes/Controller/ContractController.php` lines 35–44 —
+eight promoted `private readonly` dependencies and an empty constructor body.
+
+**Method injection is used where a constructor is not available to take
+dependencies.** There are 21 `inject*()` methods across 9 files and **zero**
+`@inject` annotations — the annotation form is not used at all, which is worth
+keeping true.
+
+The legitimate case is an abstract base class. Its constructor is part of the
+API of every class extending it, including classes in projects outside this
+repository, so adding a dependency there breaks all of them. Method injection
+keeps the constructor free:
+
+```php
+protected Context $context;
+
+#[Required]
+public function injectContext(Context $context): void
+{
+    $this->context = $context;
+}
+```
+
+`academic-persons-edit/Classes/Controller/AbstractActionController.php` lines
+62–100 does this six times, which is what lets its six `final` subclasses each
+declare their own constructor.
+
+The 6 abstract classes and what each is for:
+
+| Class                                                                             | Purpose                                                   |
+|-----------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `academic-persons/Classes/Types/AbstractTypes.php:17`                             | Type lists loaded from extension configuration            |
+| `academic-persons/Classes/DemandValues/AbstractDemandValues.php:17`               | The same pattern for demand and filter value lists        |
+| `academic-persons/Classes/Profile/AbstractProfileFactory.php:28`                  | Shared profile factory state and collaborators            |
+| `academic-persons-edit/Classes/Controller/AbstractActionController.php:46`        | Shared services for the six edit controllers, `@internal` |
+| `academic-persons-edit/Classes/Domain/Validator/AbstractFormDataValidator.php:17` | Extbase validator base pulling `AcademicPersonsSettings`  |
+| `academic-persons-edit/Classes/Domain/Model/Dto/AbstractFormData.php:13`          | Base for the form-data DTOs                               |
+
+Method injection on a **concrete** class does not have this justification.
+`academic-persons/Classes/Controller/ProfileController.php` (three `inject*()`
+methods, no constructor) and
+`academic-persons-edit/Classes/Service/ListSortingService.php` line 29 are
+existing code, not templates for new code — the latter is also cited in
+[Dependency injection](dependency-injection.md#where-the-codebase-does-not-comply)
+because its injected property is nullable and therefore mutable state.
+
+### `GeneralUtility::makeInstance()`
+
+91 call sites across the `Classes/` directories. Some are unavoidable: TCA and
+FormEngine code under `Classes/Backend/` and `Classes/Tca/` (22 sites) runs
+where no container-injected instance is available, and a `DeletedRestriction` or
+similar throwaway object is not a service at all.
+
+The rest are not unavoidable. `makeInstance()` appears inside domain models
+(9 sites, for example `academic-partners/Classes/Domain/Model/Partner.php` lines
+121 and 184), repositories (7) and controllers (15) — all places that can take a
+constructor argument instead. Prefer injection; reach for `makeInstance()` when
+there is genuinely no container, and not as a shortcut around editing a
+constructor.
+
+## Data objects are not services
+
+Models, DTOs, value objects and collections represent data. They are created
+with `new`, by a factory, or by the persistence layer — never fetched from the
+container.
+
+The immutable data objects in this repository share one recognisable shape:
+`final class` with promoted `public readonly` fields.
+
+```php
+final class SynchronizerContext
+{
+    public function __construct(
+        public readonly RecordSynchronizerInterface $recordSyncronizer,
+        public readonly Site $site,
+        public readonly SiteLanguage $defaultLanguage,
+        public readonly array $allowedSiteLanguages,
+        public readonly string $tableName,
+        public readonly int $uid,
+    ) {}
+```
+
+Others: `academic-base/Classes/Tca/TableConfiguration.php` (13 fields, and a
+**private** constructor behind the named constructor
+`TableConfiguration::create()` at line 37 — the shape to use when construction
+needs validation), and the four
+`academic-persons/Classes/Settings/` classes.
+
+Not everything under `Domain/Model/Dto/` is immutable, and that is deliberate:
+the `*Demand` and `*FormData` classes are mapping targets that Extbase property
+mapping and form submission write into, so they are mutable by necessity. Do not
+"fix" them into `readonly`.
+
+### Keep data objects out of the container
+
+A directory registered by `$services->load()` or a YAML `resource:` cannot tell
+a service from a data object. Two mechanisms keep them out, and both are in use:
+
+- The `exclude:` key in `Configuration/Services.yaml`, which is how the Extbase
+  models are excluded in most packages.
+- Symfony's `#[Exclude]` attribute on the class, for data objects that do not
+  sit under an excluded path. Three sites, all in
+  `academic-persons/Classes/Settings/`: `Validation.php:12`,
+  `ValidationSet.php:13`, `ProfileInformationType.php:12`.
+
+The `Settings/` classes show why the attribute is needed: they are immutable
+data objects that happen to live outside `Domain/Model/`, so the package's
+`exclude` does not reach them.
+
+A data object that is registered but never type hinted is discarded when the
+container is compiled, so the omission is invisible until someone type hints it
+— and the resulting build failure names the data object, not the code that
+referenced it.
+
+### Enums
+
+Four, all backed, none pure:
+
+| Enum                                                              | Backing  |
+|-------------------------------------------------------------------|----------|
+| `academic-jobs/Classes/SaveForm/FlashMessageCreationMode.php:7`   | `int`    |
+| `academic-persons/Classes/Profile/ProfileActionType.php:14`       | `string` |
+| `academic-persons-edit/Classes/Attributes/ListSortingMode.php:12` | `string` |
+| `academic-projects/Classes/Domain/Model/Dto/ActiveState.php:7`    | `string` |
+
+Back an enum whenever its values are persisted, passed through a request, or
+written into TCA — a pure enum cannot survive any of those round trips.
+
+## The Extbase `FileReference` trap
+
+Verified against the installed TYPO3 v13.4.34 tree:
+`.Build/vendor/typo3/cms-extbase/Classes/Domain/Model/FileReference.php` is 52
+lines and declares **two** public methods:
+
+```php
+public function setOriginalResource(\TYPO3\CMS\Core\Resource\FileReference $originalResource): void   // line 37
+public function getOriginalResource(): \TYPO3\CMS\Core\Resource\FileReference                        // line 43
+```
+
+Everything else it has is inherited from `AbstractEntity` →
+`AbstractDomainObject`: `getUid()`, `getPid()`, `setPid()` and the
+underscore-prefixed internal API.
+
+It has **no** `getTitle()`, `getAlternative()`, `getDescription()`, `getLink()`,
+`getName()`, `getPublicUrl()`, `getProperty()` or `getProperties()`.
+
+The consequence in Fluid is the trap, because Fluid does not raise an error for
+a property it cannot resolve — it renders an empty string. So
+`{profile.image.title}` produces silently empty markup: an `alt` attribute that
+is present and blank, a caption block that renders as an empty element. Nothing
+in a test or a log points at it.
+
+Go through `originalResource` to reach the core
+`TYPO3\CMS\Core\Resource\FileReference`, which does expose those getters:
+
+```html
+alt="{profile.image.originalResource.alternative}"
+title="{profile.image.originalResource.title}"
+```
+
+`academic-persons-edit/Resources/Private/Partials/Profile/Show/Image.html` lines
+50, 51, 56 and 57 is the only place in the repository that accesses file
+reference metadata, and it is the only place using `originalResource`.
+Everywhere else the Extbase `FileReference` is passed straight to `<f:image>` or
+`<f:uri.image>`, which resolves it internally — no property access, no trap.
+
+One further step down: on the **core** `FileReference`, `getProperty()` throws
+`\InvalidArgumentException` (code 1314226805) when the property is missing —
+verified at `.Build/vendor/typo3/cms-core/Classes/Resource/FileReference.php`
+lines 112–119. For an optional field use `getProperties()` (line 141) and index
+into it, or guard with `hasProperty()` (line 101). Do not call `getProperty()`
+on a field that may not be set.
+
+## Strict types
+
+226 of the 234 files declare `strict_types=1`. New files must. The 8 that do not
+are worth knowing so they are fixed rather than copied:
+
+| File                                                                  |
+|-----------------------------------------------------------------------|
+| `academic-partners/Classes/DataProcessing/PartnershipProcessor.php`   |
+| `academic-partners/Classes/DataProcessing/PartnerProcessor.php`       |
+| `academic-contact4pages/Classes/DataProcessing/ContactsProcessor.php` |
+| `academic-programs/Classes/DataProcessing/ProgramDataProcessor.php`   |
+| `academic-persons/Classes/Event/ModifySelectedProfilesEvent.php`      |
+| `academic-persons/Classes/Event/ModifySelectedContractsEvent.php`     |
+| `academic-persons/Classes/Settings/Validation.php`                    |
+| `academic-projects/Classes/ViewHelpers/Format/ReplaceViewHelper.php`  |
+
+Four of the eight are `DataProcessing/` classes, which suggests one origin
+rather than eight independent omissions.
+
+## Static analysis
+
+PHPStan runs at **level 8** in both `Build/phpstan/Core13/phpstan.neon` and
+`Build/phpstan/Core14/phpstan.neon` (line 13 of each). Level 8 is what makes the
+nullability of a property meaningful, so a `?Foo $foo = null` that is really
+always set has to be justified rather than assumed.
+
+Note that `paths` is `../../../packages` only: **`packages-dev/` is not analysed
+by PHPStan**. The two shared meta packages, including the functional test traits
+in `packages-dev/testing-helper/`, are outside the gate. Keep that in mind when
+changing them — lint and the tests themselves are the only checks they get.
+
+## See also
+
+- [Dependency injection](dependency-injection.md)
+- [Core version aware code](core-version-aware-code.md)
+- `AGENTS.md` — repository conventions and database query rules

--- a/docs/architecture/core-version-aware-code.md
+++ b/docs/architecture/core-version-aware-code.md
@@ -1,0 +1,399 @@
+# Core version aware code
+
+Branch `main` (`3.0.0-dev`) supports **TYPO3 v13 and v14 from one code base**.
+Code that cannot be written for both at once is *core version aware*: it asks
+the running TYPO3 version and picks a form, or it exists once per version and
+only the matching variant is used.
+
+This page documents what this repository does today, which is deliberately the
+smaller of those two options.
+
+## There is no `Core13/` / `Core14/` split here
+
+Verified across the whole repository: no `Core13/` or `Core14/` directory
+exists under `packages/` or `packages-dev/`. Every core version difference is
+currently resolved **inside** the file that has it.
+
+Three mechanisms are in use, and they differ by *where* the difference sits —
+not by preference:
+
+| Mechanism                                  | Used in                               | Count              |
+|--------------------------------------------|---------------------------------------|--------------------|
+| Version switch inside a PHP class          | `packages/fgtclb/*/Classes/`          | 1 file, 2 switches |
+| Version switch inside a configuration file | `packages/fgtclb/*/Configuration/`    | 15 files           |
+| Version dependent constant                 | `packages/fgtclb/*/EXT_CONSTANTS.php` | 2 files            |
+
+All of them switch on `(new Typo3Version())->getMajorVersion()`.
+
+### A switch inside a class
+
+Exactly one class under any `Classes/` directory carries a version switch:
+[`packages/fgtclb/academic-base/Classes/TcaManipulator.php`](../../packages/fgtclb/academic-base/Classes/TcaManipulator.php).
+It has two, and both exist because the two core versions want incompatible
+input for the same job.
+
+**`addContentElementPlugin()` — line 137.** The signature of
+`ExtensionManagementUtility::addPlugin()` changed. On v13 it takes
+`($item, $type, $extensionKey)` and only registers a CType when `$type` is
+`ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT`. TYPO3 v14 removed the
+`list_type` sub-type concept: `addPlugin()` takes `($item, $flexForm)` and
+always registers the plugin value as a first-class CType, so passing the old
+arguments is a signature error. The wrapper builds an argument array and
+spreads it, so the argument count is resolved at runtime and static analysis
+does not flag either version:
+
+```php
+$arguments = [$item];
+if ((new Typo3Version())->getMajorVersion() < 14) {
+    $arguments[] = ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT;
+    $arguments[] = $extensionKey;
+}
+ExtensionManagementUtility::addPlugin(...$arguments);
+```
+
+**`addContentElementPluginFlexForm()` — line 168.** The FlexForm `ds` shape
+differs, and **neither version tolerates the other's**:
+
+```php
+$GLOBALS['TCA']['tt_content']['types'][$cType]['columnsOverrides']['pi_flexform']['config']['ds']
+    = (new Typo3Version())->getMajorVersion() >= 14
+        ? $dataStructure
+        : ['default' => $dataStructure];
+```
+
+The two failure modes are not symmetric, which is why this is worth spelling
+out (the reasoning is recorded in the method's own docblock, lines 145–158):
+
+- **v13 given a string** resolves `ds` through `ds_pointerField` and requires
+  an array. It throws from `FlexFormTools` (code 1463826960) and the content
+  element can no longer be opened in the backend at all — loud, and obvious.
+- **v14 given an array** resolves the data structure through the record type of
+  the TCA schema and requires the string. It throws `InvalidTcaException` (code
+  1751796940) — but `TcaFlexPrepare` catches it, so the backend silently
+  renders an **empty** FlexForm tab. Nothing fails visibly; the plugin just
+  loses its settings.
+
+A wrong guess in this one place is therefore not caught by "the backend still
+loads". Both directions are covered by tests, see
+[Core version aware tests](#core-version-aware-tests).
+
+### A switch inside a configuration file
+
+TCA, TypoScript and `ext_localconf.php` are loaded by TYPO3 from a fixed path
+and cannot be swapped per core version. A difference there has to be resolved
+in the file. 15 files under `packages/fgtclb/*/Configuration/` do this, and
+they follow a consistent shape: build the array, adjust it at the end, return
+it. For example
+[`packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php`](../../packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php)
+lines 386–394:
+
+```php
+// The 'searchFields' TCA ctrl option was removed in TYPO3 v14 (Breaking #106972);
+// v14 makes suitable field types searchable by default. Keep the explicit
+// inclusion list on v13, which still evaluates 'searchFields'.
+// @todo Remove once TYPO3 v13 support is dropped.
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 14) {
+    $tcaConfiguration['ctrl']['searchFields'] = '...';
+}
+
+return $tcaConfiguration;
+```
+
+Three properties make this readable rather than corrosive, and they are worth
+copying:
+
+- The switch is **at the end**, applied to the finished array, not scattered
+  through it.
+- It carries a **`@todo` naming its exit condition**. A version switch without
+  one becomes permanent.
+- It names the **changelog issue**, so the reason can be looked up rather than
+  recalled. The changelogs ship with `typo3/cms-core` under
+  `Documentation/Changelog/`.
+
+Dropping the option instead of guarding it is not equivalent: v14 removed it,
+but v13 still evaluates it and would search nothing without it.
+
+[`packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php`](../../packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php)
+line 62 shows the same shape for a registry call rather than an array key: v13
+has no `allowedRecordTypes` TCA option and still resolves allowed tables
+through `PageDoktypeRegistry`, whose `ext_tables.php` registration was
+deprecated in v14.3.
+
+### A constant, when the difference is inside an attribute argument
+
+The third mechanism exists because the other two are unavailable. PHP attribute
+arguments must be constant expressions, so a version switch cannot be written
+inside one. The Extbase `#[Cascade]` attribute takes the array form
+`['value' => 'remove']` on v13 and the plain string `'remove'` on v14, and
+passing the wrong one is fatal.
+
+[`packages/fgtclb/academic-persons/EXT_CONSTANTS.php`](../../packages/fgtclb/academic-persons/EXT_CONSTANTS.php)
+lines 28–34 resolves this by defining the value once, before the models are
+loaded:
+
+```php
+defined('ACADEMIC_PERSONS_CASCADE_REMOVE')
+    || define(
+        'ACADEMIC_PERSONS_CASCADE_REMOVE',
+        (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 14
+            ? 'remove'
+            : ['value' => 'remove']
+    );
+```
+
+Domain models then write `#[Cascade(ACADEMIC_PERSONS_CASCADE_REMOVE)]`. The
+file is loaded twice on purpose — through `autoload.files` in `composer.json`
+(Composer mode) and through a `require_once` in `ext_localconf.php` (Classic
+mode) — and the `defined()` guard makes the double include harmless.
+
+`academic_persons` and `academic_jobs` each ship one, with their own constant
+name. Both are excluded from PHPStan (`Build/phpstan/Core*/phpstan.neon` line
+20) and mirrored for analysis in `Build/phpstan/Core*/phpstan-constants.php`,
+because the constant's *type* differs per core version and static analysis has
+to be told which one it is looking at.
+
+## The rule
+
+**Keep a one- or two-line difference as a version switch. Reach for a folder
+split only when a whole class has to differ.**
+
+The switches above are each one condition applied to one value, next to a
+comment explaining the core behaviour and a `@todo` naming when it goes away.
+Splitting a class in two to express that would cost more than it saves, and it
+would double the code to delete when v13 support ends.
+
+The threshold is not the number of switches but their reach: once a class needs
+different *dependencies*, different *method signatures*, or an API that does
+not exist on the other version at all, a switch cannot express it and the class
+has to exist twice.
+
+## What a folder split would look like
+
+Not used in this repository — documented so the shape is agreed on before
+someone needs it. The technique can be looked up in
+`web-vision/deepltranslate-core` or `fgtclb/environment-state-manager`.
+
+Two additional class folders, one per supported core version of the branch,
+with the core version as the **third namespace level**:
+
+```json
+"autoload": {
+    "psr-4": {
+        "FGTCLB\\AcademicBase\\": "Classes/",
+        "FGTCLB\\AcademicBase\\Core13\\": "Core13/",
+        "FGTCLB\\AcademicBase\\Core14\\": "Core14/"
+    }
+}
+```
+
+Composer autoloads **all** of them on every core version. That is unavoidable
+and harmless, as long as a class is never *instantiated* on the wrong version.
+The selection therefore happens in the dependency injection container, in
+`Configuration/Services.php`, which loads only the folder matching the running
+major version:
+
+```php
+// TYPO3 core-version specific sources: only the folder matching the running
+// TYPO3 major version is loaded. The concrete services are published and
+// wired through Symfony dependency injection attributes on the classes
+// themselves (#[AsAlias], #[Autoconfigure], #[Autowire]).
+$majorVersion = (new Typo3Version())->getMajorVersion();
+$services->load(
+    sprintf('FGTCLB\\AcademicBase\\Core%d\\', $majorVersion),
+    sprintf(__DIR__ . '/../Core%d/*', $majorVersion),
+);
+```
+
+The pattern that makes this work is not the split itself:
+
+1. Declare an **interface** in `Classes/` — consumers only ever type hint it.
+2. Put shared behaviour in an **abstract base class** in `Classes/`.
+3. Implement it once per core version, each registering itself as the default
+   implementation of the interface with `#[AsAlias]`.
+
+Steps 1 and 2 are worth having without any split. Note that adopting this in an
+existing extension here also means adopting a `Services.php` that loads
+directories, which most extensions in this repository do not currently have —
+see [Dependency injection](dependency-injection.md).
+
+## Static analysis
+
+PHPStan runs per core version, selected by `runTests.sh -t 13|14`, against
+`Build/phpstan/Core13/` or `Build/phpstan/Core14/`. Both are level 8.
+
+The two `phpstan.neon` files are **byte identical**; what differs between the
+directories is:
+
+| File                    | Difference                                                             |
+|-------------------------|------------------------------------------------------------------------|
+| `phpstan.neon`          | none — identical, `paths` is `../../../packages` in both               |
+| `phpstan-baseline.neon` | separate baselines (216 lines on Core13, 231 on Core14)                |
+| `phpstan-constants.php` | the `#[Cascade]` constant: array form on Core13, string form on Core14 |
+
+Because `paths` points at `packages` as a whole rather than at named
+subdirectories, a new `Core13/` or `Core14/` folder inside a package would be
+picked up automatically — no `paths` entry to add. The entry that *would* be
+needed is an `excludePaths` one, so that each configuration does **not** analyse
+the other version's folder: analysing v14-only sources against an installed v13
+reports API that legitimately does not exist there.
+
+Note that `paths` also means **`packages-dev/` is not analysed by PHPStan at
+all** — the two shared meta packages, including the functional test traits in
+`packages-dev/testing-helper/`, sit outside the gate on both core versions. A
+core version aware helper added there would get no static analysis; only
+`lintPhp` and the tests themselves would cover it.
+
+Both core versions must be checked before opening a pull request, each after
+its own `composerUpdate` — `-t` selects configuration only, never the installed
+vendor tree.
+
+## APIs that cannot be modernised yet
+
+Three APIs on `main` have newer replacements that **do not exist on TYPO3 v13**,
+so none of them can be migrated while the branch still supports v13. They are
+tracked as **ACE-294** (epic) with ACE-295, ACE-296 and ACE-297.
+
+Static analysis and IDE inspections will keep offering the replacements. Ignore
+them here: a "helpful" import rewrite is a fatal error on v13.
+
+**What could be verified.** The test vendor tree at `.Build/vendor/typo3/` is
+currently installed at **TYPO3 v13.4.34**
+(`.Build/vendor/typo3/cms-core/Classes/Information/Typo3Version.php` line 22),
+so only the v13 half of each claim is verifiable there. The v14 column below
+was checked against the development instance `core-14/vendor/`, which its
+tracked `composer.lock` pins to **v14.3.6**.
+
+In all three cases the old name still works on v14 — deprecated, not removed —
+so the code compiles and runs on both versions today. What blocks the migration
+is the **replacement**, which does not exist on v13.
+
+| API                                                    | On v13.4.34 | On v14.3.6                        | Replacement — absent on v13                       |
+|--------------------------------------------------------|-------------|-----------------------------------|---------------------------------------------------|
+| `Extbase\Annotation\*`                                 | present     | deprecated, kept as class alias   | `Extbase\Attribute\*`                             |
+| `Install\Updates\*`, `Install\Attribute\UpgradeWizard` | present     | deprecated, kept as subclass shim | `Core\Upgrades\*`, `Core\Attribute\UpgradeWizard` |
+| `Core\Service\FlexFormService`                         | present     | deprecated, kept as class alias   | `FlexFormTools::convertFlexFormContentToArray()`  |
+
+TYPO3 v14 keeps a deprecated class available by one of **two** mechanisms, and
+they look different on disk. Check both before concluding a class is gone —
+looking only in the owning package's `Classes/` directory is misleading:
+
+1. **A class alias.** The package declares
+   `extra.typo3/class-alias-loader.class-alias-maps` in its `composer.json`,
+   pointing at `Migrations/Code/ClassAliasMap.php`. Composer's
+   `typo3/class-alias-loader` plugin merges those into
+   `vendor/composer/autoload_classaliasmap_static.php`, where the keys are
+   **lowercased** — a case-sensitive grep for the original class name finds
+   nothing there.
+2. **A subclass shim** in a `DeprecatedClasses/` directory, autoloaded by a
+   `classmap` entry rather than by PSR-4, so the file path does not follow the
+   namespace.
+
+Details, so each row can be re-checked rather than trusted:
+
+- **Extbase annotations** — mechanism 1. `cms-extbase/Classes/Annotation/`
+  exists on v13 and not on v14, but
+  `cms-extbase/Migrations/Code/ClassAliasMap.php`
+  lines 19–24 alias all six old names onto `Extbase\Attribute\*`, and those
+  entries are present in the generated map. `cms-extbase/Classes/Attribute/`
+  does not exist on v13, so the new names cannot be used. 10 imports in 6
+  files, all under `packages/fgtclb/*/Classes/`.
+- **`FlexFormService`** — mechanism 1.
+  `cms-core/Migrations/Code/ClassAliasMap.php`
+  line 19 aliases it onto `FlexFormTools`. The method this repository needs,
+  `convertFlexFormContentToArray()`, exists on `FlexFormTools` only on v14
+  (line 298); on v13 the class exists without it. One call site:
+  `packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php`
+  lines 11 and 33.
+- **Upgrade wizards** — mechanism 2. 9 wizards in 5 extensions import
+  `TYPO3\CMS\Install\Attribute\UpgradeWizard`,
+  `TYPO3\CMS\Install\Updates\UpgradeWizardInterface` and
+  `TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite`. On v14 these classes
+  are **not** under `cms-install/Classes/` any more; they live in
+  `cms-core/DeprecatedClasses/ext-install/` — nine files under `Updates/` plus
+  `Attribute/UpgradeWizard.php` — and are autoloaded through
+  `"classmap": ["DeprecatedClasses/ext-install/"]` in `cms-core/composer.json`.
+  Each is a one-line shim over the new class, for example:
+
+  ```php
+  namespace TYPO3\CMS\Install\Updates;
+
+  use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface as CoreInterface;
+
+  /**
+   * @deprecated since v14.0, will be removed in TYPO3 v15.0. Use \TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface instead.
+   */
+  interface UpgradeWizardInterface extends CoreInterface {}
+  ```
+
+  The wizards therefore load and work unchanged on v14. `Core\Upgrades\*` and
+  `Core\Attribute\UpgradeWizard` exist on v14.3.6 and not on v13.4.34, which is
+  what blocks the migration, exactly as for the other two rows.
+
+The deprecation of the upgrade wizard shims is **docblock only** — there is no
+`trigger_error()` anywhere under `cms-core/DeprecatedClasses/`. It therefore
+does not interact with `failOnDeprecation` in the test suites, and no test will
+report it. The v15 removal date has to be tracked deliberately; nothing in the
+build will raise it.
+
+There are two ways out of the epic, and the choice belongs to it rather than to
+an individual change: drop v13 support first (expected), or introduce the
+folder split above — disproportionate for roughly 19 call sites.
+
+**Not on this list:** references to core labels marked `x-unused-since="14.0"`.
+They look similar, but they are labels on this repository's *own* TCA, so
+shipping its own text resolves them today on both core versions (**ACE-298**).
+
+## Core version aware tests
+
+`Build/Scripts/runTests.sh` always passes
+`--exclude-group not-core-${CORE_VERSION}` for the selected core version —
+lines 659 (functional), 751 (unit) and 757
+(`unitRandom`). A test tagged `not-core-13` therefore runs on v14 only, and
+vice versa. Nothing else has to be wired up.
+
+Two shapes are in use.
+
+**A whole class that only applies to one version** carries the group on the
+class:
+
+```php
+#[Group('not-core-13')]
+final class AcademicJobsNewJobFormUploadTest extends AbstractAcademicJobsTestCase
+```
+
+[`packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php`](../../packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php)
+line 32, and
+[`packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php`](../../packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php)
+line 29. Both carry a docblock naming the core behaviour that forces the
+exclusion and a `@todo` to drop the group when v13 support ends.
+
+**A single method, or a class that only differs in fixtures**, carries the
+group on the method. This is the shape to use when both versions need
+asserting, because the two methods then sit next to each other and neither can
+be forgotten:
+[`packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php`](../../packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php)
+lines 565 and 584 pin exactly the FlexForm `ds` shapes described above —
+`pluginFlexFormIsAssignedAsArrayOnCoreV13()` with `#[Group('not-core-14')]` and
+`pluginFlexFormIsAssignedAsStringOnCoreV14()` with `#[Group('not-core-13')]`.
+
+The `not-core-13` group also appears on four `DeprecatedCoreLabelsTest` classes
+(`academic-partners`, `academic-persons`, `academic-contact4pages`,
+`academic-jobs`, each at line 19), whose shared trait
+[`packages-dev/testing-helper/Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php)
+documents why the assertion is v14 only.
+
+`AGENTS.md` also describes a `Core13/`/`Core14/` subfolder of `Tests/Unit` or
+`Tests/Functional` for a whole version specific test class. That is policy, not
+practice: no such directory exists yet, and the class-level group above is what
+is actually used.
+
+Note that `--exclude-group` composes with the DBMS exclusion on functional runs
+(`--exclude-group not-${DBMS}`, same line 659), so a test can be restricted
+along both axes independently.
+
+## See also
+
+- [Dependency injection](dependency-injection.md)
+- [Class design](class-design.md)
+- `AGENTS.md` — repository conventions, version support and backport targets
+- `Build/Scripts/runTests.sh` — the `-t` core version selector

--- a/docs/architecture/database-queries.md
+++ b/docs/architecture/database-queries.md
@@ -1,0 +1,413 @@
+# Database queries
+
+Two rules govern every hand-written query in this repository. Both were learned
+from defects that reached a release — ACE-349 and ACE-356 — and both share a
+property that makes them expensive: the broken code runs green on the default
+test setup and only fails somewhere else, on another database, in production.
+
+Neither rule is a style preference. Each one describes a mechanism in the query
+builder that is easy to misread, and the shape of code that stays correct once
+the mechanism is understood.
+
+## Which query builder this is about
+
+Both rules are about the **decorated TYPO3 query builder**,
+`TYPO3\CMS\Core\Database\Query\QueryBuilder`, obtained from the connection pool:
+
+```php
+$queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_category');
+```
+
+It is declared in
+`.Build/vendor/typo3/cms-core/Classes/Database/Query/QueryBuilder.php:66` and
+describes itself as "a facade to the Doctrine DBAL QueryBuilder that implements
+PHP7 type hinting and automatic quoting of table and column names"
+(class docblock, lines 50-65). Its expression builder is
+`TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder`
+(`.Build/vendor/typo3/cms-core/Classes/Database/Query/Expression/ExpressionBuilder.php:39`),
+which extends the Doctrine one.
+
+It is **not** the Extbase query object. `TYPO3\CMS\Extbase\Persistence\Generic\Query`
+(`.Build/vendor/typo3/cms-extbase/Classes/Persistence/Generic/Query.php:16`)
+also offers an `in()` method (line 503), but that one takes a plain PHP array
+by design and builds an object-level constraint, not SQL. Extbase repository
+code such as
+`packages/fgtclb/academic-persons/Classes/Domain/Repository/ProfileRepository.php:198`
+(`$query->matching($query->in('uid', $profileUidArray))`) is therefore outside
+the scope of both rules below. Check which object is in the variable before
+applying either rule to a piece of code.
+
+## Rule 1 — never hand a raw array to `in()` or `notIn()`
+
+### The correct form
+
+Quote the list with the query builder helper meant for it, and pass the
+resulting string:
+
+```php
+$queryBuilder->expr()->in('uid', $queryBuilder->quoteArrayBasedValueListToIntegerList($uids));
+$queryBuilder->expr()->in('CType', $queryBuilder->quoteArrayBasedValueListToStringList($types));
+```
+
+Use the integer variant for uid-like lists and the string variant for
+identifier lists such as `CType` values or category type keys.
+
+### Why this works — verified in the installed core
+
+The installed core in `.Build/vendor/` is **TYPO3 v13.4.34** with
+`doctrine/dbal` 4.4.4. The development instance in `core-14/vendor/` carries
+**TYPO3 v14.3.6** with the same DBAL version, and was used to confirm the same
+behaviour on v14.
+
+Both helpers live on the query builder itself and start with the same guard:
+
+| Method                                    | v13.4.34 (`.Build/vendor/`) | v14.3.6 (`core-14/vendor/`) |
+|-------------------------------------------|-----------------------------|-----------------------------|
+| `quoteArrayBasedValueListToIntegerList()` | `QueryBuilder.php:1145`     | `QueryBuilder.php:1148`     |
+| `quoteArrayBasedValueListToStringList()`  | `QueryBuilder.php:1176`     | `QueryBuilder.php:1179`     |
+
+The integer variant reads (v13.4.34, `QueryBuilder.php:1145-1158`):
+
+```php
+public function quoteArrayBasedValueListToIntegerList(array $values): string
+{
+    if (empty($values)) {
+        return 'NULL';
+    }
+    // Ensure values are all integer
+    $values = GeneralUtility::intExplode(',', implode(',', $values));
+    // Ensure all values are quoted as int for used dbms
+    $connection = $this;
+    array_walk($values, static function (mixed &$value) use ($connection): void {
+        $value = $connection->quote((string)$value);
+    });
+    return implode(',', $values);
+}
+```
+
+Two things matter here. The empty array returns the **string** `NULL`, so the
+condition renders as `field IN (NULL)` — syntactically valid on every supported
+DBMS and matching no row, because a comparison against `NULL` is never true.
+And the non-empty case quotes every element through the connection, which is
+what makes it safe to inline the values into the SQL instead of binding them.
+
+The core docblock states the intent explicitly
+(`QueryBuilder.php:1129-1144`): the value list is meant "to be used as direct
+value list for database 'in(...)' or 'notIn(...)' expressions. Empty array will
+return 'NULL' as string to avoid database query failure, as 'IN()' is invalid,
+but 'IN(NULL)' is fine." It also carries a caveat worth knowing: the returned
+string cannot be used in a prepared statement that is re-bound with different
+values for a subsequent execution.
+
+### What happens without the helper
+
+Passing the array straight through has three different outcomes depending on
+the core version and the database, which is exactly why the defect survived
+review:
+
+| Core version | Empty array passed to `in()` / `notIn()`            | Where it surfaces                    |
+|--------------|-----------------------------------------------------|--------------------------------------|
+| v13, v14     | `\InvalidArgumentException` before any SQL is built | Everywhere, immediately              |
+| v12          | No guard; `field IN ()` reaches the database        | MariaDB, MySQL, PostgreSQL reject it |
+| v12          | No guard; `field IN ()` reaches the database        | SQLite accepts it and returns no row |
+
+The v13 guard is verifiable from this checkout
+(`ExpressionBuilder.php:227-234` on v13.4.34, `:223-230` on v14.3.6):
+
+```php
+public function in(string $fieldName, $value): string
+{
+    if ($value === []) {
+        throw new \InvalidArgumentException(
+            'ExpressionBuilder::in() can not be used with an empty array value.',
+            1701857902
+        );
+    }
+```
+
+`notIn()` carries the same guard with code `1701857904`
+(`ExpressionBuilder.php:255-262`); the empty-string variants are `1701857903`
+and `1701857905`.
+
+**What could not be verified from this checkout:** no TYPO3 v12 vendor tree
+exists here — `main` supports v13 and v14 only — so the statement that v12 has
+no guard at all, and the per-DBMS behaviour of a literal `IN ()`, are taken
+from the ACE-349 analysis recorded in
+`packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRepositoryEmptyUidList.rst`
+and not re-checked against a v12 installation. The same applies to the claim
+that both helpers exist since TYPO3 v11.5: only v13.4.34 and v14.3.6 were
+inspected. The v12 case still matters for branch `2`, which supports v12 and
+v13.
+
+The practical consequence is the same on every branch: **the default
+`-d sqlite` functional run does not reveal this defect on v12**, and on v13/v14
+it turns a silently empty result into a hard exception the moment a list
+happens to be empty in production.
+
+### Named parameters are equally safe
+
+Binding the list instead of inlining it has the same empty-array behaviour:
+
+```php
+$queryBuilder->expr()->in(
+    't3ver_wsid',
+    $queryBuilder->createNamedParameter([0, $workspaceUid], Connection::PARAM_INT_ARRAY)
+)
+```
+
+That is the form used in
+`packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php:317-320`.
+Doctrine expands an array parameter when the statement is prepared, and an
+empty one becomes the literal `NULL`
+(`.Build/vendor/doctrine/dbal/src/ExpandArrayParameters.php:99-103`):
+
+```php
+if (count($value) === 0) {
+    $this->convertedSQL[] = 'NULL';
+
+    return;
+}
+```
+
+`Connection::PARAM_INT_ARRAY` and `Connection::PARAM_STR_ARRAY` are aliases for
+Doctrine's `ArrayParameterType` cases
+(`.Build/vendor/typo3/cms-core/Classes/Database/Connection.php:75` and `:80`).
+
+Pick between the two forms on the merits: a named parameter is the general
+default, while the quoting helpers are the way out when a list can grow large
+enough to approach the driver's placeholder limit, or when the statement is a
+prepared statement that would otherwise need re-binding.
+
+### Do not guard on the caller side
+
+The tempting repair after hitting exception 1701857902 is a guard at the call
+site:
+
+```php
+// Wrong: works around the API instead of using it.
+if ($uids !== []) {
+    $categories = $categoryRepository->findByGroupAndUidList($group, $uids);
+}
+```
+
+This is worse than it looks. It pushes a database-layer detail into every
+caller, it has to be repeated at each one, and it forces every caller to invent
+an answer for "what does no selection mean" — which is a domain question, not a
+query question. In ACE-349 the answer was already settled: the uid list is a
+**positive** selection, so an empty list means "no categories", deliberately
+not "no restriction". Expressing that in the query with `IN (NULL)` gives every
+caller the same answer for free, and the changelog entry for that fix
+explicitly invites existing caller-side guards to be removed.
+
+There is one legitimate caller-side condition, and it is a different thing: a
+check that decides whether a constraint applies **at all**. In
+`packages/fgtclb/academic-persons/Classes/Provider/FrontendUserProvider.php:84-99`
+an empty include or exclude list means "do not narrow the query", so the whole
+`andWhere()` is skipped — and the list is still quoted with the helper when it
+is added. The rule is about how a list becomes SQL, not about whether a
+constraint is added.
+
+### Literal lists are not affected
+
+A hard-coded list can never be empty, so it does not need the helper:
+
+```php
+$queryBuilder->expr()->in('sys_category.sys_language_uid', [0, -1]),
+```
+
+That form appears five times in
+`packages/fgtclb/typo3-category-types/Classes/Domain/Repository/CategoryRepository.php`
+(lines 69, 111, 155, 207 and 250) and three times in
+`packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php`
+(lines 222, 239 and 258), and is correct as written. The rule targets lists
+whose length comes from outside the function — request data, a repository
+result, a configuration value.
+
+### Call sites to copy from
+
+Eight classes under `packages/fgtclb/*/Classes/` use the quoting helpers, 16
+call sites in total. A representative selection, all paths relative to
+`packages/fgtclb/`:
+
+| File                                                                       | Line    | Form                                              |
+|----------------------------------------------------------------------------|---------|---------------------------------------------------|
+| `typo3-category-types/Classes/Domain/Repository/CategoryRepository.php`    | 156-159 | `...ToIntegerList()` with `in()`, the ACE-349 fix |
+| `typo3-category-types/Classes/Domain/Repository/CategoryRepository.php`    | 317-320 | `createNamedParameter()` array parameter          |
+| `academic-persons/Classes/Provider/FrontendUserProvider.php`               | 86-89   | `...ToIntegerList()` with `notIn()`               |
+| `academic-contact4pages/Classes/Backend/FormEngine/AddressRecordItems.php` | 158-161 | `...ToIntegerList()` on a literal list            |
+| `academic-projects/Classes/Upgrades/FlexFormUpgradeWizard.php`             | 51-54   | `...ToStringList()` with `in()`                   |
+| `academic-jobs/Classes/Upgrades/PluginUpgradeWizard.php`                   | 69-72   | `...ToStringList()` with `in()`                   |
+
+The fourth row quotes the constant `[-1, 0]`, which the previous section marks
+as not strictly needing it. That is harmless and arguably preferable: it keeps
+one shape for every value list in the class, so the reader never has to decide
+whether a given list can be empty.
+
+The canonical one is the ACE-349 fix itself
+(`typo3-category-types/Classes/Domain/Repository/CategoryRepository.php:156-159`):
+
+```php
+$queryBuilder->expr()->in(
+    'uid',
+    $queryBuilder->quoteArrayBasedValueListToIntegerList($idList),
+),
+```
+
+## Rule 2 — build the constraint on the builder that executes it
+
+### The mechanism
+
+`createNamedParameter()` does not return a value, it returns a **placeholder
+name** and registers the value on the builder it was called on
+(`QueryBuilder.php:991-998`, delegating to the concrete Doctrine builder). The
+placeholder is therefore bound to one specific query builder instance.
+
+A `WHERE` fragment assembled on builder A and handed to builder B carries a
+placeholder that was never bound on B. Worse, the counters are per builder, so
+the name A produced can collide with a name B produced independently — and
+`set()` produces one silently: it wraps its value in `createNamedParameter()`
+by default (`QueryBuilder.php:719-727`):
+
+```php
+public function set(string $key, $value, bool $createNamedParameter = true, ParameterType|ArrayParameterType $type = Connection::PARAM_STR): QueryBuilder
+{
+    $concreteQueryBuilder = $this->concreteQueryBuilder;
+    $concreteQueryBuilder->set(
+        $this->quoteIdentifier($key),
+        $createNamedParameter ? $this->createNamedParameter($value, $type) : $value
+    );
+    return $this;
+}
+```
+
+So an `UPDATE` that calls `set()` once has already claimed `:dcValue1` on its
+own builder before the `WHERE` is attached.
+
+### The defect (ACE-356)
+
+`FGTCLB\AcademicProjects\Upgrades\FlexFormUpgradeWizard` built the constraint of
+its `UPDATE` on the query builder of the enclosing `SELECT`:
+
+```php
+// Wrong: the expression and its parameter belong to the select builder.
+$updateQueryBuilder->update('tt_content')
+    ->set('pi_flexform', $this->array2xml($flexFormData))
+    ->where(
+        $queryBuilder->expr()->in(
+            'uid',
+            $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
+        )
+    )
+    ->executeStatement();
+```
+
+Both `set()` and the misplaced `createNamedParameter()` produced `:dcValue1`,
+each on its own builder. The first record therefore executed:
+
+```sql
+UPDATE tt_content SET pi_flexform = :dcValue1 WHERE uid IN (:dcValue1)
+```
+
+comparing the FlexForm XML against `uid`. Every following record referred to a
+placeholder that did not exist on the update builder at all, because the select
+builder's counter kept advancing while the fresh update builder's did not.
+
+The wizard reported success and migrated nothing. The correct form keeps
+expression, parameter and execution on the same object
+(`packages/fgtclb/academic-projects/Classes/Upgrades/FlexFormUpgradeWizard.php:80-91`,
+using `eq()` because the value is a single uid):
+
+```php
+$updateQueryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
+$updateQueryBuilder->update('tt_content')
+    ->set('pi_flexform', $this->array2xml($flexFormData))
+    ->where(
+        // The constraint must be built on the builder that executes it: a named
+        // parameter is bound to the query builder that created it.
+        $updateQueryBuilder->expr()->eq(
+            'uid',
+            $updateQueryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
+        )
+    )
+    ->executeStatement();
+```
+
+The pattern to internalise: when a loop over a result set builds one statement
+per record, the statement gets its **own** builder, and everything that goes
+into that statement is created on it.
+
+### PostgreSQL is the database that names the mechanism
+
+The per-DBMS outcome of the broken statement was:
+
+| DBMS       | Outcome                                                                       |
+|------------|-------------------------------------------------------------------------------|
+| MySQL      | Reported success, changed nothing                                             |
+| MariaDB    | Reported success, changed nothing                                             |
+| SQLite     | Reported success, changed nothing                                             |
+| PostgreSQL | `Doctrine\DBAL\Exception\DriverException`, *invalid input syntax for integer* |
+
+PostgreSQL is strict about types and quotes the offending value in its error
+message, so the failure text contains the FlexForm XML that was being compared
+against an integer `uid` column. That message points straight at the mechanism.
+The three permissive databases coerce the comparison and update zero rows —
+which `executeStatement()` does not treat as an error.
+
+**Run a suspected parameter defect on PostgreSQL first.** It is the fastest
+route from "this does nothing" to "this is comparing the wrong two things".
+
+## Testing this class of defect
+
+Both rules fail in the direction the default test run cannot see: rule 1 hides
+behind SQLite's tolerance of `IN ()` on v12, rule 2 hides behind three
+databases silently updating nothing. The functional suite defaults to SQLite
+(`Build/Scripts/runTests.sh:392`, `DBMS="sqlite"`), so a green local run proves
+less than it appears to.
+
+Three habits follow.
+
+**Run anything that writes on PostgreSQL as well.** After the SQLite run:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s composerUpdate
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s functional -d postgres \
+    packages/fgtclb/academic-projects/Tests/Functional/Upgrades
+```
+
+CI reaches the same coverage eventually — `functional-dbms` in
+`.github/workflows/ci.yml:250-265` runs MySQL 8.0, MariaDB 10.4, MariaDB 10.6
+and PostgreSQL 10 — but only after the SQLite jobs pass, so a defect of this
+kind is reported one stage late unless it was reproduced locally first.
+
+**Assert the effect, not the return value.** `executeStatement()` returning
+without an exception says nothing about rows changed. Read the record back and
+compare it, as
+`packages/fgtclb/academic-projects/Tests/Functional/Upgrades/FlexFormUpgradeWizardTest.php`
+does.
+
+**Seed more than one record.** The class docblock of that test spells out why:
+
+> **More than one record per test on purpose.** The wizard builds one update
+> statement per record; a defect in how that statement is parameterised shows up
+> differently in the first iteration than in the following ones, so a
+> single-record fixture can pass while the wizard is broken (ACE-356).
+
+For rule 1, cover the empty list explicitly. The ACE-349 fix added
+`emptyUidListReturnsAnEmptyCollection()` and
+`collectionOfAnEmptyUidListStillKnowsTheGroupTypes()` to
+`packages/fgtclb/typo3-category-types/Tests/Functional/Domain/Repository/CategoryRepositoryGroupSelectionTest.php`
+(lines 158 and 169) — one asserting that the query runs and returns nothing, the
+other asserting that the empty result still has the shape a template expects.
+
+## See also
+
+- `AGENTS.md`, section *Database queries* — the condensed form of both rules.
+- `packages/fgtclb/typo3-category-types/Documentation/Changelog/3.0/Important-CategoryRepositoryEmptyUidList.rst`
+  — the ACE-349 changelog entry, including the per-DBMS analysis for TYPO3 v12.
+- `packages/fgtclb/academic-projects/Documentation/Changelog/3.0/Important-FlexFormUpgradeWizardMigratesRecords.rst`
+  — the ACE-356 changelog entry, including how to re-run the repaired wizard.
+- `.Build/vendor/typo3/cms-core/Classes/Database/Query/QueryBuilder.php` and
+  `.../Query/Expression/ExpressionBuilder.php` — the authoritative source for
+  both mechanisms; read the installed version, not the documentation of another.
+- TYPO3 forge issue [#96434](https://forge.typo3.org/issues/96434) — the change
+  that introduced the array quoting helpers.

--- a/docs/architecture/dependency-injection.md
+++ b/docs/architecture/dependency-injection.md
@@ -1,0 +1,308 @@
+# Dependency injection
+
+Every extension in this repository wires its services through the TYPO3
+dependency injection container, which is Symfony's container with TYPO3
+compiler passes on top. This page records the preference, what the codebase
+actually does today, and the two rules that are not negotiable.
+
+## Where the codebase stands
+
+`AGENTS.md` states a preference for `Configuration/Services.php` (PHP form)
+over `Services.yaml`, and for Symfony attributes over service definitions. The
+measured reality is different in one direction and better than expected in the
+other, so the preference is best read as a direction of travel rather than a
+description.
+
+| Package                                  | `Services.php` | `Services.yaml` |
+|------------------------------------------|----------------|-----------------|
+| `packages/fgtclb/academic-base`          | –              | yes             |
+| `packages/fgtclb/academic-bite-jobs`     | –              | yes             |
+| `packages/fgtclb/academic-contact4pages` | –              | yes             |
+| `packages/fgtclb/academic-jobs`          | –              | yes             |
+| `packages/fgtclb/academic-partners`      | –              | yes             |
+| `packages/fgtclb/academic-persons`       | **yes**        | yes             |
+| `packages/fgtclb/academic-persons-edit`  | –              | yes             |
+| `packages/fgtclb/academic-persons-sync`  | –              | –               |
+| `packages/fgtclb/academic-programs`      | –              | yes             |
+| `packages/fgtclb/academic-projects`      | –              | yes             |
+| `packages/fgtclb/academic-study-plan`    | –              | yes             |
+| `packages/fgtclb/typo3-category-types`   | –              | yes             |
+| `packages-dev/monorepo-shared`           | –              | –               |
+| `packages-dev/testing-helper`            | –              | –               |
+
+So: **11 `Services.yaml`, 1 `Services.php`**, and `academic-persons` is the only
+package carrying both. Three packages have neither — `academic-persons-sync`
+ships only domain models under `Classes/Domain/`, and the two `packages-dev/`
+meta packages have no `Classes/` requiring registration at all.
+
+### What the YAML files contain
+
+All 11 share the same header and differ only after it:
+
+```yaml
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  FGTCLB\AcademicJobs\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'
+```
+
+`autoconfigure: true` on the defaults is what makes PHP attributes work at all,
+which is why the two styles coexist without friction. Beyond the header, seven
+files carry real definitions: `event.listener` tags, `data.processor` tags, an
+`extbase.type_converter` tag, two `console.command` tags, factory-produced
+services, one interface alias, and several `public: true` markers on
+repositories and registries.
+
+Two spellings are worth knowing because they are inconsistent across the
+packages and the difference is not cosmetic:
+
+- `resource: '../Classes/*'` versus `resource: '../Classes'`
+- `exclude: '../Classes/Domain/Model/*'` versus `'../Classes/Domain/Model'`
+  versus no `exclude` at all
+  (`academic-bite-jobs` and `academic-study-plan` exclude nothing)
+
+The `exclude` is what keeps Extbase domain models out of the container. A model
+that is registered but never type hinted is dropped again when the container is
+compiled, so omitting it breaks nothing and warns about nothing — until someone
+type hints the model, and the container then fails to build with an error
+pointing at the model rather than at the code that referenced it.
+
+### The one `Services.php`
+
+[`packages/fgtclb/academic-persons/Configuration/Services.php`](../../packages/fgtclb/academic-persons/Configuration/Services.php)
+is not the boilerplate `defaults()` + `load()` file the preference implies. It
+exists for the one thing YAML cannot express — registering autoconfiguration
+for an interface — and it does only that (lines 20–26):
+
+```php
+return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder): void {
+    $containerBuilder->registerForAutoconfiguration(TypesInterface::class)->setPublic(true);
+    $containerBuilder->registerForAutoconfiguration(DemandValuesInterface::class)->setPublic(true);
+    $containerBuilder->registerForAutoconfiguration(ProfileFactoryInterface::class)
+        ->setPublic(true)
+        ->setShared(true);
+};
+```
+
+The registration of the classes themselves still happens in that package's
+`Services.yaml`. TYPO3 loads both files when both are present.
+
+### Attributes are already in use
+
+Contrary to the note in `AGENTS.md` that these extensions do not use attributes,
+they are used in production code across five packages:
+
+| Attribute          | Sites | Examples                                                                  |
+|--------------------|-------|---------------------------------------------------------------------------|
+| `#[Autoconfigure]` | 9     | `academic-base/Classes/Service/ArrayObjectMapper.php:24` (`public: true`) |
+| `#[Autowire]`      | 6     | same file, line 28 — `#[Autowire(service: 'academic-base.serializer')]`   |
+| `#[AsAlias]`       | 2     | `academic-persons/Classes/Service/RecordSynchronizer.php:21`              |
+| `#[Exclude]`       | 3     | `academic-persons/Classes/Settings/Validation.php:12` and two siblings    |
+| `#[AsCommand]`     | 1     | `academic-partners/Classes/Command/GeocodeCommand.php:23`                 |
+
+`#[AsCommand]` there is Symfony's **Console** attribute
+(`Symfony\Component\Console\Attribute\AsCommand`), not a DI one; the other two
+commands in `academic-persons` are still registered with `console.command` tags
+in YAML. `#[AsTaggedItem]`, `#[AsController]` and `#[AsEventListener]` have zero
+sites.
+
+The `#[Autowire]` example is the clearest illustration of the two styles working
+together: `academic-base/Configuration/Services.yaml` lines 13–15 define a
+factory-produced service under the string id `academic-base.serializer`, and the
+consuming class pins it to one constructor argument by attribute. A string id
+cannot be autowired by type, so it has to be named somewhere — naming it on the
+argument keeps that fact next to the code that depends on it.
+
+### Which style to use
+
+Match the surrounding extension. Adding a `Services.php` to a package that has a
+working `Services.yaml` is churn, and the two files are loaded together, so a
+split registration is harder to follow than either style alone. What is worth
+doing on **new** code, in any package:
+
+- Put service *metadata* on the class with attributes — `#[Autoconfigure]`,
+  `#[AsAlias]`, `#[Autowire]`, `#[Exclude]` — rather than in a definition block.
+  It cannot drift away from the class it describes, and it survives a rename.
+- Keep in the configuration file only what cannot live on a class: the
+  `_defaults`, the `resource`/`exclude` load, `registerForAutoconfiguration()`,
+  and definitions for services whose class this repository does not own.
+
+## Services are stateless
+
+**New services must be stateless. Existing services must not gain new state.**
+
+The reason is the container's lifecycle, not style. A service is shared by
+default: the container builds it once and hands the same instance to every
+consumer for the rest of the process. Anything a method stores on `$this`
+therefore outlives the call that produced it and is visible to the next caller
+— which in TYPO3 is routinely a different record, a different language overlay
+or a different frontend user. Under a persistent process (a CLI worker, a long
+running import command) the same instance can span an entire run.
+
+The failure mode is a wrong value, not an exception, and it depends on call
+order. It surfaces as "the second profile shows the first one's data" long
+after the change that caused it.
+
+Pass what a method needs as arguments and return what it produces. Inject
+collaborators through the constructor and keep them `private readonly`.
+
+### What compliant code looks like
+
+[`packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizer.php`](../../packages/fgtclb/academic-persons/Classes/Service/RecordSynchronizer.php)
+lines 21–27: two attributes, one injected collaborator, no instance state.
+
+```php
+#[AsAlias(id: RecordSynchronizerInterface::class, public: true)]
+#[Autoconfigure(public: true)]
+class RecordSynchronizer implements RecordSynchronizerInterface
+{
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+```
+
+The three event listeners follow the same shape — a single `__invoke()` and
+promoted `private readonly` dependencies:
+`academic-jobs/Classes/EventListener/GenerateJobSlug.php`,
+`academic-persons-edit/Classes/EventListener/GenerateSlugForProfile.php` and
+`.../SyncChangesToTranslations.php`.
+
+### Where the codebase does not comply
+
+Stating this plainly, because a rule presented as universally followed is a rule
+nobody checks:
+
+- [`academic-bite-jobs/Classes/Services/BiteJobsService.php`](../../packages/fgtclb/academic-bite-jobs/Classes/Services/BiteJobsService.php)
+  line 21 holds `protected $responseBody;`, written in `fetchBiteJobs()` and
+  read afterwards. The code says so itself, at line 19:
+  `@todo Response state on a service class ? A really really bad idea.`
+- [`academic-persons-edit/Classes/Service/ListSortingService.php`](../../packages/fgtclb/academic-persons-edit/Classes/Service/ListSortingService.php)
+  line 26 keeps a nullable `PersistenceManagerInterface` filled by a
+  `#[Required] injectPersistenceManager()` method, while its own docblock at
+  line 18 reads `@note Service must be kept stateless.`
+- `academic-jobs/Classes/Loader/AcademicJobsSettingsLoader.php:15` and
+  `typo3-category-types/Classes/Loader/CategoryTypeLoader.php:16` memoize their
+  built registry in a nullable property. Both are `load()` factories for a
+  shared, `public: true` registry, so the cached value is process-wide.
+- `academic-persons/Classes/Profile/AbstractProfileFactory.php` lines 34 and 38
+  hold genuine runtime state (`$autoCreateProfiles`,
+  `$userGroupsToCreateProfilesFor`) filled from `initializeObject()`. Its
+  subclass `ProfileFactory` is registered `#[Autoconfigure(public: true,
+  shared: true)]` (line 25) — explicitly shared while stateful.
+
+None of these are cleared by the rule. They are the reason for it. Do not use
+them as precedent, and do not add state to them.
+
+Note that a genuinely configurable service is possible, but it must be declared
+`#[Autoconfigure(shared: false)]` so each retrieval returns a fresh instance.
+No service in this repository is declared that way today.
+
+## Attributes safe on both core versions
+
+Not every attribute exists in every supported version, so an attribute has to be
+checked against **both** before it is used. The following was verified by
+listing the attribute directories of both installed trees: `.Build/vendor/`
+(TYPO3 v13.4.34, the tree the test suite runs against) and `core-14/vendor/`
+(TYPO3 v14.3.6, the development instance).
+
+**Symfony `Symfony\Component\DependencyInjection\Attribute\*` — identical on
+both trees** (21 attributes each), so all of these are safe:
+
+| Attribute                                                         | Use                                                    |
+|-------------------------------------------------------------------|--------------------------------------------------------|
+| `#[Autoconfigure]`                                                | Publish, mark non-shared, add tags                     |
+| `#[AsAlias]`                                                      | Register the default implementation of an interface    |
+| `#[Autowire]`                                                     | Pin a service, parameter or expression to one argument |
+| `#[Exclude]`                                                      | Keep a class out of the container                      |
+| `#[AsTaggedItem]`, `#[AutowireIterator]`, `#[AutowireLocator]`    | Tagged collections                                     |
+| `#[AsDecorator]`, `#[Lazy]`, `#[Target]`, `#[When]`, `#[WhenNot]` | Less common, all present on both                       |
+
+**TYPO3 attributes — verified per tree**, because these are where the two
+versions diverge:
+
+| Attribute                                                            | v13.4.34 | v14.3.6         | Safe on both                   |
+|----------------------------------------------------------------------|----------|-----------------|--------------------------------|
+| `TYPO3\CMS\Core\Attribute\AsEventListener`                           | yes      | yes             | **yes**                        |
+| `TYPO3\CMS\Core\Attribute\AsAllowedCallable`                         | yes      | yes             | **yes**                        |
+| `TYPO3\CMS\Core\Attribute\WebhookMessage`                            | yes      | yes             | **yes**                        |
+| `TYPO3\CMS\Backend\Attribute\AsController`                           | yes      | yes             | **yes**                        |
+| `TYPO3\CMS\Install\Attribute\UpgradeWizard`                          | yes      | deprecated shim | works, but do not add new uses |
+| `TYPO3\CMS\Core\Attribute\UpgradeWizard`                             | **no**   | yes             | no                             |
+| `TYPO3\CMS\Core\Attribute\AsModuleAccessGate`                        | **no**   | yes             | no                             |
+| `TYPO3\CMS\Core\Attribute\AsNonSchedulableCommand`                   | **no**   | yes             | no                             |
+| `TYPO3\CMS\Backend\Attribute\AsAvatarProvider`, `AsSidebarComponent` | **no**   | yes             | no                             |
+
+`TYPO3\CMS\Extbase\Attribute\*` does not exist on v13 at all. The
+`Install\Attribute\UpgradeWizard` row is the one the nine upgrade wizards use:
+on v14 it survives as a deprecated subclass shim in
+`cms-core/DeprecatedClasses/ext-install/`, so it still works, but its
+replacement `Core\Attribute\UpgradeWizard` is absent on v13. See
+[Core version aware code](core-version-aware-code.md#apis-that-cannot-be-modernised-yet)
+for both.
+
+There is no `TYPO3\CMS\Core\Attribute\Autoconfigure` and no
+`TYPO3\CMS\Core\Attribute\AsCommand` on either version; use the Symfony
+attributes for those.
+
+## Never use Symfony's `#[AsEventListener]`
+
+Both classes exist and both are importable, so nothing stops the wrong one being
+used:
+
+| Class                                                         | Present on v13.4.34 and v14.3.6 | Emits tag               |
+|---------------------------------------------------------------|---------------------------------|-------------------------|
+| `TYPO3\CMS\Core\Attribute\AsEventListener`                    | yes                             | `event.listener`        |
+| `Symfony\Component\EventDispatcher\Attribute\AsEventListener` | yes                             | `kernel.event_listener` |
+
+**Always the TYPO3 one.** TYPO3's attribute declares
+`public const TAG_NAME = 'event.listener'` (line 26 in both trees), and
+`typo3/cms-core/Configuration/Services.php` lines 25–39 registers it for
+autoconfiguration so the attribute is turned into that tag. TYPO3's
+`ListenerProviderPass` then collects exactly that tag and feeds it to the
+`ListenerProvider`.
+
+Symfony's attribute produces `kernel.event_listener`, which is read by Symfony's
+`RegisterListenersPass` — a compiler pass TYPO3 does not register. Nothing reads
+the tag, so **the container builds cleanly and the listener is never called**.
+There is no error, no warning and no failing test unless a test asserts the
+effect of the listener. That silence is the entire reason for the rule.
+
+The TYPO3 attribute takes `identifier`, `event`, `method`, `before` and `after`.
+Always set `identifier` explicitly — it is what `before`/`after` ordering in
+other extensions refers to, and an auto-derived one changes when the class is
+renamed.
+
+All three production listeners here are currently registered by YAML tag rather
+than by attribute (`academic-jobs/Configuration/Services.yaml` lines 11–15 and
+`academic-persons-edit/Configuration/Services.yaml` lines 10–20), which is
+equivalent — the attribute is only a shorter spelling of the same tag. New
+listeners should prefer the attribute. Note that `academic-persons`' own user
+manual already documents the TYPO3 attribute as the way integrators register a
+listener against its events, in
+`packages/fgtclb/academic-persons/Documentation/Changelog/2.4/Feature-DispatchModifyTcaSelectFieldItemsEventInItemsProcFunc.rst`
+lines 41–43.
+
+## Other rules
+
+- **Do not inject the container.** Inject the concrete collaborator, or a
+  tagged locator/iterator when the set of implementations is open.
+- **Keep services private.** `public: false` is the default in every
+  `Services.yaml` header here. Publish only what has to be fetched from the
+  container — TYPO3 API entry points and, occasionally, functional tests — and
+  make it deliberate rather than habitual. Several repositories and registries
+  in this repository are `public: true`; that is not a pattern to copy without
+  a reason.
+- **Data objects are not services.** Models, DTOs and value objects are created
+  with `new`, by a factory, or by the persistence layer. See
+  [Class design](class-design.md).
+
+## See also
+
+- [Class design](class-design.md)
+- [Core version aware code](core-version-aware-code.md)
+- `AGENTS.md` — repository conventions

--- a/docs/development/Index.md
+++ b/docs/development/Index.md
@@ -1,0 +1,44 @@
+# Development
+
+Everything about getting a working copy running, what the repository is made of,
+and what has to pass before a change is done.
+
+## Quick start
+
+The only requirement on the host is a container runtime — **podman** (preferred)
+or **docker**. Everything else runs inside images.
+
+```bash
+# Install dependencies for the core version and PHP version you will test.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+
+# Gates.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s lintPhp
+
+# Tests.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+# All options.
+Build/Scripts/runTests.sh -h
+```
+
+Everything has to pass for **both** supported core versions, each after its own
+`composerUpdate` — see [Dual core setup](dual-core-setup.md).
+
+## Pages
+
+| Page                                      | Contents                                                                                                                             |
+|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| [Development environment](environment.md) | The `runTests.sh` wrapper, container runtimes, every suite and every option.                                                         |
+| [Monorepo layout](monorepo-layout.md)     | What each directory is for, the twelve extensions and their split repositories, extension keys, how a path package gets its version. |
+| [Dual core setup](dual-core-setup.md)     | Why the installed dependency set must match `-t`, how to check which core is installed, and how tests are scoped per version.        |
+| [Quality gates](quality-gates.md)         | Each gate and what it actually runs, PHPStan per core version, and how continuous integration stages them.                           |
+
+## See also
+
+- [Architecture](../architecture/Index.md) — the rules the code itself follows.
+- [Testing](../testing/Index.md) — both test suites and their conventions.
+- [Workflow](../workflow/Index.md) — commits, pull requests, releases.

--- a/docs/development/dual-core-setup.md
+++ b/docs/development/dual-core-setup.md
@@ -1,0 +1,260 @@
+# Dual core setup
+
+Branch `main` supports TYPO3 v13 and v14 from one code base, on PHP 8.2 to 8.5.
+Only one dependency set can be installed in `.Build/` at a time, and nothing in
+the tooling notices when the installed one is not the one a command was asked
+for. That makes the rule below the single most important habit in this
+repository.
+
+## The rule
+
+> The dependency set installed in `.Build/` must match the `-t` value the
+> command is run with.
+
+`-t <13|14>` selects **configuration only**. It picks the phpstan config
+(`Build/phpstan/Core${CORE_VERSION}/phpstan.neon`,
+`Build/Scripts/runTests.sh:738`) and the phpunit exclude group
+(`--exclude-group not-core-${CORE_VERSION}`, `Build/Scripts/runTests.sh:659`
+and `:751`). It installs nothing.
+
+The only suite that changes what is in `.Build/` is `composerUpdate`
+(`Build/Scripts/runTests.sh:646-655`):
+
+```bash
+rm -rf .Build composer.lock composer.json.orig
+cp -f composer.json composer.json.orig
+composer require --dev --no-update "typo3/minimal":"^${CORE_VERSION}"
+composer install
+cp -f composer.json.orig composer.json
+```
+
+It removes `.Build/`, pins `typo3/minimal` to the requested major in a
+throwaway copy of `composer.json`, installs, and restores the original
+`composer.json` afterwards — which is why a core switch never shows up as a
+working-tree change.
+
+So the sequence is always install first, then run:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s composerUpdate
+
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s functional
+```
+
+Running `-t 14` while the v13 set is installed does not fail with a useful
+message. It produces wrong answers: phpstan reports unknown classes for APIs
+that only exist in the other major and misses the errors it was supposed to
+find, and tests pass or fail for reasons that have nothing to do with the
+change under test. The default is `-t 13` (`Build/Scripts/runTests.sh:391`),
+so the trap is easiest to fall into right after finishing a v14 round and
+omitting `-t` on the next command.
+
+Both `.Build/` and `composer.lock` are git-ignored, so nothing is lost by
+reinstalling. The composer download cache lives in `.cache/composer`, outside
+`.Build/`, so a switch back and forth does not re-download the world.
+
+## `-p` is part of the dependency set too
+
+`-p <8.2|8.3|8.4|8.5>` has exactly the same property, and it is easier to
+overlook because a PHP version does not feel like a dependency.
+
+`composerUpdate` runs `composer` inside the container image selected by `-p`
+(`IMAGE_PHP="ghcr.io/typo3/core-testing-php${PHP_VERSION}"`,
+`Build/Scripts/runTests.sh:524`, used for the composer calls at
+`Build/Scripts/runTests.sh:649` and `:652`). The root `composer.json` sets no
+`config.platform`, so composer resolves against the PHP version it is actually
+running on. A tree resolved on 8.2 can therefore hold different package
+versions than one resolved on 8.5, and running the 8.5 image against a tree
+resolved on 8.2 tests something other than what continuous integration will
+test.
+
+`.github/workflows/ci.yml` follows this without exception: every job that runs
+a suite runs `composerUpdate` first with the same `-t` **and** `-p` values it
+then uses (`ci.yml:106/109`, `:149/152`, `:205/208`, `:245/248`, `:289/292`).
+The one job that does not is `lint`, which passes neither `-t` nor
+`composerUpdate` (`ci.yml:171`) because `lintPhp` only runs `php -l` over the
+sources and needs no vendor tree at all.
+
+Treat `-t` and `-p` together as the identity of the installed tree: change
+either, reinstall.
+
+## Which core version is installed right now
+
+The installed core states its own version. Reading it needs no container:
+
+```bash
+grep -n "protected const VERSION" \
+  .Build/vendor/typo3/cms-core/Classes/Information/Typo3Version.php
+```
+
+On a v13 tree that prints, for example:
+
+```
+22:    protected const VERSION = '13.4.34';
+```
+
+The equivalent through the harness, which also shows the constraint the package
+was resolved with, is the `composer` suite — it dispatches all remaining
+arguments to composer inside the container:
+
+```bash
+Build/Scripts/runTests.sh -s composer show typo3/cms-core
+```
+
+If `.Build/vendor/` does not exist at all, no dependency set is installed and
+every suite except `lintPhp` and the `composer*` ones will fail.
+
+## The changelogs come with the dependency set
+
+The TYPO3 changelogs are shipped inside `typo3/cms-core`, so they are installed
+along with everything else:
+
+```
+.Build/vendor/typo3/cms-core/Documentation/Changelog/
+```
+
+A core package carries the changelogs of its own version and of every earlier
+one. With the v13 set installed the directory ends at `13.4/` and `13.4.x/`,
+and there is no `14.0/`; installing v14 adds the `14.*` folders on top. To look
+up a v14 behaviour change, install the v14 set first — reading a changelog is
+not running a gate, so switching back afterwards costs nothing but the install.
+
+Use it whenever a difference between the two majors has to be explained rather
+than guessed at: a deprecation notice in a test run, an API that behaves
+differently, a signature that changed. The entry names the affected API, gives
+the migration and carries the forge issue number, which is what belongs in a
+commit message or an `@todo`.
+
+Read the entries, do not guess filenames. The naming scheme is
+`<Type>-<IssueNumber>-<Title>.rst`, and the issue number is not something to
+reconstruct. List the folder and grep it:
+
+```bash
+ls .Build/vendor/typo3/cms-core/Documentation/Changelog/13.4/
+grep -rl "FlexFormService" .Build/vendor/typo3/cms-core/Documentation/Changelog/
+```
+
+A path assembled from a remembered issue number is how a wrong changelog ends
+up cited in a commit message.
+
+## Test grouping
+
+Not every test can run on both core versions. Two mechanisms exist and they are
+picked by scope, not by taste.
+
+`runTests.sh` always passes `--exclude-group not-core-${CORE_VERSION}` to
+phpunit — for `functional` (`Build/Scripts/runTests.sh:659`), `unit` (`:751`)
+and `unitRandom` (`:757`). The group therefore names the version the test must
+**not** run on:
+
+| Group         | Runs on     | Meaning                                     |
+|---------------|-------------|---------------------------------------------|
+| `not-core-13` | v14 only    | Excluded from a `-t 13` run.                |
+| `not-core-14` | v13 only    | Excluded from a `-t 14` run.                |
+| _(no group)_  | v13 and v14 | The normal case. Most tests carry no group. |
+
+The inversion is deliberate: an untagged test runs everywhere, so a new test is
+version neutral until someone states otherwise.
+
+### Shape one: a single method
+
+When only one assertion differs, the method carries the attribute and stays in
+the shared test class next to its counterpart. The clearest example is
+`packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php`, where the
+FlexForm data structure assignment differs between the majors and neither
+version tolerates the other's shape:
+
+- `:565` — `#[Group('not-core-14')]` on
+  `pluginFlexFormIsAssignedAsArrayOnCoreV13()`
+- `:584` — `#[Group('not-core-13')]` on
+  `pluginFlexFormIsAssignedAsStringOnCoreV14()`
+
+Both methods sit in the same class, so the two expectations are readable side
+by side. That is the whole argument for this shape: the difference is the
+subject of the test.
+
+### Shape two: a whole class
+
+When the subject itself only exists on one version, the attribute goes on the
+class:
+
+- `packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php:32`
+  — `#[Group('not-core-13')]`, with a class comment explaining that TYPO3 v13
+  calls `is_uploaded_file()` unconditionally, which can never be true in a CLI
+  test run.
+- `packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php:29`
+  — same group, same reason.
+- `packages/fgtclb/academic-partners/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php:19`,
+  and the identical files in `academic-persons`, `academic-contact4pages` and
+  `academic-jobs` — `#[Group('not-core-13')]`, because the deprecated core
+  labels they assert about only emit their deprecation on v14.
+
+For such a class the convention is a `Core13/` or `Core14/` subfolder of
+`Tests/Unit` or `Tests/Functional`, with the group attribute on top. **No
+package uses that folder split yet** — the class-level cases above all live in
+their regular folders. The phpunit suites glob
+`packages/*/*/Tests/Unit/` and `packages/*/*/Tests/Functional/` recursively
+(`Build/phpunit/UnitTests.xml:42`, `Build/phpunit/FunctionalTests.xml:42`), so
+such a subfolder would be discovered without any configuration change.
+
+Whichever shape is used, add a comment saying **why** the test is limited and,
+where the limitation ends with v13 support, a `@todo` to drop the group. The
+upload test does both.
+
+## Verifying a change
+
+A change is verified when the full set of gates has run for **both** core
+versions. Continuous integration will do it either way, but it reports after
+the pull request is open, and core-version-dependent code is exactly where the
+mistakes are.
+
+```bash
+for core in 13 14; do
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s composerUpdate
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s lintPhp
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s cgl -n
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s phpstan
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s unit
+  Build/Scripts/runTests.sh -t "$core" -p 8.2 -s functional
+done
+```
+
+Notes on that loop:
+
+- `composerUpdate` is inside the loop, and it is the reason the loop works. Do
+  not lift it out.
+- `-s cgl -n` reports without modifying, which is what continuous integration
+  runs. Drop the `-n` to let php-cs-fixer apply the fixes, then rerun with
+  `-n`.
+- `-s functional` defaults to `-d sqlite`. Add a run with `-d postgres` — and
+  `-d mariadb` or `-d mysql` — whenever the change touches queries, schema or
+  TCA. SQLite is the most forgiving of the four and has hidden real defects in
+  this repository before.
+- PHP 8.2 and 8.5 are the edges the matrix tests. A change that touches
+  language-level behaviour deserves a second pass with `-p 8.5`, and that pass
+  needs its own `composerUpdate`.
+- Restrict a run while iterating by appending a path, for example
+  `-s unit packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php`.
+  The trailing path is the restriction mechanism; there is no dedicated flag
+  for handing extra options to phpunit, apart from `-o <seed>` for
+  `unitRandom` (`Build/Scripts/runTests.sh:447-448`).
+
+Run the unrestricted sequence once before pushing, no matter how narrow the
+change looked.
+
+## See also
+
+- [Monorepo layout](monorepo-layout.md) — what lives where, and why the
+  extensions are developed together
+- [Development environment](environment.md) — host requirements and the full
+  `runTests.sh` option list
+- [Quality gates](quality-gates.md) — what each suite checks
+- [Core version aware code](../architecture/core-version-aware-code.md) — how
+  production code handles the v13/v14 difference
+- [PHPUnit configuration](../testing/phpunit-configuration.md)
+- [Commit messages](../workflow/commit-messages.md) — how to reference a TYPO3
+  behaviour change
+- [`README.md`](../../README.md) — branch and core version support matrix

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -1,0 +1,321 @@
+# Development environment
+
+Every check in this repository runs inside a container, driven by
+[`Build/Scripts/runTests.sh`](../../Build/Scripts/runTests.sh). Nothing is run
+against the host PHP: the wrapper starts a `ghcr.io/typo3/core-testing-php8x`
+image, mounts the repository into it and executes composer, PHPUnit, PHPStan,
+php-cs-fixer or the documentation renderer there.
+
+That is the whole point of the harness. A gate behaves identically on a
+developer machine and on a GitHub runner because both go through the same
+script and the same image, so "green here, red in the pipeline" is not a class
+of problem that exists in this repository.
+
+## Host requirements
+
+One container runtime, and nothing else. No PHP, no Composer, no PHPUnit on the
+host. The script refuses to start when neither runtime is installed
+(`Build/Scripts/runTests.sh:384-387`):
+
+```bash
+if ! type "docker" >/dev/null 2>&1 && ! type "podman" >/dev/null 2>&1; then
+    echo "This script relies on docker or podman. Please install" >&2
+    exit 1
+fi
+```
+
+**podman is preferred.** When `-b` is not given, the runtime is picked at
+`Build/Scripts/runTests.sh:516-522`: podman if it is on the `PATH`, docker
+otherwise. `-b docker|podman` overrides the choice, and an argument that is
+neither is rejected as an invalid option
+(`Build/Scripts/runTests.sh:414-419`).
+
+The two runtimes are not interchangeable in their details, which is why the
+script branches on the selected one (`Build/Scripts/runTests.sh:549-578`):
+
+* docker needs `--add-host host.docker.internal:host-gateway` for Xdebug to
+  reach an IDE on the host; podman has `host.containers.internal` built in.
+* The tmpfs holding the SQLite test databases is mounted with an explicit
+  `uid`/`gid` under docker, because `--user $HOST_UID` passes a user but no
+  group and the container would not own the mount. Under rootless podman the
+  container root already maps to the host user.
+* On Linux, podman gets the SELinux relabel flag (`:Z`) on the repository
+  mount.
+
+The GitHub workflows pass `-b docker` on every step. That is not a statement
+about which runtime is better — it works around a crun failure on hosted
+runners and is documented in `.github/workflows/ci.yml:44-52`. There is no
+reason to pass it locally.
+
+Each run creates its own container network named `academic-extensions-<random>`
+(`Build/Scripts/runTests.sh:545-547`) and removes it together with every
+attached container in `cleanUp()` (`Build/Scripts/runTests.sh:109-115`), so
+parallel runs on one machine do not collide.
+
+## Options
+
+The wrapper parses exactly these options
+(`Build/Scripts/runTests.sh:409-468`); everything left over after them is the
+optional trailing argument.
+
+| Option            | Meaning                                                                             | Default             |
+|-------------------|-------------------------------------------------------------------------------------|---------------------|
+| `-s <suite>`      | Suite to run. See the table below.                                                  | `help`              |
+| `-t <13\|14>`     | TYPO3 core major version. Selects the dependency set and the PHPStan configuration. | `13`                |
+| `-p <8.2…8.5>`    | PHP version, one of `8.2`, `8.3`, `8.4`, `8.5`. Picks the testing image.            | `8.2`               |
+| `-d <dbms>`       | DBMS for functional tests: `sqlite`, `mariadb`, `mysql`, `postgres`.                | `sqlite`            |
+| `-i <version>`    | DBMS version, only with `-d mariadb\|mysql\|postgres`.                              | per DBMS, see below |
+| `-a <driver>`     | Database driver, only with `-d mariadb\|mysql`: `mysqli` or `pdo_mysql`.            | `mysqli`            |
+| `-n`              | Dry run for `cgl` and `cglHeader`: report offending files, change nothing.          | off                 |
+| `-x`              | Enable Xdebug and send debugging information to the host IDE.                       | off                 |
+| `-y <port>`       | Xdebug client port on the host, when the IDE does not listen on the default.        | `9003`              |
+| `-o <seed>`       | Random order seed for `unitRandom`, to replay a specific order.                     | none                |
+| `-u`              | Update the local `typo3/core-testing-*` images and drop dangling ones.              | —                   |
+| `-b <runtime>`    | Container runtime, `docker` or `podman`.                                            | podman, else docker |
+| `-h`              | Print the help text and exit.                                                       | —                   |
+| trailing `[file]` | Path passed on to the tool of the suite — for PHPUnit a test file or directory.     | none                |
+
+`-u` is not a modifier: it sets the suite to `update`
+(`Build/Scripts/runTests.sh:458-460`), so it cannot be combined with `-s`.
+
+`-t` and `-p` are validated against a fixed list
+(`Build/Scripts/runTests.sh:431-440`); anything else aborts the run before a
+container is started.
+
+The `-a`, `-d` and `-i` combinations are validated together in
+`handleDbmsOptions()` (`Build/Scripts/runTests.sh:117-188`), which also holds
+the per-DBMS defaults and the accepted version lists:
+
+| `-d`       | Default `-i` | Accepted `-i`                     | `-a`                              |
+|------------|--------------|-----------------------------------|-----------------------------------|
+| `sqlite`   | —            | rejected                          | rejected                          |
+| `mariadb`  | `10.4`       | `10.4` … `10.11`, `11.0` … `11.4` | `mysqli` (default) or `pdo_mysql` |
+| `mysql`    | `8.0`        | `8.0`, `8.1`, `8.2`, `8.3`, `8.4` | `mysqli` (default) or `pdo_mysql` |
+| `postgres` | `10`         | `10` … `16`                       | rejected                          |
+
+### Restricting a run
+
+**There is no option for handing extra arguments to PHPUnit.** No `-e`, and no
+suite that takes a filter. A run is restricted with the trailing path:
+
+```bash
+# One directory.
+Build/Scripts/runTests.sh -t 13 -s functional \
+  packages/fgtclb/academic-persons/Tests/Functional/Domain
+
+# One file.
+Build/Scripts/runTests.sh -t 13 -s unit \
+  packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
+```
+
+The trailing argument means different things per suite. For `unit`,
+`unitRandom`, `functional` and `phpstan` it is appended to the tool's command
+line (`Build/Scripts/runTests.sh:659`, `739`, `751`, `757`). For
+`checkRstRenderingSingle` and `openDocumentation` it is not a path at all but
+the **extension folder name** below `packages/fgtclb/`
+(`Build/Scripts/runTests.sh:624`, `723`). For `composer` it is the composer
+command with its arguments (`Build/Scripts/runTests.sh:642`).
+
+> [!NOTE]
+> A `--` separator does technically end the wrapper's own option parsing, and
+> the remainder then reaches the dispatched tool, because every one of those
+> suites appends `"$@"`. It is neither documented in `-h` nor used by the
+> workflows, and the single mention of a separator in the help text — under
+> `unitRandom`, `Build/Scripts/runTests.sh:269` — points at what `-o` already
+> does. Use `-o` for the seed and the trailing path for everything else; do not
+> build tooling on the separator.
+
+## Suites
+
+Taken from the `case` statement at `Build/Scripts/runTests.sh:589-783`, which
+is the authority — the help text is not complete, see below.
+
+| Suite                     | What it runs                                                                                        |
+|---------------------------|-----------------------------------------------------------------------------------------------------|
+| `cgl`                     | php-cs-fixer with `Build/php-cs-fixer/config.php`. Fixes in place, `-n` only reports.               |
+| `cglHeader`               | php-cs-fixer with `Build/php-cs-fixer/header-comment.php` for the file header.                      |
+| `checkRstRenderingAll`    | Renders `Documentation/` of every extension in `packages/fgtclb/`.                                  |
+| `checkRstRenderingSingle` | The same for one extension folder, given as trailing argument.                                      |
+| `composer`                | `composer` with all remaining arguments dispatched into the container.                              |
+| `composerUpdate`          | Installs the dependency set for `-t`, see below.                                                    |
+| `functional`              | PHPUnit with `Build/phpunit/FunctionalTests.xml` against the DBMS from `-d`.                        |
+| `lintPhp`                 | `php -l` over every `*.php` outside the excluded trees.                                             |
+| `openDocumentation`       | Opens a previously rendered documentation in the browser (Linux only, `xdg-open`).                  |
+| `phpstan`                 | PHPStan with `Build/phpstan/Core<13\|14>/phpstan.neon`.                                             |
+| `phpstanGenerateBaseline` | Rewrites `Build/phpstan/Core<13\|14>/phpstan-baseline.neon`.                                        |
+| `unit`                    | PHPUnit with `Build/phpunit/UnitTests.xml`.                                                         |
+| `unitRandom`              | The same, with `--order-by=random` and the seed from `-o`.                                          |
+| `update`                  | Pulls newer `ghcr.io/typo3/core-testing-*` images and removes dangling ones. Also reached via `-u`. |
+| `help`                    | Prints the help text. This is the default when `-s` is omitted.                                     |
+
+Anything else prints the help and exits non-zero
+(`Build/Scripts/runTests.sh:776-782`).
+
+### Where the help text and the script disagree
+
+`-h` renders a text block maintained by hand in `loadHelp()`
+(`Build/Scripts/runTests.sh:246-381`), and it has drifted from the `case`
+statement. Read the script when in doubt:
+
+* **`functional` is missing from the help text entirely**, although it is a
+  suite (`Build/Scripts/runTests.sh:657`), is described under `-d` and `-a`,
+  and appears in the examples. `update` and `help` are missing as well.
+* `-o` is not listed as an option at all, even though it is parsed
+  (`Build/Scripts/runTests.sh:447-449`).
+* `-t` is documented as being usable only with the suites `composerInstall`,
+  `composerInstallMin` and `composerInstallMax`. None of those three exists
+  here, and `-t` in fact also selects the PHPStan configuration and the
+  excluded PHPUnit group.
+* `-n` is documented for `cgl|cglGit|cglHeader|cglHeaderGit`; the `*Git`
+  variants do not exist.
+* The `-i` lists carry TYPO3 Core's maintenance annotations, which are dated
+  and say nothing about this repository.
+
+Correcting the help text is worthwhile; until then, the `case` statement and
+the `getopts` string are the specification.
+
+## Quick start
+
+```bash
+# 1. Install the dependency set for the core and PHP version to be tested.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+
+# 2. Run the gates.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s lintPhp
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+# 3. Repeat for the other core version supported by this branch.
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s composerUpdate
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s phpstan
+# ...
+```
+
+## Dependencies: one tree, one core version, one PHP version
+
+`composerUpdate` (`Build/Scripts/runTests.sh:646-656`) does four things:
+
+1. `rm -rf .Build composer.lock composer.json.orig` — the vendor tree is
+   rebuilt from scratch, never patched.
+2. Copies `composer.json` aside, then runs
+   `composer require --dev --no-update typo3/minimal:"^${CORE_VERSION}"` inside
+   the container, which is how `-t` reaches the dependency resolution.
+3. `composer install`.
+4. Restores the original `composer.json` from the copy, so the requirement
+   added in step 2 never ends up in a commit.
+
+Everything is installed into the git-ignored `.Build/` directory: the root
+`composer.json` sets `vendor-dir` to `.Build/vendor`, `bin-dir` to
+`.Build/bin`, and TYPO3's `web-dir` to `.Build/Web`. That is why every suite
+calls `.Build/bin/phpunit`, `.Build/bin/phpstan` and `.Build/bin/php-cs-fixer`
+rather than a globally installed tool.
+
+Two consequences that cause most of the confusing local failures:
+
+* **`-t` selects configuration, not dependencies.** Running `-t 14 -s phpstan`
+  after a `-t 13 -s composerUpdate` analyses v14-flavoured configuration
+  against a v13 vendor tree. The result is neither a pass nor a meaningful
+  failure.
+* **`-p` needs a `composerUpdate` just as much as `-t`.** The lock file is
+  resolved for the PHP version of the container that resolved it, so switching
+  `-p` without reinstalling can run a tree that the new PHP version was never
+  offered.
+
+The workflows follow this rule literally: every job that needs a vendor tree
+runs `composerUpdate` for its own `-t`/`-p` pair first, and the `lint` job,
+which needs no vendor tree, does not run it at all
+(`.github/workflows/ci.yml:154-171`).
+
+## Caches: `.cache/` at the repository root
+
+Composer downloads land in `.cache/composer` and the PHPStan result cache in
+`.cache/phpstan`. The directory is created before any container starts
+(`Build/Scripts/runTests.sh:502-503`), passed in as `COMPOSER_CACHE_DIR` on
+every composer-facing suite, and configured as PHPStan's `tmpDir`
+(`Build/phpstan/Core13/phpstan.neon:11`).
+
+It sits **next to** `.Build/`, not inside it, and that placement is deliberate.
+`composerUpdate` begins with `rm -rf .Build`, so a cache below it would be
+thrown away on every single dependency install — locally, and once per job in
+CI. The reasoning is recorded in `.gitignore:17-20`.
+
+The workflows cache only `.cache/composer/files` — the content-addressed dist
+archives — and never the `repo/` metadata next to it, because restoring stale
+packagist metadata makes the `restore-keys` fallback resolve against an old
+package list (`.github/workflows/ci.yml:88-103`).
+
+`.cache` and `.php-cs-fixer.cache` are what `cleanCacheFiles()` removes
+(`Build/Scripts/runTests.sh:190-196`).
+
+## Container images
+
+| Purpose          | Image                                              |
+|------------------|----------------------------------------------------|
+| PHP, all suites  | `ghcr.io/typo3/core-testing-php<version>:latest`   |
+| Documentation    | `ghcr.io/typo3-documentation/render-guides:latest` |
+| MariaDB          | `docker.io/mariadb:<-i>`                           |
+| MySQL            | `docker.io/mysql:<-i>`                             |
+| PostgreSQL       | `docker.io/postgres:<-i>-alpine`                   |
+| Port wait helper | `docker.io/alpine:3.8`                             |
+
+Defined at `Build/Scripts/runTests.sh:524-531`. The `docker.io` images are
+pulled through `ensureImage()` (`Build/Scripts/runTests.sh:60-79`), which
+checks the local image first and retries a failed pull up to three times: an
+anonymous Docker Hub pull is rate limited per source IP, hosted runners share
+address space, and a single failed pull otherwise ends a job with exit 125
+before a test has run. The `ghcr.io` images have never needed it, which is why
+only the Docker Hub ones are guarded.
+
+`-u` refreshes the PHP images that already exist locally and removes the
+dangling ones (`Build/Scripts/runTests.sh:761-770`). Run it when tests start
+failing in ways that do not match the code.
+
+## Xdebug
+
+`-x` switches the PHP container from `XDEBUG_MODE=off` to `debug` and points
+the client at the host (`Build/Scripts/runTests.sh:580-586`). The host address
+differs per runtime — `host.docker.internal` for docker,
+`host.containers.internal` for podman — and the wrapper sets the right one.
+`-y <port>` changes the client port when the IDE does not listen on 9003.
+
+```bash
+Build/Scripts/runTests.sh -x -p 8.3 -s unit \
+  packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/ProfileInformationTest.php
+```
+
+## Development instances are not part of the harness
+
+`core-13/` and `core-14/` at the repository root are ready-to-start TYPO3
+instances, one per supported core version, backed by SQLite and seeded from the
+committed templates in `sqlite-databases/`. They are for looking at the
+extensions in a running backend and frontend.
+
+**`runTests.sh` never touches them.** They have their own `composer.json` and
+their own `composer.lock`, their own git-ignored `vendor/`, `public/` and
+`var/` trees, and they play no part in any suite. The single point of contact
+is negative: `lintPhp` explicitly excludes `./core-1*/vendor/`,
+`./core-1*/public/` and `./core-1*/var/` from the `find`
+(`Build/Scripts/runTests.sh:709-718`), because those are third-party trees —
+`typo3/class-alias-loader` ships a template file that is deliberately not valid
+PHP. The instances' tracked `config/system/*.php` is still linted, on purpose.
+
+Do not run a gate expecting an instance to be updated, and do not fix a failing
+instance by running `composerUpdate` — that installs the root project's
+dependency tree into `.Build/`, which is a different thing entirely. Instance
+handling, DDEV project names, the SQLite backup/restore scripts and the branch
+switching collision are described in
+[`README.md`](../../README.md#development-instances).
+
+## See also
+
+- [Quality gates](quality-gates.md) — what each suite asserts, and the CI
+  staging that runs them.
+- [Dual core setup](dual-core-setup.md) — why the dependency set has to match
+  `-t` and `-p`, and how to tell which one is installed.
+- [Monorepo layout](monorepo-layout.md) — what lives where, and why the harness
+  sits at the repository root.
+- [PHPUnit configuration](../testing/phpunit-configuration.md)
+- [`AGENTS.md`](../../AGENTS.md) — the short form of this page.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md)

--- a/docs/development/monorepo-layout.md
+++ b/docs/development/monorepo-layout.md
@@ -1,0 +1,364 @@
+# Monorepo layout
+
+`fgtclb/academic-extensions` is a mono repository. It develops a set of
+interdependent TYPO3 extensions together, in one checkout, with one test
+harness and one continuous integration workflow, and mirrors each extension
+outward into its own standalone repository.
+
+The reason is the dependency graph. Eleven of the twelve extensions require
+`fgtclb/academic-base`, three require `fgtclb/category-types`, and
+`academic-persons-sync` requires two further academic extensions on top — read
+from the `require` sections of `packages/fgtclb/*/composer.json`. A change to
+the base extension therefore regularly needs a matching change in several
+dependents. Split across twelve repositories, that would be several pull
+requests that cannot be tested together until all of them are merged. Here it
+is one branch, one pull request, and one test run that sees the real, combined
+code.
+
+The repository root is itself a composer `project` (`composer.json:4`), not an
+extension. It pulls every extension in through path repositories so that
+composer resolves the whole graph from the working tree.
+
+## Top-level directories
+
+| Path                      | Tracked | What it is                                                                                |
+|---------------------------|---------|-------------------------------------------------------------------------------------------|
+| `packages/fgtclb/`        | yes     | The twelve extensions. One composer `typo3-cms-extension` each. Source changes go here.   |
+| `packages-dev/`           | yes     | Two meta packages that exist only for development: shared constraints and test helpers.   |
+| `Build/`                  | yes     | The test harness and every tool configuration: phpunit, phpstan, php-cs-fixer, templates. |
+| `bin/`                    | yes     | Release tooling: `bin/set-version` and `bin/release`.                                     |
+| `core-13/`, `core-14/`    | partly  | Ready-to-start development instances, one per supported core version.                     |
+| `sqlite-databases/`       | yes     | Committed database templates the development instances are seeded from.                   |
+| `patches/`                | yes     | Composer patch pool shared by both development instances. Currently only a `.gitkeep`.    |
+| `.Build/`                 | no      | Generated composer install target. Removed and rebuilt by `composerUpdate`.               |
+| `.cache/`                 | no      | Composer download cache and the phpstan result cache.                                     |
+| `documentation-rendered/` | no      | Output of the reST rendering suites, one folder per extension.                            |
+
+### `packages/fgtclb/`
+
+The real extensions. Every subdirectory is a composer package of type
+`typo3-cms-extension` with its own `composer.json`, `ext_emconf.php`, `VERSION`
+file, `Tests/` folder and reST manual in `Documentation/`. All twelve carry
+version `3.0.0-dev` on `main`.
+
+### `packages-dev/`
+
+Two packages that are never released as extensions and never shipped to an
+installation:
+
+- `packages-dev/monorepo-shared/` — `fgtclb/academics-monorepo-shared`, type
+  `library`. It centralizes the TYPO3 core dependency constraints.
+- `packages-dev/testing-helper/` — `fgtclb/academics-monorepo-testing-helper`,
+  type `library`. Shared functional-test traits.
+
+Both are covered in their own sections below.
+
+### `Build/`
+
+- `Build/Scripts/runTests.sh` — the containerized harness every check runs
+  through.
+- `Build/phpunit/` — `UnitTests.xml` and `FunctionalTests.xml`. Test discovery
+  is repository-wide: the suites glob `../../packages/*/*/Tests/Unit/`
+  (`Build/phpunit/UnitTests.xml:42`) and `../../packages/*/*/Tests/Functional/`
+  (`Build/phpunit/FunctionalTests.xml:42`). There is no per-extension phpunit
+  configuration; a run always covers all extensions unless it is restricted by
+  a trailing path argument.
+- `Build/phpstan/Core13/` and `Build/phpstan/Core14/` — one configuration and
+  one baseline per core version. Of the three source gates (`cgl`, `phpstan`,
+  `lintPhp`), phpstan is the only one that is core version specific, because it
+  analyses against the installed core rather than against the sources alone.
+- `Build/php-cs-fixer/` — `config.php` and `header-comment.php`.
+- `Build/Documentation/Templates/` — reST skeletons for changelog entries
+  (`Changelog-Breaking.rst`, `Changelog-Deprecation.rst`,
+  `Changelog-Feature.rst`, `Changelog-Important.rst`).
+- `Build/templates/extensions/LICENSE` — the per-extension license template.
+
+### `bin/`
+
+`bin/set-version <version> <type>` applies a version across the whole
+repository: every extension's `composer.json`, `ext_emconf.php`, `VERSION` file
+and tailor metadata, the functional-test fixture extensions, the `packages-dev`
+meta packages, the development instances, the root `composer.json` and the
+`COMPOSER_ROOT_VERSION` in `runTests.sh` (`Build/Scripts/runTests.sh:483`). It
+discovers the package list from the repository rather than carrying one, so a
+new extension needs no change there. It only edits files; it runs no git and no
+network operation.
+
+`bin/release <version>` drives the two-phase GitHub release on top of it —
+release branch, `[RELEASE]` commit, pull request, tag, then the follow-up
+version bump. Remote operations happen only with `--execute`.
+
+### `core-13/` and `core-14/`
+
+Two ready-to-start TYPO3 instances at the repository root, one per supported
+core version, with DDEV project names `core13-academics-v3` and
+`core14-academics-v3` (`core-13/.ddev/config.yaml:1`,
+`core-14/.ddev/config.yaml:1`). Both run on SQLite, so no database container is
+started, and both are seeded on first start from `sqlite-databases/`.
+
+Their `config/` and `composer.lock` are tracked; `public/`, `var/`, `vendor/`
+and `config/system/additional/*.php` are not (`.gitignore`). They consume the
+extensions through path repositories pointing back at `../packages/*/*`, the
+same way the root does.
+
+The instances are development aids only. `runTests.sh` never touches them and
+no test run depends on them.
+
+### `sqlite-databases/` and `patches/`
+
+`sqlite-databases/core-13.sqlite` and `sqlite-databases/core-14.sqlite` are the
+committed database templates. Each instance restores from and backs up to its
+own file through the composer scripts `sqlite:apply` and `sqlite:backup`
+declared in `core-13/composer.json` and `core-14/composer.json`.
+
+`patches/` is the shared pool for `vaimo/composer-patches`. Both instances
+require that plugin and declare `"patches-search": "patches/"`
+(`core-14/composer.json:53`), and each has a `patches` symlink pointing at
+`../patches`, so a patch is written once and applied by both. The pool is empty
+at the moment and holds only a `.gitkeep` so git keeps the directory.
+
+### `.Build/`, `.cache/` and `documentation-rendered/`
+
+`.Build/` is where composer installs: `bin-dir` is `.Build/bin`, `vendor-dir`
+is `.Build/vendor` (`composer.json:26-27`), and the TYPO3 web and app
+directories are `.Build/Web` and `.Build` (`composer.json:37-38`). It is
+git-ignored and disposable — `runTests.sh -s composerUpdate` starts by removing
+it (`Build/Scripts/runTests.sh:647`).
+
+`.cache/` holds the composer download cache and the phpstan result cache. It
+sits next to `.Build/` rather than inside it precisely because
+`composerUpdate` deletes `.Build/`; a cache below it would be thrown away on
+every dependency install, locally and in continuous integration alike. The
+phpstan configuration points its `tmpDir` at `../../../.cache/phpstan`
+(`Build/phpstan/Core13/phpstan.neon:11`).
+
+`documentation-rendered/` receives the output of `checkRstRenderingAll` and
+`checkRstRenderingSingle`, one folder per extension
+(`Build/Scripts/runTests.sh:223-225`). It is git-ignored and uploaded as a
+continuous integration artifact.
+
+## The extensions and their split repositories
+
+Every extension is git-split out of this repository into a standalone,
+**read-only** GitHub repository. Those mirrors are what composer and the TYPO3
+Extension Repository consume — and they are never a source of truth. A commit
+pushed to a split repository would be overwritten by the next split. All
+changes happen here.
+
+| Directory                                | Composer package                 | Extension key             | Split repository                                                                  |
+|------------------------------------------|----------------------------------|---------------------------|-----------------------------------------------------------------------------------|
+| `packages/fgtclb/academic-base`          | `fgtclb/academic-base`           | `academic_base`           | [fgtclb/academic-base](https://github.com/fgtclb/academic-base)                   |
+| `packages/fgtclb/academic-bite-jobs`     | `fgtclb/academic-bite-jobs`      | `academic_bite_jobs`      | [fgtclb/academic-bite-jobs](https://github.com/fgtclb/academic-bite-jobs)         |
+| `packages/fgtclb/academic-contact4pages` | `fgtclb/academic-contacts4pages` | `academic_contacts4pages` | [fgtclb/academic-contact4pages](https://github.com/fgtclb/academic-contact4pages) |
+| `packages/fgtclb/academic-jobs`          | `fgtclb/academic-jobs`           | `academic_jobs`           | [fgtclb/academic-jobs](https://github.com/fgtclb/academic-jobs)                   |
+| `packages/fgtclb/academic-partners`      | `fgtclb/academic-partners`       | `academic_partners`       | [fgtclb/academic-partners](https://github.com/fgtclb/academic-partners)           |
+| `packages/fgtclb/academic-persons`       | `fgtclb/academic-persons`        | `academic_persons`        | [fgtclb/academic-persons](https://github.com/fgtclb/academic-persons)             |
+| `packages/fgtclb/academic-persons-edit`  | `fgtclb/academic-persons-edit`   | `academic_persons_edit`   | [fgtclb/academic-persons-edit](https://github.com/fgtclb/academic-persons-edit)   |
+| `packages/fgtclb/academic-persons-sync`  | `fgtclb/academic-persons-sync`   | `academic_persons_sync`   | [fgtclb/academic-persons-sync](https://github.com/fgtclb/academic-persons-sync)   |
+| `packages/fgtclb/academic-programs`      | `fgtclb/academic-programs`       | `academic_programs`       | [fgtclb/academic-programs](https://github.com/fgtclb/academic-programs)           |
+| `packages/fgtclb/academic-projects`      | `fgtclb/academic-projects`       | `academic_projects`       | [fgtclb/academic-projects](https://github.com/fgtclb/academic-projects)           |
+| `packages/fgtclb/academic-study-plan`    | `fgtclb/academic-study-plan`     | `academic_study_plan`     | [fgtclb/academic-study-plan](https://github.com/fgtclb/academic-study-plan)       |
+| `packages/fgtclb/typo3-category-types`   | `fgtclb/category-types`          | `category_types`          | [fgtclb/typo3-category-types](https://github.com/fgtclb/typo3-category-types)     |
+
+The table was read from each `packages/fgtclb/*/composer.json`
+(`extra.typo3/cms.extension-key` for the key, `name` for the package). It
+agrees with the table in `README.md:81-94`, except that the link label for
+`category_types` there reads `fgtclb/fgtclb/typo3-category-types` while its
+target is the correct `https://github.com/fgtclb/typo3-category-types`.
+
+### The directory name is not the extension key
+
+Three identifiers exist per extension and they do not all follow from each
+other. Ten of the twelve directories are the extension key with underscores
+turned into hyphens, which makes the two that are not easy to miss:
+
+| Directory                | Composer package                 | Extension key             | Divergence                                                            |
+|--------------------------|----------------------------------|---------------------------|-----------------------------------------------------------------------|
+| `academic-contact4pages` | `fgtclb/academic-contacts4pages` | `academic_contacts4pages` | Directory says `contact4pages`, package and key say `contacts4pages`. |
+| `typo3-category-types`   | `fgtclb/category-types`          | `category_types`          | Directory carries a `typo3-` prefix that neither package nor key has. |
+
+The authoritative source is always `extra.typo3/cms.extension-key` in the
+package's `composer.json`. Anything that needs the key derives it from there
+rather than from the path — the release workflow reads it with `jq` at runtime
+for exactly this reason (`.github/workflows/publish.yml:76`), and
+`bin/set-version` discovers the mapping the same way.
+
+Note also that the split repository name follows the directory, not the package
+— `fgtclb/academic-contact4pages` and `fgtclb/typo3-category-types`.
+
+## Path repositories and package versions
+
+The root declares two path repositories (`composer.json:71-78`):
+
+```json
+"repositories": {
+    "packages-dev": { "type": "path", "url": "packages-dev/*" },
+    "packages":     { "type": "path", "url": "packages/*/*" }
+}
+```
+
+A stock composer `path` repository derives a package's version from its
+`composer.json` `version` field and falls back to a placeholder otherwise,
+which historically forced a `repositories.*.options.versions` map to be
+maintained next to every path repository — in the root, in both development
+instances and in `monorepo-shared`. Four maps for the same twelve packages,
+each able to drift.
+
+Those maps are gone. Every `composer.json` that declares a path repository also
+requires the composer plugin `sbuerk/extended-path-repository`
+(`composer.json:15`, `packages-dev/monorepo-shared/composer.json`,
+`core-13/composer.json`, `core-14/composer.json`). The plugin extends the
+built-in `path` repository with two behaviours: it derives a path package's
+version from `composer.json` `version`, from `extra."typo3/cms".version` or
+from a sibling `VERSION` file before falling back to composer's stock
+determination, and it silently ignores a configured `url` that matches nothing
+instead of aborting the run.
+
+So a package's version is written on the package itself, in two places that are
+kept identical:
+
+- `extra.typo3/cms.version` in its `composer.json`
+- its `VERSION` file
+
+Both read `3.0.0-dev` for all twelve extensions and both `packages-dev`
+packages on `main`. A release additionally bumps `version` in
+`ext_emconf.php`, which currently reads `3.0.0` everywhere — the publish
+workflow fails deliberately when the release tag and an `ext_emconf.php`
+version disagree.
+
+Practical consequence: to change a version, change it on the package. There is
+no second place to remember.
+
+## `packages-dev/monorepo-shared/` — one place for core constraints
+
+`fgtclb/academics-monorepo-shared` requires all twelve extensions plus the
+TYPO3 system extensions the repository needs, and it is what the root and both
+development instances require in turn (`composer.json:14`,
+`core-13/composer.json`, `core-14/composer.json`).
+
+Its point is that the TYPO3 core constraint appears once per system extension
+rather than once per consuming package. Every `typo3/cms-*` entry in
+`packages-dev/monorepo-shared/composer.json:27-50` reads:
+
+```
+"typo3/cms-core": "~13.4.0@dev || ~14.3.6@dev",
+```
+
+Raising the supported v14 patch level, or adding v15 later, is one edit in that
+file. The individual extensions declare only the system extensions they
+themselves use, and adding a system extension for a test only needs it added
+here.
+
+## `packages-dev/testing-helper/` — shared test traits
+
+`fgtclb/academics-monorepo-testing-helper` autoloads
+`FGTCLB\TestingHelper\` from `Classes/` and is required as a dev dependency of
+the root. It ships seven functional-test traits in
+`packages-dev/testing-helper/Classes/FunctionalTestCase/`:
+
+| Trait                                  | Purpose                                                                             |
+|----------------------------------------|-------------------------------------------------------------------------------------|
+| `DeprecatedCoreLabelsTrait`            | Asserts that no TCA label points at a core label deprecated on the running version. |
+| `EnsureTtContentListTypeColumnTrait`   | Ensures the `tt_content` list type column exists for a test.                        |
+| `ExtensionCoreVersionCompatTestsTrait` | Proves a suite really ran against the core version it was asked for.                |
+| `ExtensionsLoadedTestsTrait`           | Asserts the extension set under test is loaded.                                     |
+| `FrontendPluginRenderingTrait`         | Renders a frontend plugin through a real request.                                   |
+| `PluginFlexFormDataStructureTrait`     | Resolves and asserts a plugin's FlexForm data structure.                            |
+| `TcaHelperMethodsTrait`                | Shared TCA lookup helpers for assertions.                                           |
+
+They live in a package rather than in one extension's `Tests/` folder because
+every extension needs them and no extension may depend on another extension's
+test code. The package is development-only and is never part of a release.
+
+## Per-package `.gitattributes`
+
+Each package carries its own `.gitattributes` marking development-only paths
+with `export-ignore`. `export-ignore` is a `git archive` directive: it removes
+the marked path from a generated source archive. In this repository that
+matters for the tag tarball GitHub generates for a split repository, which is
+what composer downloads on a `dist` install — the root pins
+`"preferred-install": { "*": "dist" }` (`composer.json:28-30`).
+
+Two things it does **not** do, both worth knowing before changing such a file:
+
+- It does not shrink the split repository. The split mirrors the tree, so an
+  `export-ignore`d path is still present there. `fgtclb/academic-persons`
+  marks `/Tests export-ignore` and the split repository contains `Tests`
+  nonetheless.
+- It does not shape the TER artifact. `typo3/tailor create-artefact` builds its
+  zip from its own exclude list
+  (`.Build/vendor/typo3/tailor/conf/ExcludeFromPackaging.php`, overridable via
+  `TYPO3_EXCLUDE_FROM_PACKAGING`) and never reads `.gitattributes`. That list
+  already drops `tests`, `build`, `.github`, `.ddev`, `vendor` and more.
+
+### The files are not consistent
+
+All twelve were read, and they fall into two shapes plus per-package
+deviations. This is history, not design — the packages joined the mono
+repository from separately maintained repositories and kept the file they
+arrived with.
+
+**Shape A** — a bare `export-ignore` list, no comments, no end-of-line
+normalization. Eight packages: `academic-base`, `academic-bite-jobs`,
+`academic-jobs`, `academic-persons`, `academic-persons-edit`,
+`academic-persons-sync`, `academic-projects`, `academic-study-plan`. Typical
+entries are `/.gitlab-ci.yml`, `/.php-cs-fixer.dist.php`, `/phpstan.neon`,
+`/readme.md`, `/UnitTests.xml`, `/FunctionalTests.xml`, `/.ddev`, `/.gitlab`,
+`/config`, `/Migrations`, `/patches` and `/Tests`.
+
+**Shape B** — a commented `# Folders` / `# Files` list followed by a block of
+`text eol=lf` rules for two dozen file extensions. Four packages:
+`academic-contact4pages`, `academic-partners`, `academic-programs`,
+`typo3-category-types`. It ignores `/.github`, `/.vscode`, `/.Build`,
+`/Tests/`, `.php-cs-fixer.php`, `.phplint.yml`, `.stylelintrc` and
+`docker-compose.yaml`.
+
+The two shapes disagree on more than formatting:
+
+| Aspect                        | Shape A                                           | Shape B                                               |
+|-------------------------------|---------------------------------------------------|-------------------------------------------------------|
+| End-of-line normalization     | none                                              | `text eol=lf` for 20 file extensions                  |
+| `/.github`                    | kept in the archive                               | `export-ignore`                                       |
+| `/.Build`                     | not listed                                        | `export-ignore`                                       |
+| php-cs-fixer config file name | `.php-cs-fixer.dist.php`                          | `.php-cs-fixer.php`                                   |
+| Ignored tooling files         | `phpstan.neon`, `UnitTests.xml`, `.gitlab-ci.yml` | `.phplint.yml`, `.stylelintrc`, `docker-compose.yaml` |
+
+Individual deviations on top of that:
+
+- `academic-persons-sync` has the shortest list of all and does **not**
+  `export-ignore` `/Tests`, `/Migrations`, `/patches`, `UnitTests.xml` or
+  `FunctionalTests.xml`. Its test folder ends up in a generated archive.
+- `academic-persons-edit` lists `UnitTests.xml` but not `FunctionalTests.xml`.
+- `academic-persons` is the only shape A package that also ignores `/Build` and
+  `/tailor-version-artefact`.
+- `academic-contact4pages` is the only shape B package that does not ignore
+  `/Build/` or `/.ddev`.
+- Several shape A files end without a trailing newline.
+- Neither the repository root nor the two `packages-dev` packages has a
+  `.gitattributes` at all. The root is a `project` that is never installed as a
+  dependency and the meta packages are development-only, so nothing generates
+  an archive from them.
+
+Most of the files also still reference tooling this repository no longer uses
+per package — `.gitlab-ci.yml`, `.gitlab/`, `docker-compose.yaml`,
+`phpstan.neon` next to the package. Checks run through
+`Build/Scripts/runTests.sh` and `.github/workflows/ci.yml` at the root instead.
+The stale entries are harmless: `export-ignore` on a path that does not exist
+is a no-op. They are listed here so nobody reads them as evidence of a
+per-package tool chain.
+
+Aligning the twelve files is a worthwhile cleanup, but it is a deliberate
+change with a release-visible effect on archive contents, not something to do
+in passing while editing an extension.
+
+## See also
+
+- [Dual core setup](dual-core-setup.md) — why the installed dependency set has
+  to match `-t` and `-p`
+- [Development environment](environment.md) — host requirements and the
+  `runTests.sh` options
+- [Quality gates](quality-gates.md) — what each suite checks and how continuous
+  integration stages them
+- [Core version aware code](../architecture/core-version-aware-code.md)
+- [`README.md`](../../README.md) — support matrix, split repository table and
+  the maintainer release walkthrough

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -1,0 +1,434 @@
+# Quality gates
+
+The same gates run on a developer machine and in the GitHub Actions workflows,
+through the same wrapper and the same container images — see
+[Development environment](environment.md). A change is finished when they are
+green for **every core version this branch supports**, each after its own
+`composerUpdate`.
+
+```bash
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s lintPhp
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s composerUpdate
+# ... the same list again
+```
+
+| Gate                                              | Tool             | Configuration                                    | Depends on the core version |
+|---------------------------------------------------|------------------|--------------------------------------------------|-----------------------------|
+| `cgl`                                             | php-cs-fixer     | `Build/php-cs-fixer/config.php`                  | no                          |
+| `cglHeader`                                       | php-cs-fixer     | `Build/php-cs-fixer/header-comment.php`          | no                          |
+| `lintPhp`                                         | `php -l`         | none, a `find` in the suite itself               | no                          |
+| `phpstan`                                         | PHPStan, level 8 | `Build/phpstan/Core13/`, `Build/phpstan/Core14/` | **yes**                     |
+| `unit`, `unitRandom`                              | PHPUnit          | `Build/phpunit/UnitTests.xml`                    | through the excluded group  |
+| `functional`                                      | PHPUnit          | `Build/phpunit/FunctionalTests.xml`              | through the excluded group  |
+| `checkRstRenderingAll`, `checkRstRenderingSingle` | render-guides    | each extension's own `Documentation/`            | no                          |
+
+## Coding guidelines — `cgl`
+
+`Build/Scripts/runTests.sh:590-599` runs php-cs-fixer with
+[`Build/php-cs-fixer/config.php`](../../Build/php-cs-fixer/config.php). Without
+`-n` it **rewrites files in place**; with `-n` it adds `--dry-run --diff` and
+only reports, which is the form CI uses (`.github/workflows/ci.yml:108-109`).
+
+The rule set is `@PER-CS1.0` plus `@DoctrineAnnotation` and some fifty
+individual rules (`Build/php-cs-fixer/config.php:64-133`), risky rules allowed.
+It is TYPO3 Core's set, with the same `@todo` markers for the rules that can be
+dropped once `@PER-CS2.0` is adopted.
+
+What it scans matters more than the rules, because it is narrower than the
+repository (`Build/php-cs-fixer/config.php:49-62`):
+
+| Finder call              | Value                                       |
+|--------------------------|---------------------------------------------|
+| `in()`                   | `packages/fgtclb/`, `Build`                 |
+| `exclude()`              | `.Build/`, `Build/`, `var/`, `node_modules` |
+| `ignoreVCSIgnored(true)` | anything git ignores is skipped             |
+
+So `packages-dev/`, `bin/`, `core-13/`, `core-14/` and the PHP files at the
+repository root are **not** covered by this gate at all. A file placed there is
+never reformatted and never reported — which is worth knowing before concluding
+from a green run that the whole repository is formatted.
+
+`ignoreVCSIgnored(true)` is what keeps generated trees out even when they sit
+inside a scanned directory, so the gate does not depend on the `exclude()` list
+staying complete.
+
+## File headers — `cglHeader`
+
+A second php-cs-fixer run with
+[`Build/php-cs-fixer/header-comment.php`](../../Build/php-cs-fixer/header-comment.php),
+which enables exactly two rules: `header_comment` and `no_extra_blank_lines`,
+with risky rules disabled (`Build/php-cs-fixer/header-comment.php:59-71`). The
+header is placed `after_declare_strict` and reads "This file is part of the
+fgtclb/academic extension collection."
+(`Build/php-cs-fixer/header-comment.php:46-57`).
+
+Its Finder scans the same two roots but skips `Configuration`, `Documentation`,
+`node_modules` and `Acceptance/Support/_generated`, plus the files that must not
+carry a header: `*locallang*.php`, `ext_localconf.php`, `ext_tables.php`,
+`ext_emconf.php` and `ClassAliasMap.php`
+(`Build/php-cs-fixer/header-comment.php:26-43`).
+
+> [!IMPORTANT]
+> **This gate is currently not enforced.** Its CI step is commented out with a
+> `@todo` — "Disabled until the correct file header has been determined for
+> extensions" (`.github/workflows/ci.yml:111-113`). Running it locally without
+> `-n` therefore rewrites headers across the code base and produces a diff
+> nobody asked for. Run it with `-n` if at all, until the header is settled.
+
+## PHP linting — `lintPhp`
+
+`php -l` over every `*.php` in the repository, four processes in parallel, with
+Xdebug off (`Build/Scripts/runTests.sh:709-721`). It has no configuration file;
+the specification is the `find` invocation, and its exclusions are load-bearing:
+
+* `./.Build/*` — the installed vendor tree.
+* `./.agent/*` — the git-ignored working tree for drafts and partial snippets;
+  a snippet that does not parse must not turn this gate red.
+* `./core-1*/vendor/*`, `./core-1*/public/*`, `./core-1*/var/*` — the
+  development instances' generated trees. `typo3/class-alias-loader` ships a
+  template file there that is deliberately not valid PHP.
+
+The instances' **tracked** `config/system/*.php` is deliberately still linted.
+
+This is the only gate that needs neither a vendor tree nor a core version,
+which is why CI runs it without `composerUpdate` and across all four PHP
+versions (`.github/workflows/ci.yml:154-171`). It is also the cheapest way to
+find a syntax error that is specific to one PHP version.
+
+## Static analysis — `phpstan`
+
+PHPStan runs at **level 8** against `packages/`, excluding `ext_emconf.php`,
+`EXT_CONSTANTS.php` and `Migrations/*`
+(`Build/phpstan/Core13/phpstan.neon:13-21`). Three extension packages are
+included from the installed vendor tree: `bnf/phpstan-psr-container`,
+`friendsoftypo3/phpstan-typo3` and `phpstan/phpstan-phpunit`.
+
+### Why it is configured per core version
+
+`-t` selects `Build/phpstan/Core${CORE_VERSION}/phpstan.neon`
+(`Build/Scripts/runTests.sh:737-742`). PHPStan analyses the sources **against
+the core that is installed in `.Build/`**, so the same code produces different
+findings on v13 and on v14: a method that exists only in one of them, a
+signature that changed, a return type that was narrowed. Running the gate for
+one version would miss half of them. It is the only source gate CI runs per
+core version (`.github/workflows/ci.yml:115-125`).
+
+The two `phpstan.neon` files are byte-identical today. The version specific
+part sits next to them:
+
+| File                    | Core13                                     | Core14                                   |
+|-------------------------|--------------------------------------------|------------------------------------------|
+| `phpstan.neon`          | identical                                  | identical                                |
+| `phpstan-constants.php` | `#[Cascade]` constants as `['value' => …]` | `#[Cascade]` constants as a plain string |
+| `phpstan-baseline.neon` | its own findings, 216 lines                | its own findings, 231 lines              |
+
+`phpstan-constants.php` is loaded as a `bootstrapFile` and mirrors
+`packages/fgtclb/academic-persons/EXT_CONSTANTS.php`, which resolves the
+Extbase `#[Cascade]` attribute shape that differs between the two versions.
+That single file is why the identical `phpstan.neon` pair must stay a pair.
+
+If a core-version-specific source folder is ever introduced, it has to be added
+to the `paths` of the matching configuration — nothing discovers it
+automatically.
+
+### The baseline
+
+Each core version has its own `phpstan-baseline.neon`, included from its
+`phpstan.neon:1`. It is regenerated per version:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -s phpstanGenerateBaseline
+Build/Scripts/runTests.sh -t 14 -s phpstanGenerateBaseline
+```
+
+which writes `Build/phpstan/Core<version>/phpstan-baseline.neon` with
+`--allow-empty-baseline` (`Build/Scripts/runTests.sh:743-748`).
+
+**A growing baseline is a defect, not a configuration change.** Regenerating it
+to make a new finding disappear removes exactly the signal the gate exists for,
+and it does so silently: the pull request stays green and the entry is one more
+line in a file nobody reads. Fix the finding; regenerate only when the tooling
+itself changed, and say so in the commit message.
+
+### A stale result cache after switching core versions
+
+PHPStan's result cache lives in `.cache/phpstan`
+(`Build/phpstan/Core13/phpstan.neon:11`) and is **shared by both core
+versions** — the `tmpDir` is the same path in both configurations. After
+switching from one `-t` to the other, a run has been seen to report entries
+like "Ignored error pattern … was not matched in reported errors" for baseline
+entries that are perfectly valid, because the finding they refer to came from
+the cache instead of being reported again. Before treating such a report as a
+change to the baseline, clear the cache and run once more:
+
+```bash
+rm -rf .cache/phpstan
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s phpstan
+```
+
+The directory holds nothing but cached analysis results, so removing it costs
+one slower run and never loses anything.
+
+## Tests — `unit`, `unitRandom`, `functional`
+
+`unit` and `unitRandom` use
+[`Build/phpunit/UnitTests.xml`](../../Build/phpunit/UnitTests.xml),
+`functional` uses
+[`Build/phpunit/FunctionalTests.xml`](../../Build/phpunit/FunctionalTests.xml)
+(`Build/Scripts/runTests.sh:749-760`, `657-708`). `unitRandom` adds
+`--order-by=random` and the seed from `-o`, which is how an order dependency
+between tests is found and then replayed.
+
+### Strictness
+
+Both configurations carry the same flags. Four `failOn*` switches are on, which
+means the suite is red for far more than a failed assertion:
+
+| Setting                                   | Value   | Effect                                            |
+|-------------------------------------------|---------|---------------------------------------------------|
+| `failOnDeprecation`                       | `true`  | A triggered deprecation fails the test.           |
+| `failOnNotice`                            | `true`  | A notice fails the test.                          |
+| `failOnRisky`                             | `true`  | A risky test fails.                               |
+| `failOnWarning`                           | `true`  | A warning fails the test.                         |
+| `beStrictAboutTestsThatDoNotTestAnything` | `false` | A test without an assertion passes silently.      |
+| `backupGlobals`                           | `true`  | Globals are restored between tests.               |
+| `cacheResult`                             | `false` | No result cache, every run starts from scratch.   |
+| `requireCoverageMetadata`                 | `false` | No coverage annotation required.                  |
+| `displayDetailsOnTestsThatTrigger…`       | `true`  | Deprecations, errors, notices and warnings shown. |
+
+(`Build/phpunit/UnitTests.xml:20-34`, `Build/phpunit/FunctionalTests.xml:20-34`.)
+
+Two of these have practical consequences worth stating.
+
+`failOnDeprecation="true"` makes the test suite the enforcement point for
+TYPO3 deprecations. Code that calls a v14-deprecated API turns the suite red on
+v14 even when it behaves correctly — which is intended, and is why some
+migrations are blocked until v13 support is dropped rather than being worked
+around.
+
+`beStrictAboutTestsThatDoNotTestAnything="false"` is the one strictness knob
+that is off. A test that asserts nothing — because the assertion was lost in a
+refactoring, or because the subject silently returned early — is reported as
+passing. Nothing in the harness will tell you; a new test has to be shown to
+fail before it is accepted as proof.
+
+### Discovery: all extensions at once
+
+```xml
+<directory>../../packages/*/*/Tests/Unit/</directory>
+<directory>../../packages/*/*/Tests/Functional/</directory>
+```
+
+(`Build/phpunit/UnitTests.xml:42`, `Build/phpunit/FunctionalTests.xml:42`.)
+
+The glob is `packages/*/*`, so it picks up the tests of **every** extension in
+the mono repository in one run — twelve of them under `packages/fgtclb/` today
+— and would pick up another vendor directory as well.
+
+**There is no per-extension PHPUnit configuration**, and adding one would be a
+step backwards: the extensions depend on each other, and a test suite that only
+sees one of them cannot detect that a change in `academic-base` broke
+`academic-persons`. Restrict a run with the trailing path instead:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -s functional \
+  packages/fgtclb/academic-persons/Tests/Functional
+```
+
+### Functional tests and the DBMS
+
+`functional` starts the database in its own container, waits for the port,
+hands the connection parameters to PHPUnit as environment variables and removes
+the container afterwards (`Build/Scripts/runTests.sh:657-708`). With the
+default `-d sqlite` no container is started; the databases are created in a
+tmpfs below `.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/`.
+
+SQLite is the fast default, not the complete one. It accepts SQL that MariaDB,
+MySQL and PostgreSQL reject, so a defect in a query can pass locally and fail
+in the DBMS matrix. Run PostgreSQL as well for anything that writes:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -s functional -d postgres -i 16
+```
+
+`functional` also excludes the group `not-${DBMS}`
+(`Build/Scripts/runTests.sh:659`), so a test that cannot work on one DBMS can
+be tagged `#[Group('not-postgres')]` instead of being skipped at runtime. No
+test uses this at the moment; a DBMS difference has so far always been a defect
+in the query, not a property of the test.
+
+## Core version aware tests: `not-core-13` and `not-core-14`
+
+Every PHPUnit suite is started with `--exclude-group not-core-${CORE_VERSION}`
+(`Build/Scripts/runTests.sh:659`, `751`, `757`). The name reads as an
+exclusion, so the effect is inverted from what it looks like:
+
+| Group attribute           | Runs on |
+|---------------------------|---------|
+| `#[Group('not-core-13')]` | v14     |
+| `#[Group('not-core-14')]` | v13     |
+
+Two shapes are in use, and the choice follows the size of the difference:
+
+* **Whole class**, when the test only makes sense on one version — the
+  attribute goes on the class:
+  `packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php:32`
+  and
+  `packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileImageUploadTest.php:29`.
+* **Single method**, when a class differs in one behaviour only:
+  `packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php:565` is
+  `not-core-14`, and `:584` is `not-core-13` — the two halves of the same
+  assertion about a signature that changed between the versions.
+
+The `Tests/Unit/Core13/` and `Tests/Unit/Core14/` folder split is the other
+option; no extension uses it at the moment.
+
+A group attribute is invisible in a green run. When a test is tagged, the
+reason belongs in the code as a comment or in the commit message, otherwise the
+tag outlives the incompatibility that justified it.
+
+## Documentation rendering — `checkRstRenderingAll` / `checkRstRenderingSingle`
+
+The user-facing manuals live per package in
+`packages/fgtclb/<extension>/Documentation/` and are reST, not Markdown.
+`checkRstRenderingAll` iterates over every extension folder that has a
+`Documentation/` directory — twelve today — and renders each one with the
+`ghcr.io/typo3-documentation/render-guides` image
+(`Build/Scripts/runTests.sh:610-622`, rendering in `executeRstRendering()` at
+`Build/Scripts/runTests.sh:213-227`).
+
+**This is a real gate, not an artifact producer.** The renderer is invoked with
+`--fail-on-log --fail-on-error`, so a warning fails the job. The results are
+collected in `documentation-rendered/<extension>/Documentation-GENERATED-temp/`,
+which CI uploads as an artifact.
+
+```bash
+# Everything.
+Build/Scripts/runTests.sh -s checkRstRenderingAll
+
+# One extension, by folder name below packages/fgtclb/.
+Build/Scripts/runTests.sh -s checkRstRenderingSingle academic-persons
+
+# Open the result (Linux only).
+Build/Scripts/runTests.sh -s openDocumentation academic-persons
+```
+
+Note the argument is the **folder** name, which is not always the extension
+key — `academic-contact4pages` ships `academic_contacts4pages`.
+
+## Continuous integration
+
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) is the single
+pull-request workflow. The TYPO3 core version is a matrix dimension rather than
+a separate workflow file, and that is what makes the staging possible at all:
+job dependencies cannot cross workflows, so the earlier layout of one workflow
+file per core version had no way to make the expensive jobs wait for the cheap
+ones.
+
+```
+cgl     ─┐
+phpstan ─┼─> unit ─> functional (SQLite) ─> functional (MySQL, MariaDB, Postgres)
+lint    ─┘
+
+documentation   (independent)
+```
+
+| Job                 | Line | Needs              | Matrix                     |
+|---------------------|------|--------------------|----------------------------|
+| `cgl`               | 73   | —                  | PHP 8.2, v13               |
+| `phpstan`           | 115  | —                  | PHP 8.2 × v13, v14         |
+| `lint`              | 154  | —                  | PHP 8.2, 8.3, 8.4, 8.5     |
+| `unit`              | 173  | cgl, phpstan, lint | PHP 8.2, 8.5 × v13, v14    |
+| `functional-sqlite` | 213  | unit               | PHP 8.2, 8.5 × v13, v14    |
+| `functional-dbms`   | 250  | functional-sqlite  | the same × 4 DBMS, 16 jobs |
+| `documentation`     | 294  | —                  | none                       |
+
+The DBMS matrix is the expensive part — sixteen jobs, each starting a database
+container. It runs only after the same tests passed on SQLite for both core
+versions and both edge PHP versions, so a defect that is not DBMS specific is
+reported by four jobs instead of twenty
+(`.github/workflows/ci.yml:250-255`).
+
+### Three PHP sets
+
+They are three, and they have to be changed together
+(`.github/workflows/ci.yml:26-36`):
+
+| Set    | PHP versions       | Used by              | Why                                            |
+|--------|--------------------|----------------------|------------------------------------------------|
+| all    | 8.2, 8.3, 8.4, 8.5 | `lint`               | A syntax error can be specific to one version. |
+| edges  | 8.2, 8.5           | `unit`, `functional` | The ends of the supported range.               |
+| lowest | 8.2                | `cgl`, `phpstan`     | They inspect files, not the running PHP.       |
+
+### Every step goes through `runTests.sh`
+
+There is no `composer install` step, no `php -l` step and no PHPUnit
+invocation in the workflow — every step is a `Build/Scripts/runTests.sh` call.
+A gate therefore cannot behave differently in CI than locally, and reproducing
+a red pipeline is a matter of copying the command from the log.
+
+The two deviations from a plain local run are both explained in the workflow
+itself: `-b docker` on every step (`.github/workflows/ci.yml:44-52`) and the
+`composerUpdate` that precedes every job needing a vendor tree.
+
+### Why the pull-request comment is a separate workflow
+
+[`.github/workflows/pr-comment.yml`](../../.github/workflows/pr-comment.yml)
+posts one comment, updated in place, linking the rendered documentation
+artifact. It is a separate workflow on the `workflow_run` event on purpose.
+
+A pull request **from a fork** gets a read-only `GITHUB_TOKEN` and no secrets.
+Commenting needs `pull-requests: write`, so a comment step inside `ci.yml`
+would work for branches in this repository and silently fail for exactly the
+contributors it is meant to serve. `ci.yml` therefore declares
+`permissions: contents: read` and writes nothing at all
+(`.github/workflows/ci.yml:62-63`).
+
+`workflow_run` fires when `ci.yml` finishes, runs in the context of the default
+branch rather than the fork, and its token can write. No code from the pull
+request is checked out or executed there, which is what makes the write
+permission safe. `pull_request_target` is deliberately not used: it also has a
+write token, but it runs the pull request's own code under it.
+
+Two consequences follow, and both have cost time before:
+
+1. **A change to `pr-comment.yml` only takes effect once it is on the default
+   branch.** It never changes the behaviour of the pull request that changes
+   it.
+2. `github.event.workflow_run.pull_requests` is empty for a fork, so the pull
+   request number cannot be read from the event. `ci.yml` writes it into the
+   `pull-request-context` artifact before rendering, so the comment lands on
+   the right pull request even when the rendering fails
+   (`.github/workflows/ci.yml:302-320`).
+
+## Before pushing
+
+* `lintPhp`, `cgl -n`, `phpstan` and `unit` green for **every** core version
+  the branch supports, each after its own `composerUpdate`.
+* `functional` green for the same versions whenever the change can affect
+  runtime behaviour, and against a real DBMS when it writes.
+* New behaviour has a test, and the test was shown to fail without the change —
+  the suite will not tell you, see `beStrictAboutTestsThatDoNotTestAnything`
+  above.
+* `checkRstRenderingAll` when any `Documentation/` changed.
+
+## See also
+
+- [Development environment](environment.md) — the wrapper, its options and the
+  dependency rules these gates depend on.
+- [Dual core setup](dual-core-setup.md) — running every gate twice, and how the
+  test groups follow from it.
+- [PHPUnit configuration](../testing/phpunit-configuration.md) — the two
+  configurations and their bootstraps in detail.
+- [Core version aware code](../architecture/core-version-aware-code.md)
+- [Pull requests](../workflow/pull-requests.md) — what has to be green before
+  pushing, and how to read a red pipeline.
+- [`AGENTS.md`](../../AGENTS.md) — the short form, including the definition of
+  done.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md)

--- a/docs/testing/Index.md
+++ b/docs/testing/Index.md
@@ -1,0 +1,51 @@
+# Testing
+
+Two suites, both containerized, both discovered across all extensions at once.
+
+## Quick start
+
+```bash
+# Always install the dependency set for the version you are about to test.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+# Restrict a run to a directory or a single file with a trailing path.
+Build/Scripts/runTests.sh -t 13 -s unit packages/fgtclb/academic-base/Tests/Unit
+
+# Anything that writes to the database is also run on PostgreSQL.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -d postgres -s functional
+```
+
+## Rules that apply to every test
+
+- **The suites are hard breaking.** Deprecations, notices, warnings and risky
+  tests all fail the run. Never silence one to get a run green; fix the cause.
+- **A test without an assertion still passes** — that flag is deliberately
+  relaxed. So prove a new test can fail: break what it covers, watch it go red,
+  restore.
+- **SQLite is the default and is not sufficient.** Several defects in this
+  repository were invisible on SQLite and only appeared on MySQL, MariaDB or
+  PostgreSQL — and at least one was the other way round.
+- A test that applies to only one core version is scoped with the
+  `not-core-13` / `not-core-14` groups, never with a runtime condition.
+
+## Pages
+
+| Page                                              | Contents                                                                                              |
+|---------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| [PHPUnit configuration](phpunit-configuration.md) | Where the configuration comes from, what deviates from the template, and the exact strictness policy. |
+| [Unit tests](unit-tests.md)                       | Running them, discovery, conventions, core version aware tests.                                       |
+| [Functional tests](functional-tests.md)           | Databases and why the default is not enough, loading extensions, real defects each DBMS caught.       |
+| [Fixture extensions](fixture-extensions.md)       | The test-only extensions and the mechanism that registers them.                                       |
+| [Testing helper](testing-helper.md)               | Every trait in `packages-dev/testing-helper/`, and the defect each one exists for.                    |
+
+## See also
+
+- [Quality gates](../development/quality-gates.md) — where the suites sit among
+  the other gates.
+- [Dual core setup](../development/dual-core-setup.md) — the group convention
+  and the dependency set rule.
+- [Database queries](../architecture/database-queries.md) — the defects that
+  motivate running PostgreSQL.

--- a/docs/testing/fixture-extensions.md
+++ b/docs/testing/fixture-extensions.md
@@ -1,0 +1,240 @@
+# Fixture extensions
+
+Some things cannot be set up from inside a test method: a TCA table that has to
+exist before the instance is built, a service that has to be wired by dependency
+injection, a template override that TypoScript must be able to find, an
+`ext_localconf.php` that has to run during bootstrap. For those, the test ships
+a small TYPO3 extension of its own.
+
+Seven such fixture extensions exist, in five of the twelve extensions. That is
+the whole population — this is a mechanism used sparingly and only where nothing
+smaller works.
+
+## Where they live and what they are
+
+They sit next to the tests that use them, under
+`packages/fgtclb/<extension>/Tests/Functional/Fixtures/Extensions/<extension_key>/`:
+
+| Extension key                    | Composer package name                  | Owned by               | Provides                                                                |
+|----------------------------------|----------------------------------------|------------------------|-------------------------------------------------------------------------|
+| `test_base_dependency_injection` | `tests/base-test-dependency-injection` | `academic-base`        | Two services to resolve through the container, plus `Services.yaml`.    |
+| `test_bitejobs_stub`             | `tests/test-bitejobs-stub`             | `academic-bite-jobs`   | An `ext_localconf.php` replacing the Guzzle handler stack.              |
+| `test_jobcontact_schema`         | `tests/test-jobcontact-schema`         | `academic-jobs`        | `ext_tables.sql` and TCA for a legacy table an upgrade wizard migrates. |
+| `test_language_files`            | `tests/language-files`                 | `academic-persons`     | An XLF pair with awkward label keys (dots, dashes).                     |
+| `test_messy_profile_factory`     | `tests/test-messy-profile-factory`     | `academic-persons`     | A deliberately misbehaving profile factory and two event listeners.     |
+| `test_plugin_templates`          | `tests/plugin-templates`               | `academic-persons`     | Simplified Fluid templates and the TypoScript pointing at them.         |
+| `test_category_types_group`      | `tests/category-types-group`           | `typo3-category-types` | A `CategoryTypes.yaml` registering a group, plus a test ViewHelper.     |
+
+Each is a real, complete TYPO3 extension: a `composer.json` of type
+`typo3-cms-extension`, an `ext_emconf.php`, and whatever it exists to provide.
+Four of the seven have a `Classes/` folder with a `TESTS\…` PSR-4 root; the
+other three are pure resources.
+
+A minimal one, complete:
+
+```json
+{
+    "name": "tests/plugin-templates",
+    "description": "Plugin template overrides for tests",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "typo3/cms-core": "~13.4.0@dev || ~14.3.6@dev",
+        "fgtclb/academic-persons": "~3.0.0@dev"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_plugin_templates",
+            "version": "3.0.0-dev",
+            "Package": {
+                "providesPackages": []
+            }
+        }
+    }
+}
+```
+
+— [`test_plugin_templates/composer.json`](../../packages/fgtclb/academic-persons/Tests/Functional/Fixtures/Extensions/test_plugin_templates/composer.json)
+
+The core constraint mirrors
+[`packages-dev/monorepo-shared/composer.json`](../../packages-dev/monorepo-shared/composer.json).
+A fixture extension pinned to a narrower range than the branch supports would
+fail the run for the other core version, so it has to be updated with the rest.
+
+## How they are wired
+
+This is where the mechanism differs from the more common one. The fixture
+extensions are **not** path repositories and are **not** required by anything —
+neither the root nor the owning extension mentions them in `require` or
+`require-dev`. Adding one changes no `composer.json` other than its own.
+
+Instead, the composer plugin `sbuerk/fixture-packages` (1.1.3, a `require-dev`
+of the root) discovers them by glob. The root
+[`composer.json`](../../composer.json) declares:
+
+```json
+"extra": {
+    "sbuerk/fixture-packages": {
+        "paths": {
+            "packages/*/*/Tests/Functional/Fixtures/Extensions/*": [
+                "autoload",
+                "autoload-dev"
+            ],
+            "packages/*/*": [
+                "autoload-dev"
+            ]
+        }
+    }
+}
+```
+
+Two globs, two jobs:
+
+- The first finds every fixture extension and merges **both** its `autoload` and
+  `autoload-dev` sections into the root autoloader. That is what makes
+  `TESTS\TestBitejobsStub\Http\StubHttpHandler` resolvable at all. Verified in
+  the generated `.Build/vendor/composer/autoload_psr4.php`, which maps
+  `TESTS\TestMessyProfileFactory\`, `TESTS\TestBitejobsStub\`,
+  `TESTS\CategoryTypesGroup\` and `TESTS\BaseTestDependencyInjection\` to their
+  `Classes/` folders.
+- The second merges the `autoload-dev` of every package, which is how each
+  extension's own `FGTCLB\<Name>\Tests\` namespace reaches the root autoloader.
+
+The plugin also writes `.Build/vendor/sbuerk/fixture-packages.php`, a plain PHP
+array of every discovered fixture package with its name, type, path and
+`extra.typo3/cms`. That file is what turns the packages into something the
+testing framework can load — see the next section.
+
+Both effects are produced at install time. **A new fixture extension is
+invisible until the next `composerUpdate`**:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s composerUpdate
+```
+
+Skipping that produces a "package not found" style failure that looks like a
+typo in `$testExtensionsToLoad`, which is the single most common way to lose an
+hour here.
+
+## How the test suite picks them up
+
+The functional bootstrap
+([`Build/phpunit/FunctionalTestsBootstrap.php:35-54`](../../Build/phpunit/FunctionalTestsBootstrap.php#L35-L54))
+hands the generated data file to `SBUERK\AvailableFixturePackages` and calls
+`adoptFixtureExtensions()`, which registers each fixture package with the
+testing framework's `ComposerPackageManager`. Its own docblock states the
+purpose:
+
+> Automatically add fixture extensions to the `typo3/testing-framework`
+> `ComposerPackageManager` to allow composer package name or extension keys of
+> fixture extension in `FunctionalTestCase::$testExtensionToLoad`.
+
+The block contains a documented workaround —
+`AvailableFixturePackages::$dataFile` is built with a missing slash, so the
+correct path is injected by reflection.
+See [PHPUnit configuration](phpunit-configuration.md#the-functional-bootstrap)
+before touching it.
+
+## Using one in a test
+
+A fixture extension is loaded like any other extension, by **composer package
+name**, and referenced in resource paths by **extension key**:
+
+```php
+protected function setUp(): void
+{
+    $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+    $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+    $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
+    parent::setUp();
+}
+```
+
+```php
+'setup' => [
+    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+    'EXT:academic_persons/Configuration/TypoScript/setup.typoscript',
+    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+    // …
+],
+```
+
+— [`AcademicPersonsListPluginTest.php:35-36`](../../packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php#L35-L36)
+and [`:57-62`](../../packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php#L57-L62)
+
+Other spellings in use:
+
+```php
+$this->testExtensionsToLoad[] = 'tests/test-jobcontact-schema';
+```
+— [`ContactTcaUpgradeWizardTest.php:17`](../../packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/ContactTcaUpgradeWizardTest.php#L17)
+
+```php
+protected array $testExtensionsToLoad = [
+    // …
+    'tests/language-files',
+];
+```
+— [`ProfileTitleProviderTest.php:27`](../../packages/fgtclb/academic-persons/Tests/Functional/PageTitle/ProfileTitleProviderTest.php#L27)
+
+**The package name is not derivable from the extension key.** All seven use the
+`tests/` vendor, but the second segment follows no rule: `test_plugin_templates`
+is `tests/plugin-templates` (prefix dropped), `test_bitejobs_stub` is
+`tests/test-bitejobs-stub` (prefix kept), and `test_base_dependency_injection`
+is `tests/base-test-dependency-injection` (words reordered). Read the package
+name out of the fixture's `composer.json` rather than guessing it. New fixtures
+should prefer the mechanical form — the key with underscores turned into
+hyphens — but the existing seven are not going to be renamed for cosmetics.
+
+## What a fixture extension is for, and what it is not
+
+The seven existing ones show the cases that justify one:
+
+- **Bootstrap-time configuration.** `test_bitejobs_stub` replaces
+  `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler']` in `ext_localconf.php` so no
+  functional test ever reaches the b-ite API. There is no other point at which
+  that assignment happens early enough.
+- **Schema and TCA.** `test_jobcontact_schema` ships `ext_tables.sql` and TCA for
+  a table the upgrade wizard tests migrate away from. The table has to exist when
+  the instance is built.
+- **Dependency injection.** `test_base_dependency_injection` and
+  `test_messy_profile_factory` ship `Services.yaml` plus classes, so the
+  container really wires them.
+- **Resources resolved through `EXT:` paths.** `test_plugin_templates` and
+  `test_language_files` exist because TypoScript and `LLL:` references need a
+  real extension path.
+- **Registered configuration.** `test_category_types_group` ships a
+  `Configuration/CategoryTypes.yaml` so the registry is filled the way an
+  installing extension fills it.
+
+Anything that does *not* need one should not have one. Records go into a CSV
+fixture and are imported with `importCSVDataSet()`; TypoScript that is only read
+by one test can be a `.typoscript` file under that test's `Fixtures/` folder
+without an extension around it — `academic-persons` does exactly that with
+`Tests/Functional/Plugins/Fixtures/TypoScript/`. A fixture extension is loaded
+for every test of every class that names it, so its side effects are wide;
+prefer the narrower tool.
+
+## Adding one
+
+1. Create
+   `packages/fgtclb/<extension>/Tests/Functional/Fixtures/Extensions/<extension_key>/`.
+2. Write `composer.json` — type `typo3-cms-extension`, a `tests/…` name,
+   `extra.typo3/cms.extension-key`, `version`, `Package.providesPackages: []`,
+   and a `typo3/cms-core` constraint matching `monorepo-shared`.
+3. Write `ext_emconf.php`. The `version` and the `constraints.depends.typo3`
+   range are read from it by TYPO3, so keep them consistent with the composer
+   file.
+4. Add `Classes/` with a `TESTS\<Something>\` PSR-4 root only if classes are
+   needed.
+5. Run `composerUpdate` for the core version you will test on. Nothing else
+   registers the package.
+6. Name it in `$testExtensionsToLoad` by its composer package name.
+
+No file outside the new folder has to change.
+
+## See also
+
+- [Functional tests](functional-tests.md)
+- [PHPUnit configuration](phpunit-configuration.md)
+- [Testing helper](testing-helper.md)

--- a/docs/testing/functional-tests.md
+++ b/docs/testing/functional-tests.md
@@ -1,0 +1,274 @@
+# Functional tests
+
+A functional test boots a real TYPO3 instance against a real database, loads a
+declared set of extensions, imports records and then exercises the subject
+through the same code paths production uses. It is the only suite here that
+sees the database, the TCA that TYPO3 actually compiled, dependency injection,
+and — for the plugin tests — a rendered frontend page.
+
+It is also by far the larger suite: 118 functional test classes against 30 unit
+test classes, and 222 CSV fixtures.
+
+| Extension                | Functional | Unit |
+|--------------------------|------------|------|
+| `academic-base`          | 8          | 2    |
+| `academic-bite-jobs`     | 4          | 1    |
+| `academic-contact4pages` | 8          | 2    |
+| `academic-jobs`          | 13         | 1    |
+| `academic-partners`      | 9          | 1    |
+| `academic-persons`       | 26         | 6    |
+| `academic-persons-edit`  | 13         | 3    |
+| `academic-persons-sync`  | 2          | 1    |
+| `academic-programs`      | 8          | 1    |
+| `academic-projects`      | 11         | 1    |
+| `academic-study-plan`    | 5          | 1    |
+| `typo3-category-types`   | 11         | 10   |
+
+## Running them
+
+```bash
+# Prepare the vendor tree for the core version first — always.
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s composerUpdate
+
+# The whole suite on the default DBMS (SQLite).
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s functional
+
+# Restricted to one extension's functional tests.
+Build/Scripts/runTests.sh -t 13 -s functional packages/fgtclb/academic-persons/Tests/Functional
+
+# Restricted to one file, on PostgreSQL, with xdebug attached.
+Build/Scripts/runTests.sh -x -p 8.3 -s functional -d postgres \
+  packages/fgtclb/academic-persons/Tests/Functional/Domain
+```
+
+Point the trailing path at `Tests/Functional`, not at the extension root. The
+extension root also contains `Tests/Unit`, which the functional configuration
+neither expects nor can bootstrap.
+
+As with the unit suite, the trailing path is the only way to narrow a run;
+`runTests.sh` has no argument passthrough to PHPUnit.
+
+### DBMS selection
+
+| Option | Values                                   | Default   | Notes                                                                     |
+|--------|------------------------------------------|-----------|---------------------------------------------------------------------------|
+| `-d`   | `sqlite`, `mariadb`, `mysql`, `postgres` | `sqlite`  | Chooses the DBMS. Anything else aborts the script.                        |
+| `-i`   | a version of the selected DBMS           | see below | Rejected for `-d sqlite`.                                                 |
+| `-a`   | `mysqli`, `pdo_mysql`                    | `mysqli`  | Only for `-d mysql` and `-d mariadb`; rejected for SQLite and PostgreSQL. |
+
+Defaults and accepted versions are validated in `handleDbmsOptions()`,
+[`Build/Scripts/runTests.sh:117`](../../Build/Scripts/runTests.sh#L117) onwards:
+MariaDB `10.4`, MySQL `8.0`, PostgreSQL `10`. An invalid combination is refused
+before a container starts, with the offending pair echoed.
+
+SQLite needs no container: the script creates
+`.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/` and mounts it as tmpfs
+([`runTests.sh:693-706`](../../Build/Scripts/runTests.sh#L693-L706)). The other
+three start a database container, wait for its port, and pass the connection
+through `typo3Database*` environment variables. That is the whole reason SQLite
+is the default — it is the fastest loop, and it needs the least of the host.
+
+## Why the default is not enough
+
+SQLite is the fastest DBMS to run and the most forgiving one to be wrong on.
+Four defects from this repository's own history show the failure modes, in all
+directions — this is not "SQLite is lax", it is "the four disagree":
+
+**A statement SQLite accepts and the other three reject.** ACE-349
+(`90361d630`): `CategoryRepository::findByGroupAndUidList()` handed a plain
+array to `ExpressionBuilder::in()`. On TYPO3 v12 that reached the database as
+`uid IN ()` —
+
+> which MariaDB, MySQL and PostgreSQL reject with a syntax error while SQLite
+> accepts it.
+
+The fix is the rule now recorded in [`AGENTS.md`](../../AGENTS.md#database-queries):
+quote the list with `quoteArrayBasedValueListToIntegerList()`, which renders
+`NULL` for an empty array.
+
+**An update that three DBMS report as successful and one aborts on.** ACE-356
+(`fe79b46bf`): `FlexFormUpgradeWizard::executeUpdate()` built its `WHERE` on the
+query builder of the enclosing `SELECT`, so the `UPDATE` referenced a
+placeholder that was never bound to it.
+
+> MySQL, MariaDB and SQLite reported success and changed nothing; PostgreSQL
+> aborted with `invalid input syntax for integer`.
+
+A test asserting "the wizard ran without error" would have passed on three of
+four. The wizard was the only one in the repository without a functional test at
+the time; it has one now.
+
+**A schema declaration only MySQL refuses.** ACE-250 (`af10dba34`): a fixture
+inserted `pages` rows without the `link` column, which `EXT:academic_partners`
+declares as `text NOT NULL`. MySQL cannot apply an effective default to a `TEXT`
+column, so the insert raised *"Field 'link' doesn't have a default value"* in
+strict mode —
+
+> SQLite tolerated the omission, which is why the functional suite passed
+> locally but failed in CI on MySQL 8.0.
+
+ACE-358 (`8b5557037`) later removed the defaults from five such `TEXT` columns
+outright.
+
+**A defect that only SQLite has.** ACE-314 (`93b41a701`):
+`CategoryRepository::getByDatabaseFields()` returned early when
+`Result::rowCount()` reported no rows, and for a `SELECT` that value is driver
+dependent — SQLite reports `0` even for a result carrying rows, so every
+category filter silently returned nothing *there and only there*. The commit
+records the verification from both ends: the rendering test fails on SQLite
+without the fix and passes unpatched on MariaDB 10.4 and PostgreSQL 10.
+
+**Practical consequence.** Run the DBMS matrix locally for anything that writes,
+changes a schema declaration, or builds a query by hand. A green SQLite run is
+evidence that the logic is right, not that the SQL is portable.
+
+CI encodes the same judgement as staging
+([`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)): the 16-job DBMS
+matrix — MySQL 8.0, MariaDB 10.4, MariaDB 10.6, PostgreSQL 10, each on two core
+versions and two PHP versions — only starts once the identical functional suite
+passed on SQLite for both core versions and both PHP edges. A defect that is not
+DBMS specific is therefore reported by 4 jobs instead of 20.
+
+## The `not-<dbms>` group
+
+`runTests.sh` always appends **two** exclusions to the functional PHPUnit call
+([`runTests.sh:659`](../../Build/Scripts/runTests.sh#L659)):
+
+```bash
+COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} --exclude-group not-core-${CORE_VERSION} "$@")
+```
+
+So `#[Group('not-postgres')]` on a test class or method would exclude it from a
+`-d postgres` run, and the same for `not-sqlite`, `not-mysql` and `not-mariadb`.
+
+**No test in this repository uses it.** The mechanism is available and
+inherited from the TYPO3 Core harness; nothing here has yet had a reason to
+exclude a test from one DBMS. Prefer keeping it that way: a test that cannot run
+on one DBMS usually means production code that does not work there either — all
+four of the defects above were fixed rather than skipped.
+
+## Declaring what a test loads
+
+Functional tests here extend
+`SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase` (from
+`sbuerk/typo3-site-based-test-trait`, a thin subclass of the testing framework's
+own `FunctionalTestCase` that adds a `constants`/`setup` aware
+`setUpFrontendRootPage()`), by way of one abstract test case per extension.
+
+Each extension's abstract test case names the extensions the whole extension's
+suite needs:
+
+```php
+abstract class AbstractAcademicBiteJobsTestCase extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'fgtclb/environment-state-manager',
+        'fgtclb/academic-base',
+        'fgtclb/academic-bite-jobs',
+    ];
+}
+```
+
+— [`AbstractAcademicBiteJobsTestCase.php`](../../packages/fgtclb/academic-bite-jobs/Tests/Functional/AbstractAcademicBiteJobsTestCase.php)
+
+Points worth knowing:
+
+- **Both lists take composer package names**, not extension keys. That works
+  because the testing framework resolves them through its
+  `ComposerPackageManager`. Extension keys are accepted too — the
+  `ExtensionsLoadedTestsTrait` asserts both spellings resolve, see
+  [Testing helper](testing-helper.md#extensionsloadedteststrait).
+- **`$testExtensionsToLoad` covers this repository's own extensions as well as
+  third-party ones.** `fgtclb/academic-base` is a sibling package, not a "test
+  extension" in any narrower sense.
+- **Dependencies are not resolved for you.** An extension that reads TCA of
+  another one has to list it, which is why every list starts with
+  `fgtclb/academic-base`.
+- **`typo3/cms-install` appears in most lists** because upgrade wizards live in
+  `EXT:install`.
+
+A single test class adds what only it needs. Assigning the array again would
+drop the inherited entries, so tests append:
+
+```php
+$this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
+$this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+```
+
+— [`AcademicPersonsListPluginTest.php:35-36`](../../packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php#L35-L36)
+
+Those two helpers come from `FrontendPluginRenderingTrait`; `academic-persons`
+additionally has `addTestExtension()`/`addCoreExtension()` on its own abstract
+case
+([`AbstractAcademicPersonsTestCase.php:31-47`](../../packages/fgtclb/academic-persons/Tests/Functional/AbstractAcademicPersonsTestCase.php#L31-L47)).
+Both do the same thing — merge instead of replace.
+
+Everything appended must be done **before** `parent::setUp()`, because that call
+is what builds the instance.
+
+## Worked examples
+
+| Test                                                                                                                                                                               | What it demonstrates                                                                                     |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| [`academic-base/Tests/Functional/ExtensionLoadedTest.php`](../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php)                                           | The smallest possible functional test: a trait plus a list of identifiers.                               |
+| [`academic-persons/Tests/Functional/Tca/PluginFlexFormTest.php`](../../packages/fgtclb/academic-persons/Tests/Functional/Tca/PluginFlexFormTest.php)                               | Compiling a piece of FormEngine data without a backend user or a page tree.                              |
+| [`academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php`](../../packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsListPluginTest.php) | Full frontend rendering: site configuration, three languages, TypoScript, a real request.                |
+| [`academic-jobs/Tests/Functional/Upgrades/ContactTcaUpgradeWizardTest.php`](../../packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/ContactTcaUpgradeWizardTest.php)         | An upgrade wizard against a table renamed for the test, using a fixture extension for the legacy schema. |
+| [`academic-base/Tests/Functional/Tca/TableConfigurationTest.php`](../../packages/fgtclb/academic-base/Tests/Functional/Tca/TableConfigurationTest.php)                             | Mutating `$GLOBALS['TCA']` safely, via `TcaHelperMethodsTrait`.                                          |
+
+Records come from CSV fixtures next to the test, imported with
+`importCSVDataSet()` (used in 55 files) and, where the test writes, asserted back
+with `assertCSVDataSet()` (14 call sites). Fixtures of a plugin test live in a
+`Fixtures/<TestClassName>/` folder beside it, one file per scenario, which keeps
+a fixture from being quietly reused by a test it was not written for.
+
+## Version-gated tests
+
+Three mechanisms coexist, and they are not interchangeable:
+
+| Mechanism                                 | Granularity     | Use when                                                                |
+|-------------------------------------------|-----------------|-------------------------------------------------------------------------|
+| `Core13/` / `Core14/` subfolder           | whole class     | The class only makes sense on one core version.                         |
+| `#[Group('not-core-13')]` / `not-core-14` | class or method | The test exists on both, but the expectation differs by major version.  |
+| `markTestSkipped()` on `Typo3Version`     | method          | The behaviour changed within a major version, at a known patch release. |
+
+The group attributes are the common case;
+[`AcademicJobsNewJobFormUploadTest.php:32`](../../packages/fgtclb/academic-jobs/Tests/Functional/Plugins/AcademicJobsNewJobFormUploadTest.php#L32)
+carries one at class level,
+[`DeprecatedCoreLabelsTest.php:19`](../../packages/fgtclb/academic-persons/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php#L19)
+at method level.
+
+The third form covers a case the groups cannot: TYPO3 v14.3.6 shipped the fix
+for forge #88886, so Extbase honours a site language `fallbackType: strict` for
+untranslated selected records from that patch release on, and v13.4 never gets
+the fix. Five tests were therefore split into pairs — the plain name asserting
+the corrected behaviour and skipping below 14.3.6, a `…_beforeCoreFix` sibling
+asserting the previous behaviour and skipping from 14.3.6 on (ACE-378,
+`7fa1ca167`). Both halves state their reason in the skip message and link the
+Gerrit changes:
+
+```php
+if (version_compare((new Typo3Version())->getVersion(), '14.3.6', '<')) {
+    $this->markTestSkipped(
+        'Extbase honours "fallbackType: strict" for untranslated selected profiles only since '
+        . 'TYPO3 v14.3.6 (core fix …, forge #88886; not backported to v13.4).'
+    );
+}
+```
+
+— [`AcademicPersonsSelectedProfilesPluginTest.php:145-152`](../../packages/fgtclb/academic-persons/Tests/Functional/Plugins/AcademicPersonsSelectedProfilesPluginTest.php#L145-L152)
+
+Never delete the older half while the older core version is supported. Behaviour
+that differs is documented by stating both sides, not by asserting the newer one
+and skipping the rest.
+
+## See also
+
+- [PHPUnit configuration](phpunit-configuration.md)
+- [Unit tests](unit-tests.md)
+- [Fixture extensions](fixture-extensions.md)
+- [Testing helper](testing-helper.md)

--- a/docs/testing/phpunit-configuration.md
+++ b/docs/testing/phpunit-configuration.md
@@ -1,0 +1,204 @@
+# PHPUnit configuration
+
+Four files configure both PHPUnit suites of this mono repository. They live
+together in [`Build/phpunit/`](../../Build/phpunit), next to the configuration
+of every other tool:
+
+| File                                                                                             | Lines | Role                                           |
+|--------------------------------------------------------------------------------------------------|-------|------------------------------------------------|
+| [`Build/phpunit/UnitTests.xml`](../../Build/phpunit/UnitTests.xml)                               | 49    | PHPUnit configuration of the unit suite.       |
+| [`Build/phpunit/UnitTestsBootstrap.php`](../../Build/phpunit/UnitTestsBootstrap.php)             | 101   | Bootstrap referenced by `UnitTests.xml`.       |
+| [`Build/phpunit/FunctionalTests.xml`](../../Build/phpunit/FunctionalTests.xml)                   | 49    | PHPUnit configuration of the functional suite. |
+| [`Build/phpunit/FunctionalTestsBootstrap.php`](../../Build/phpunit/FunctionalTestsBootstrap.php) | 60    | Bootstrap referenced by `FunctionalTests.xml`. |
+
+Nothing selects them implicitly. `Build/Scripts/runTests.sh` passes the matching
+file with `-c` for every suite it starts — see
+[`Build/Scripts/runTests.sh:658`](../../Build/Scripts/runTests.sh#L658) for the
+functional suite and
+[`Build/Scripts/runTests.sh:750`](../../Build/Scripts/runTests.sh#L750) and
+[`:756`](../../Build/Scripts/runTests.sh#L756) for `unit` and `unitRandom`.
+
+The installed PHPUnit is `phpunit/phpunit` 11.5.56, against
+`typo3/testing-framework` 9.6.1.
+
+## Where the configuration comes from
+
+All four files are copies of the boilerplate that `typo3/testing-framework`
+ships in
+`.Build/vendor/typo3/testing-framework/Resources/Core/Build/`. That package
+states the intent in the file header it also ships:
+
+> This file is loosely maintained within TYPO3 testing-framework, extensions
+> are encouraged to not use it directly, but to copy it to an own place […]
+
+"Loosely maintained" is the reason to copy rather than reference: the template
+tracks what TYPO3 Core itself needs, changes without a deprecation path, and
+would otherwise move under the repository's feet on every dependency update.
+Copying makes every deviation below a decision recorded in git rather than a
+difference nobody notices.
+
+The trade-off is that the copies do not follow the template forward. When
+`typo3/testing-framework` is raised, diffing the four files against the vendor
+originals is the only thing that reveals a new upstream default.
+
+## The deliberate deviations
+
+Diffed against the installed template, the copies differ in these points and
+nothing else:
+
+| File                           | Template                                                                     | Here                                                                              | Why                                                                                                                              |
+|--------------------------------|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| both `.xml`                    | `<directory>../../../../../../typo3/sysext/*/Tests/Unit/</directory>`        | `<directory>../../packages/*/*/Tests/Unit/</directory>`                           | The template points into a TYPO3 Core checkout. Here the tests live in the mono repository's package tree.                       |
+| both `.xml`                    | `xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"` | `xsi:noNamespaceSchemaLocation="../../.Build/vendor/phpunit/phpunit/phpunit.xsd"` | The schema of the *installed* PHPUnit, not a pinned remote one. No network access, and it cannot drift from the running version. |
+| both `.xml`                    | attribute absent                                                             | `beStrictAboutTestsThatDoNotTestAnything="false"`                                 | See [the strictness policy](#strictness-policy) below.                                                                           |
+| `UnitTestsBootstrap.php`       | fully qualified class names inline                                           | `use` imports                                                                     | Cosmetic; the file is linted and CGL-checked like every other PHP file here.                                                     |
+| `FunctionalTestsBootstrap.php` | plain `Testbase` setup                                                       | additional fixture package adoption block                                         | See [the functional bootstrap](#the-functional-bootstrap) below.                                                                 |
+
+The `phpunit v10.1 compatible version.` line in both XML headers is a local
+addition that no longer describes anything — the configuration is read by
+PHPUnit 11 and validates against its schema. Treat it as a leftover, not as a
+constraint.
+
+## Strictness policy
+
+Both XML files carry an identical attribute block,
+[`UnitTests.xml:20-34`](../../Build/phpunit/UnitTests.xml#L20-L34) and
+[`FunctionalTests.xml:20-34`](../../Build/phpunit/FunctionalTests.xml#L20-L34).
+The "PHPUnit default" column is read from the schema the installed PHPUnit
+ships, `.Build/vendor/phpunit/phpunit/phpunit.xsd`:
+
+| Attribute                                      | Value here | PHPUnit default | Effect                                                                 |
+|------------------------------------------------|------------|-----------------|------------------------------------------------------------------------|
+| `backupGlobals`                                | `true`     | `false`         | `$GLOBALS` is restored after every test — `$GLOBALS['TCA']` above all. |
+| `beStrictAboutTestsThatDoNotTestAnything`      | `false`    | `true`          | **Relaxed.** A test without an assertion is not reported risky.        |
+| `cacheResult`                                  | `false`    | `true`          | No result cache, so no ordering that depends on a previous run.        |
+| `colors`                                       | `true`     | `false`         | Coloured output.                                                       |
+| `displayDetailsOnTestsThatTriggerDeprecations` | `true`     | `false`         | Deprecations are printed with their origin, not only counted.          |
+| `displayDetailsOnTestsThatTriggerErrors`       | `true`     | `false`         | Same for errors.                                                       |
+| `displayDetailsOnTestsThatTriggerNotices`      | `true`     | `false`         | Same for notices.                                                      |
+| `displayDetailsOnTestsThatTriggerWarnings`     | `true`     | `false`         | Same for warnings.                                                     |
+| `failOnDeprecation`                            | `true`     | `false`         | A triggered deprecation fails the run.                                 |
+| `failOnNotice`                                 | `true`     | `false`         | A notice fails the run.                                                |
+| `failOnRisky`                                  | `true`     | `false`         | A risky test fails the run.                                            |
+| `failOnWarning`                                | `true`     | `false`         | A warning fails the run.                                               |
+| `requireCoverageMetadata`                      | `false`    | `false`         | No coverage annotations required. There is no coverage gate here.      |
+
+Everything the schema knows and the files do not name keeps the PHPUnit
+default. Notably absent, and therefore off: `failOnIncomplete`, `failOnSkipped`,
+`failOnEmptyTestSuite` and `failOnAllIssues`. `failOnSkipped` staying off is
+load-bearing — several tests skip themselves on a core version, see
+[Functional tests](functional-tests.md).
+
+### The one relaxation
+
+`beStrictAboutTestsThatDoNotTestAnything="false"` is the only setting that is
+weaker than PHPUnit's default, and it is not decoration: with `failOnRisky` set
+to `true`, "risky" is fatal, so the two settings have to be read together.
+Turning strictness back on would fail assertion-free tests such as
+
+```php
+#[Test]
+public function canBeCreated(): void
+{
+    new Email();
+}
+```
+
+from
+[`academic-persons/Tests/Unit/Domain/Model/EmailTest.php:13-17`](../../packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php#L13-L17).
+That test does state something worth stating — the constructor of a model with
+no required arguments does not throw — but it has no assertion to prove it with.
+
+The cost is real and worth knowing: a test that lost its assertions in a
+refactoring passes silently. When a test *can* assert, it must; the relaxation
+exists for the handful that structurally cannot.
+
+### What `failOnDeprecation` means across two core versions
+
+The `main` branch supports TYPO3 v13 and v14 from one code base, and CI runs
+every suite once per core version. A deprecation is version specific by nature:
+core raises `E_USER_DEPRECATED` for an API on the newer version while the older
+one still considers it current. With `failOnDeprecation="true"` this asymmetry
+becomes a red matrix leg — the v14 job fails and the v13 job stays green on
+exactly the same commit.
+
+Two consequences follow.
+
+**A deprecation cannot be waited out.** The repository fixes the underlying code
+instead of relaxing the option. Commit `336cb673f`
+(*Clear remaining v14 functional deprecations*) says so explicitly:
+
+> `failOnDeprecation` (and the other phpunit fail\* options) stay enabled; the
+> underlying code is fixed for TYPO3 v13 and v14.
+
+**Some deprecations are not ours and still fail the run.** TYPO3 v14 marks a set
+of core labels `x-unused-since="14.0"`; they still resolve, through a fallback
+in `LanguageService` that raises `E_USER_DEPRECATED` **on every backend form
+render**. Because this repository's TCA referenced those labels, any future test
+that compiles a backend form would have failed on v14 and passed on v13. That is
+why
+ACE-298 shipped replacement labels before such tests exist, and why
+`DeprecatedCoreLabelsTrait` now guards against the next one — see
+[Testing helper](testing-helper.md).
+
+The mirror image also exists: the three APIs listed under "TYPO3 v15 blockers"
+in [`AGENTS.md`](../../AGENTS.md) are deprecated on v14 and have no replacement
+on v13, so they cannot be migrated while v13 is supported. They are tracked as
+ACE-294 rather than silenced.
+
+## The unit bootstrap
+
+[`UnitTestsBootstrap.php`](../../Build/phpunit/UnitTestsBootstrap.php) builds
+the smallest TYPO3 that lets a class be instantiated: it sets `TYPO3_PATH_ROOT`
+and `TYPO3_PATH_WEB` when they are unset (lines 51-56), runs the testing
+framework's `SystemEnvironmentBuilder` (lines 65-71), creates the four
+`typo3temp` directories (lines 73-76), initialises `TYPO3_CONF_VARS` from
+`ConfigurationManager::getDefaultConfiguration()` (lines 83-84), and installs a
+`UnitTestPackageManager` backed by a `NullBackend` cache (lines 86-96).
+
+There is no database and no site. A unit test that needs either is a functional
+test.
+
+One inherited oddity is worth recognising before it is "fixed": line 65 reads
+
+```php
+$hasConsolidatedHttpEntryPoint = class_exists(CoreHttpApplication::class);
+```
+
+`CoreHttpApplication` is neither imported nor namespace-qualified, so it
+resolves to the global namespace, where no such class is defined in the
+installed vendor tree. The condition is therefore always false and the `else`
+branch always runs. The line is identical in the upstream template
+(`.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php:54`),
+so this is inherited, not introduced here — change it upstream, not in the copy.
+
+## The functional bootstrap
+
+[`FunctionalTestsBootstrap.php`](../../Build/phpunit/FunctionalTestsBootstrap.php)
+is short, and almost all of it is the one deviation from the template
+(lines 28-54). Before the usual `Testbase` calls it instantiates
+`SBUERK\AvailableFixturePackages` and calls `adoptFixtureExtensions()`, which
+registers the repository's test-only fixture extensions with the testing
+framework's `ComposerPackageManager`. That is what lets a test name a fixture
+extension by composer package name or extension key in `$testExtensionsToLoad`
+— see [Fixture extensions](fixture-extensions.md).
+
+The block carries a documented workaround: `AvailableFixturePackages::$dataFile`
+holds a path that is missing a slash between vendor name and data file, so the
+generated `.Build/vendor/sbuerk/fixture-packages.php` is never read. The
+bootstrap sets the private property to the correct path by reflection
+(lines 43-51) and marks the end of the workaround with a comment. Delete the
+block only after checking that the released `sbuerk/fixture-packages` — 1.1.3 at
+the time of writing — builds the path correctly; without it every fixture
+extension becomes unresolvable at once.
+
+The `class_exists()` guard around the whole block means the suite still boots
+when `sbuerk/fixture-packages` is not installed. Tests that load a fixture
+extension then fail, the run does not.
+
+## See also
+
+- [Unit tests](unit-tests.md)
+- [Functional tests](functional-tests.md)
+- [Fixture extensions](fixture-extensions.md)
+- [Testing helper](testing-helper.md)

--- a/docs/testing/testing-helper.md
+++ b/docs/testing/testing-helper.md
@@ -1,0 +1,453 @@
+# Testing helper
+
+[`packages-dev/testing-helper/`](../../packages-dev/testing-helper) is the
+composer package `fgtclb/academics-monorepo-testing-helper`. It holds nothing
+but seven PHP traits — the parts of the test setup that were being copied
+between extensions, each one carrying the memory of a defect that made the copy
+necessary.
+
+| Trait                                                                           | Purpose                                                             |
+|---------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [`ExtensionCoreVersionCompatTestsTrait`](#extensioncoreversioncompatteststrait) | Asserts the run really happens on a supported core version.         |
+| [`ExtensionsLoadedTestsTrait`](#extensionsloadedteststrait)                     | Asserts an extension resolves by package name and by extension key. |
+| [`FrontendPluginRenderingTrait`](#frontendpluginrenderingtrait)                 | The scaffolding every frontend plugin rendering test needs.         |
+| [`PluginFlexFormDataStructureTrait`](#pluginflexformdatastructuretrait)         | Resolves a plugin FlexForm the way FormEngine does.                 |
+| [`DeprecatedCoreLabelsTrait`](#deprecatedcorelabelstrait)                       | Guards TCA against core labels TYPO3 v14 retired.                   |
+| [`EnsureTtContentListTypeColumnTrait`](#ensurettcontentlisttypecolumntrait)     | Re-creates `tt_content.list_type` where v14 removed it.             |
+| [`TcaHelperMethodsTrait`](#tcahelpermethodstrait)                               | Backs up and restores `$GLOBALS['TCA']` *and* the schema factory.   |
+
+## How an extension gets access
+
+The package is a path package, resolved through the `packages-dev/*` repository
+declared in the root [`composer.json`](../../composer.json), and required there
+as a development dependency:
+
+```json
+"require-dev": {
+    "fgtclb/academics-monorepo-testing-helper": "@dev"
+}
+```
+
+Three consequences, all worth knowing before looking for a missing `require`:
+
+- **No extension requires it.** Not one `packages/fgtclb/*/composer.json`
+  mentions the package. It is installed once for the whole mono repository, and
+  its `FGTCLB\TestingHelper\` PSR-4 root lands in the root autoloader, which is
+  the same autoloader the test suites use. Every extension's tests can therefore
+  `use` a trait without declaring anything.
+- **The version is not written twice.** `sbuerk/extended-path-repository` derives
+  the path package's version from `extra.typo3/cms.version` in the package's own
+  `composer.json` — `3.0.0-dev` on this branch, matching every other package
+  here. There is no `repositories.*.options.versions` map to keep in sync.
+- **It never ships.** `require-dev` in a `project`-type root, in a directory that
+  is not split out to a public repository. It exists for this checkout only.
+
+The flip side is that the split repositories do **not** get it. An extension's
+tests are only runnable from this mono repository, which is consistent with the
+rest of the harness — `Build/phpunit/*.xml` globs across all packages at once,
+see [Unit tests](unit-tests.md#discovery).
+
+## Two things the package does not do
+
+**It declares no dependencies.** `packages-dev/testing-helper/composer.json` has
+no `require` and no `require-dev` at all — not on `phpunit/phpunit`, not on
+`typo3/testing-framework`, not on `typo3/cms-core`, although every trait uses
+all three. Nothing enforces that a consuming class actually provides
+`$this->get()`, `$this->instancePath`, `$this->coreExtensionsToLoad` or the
+assertion methods a trait calls. Using a trait in a class that does not extend a
+functional test case fails at runtime, not at install time or in static
+analysis.
+
+**It has no tests of its own.** The PHPUnit test suites glob
+`packages/*/*/Tests/…`, which does not reach `packages-dev/`. The traits are
+covered only through the extensions that use them.
+
+A namespace quirk follows from the same history: every trait lives under
+`FGTCLB\TestingHelper\FunctionalTestCase\`, but
+`ExtensionCoreVersionCompatTestsTrait` is used from **unit** tests too. The
+namespace records where the traits started, not where they are usable.
+
+---
+
+## `ExtensionCoreVersionCompatTestsTrait`
+
+[`Classes/FunctionalTestCase/ExtensionCoreVersionCompatTestsTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/ExtensionCoreVersionCompatTestsTrait.php)
+
+**What it does.** Three tests. `allowedMajorTypo3Version()` asserts the running
+TYPO3 major version is one of the branch's two. The other two assert a specific
+version, gated so each runs on exactly one leg of the matrix:
+
+```php
+#[Group('not-core-' . TYPO3_HIGHEST_SUPPORTED_MAJOR_VERSION)]
+#[Test]
+public function verifyLowestSupportedMajorVersion(): void
+
+#[Group('not-core-' . TYPO3_LOWEST_SUPPORTED_MAJOR_VERSION)]
+#[Test]
+public function verifyHighestSupportedMajorVersion(): void
+```
+
+The two constants are declared at file scope, lines 11-12:
+
+```php
+const TYPO3_LOWEST_SUPPORTED_MAJOR_VERSION = 13;
+const TYPO3_HIGHEST_SUPPORTED_MAJOR_VERSION = 14;
+```
+
+**When to use it.** Already everywhere: every extension carries a
+`Tests/Unit/VersionCompatTest.php` *and* a
+`Tests/Functional/VersionCompatTest.php` whose entire body is
+`use ExtensionCoreVersionCompatTestsTrait;`.
+`EXT:category_types` spells the unit one `VersionCompareTest.php`; same content.
+
+**The trap it exists for.** `-t` selects configuration, not dependencies. Running
+`-t 14 -s functional` after a `-t 13 -s composerUpdate` uses the v13 vendor tree
+with the v14 exclusion group, and the resulting failures point everywhere except
+at the cause. These tests fail first and say what happened.
+
+The constants are also the single place the branch's supported range is written
+for the test suite. Widening or narrowing support means editing this file — and
+forgetting to means every extension's `VersionCompatTest` goes red at once,
+which is the intended alarm rather than a nuisance.
+
+---
+
+## `ExtensionsLoadedTestsTrait`
+
+[`Classes/FunctionalTestCase/ExtensionsLoadedTestsTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/ExtensionsLoadedTestsTrait.php)
+
+**What it does.** Takes a list of identifiers and asserts
+`ExtensionManagementUtility::isLoaded()` returns `true` for each. The data
+provider labels every entry by what it is, deciding on the presence of a slash:
+
+```php
+yield sprintf("%s: %s", (str_contains($identifier, '/') ? 'composer package name' : 'extension key'), $identifier)
+```
+
+**When to use it.** Once per extension, in a
+`Tests/Functional/ExtensionLoadedTest.php` naming both spellings:
+
+```php
+final class ExtensionLoadedTest extends AbstractAcademicBaseTestCase
+{
+    use ExtensionsLoadedTestsTrait;
+
+    private static $expectedLoadedExtensions = [
+        // composer package names
+        'fgtclb/academic-base',
+        // extension keys
+        'academic_base',
+    ];
+}
+```
+
+— [`academic-base/Tests/Functional/ExtensionLoadedTest.php`](../../packages/fgtclb/academic-base/Tests/Functional/ExtensionLoadedTest.php)
+
+**The trap it exists for.** In a composer installation an extension has two
+names, and they are not derived from each other.
+`packages/fgtclb/academic-contact4pages/` ships the extension key
+`academic_contacts4pages` — directory, package name and key all differ. Asserting both spellings catches a package that loads under one
+identifier and is invisible under the other, which otherwise surfaces much later
+as a `LLL:EXT:…` that does not resolve or a TCA override that never applies.
+
+**Watch out.** The trait reads `self::$expectedLoadedExtensions` but does not
+declare it. Forgetting the property is a PHP error, not a failed assertion.
+
+---
+
+## `FrontendPluginRenderingTrait`
+
+[`Classes/FunctionalTestCase/FrontendPluginRenderingTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/FrontendPluginRenderingTrait.php)
+
+**What it does.** Collects everything a plugin rendering test needs around the
+assertion — roughly sixty lines per test class before this trait existed
+(ACE-305):
+
+| Member                              | Role                                                                    |
+|-------------------------------------|-------------------------------------------------------------------------|
+| `FRONTEND_PLUGIN_TEST_BASE`         | `https://www.acme.com/` — the base every helper here assumes.           |
+| `frontendPluginTestConfiguration()` | The instance configuration, merged recursively with what the test adds. |
+| `addCoreExtensionsToLoad()`         | Appends to `$coreExtensionsToLoad` instead of replacing it.             |
+| `addTestExtensionsToLoad()`         | The same for `$testExtensionsToLoad`.                                   |
+| `writeFrontendPluginTestSite()`     | Writes the site `acme` with the languages the test passes.              |
+| `removeWrittenSiteConfiguration()`  | Removes it again in `tearDown()`.                                       |
+| `requestFrontendPage()`             | Fires the sub request, returns the `ResponseInterface`.                 |
+| `renderFrontendPage()`              | The same, asserts `200`, returns the body as a string.                  |
+
+**When to use it.** In every test that renders a plugin. The class must also
+`use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait` and declare its own
+`LANGUAGE_PRESETS` — which languages a test needs is part of what it tests, so
+that stays with the test.
+
+```php
+protected function setUp(): void
+{
+    $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+    $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+    parent::setUp();
+}
+
+protected function tearDown(): void
+{
+    $this->removeWrittenSiteConfiguration();
+    parent::tearDown();
+}
+```
+
+**The traps it exists for.** Three, all of them silent:
+
+- `subrequestPageErrors` is switched on in the configuration. Without it the
+  frontend swallows the exception of a sub request and answers a **rendered
+  error page**, so a test asserting only the status code passes while the plugin
+  is broken. `renderFrontendPage()` asserting `200` is only meaningful because
+  of that flag.
+- A written site configuration outlives the test instance, so the next test
+  finds a site it did not write. Hence the explicit `removeWrittenSiteConfiguration()`
+  in `tearDown()`.
+- The two `add…ToLoad()` helpers exist because assigning `$testExtensionsToLoad`
+  in a subclass drops everything the abstract test case declared, and the loss
+  is not reported.
+
+---
+
+## `PluginFlexFormDataStructureTrait`
+
+[`Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/PluginFlexFormDataStructureTrait.php)
+
+This is the most consequential trait in the package. It exists because of
+ACE-293, and it is worth reading in full before changing anything about plugin
+registration.
+
+### The defect
+
+A plugin's FlexForm data structure is attached to the content type as
+`$GLOBALS['TCA']['tt_content']['types'][<CType>]['columnsOverrides']['pi_flexform']['config']['ds']`.
+**TYPO3 v13 and v14 want different shapes there, and neither tolerates the
+other's:**
+
+| Core version | Required shape                            | What the other shape does                                                                                                        |
+|--------------|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| v13          | array, e.g. `['default' => 'FILE:EXT:…']` | A string throws in `FlexFormTools` (code 1463826960). **The record cannot be opened.**                                           |
+| v14          | plain string, `'FILE:EXT:…'`              | An array throws `InvalidTcaException`, which `TcaFlexPrepare` catches — the backend renders an **empty FlexForm tab**, silently. |
+
+The v14-shaped registration was introduced when `addPiFlexFormValue()` was
+dropped for its v14 deprecation, and it made all fifteen academic plugin content
+elements unopenable in the TYPO3 v13 backend. Every gate stayed green on both
+core versions, because nothing in the suite compiled a backend form. The commit
+message of `c2e8f84de` states the lesson plainly:
+
+> That no test caught this is the point worth keeping: nothing in the suite
+> renders or compiles a backend form, so TCA that is fatal in the v13 backend
+> passes every gate on both core versions.
+
+The production side of the fix is the single version switch in
+[`academic-base/Classes/TcaManipulator.php:165-168`](../../packages/fgtclb/academic-base/Classes/TcaManipulator.php#L165-L168);
+its unit-level counterpart is the `not-core-13`/`not-core-14` pair described in
+[Unit tests](unit-tests.md#core-version-aware-unit-tests).
+
+### How the trait checks it
+
+`resolvePluginFlexFormDataStructure(string $cType)` builds a FormEngine result
+array by hand and pushes it through exactly two data providers:
+
+```php
+$result = $this->get(TcaColumnsOverrides::class)->addData($result);
+$result = $this->get(TcaFlexPrepare::class)->addData($result);
+```
+
+Those two are the first in the FormEngine chain that touch `pi_flexform` —
+`TcaColumnsOverrides` merges the type-specific `columnsOverrides` into the
+columns, `TcaFlexPrepare` resolves the `ds` reference into the parsed structure.
+Everything that can go wrong with a plugin data structure goes wrong in one of
+them. Running only those two rather than a full `FormDataCompiler` is what keeps
+the check cheap: **no backend user, no page tree, no request**, which is why
+each extension needs only one small test file.
+
+Two details in the hand-built `$result` are version specific:
+
+- `'list_type' => ''` is present in `databaseRow` because v13 resolves the data
+  structure through the `ds_pointerField` `list_type,CType` and needs the field
+  in the row. v14 dropped the column entirely.
+- `$result['tcaSchemata']` is filled from `TcaSchemaFactory::all()`, which is
+  what FormEngine's `InitializeProcessedTca` puts there.
+
+The second one carries a caveat that matters if you copy the pattern. It is
+written as a version branch:
+
+```php
+if (class_exists(TcaSchemaFactory::class)) {
+```
+
+but `TYPO3\CMS\Core\Schema\TcaSchemaFactory` **also exists on TYPO3 v13.4** —
+verified against the installed `typo3/cms-core` v13.4.34, which ships
+`Classes/Schema/TcaSchemaFactory.php` with both `all()` and `load()`. The branch
+is therefore taken on both core versions of this branch, and the key is set in
+both cases. That is fine for what the trait does, but **do not read this
+construct as a v14 gate and do not reuse it as one.** A genuine gate is
+`(new Typo3Version())->getMajorVersion()` or a `not-core-*` group.
+
+### The assertion
+
+`assertPluginFlexFormIsResolved(string $cType, string $sheetName = 'sDEF')` makes
+**two** assertions, and the second one is the load-bearing one:
+
+```php
+self::assertArrayHasKey($sheetName, $dataStructure['sheets'] ?? [], …);
+self::assertNotEmpty($dataStructure['sheets'][$sheetName]['ROOT']['el'] ?? [], …);
+```
+
+Asserting the sheet alone would pass on v14 against the empty fallback: when
+`TcaFlexPrepare` swallows an unresolvable data structure there, the caller is
+left with `['sheets' => ['sDEF' => []]]` — a sheet that exists and contains
+nothing. Only the assertion on `ROOT.el` distinguishes "resolved" from
+"silently empty".
+
+**When to use it.** One `Tests/Functional/Tca/PluginFlexFormTest.php` per
+extension that registers plugins, listing every CType in a data provider. Seven
+extensions have one. Add the CType to the provider in the same change that
+registers the plugin.
+
+---
+
+## `DeprecatedCoreLabelsTrait`
+
+[`Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/DeprecatedCoreLabelsTrait.php)
+
+**What it does.** Walks the compiled `$GLOBALS['TCA']` recursively for the tables
+matching the given prefixes and reports every reference to one of seven core
+label keys that TYPO3 v14 retired, together with the replacement key shipped in
+`EXT:academic_base/Resources/Private/Language/locallang_tca.xlf`.
+
+**When to use it.** Once per extension that owns TCA tables:
+
+```php
+#[Group('not-core-13')]
+#[Test]
+public function tcaDoesNotReferenceCoreLabelsRetiredInV14(): void
+{
+    $this->assertTcaHasNoDeprecatedCoreLabelReferences(['tx_academicpersons_']);
+}
+```
+
+— [`academic-persons/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php`](../../packages/fgtclb/academic-persons/Tests/Functional/Tca/DeprecatedCoreLabelsTest.php)
+
+**The trap it exists for.** TYPO3 v14 marks those labels `x-unused-since="14.0"`
+(#107938, #108086). They still resolve, through an `.x-unused` fallback that
+raises `E_USER_DEPRECATED` on every backend form render — and with
+`failOnDeprecation="true"` that would turn the first backend-form test red on
+v14 and leave it green on v13. The v14 language packs also no longer ship
+translations for them, so a German backend fell back to English. ACE-298 shipped
+21 replacement labels; this trait guards against the next one.
+
+**It must be scoped to TYPO3 v14.** The trait's own docblock is explicit:
+
+> **Assert this on TYPO3 v14 only** (`#[Group('not-core-13')]`). On v13 the
+> labels are not deprecated at all, and core's own `TcaEnrichment` adds them to
+> every table that declares `transOrigPointerField` without defining the column
+> — so a v13 run reports core's labels, which are none of our business.
+
+On v14 that same enrichment uses `core.db.general:l18n_parent`, so whatever the
+scan finds there is genuinely ours. Two core-generated false positives were
+observed on v13 before the assertion was scoped.
+
+It walks the *compiled* TCA rather than the source files on purpose, so labels
+assembled at runtime are covered too.
+
+---
+
+## `EnsureTtContentListTypeColumnTrait`
+
+[`Classes/FunctionalTestCase/EnsureTtContentListTypeColumnTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/EnsureTtContentListTypeColumnTrait.php)
+
+**What it does.** `ensureTtContentListTypeColumnExists()` lists the columns of
+`tt_content` through the schema manager and, if `list_type` is absent, adds it:
+
+```sql
+ALTER TABLE tt_content ADD COLUMN list_type VARCHAR(255) DEFAULT '' NOT NULL
+```
+
+On TYPO3 v13 the column already exists and the method returns early.
+
+**When to use it.** In the `setUp()` of an upgrade wizard test that migrates
+`list_type` to `CType`. Three tests do:
+[`academic-persons/…/ListTypeToCTypeUpgradeWizardTest.php:32`](../../packages/fgtclb/academic-persons/Tests/Functional/Upgrades/ListTypeToCTypeUpgradeWizardTest.php#L32),
+[`academic-jobs/…/PluginUpgradeWizardTest.php:22`](../../packages/fgtclb/academic-jobs/Tests/Functional/Upgrades/PluginUpgradeWizardTest.php#L22)
+and
+[`academic-persons-edit/…/PluginContentWizardTest.php:22`](../../packages/fgtclb/academic-persons-edit/Tests/Functional/Upgrades/PluginContentWizardTest.php#L22).
+
+**The trap it exists for.** TYPO3 v14 removed `tt_content.list_type` together
+with the plugin sub-type feature. An upgrade wizard that migrates away from
+`list_type` still has to be testable there — the wizard's entire purpose is to
+run on installations that still have the column and its data. Without the trait
+the v14 leg of those tests cannot even seed its fixture.
+
+Note the column comparison is done on `strtolower($column->getName())`, which is
+what makes it reliable across the four supported DBMS.
+
+---
+
+## `TcaHelperMethodsTrait`
+
+[`Classes/FunctionalTestCase/TcaHelperMethodsTrait.php`](../../packages-dev/testing-helper/Classes/FunctionalTestCase/TcaHelperMethodsTrait.php)
+
+**What it does.** `createTCABackup(bool $force)` snapshots `$GLOBALS['TCA']`;
+`restoreTCABackup(bool $throwExceptionWhenBackupDoesNotExists)` puts it back.
+The interesting part is the private `updateGlobalTCA()`, which does not only
+reassign the global:
+
+```php
+$GLOBALS['TCA'] = $tca;
+if (class_exists(TcaSchemaFactory::class)) {
+    $tcaSchemaFactory = $this->get(TcaSchemaFactory::class);
+    $tcaSchemaFactory->load($GLOBALS['TCA'], true);
+}
+```
+
+**When to use it.** In a test that has to modify TCA at runtime, wrapping the
+modification:
+
+```php
+protected function setUp(): void
+{
+    parent::setUp();
+    $this->createTCABackup(false);
+}
+
+protected function tearDown(): void
+{
+    $this->restoreTCABackup(true);
+    parent::tearDown();
+}
+```
+
+— [`academic-base/Tests/Functional/Tca/TableConfigurationTest.php:20,25`](../../packages/fgtclb/academic-base/Tests/Functional/Tca/TableConfigurationTest.php#L20-L25)
+
+**The trap it exists for.** From TYPO3 v13 on, `TcaSchemaFactory` holds an
+object representation of the global TCA that is immutable by design: writing to
+`$GLOBALS['TCA']` does **not** update it, and large parts of the core read the
+schema rather than the array. A test that only changes the global therefore runs
+half against its modification and half against the original — and the same on
+the way back, leaving a stale schema for the next test. The forced
+`load($GLOBALS['TCA'], true)` is what keeps the two in step.
+
+`backupGlobals="true"` in the PHPUnit configuration restores `$GLOBALS` between
+tests but knows nothing about the schema factory, so it does not replace this
+trait.
+
+Both methods take a boolean that decides whether a misuse throws:
+`createTCABackup(false)` refuses to overwrite an existing backup (code
+1759190691), `restoreTCABackup(true)` refuses to restore a backup that was never
+taken (code 1759190705). Passing the permissive value everywhere defeats the
+point — the codes exist so that a `setUp()`/`tearDown()` that drifted out of
+pairing is reported as such.
+
+The class docblock carries a `@todo` proposing extraction into a dedicated
+public helper package with its own TYPO3 and testing-framework constraints. Not
+done; the trait is used by one test class today.
+
+## See also
+
+- [Functional tests](functional-tests.md)
+- [Unit tests](unit-tests.md)
+- [Fixture extensions](fixture-extensions.md)
+- [PHPUnit configuration](phpunit-configuration.md)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -1,0 +1,244 @@
+# Unit tests
+
+Unit tests run against a bootstrapped TYPO3 class loader and nothing else — no
+database, no site, no request. Everything the subject needs is passed to it or
+stubbed. That makes the suite fast enough to run on every save, and it makes a
+failure point at one class instead of at a stack.
+
+There are 30 unit test classes across the twelve extensions, 12 of which are the
+one-line version compatibility test every extension carries (see
+[below](#the-version-compatibility-test)).
+
+## Running them
+
+Dependencies come first, always. `-t` selects configuration, it does **not**
+install anything, so a run for a core version whose dependencies are not
+installed silently uses the wrong vendor tree:
+
+```bash
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s composerUpdate
+Build/Scripts/runTests.sh -t 13 -p 8.3 -s unit
+```
+
+| Command                                                                                      | What it does                                                            |
+|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `runTests.sh -s unit`                                                                        | The whole suite, TYPO3 v13 and PHP 8.2 by default.                      |
+| `runTests.sh -t 14 -p 8.5 -s unit`                                                           | The same suite on the other end of the support matrix.                  |
+| `runTests.sh -s unitRandom`                                                                  | The suite with `--order-by=random` and a fresh seed.                    |
+| `runTests.sh -s unitRandom -o 1234`                                                          | The same, with a fixed seed — how a random-order failure is reproduced. |
+| `runTests.sh -s unit packages/fgtclb/academic-persons/Tests/Unit`                            | Restricted to one extension.                                            |
+| `runTests.sh -s unit packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php` | Restricted to one file.                                                 |
+
+The trailing path is the **only** way to narrow a run. `runTests.sh` has no
+argument passthrough to PHPUnit — no `-e`, no `--`. Anything else (a
+`--filter`, a `--group`) has to be added to the `COMMAND` array in the script
+itself, which is not how a normal run works.
+
+`-o` is parsed at
+[`Build/Scripts/runTests.sh:447-449`](../../Build/Scripts/runTests.sh#L447-L449)
+and turns into `--random-order-seed=<seed>`. It only has an effect together with
+`-s unitRandom`; the `unit` suite does not pass `PHPUNIT_RANDOM` on. Note that
+the built-in help text still documents the TYPO3 Core spelling
+`-- --random-order-seed=<number>`
+([`runTests.sh:269`](../../Build/Scripts/runTests.sh#L269)) — that form does not
+work here, use `-o`.
+
+`unitRandom` is not decoration. CI runs it right after `unit` in the same job
+([`.github/workflows/ci.yml:210-211`](../../.github/workflows/ci.yml#L210-L211)),
+because ordering dependencies between tests are exactly the kind of defect a
+fixed order hides.
+
+## Discovery
+
+There is no per-extension PHPUnit configuration. One glob in
+[`Build/phpunit/UnitTests.xml:36-44`](../../Build/phpunit/UnitTests.xml#L36-L44)
+collects every extension's unit tests into a single suite:
+
+```xml
+<testsuites>
+    <testsuite name="Unit tests">
+        <!--
+            This path either needs an adaption in extensions, or an extension's
+            test location path needs to be given to phpunit.
+        -->
+        <directory>../../packages/*/*/Tests/Unit/</directory>
+    </testsuite>
+</testsuites>
+```
+
+Three things follow from that single line.
+
+**A new extension needs no configuration change.** Drop it under
+`packages/<vendor>/<dir>/` with a `Tests/Unit/` folder and it is in the suite.
+
+**`packages-dev/` is not covered.** The glob starts at `packages/`, so the two
+meta packages — including
+[`packages-dev/testing-helper/`](../../packages-dev/testing-helper) — have no
+tests of their own. Their traits are exercised only through the extensions that
+use them.
+
+**Test classes are autoloaded, not included.** Each extension registers its own
+`Tests/` namespace as `autoload-dev`, for example
+`FGTCLB\AcademicPersons\Tests\` → `Tests/` in
+[`academic-persons/composer.json`](../../packages/fgtclb/academic-persons/composer.json).
+A test class in the wrong namespace for its path is not found, and PHPUnit
+reports nothing rather than an error.
+
+## Conventions
+
+These are read off the existing classes, not prescribed from outside. All 30 of
+them follow the shape below.
+
+**Every test class is `final`, declares `strict_types`, and extends
+`TYPO3\TestingFramework\Core\Unit\UnitTestCase`.** There is no local abstract
+unit test case, and no unit test extends another test class.
+
+**The namespace mirrors the path, which mirrors `Classes/`.**
+`FGTCLB\AcademicPersons\Tests\Unit\Domain\Model\EmailTest` tests
+`FGTCLB\AcademicPersons\Domain\Model\Email`. Finding the test of a class is a
+path transformation, never a search.
+
+**Test methods carry `#[Test]`, never a `test` prefix.** There is not a single
+`public function test…()` in the repository. Method names are readable
+statements about the subject, which is what turns the PHPUnit output into a
+specification:
+
+```php
+#[Test]
+public function getSortingReturnsIntegerZeroForNewModel(): void
+{
+    $this->assertSame(0, (new Email())->getSorting());
+}
+```
+
+— [`EmailTest.php:37-41`](../../packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php#L37-L41)
+
+**Data providers are `public static` and return a `\Generator` with named data
+sets.** The name is what a failure report shows, so it describes the case rather
+than numbering it:
+
+```php
+public static function returnsExpectedTcaArrayDataSet(): \Generator
+{
+    yield 'custom tab is added after the general tab not moving palettes to wrong tab for all types' => [
+        // …
+    ];
+}
+```
+
+— [`TcaManipulatorTest.php:15-17`](../../packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php#L15-L17)
+
+**Non-obvious tests carry a docblock that says why, not what.** The assertion
+already says what. The docblock records the defect the test descends from, so
+that a later reader does not "simplify" it away:
+
+```php
+/**
+ * A registry nobody attached anything to is a real state: only three extensions of
+ * this repository ship a `Configuration/CategoryTypes.yaml`, so an installation
+ * using `EXT:category_types` alone never fills it. `attach()` also returns early for
+ * an empty argument list, which is what the loader passes in that case.
+ */
+#[Test]
+public function freshRegistryReportsNoTypes(): void
+```
+
+— [`CategoryTypeRegistryTest.php:31-38`](../../packages/fgtclb/typo3-category-types/Tests/Unit/Registry/CategoryTypeRegistryTest.php#L31-L38)
+
+**Fixtures are built by a private helper on the test class, not by a data
+provider full of literals.** `CategoryTypeRegistryTest` has a `categoryType()`
+factory with named defaults
+([lines 15-29](../../packages/fgtclb/typo3-category-types/Tests/Unit/Registry/CategoryTypeRegistryTest.php#L15-L29)),
+so each test names only the property it is about.
+
+**Expected exceptions are pinned by code, not only by class.**
+`$this->expectExceptionCode(1683633304209)` next to
+`$this->expectException(\InvalidArgumentException::class)` keeps the test from
+passing on a different `\InvalidArgumentException` thrown three frames earlier.
+
+**No assertion-free test without a reason.** `beStrictAboutTestsThatDoNotTestAnything`
+is relaxed (see [PHPUnit configuration](phpunit-configuration.md)), so PHPUnit
+will not catch one for you.
+
+## Core-version-aware unit tests
+
+`runTests.sh` always appends `--exclude-group not-core-${CORE_VERSION}` to the
+PHPUnit call — for `unit` at
+[`runTests.sh:751`](../../Build/Scripts/runTests.sh#L751) and for `unitRandom`
+at [`:757`](../../Build/Scripts/runTests.sh#L757). The group names read as what
+they exclude:
+
+| Group         | Runs on | Meaning                      |
+|---------------|---------|------------------------------|
+| `not-core-13` | v14     | Excluded from a `-t 13` run. |
+| `not-core-14` | v13     | Excluded from a `-t 14` run. |
+| *(none)*      | both    | The normal case.             |
+
+Use them for a single method or for a class that differs only in expectations. A
+whole class that only exists for one version belongs in a `Core13/` or `Core14/`
+subfolder instead.
+
+The real example is the pair at the end of
+[`academic-base/Tests/Unit/TcaManipulatorTest.php`](../../packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php#L561-L597).
+The same production method is asserted twice, once per core version, because the
+two versions want *different and mutually incompatible* shapes for a plugin's
+FlexForm data structure:
+
+```php
+/**
+ * TYPO3 v13 resolves `ds` through `ds_pointerField` and requires an array;
+ * a string makes the content element unopenable in the backend.
+ */
+#[Group('not-core-14')]
+#[Test]
+public function pluginFlexFormIsAssignedAsArrayOnCoreV13(): void
+
+/**
+ * TYPO3 v14 resolves the data structure through the record type of the TCA
+ * schema and requires the string; an array leaves the FlexForm tab empty.
+ */
+#[Group('not-core-13')]
+#[Test]
+public function pluginFlexFormIsAssignedAsStringOnCoreV14(): void
+```
+
+Stating both sides rather than testing only the current one is the point: the
+defect behind them (ACE-293) was a v14-shaped registration that made all fifteen
+plugin content elements unopenable in the v13 backend, while every gate stayed
+green. The functional counterpart of these two tests is described in
+[Testing helper](testing-helper.md#pluginflexformdatastructuretrait).
+
+Both methods start with `unset($GLOBALS['TCA']['tt_content'])`. That is safe
+because `backupGlobals="true"` restores `$GLOBALS` after each test.
+
+## The version compatibility test
+
+Every extension ships a `Tests/Unit/VersionCompatTest.php` that is nothing but a
+`use` statement:
+
+```php
+final class VersionCompatTest extends UnitTestCase
+{
+    use ExtensionCoreVersionCompatTestsTrait;
+}
+```
+
+— [`academic-persons/Tests/Unit/VersionCompatTest.php`](../../packages/fgtclb/academic-persons/Tests/Unit/VersionCompatTest.php)
+
+The trait asserts that the running TYPO3 major version is one of the two the
+branch supports, and — via `not-core-*` groups — that the v13 leg really runs on
+13 and the v14 leg really runs on 14. It is the tripwire for "the harness
+installed a different core than the run asked for", which is otherwise a
+confusing pile of unrelated failures. See
+[Testing helper](testing-helper.md#extensioncoreversioncompatteststrait).
+
+`EXT:category_types` names its copy `VersionCompareTest.php`
+([`typo3-category-types/Tests/Unit/VersionCompareTest.php`](../../packages/fgtclb/typo3-category-types/Tests/Unit/VersionCompareTest.php));
+the content is identical. Every extension also carries the same test in its
+functional suite.
+
+## See also
+
+- [PHPUnit configuration](phpunit-configuration.md)
+- [Functional tests](functional-tests.md)
+- [Testing helper](testing-helper.md)

--- a/docs/workflow/Index.md
+++ b/docs/workflow/Index.md
@@ -1,0 +1,34 @@
+# Workflow
+
+How a change gets from a working copy into a release.
+
+## The short version
+
+1. Branch from the target branch, one branch per issue.
+2. Commit with the TYPO3 Core conventions and a **verified** issue reference.
+3. Run every gate for **both** supported core versions, each after its own
+   `composerUpdate`, before opening a pull request — and watch the pipeline
+   afterwards.
+4. Update the affected extension's `Documentation/` in the same change when it
+   is user or integrator facing, with a changelog entry.
+5. Backport to the other maintained branch as a separate, analysed change. The
+   maintained targets are `main` and `2`, and nothing else.
+
+## Pages
+
+| Page                                                          | Contents                                                                                                            |
+|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| [Commit messages](commit-messages.md)                         | The format, the tags in use, subject and body limits, and where the issue reference goes.                           |
+| [Pull requests](pull-requests.md)                             | Branch naming, the rebase merge model and what it implies, the pre-flight checklist, the repository rules.          |
+| [Backporting](backporting.md)                                 | The maintained targets, and why a backport is analysed rather than cherry-picked — starting with a file-level diff. |
+| [Changelog and documentation](changelog-and-documentation.md) | The two audiences, rendering the manual, and the changelog entry kinds.                                             |
+| [Releasing](releasing.md)                                     | Versions across twelve packages, `bin/set-version` and `bin/release`, and the three-step publishing chain.          |
+
+## See also
+
+- [Quality gates](../development/quality-gates.md) — what has to pass, and how
+  continuous integration stages it.
+- [Dual core setup](../development/dual-core-setup.md) — why every gate runs
+  twice.
+- [Monorepo layout](../development/monorepo-layout.md) — the packages, their
+  versions and their split repositories.

--- a/docs/workflow/backporting.md
+++ b/docs/workflow/backporting.md
@@ -1,0 +1,282 @@
+# Backporting
+
+Most fixes made on `main` belong on the older maintained branch as well. Getting
+them there is a small research task, not a `git cherry-pick`: the two branches
+support different TYPO3 major versions, so the same defect can need a different
+patch — or, just as often, the identical one.
+
+This page is about deciding which of the two it is, cheaply and with evidence.
+
+## The only maintained targets
+
+| Branch | Version line | TYPO3     | PHP floor | Backport target?                       |
+|--------|--------------|-----------|-----------|----------------------------------------|
+| `main` | `3.0.0-dev`  | v13 + v14 | 8.2       | yes — where changes originate          |
+| `2`    | `2.4.x-dev`  | v12 + v13 | 8.1       | yes — the one maintained backport line |
+| `2.2`  | `2.2.x`      | —         | —         | **no** — unmaintained                  |
+| `1`    | `1.x`        | —         | —         | **no** — legacy                        |
+
+The core constraints come from `packages-dev/monorepo-shared/composer.json`,
+which is where every extension's TYPO3 requirement is centralised: `main`
+declares `~13.4.0@dev || ~14.3.6@dev`, branch `2` declares
+`^12.4.22 || ^13.4`. The PHP floor comes from each extension's own
+`composer.json` (`^8.2 || …` versus `^8.1 || …`).
+
+**`2.2` and `1` are never proposed as a backport target**, and that is not a
+judgement about the change — it holds even when those branches demonstrably
+carry the same defect. Stating that fact is fine and often useful ("`2.2` has
+the same code"); planning work on it is not, unless somebody explicitly asks for
+that specific change on that specific branch.
+
+So a bugfix has at most two homes, and the question is only ever whether the
+patch for the second one is the same.
+
+## A backport is analysed, not cherry-picked
+
+The branches diverged at `ecba366f0` and have been developed apart since. What
+can differ underneath a change:
+
+* **TCA** — column types, `type` names and their options moved between v12, v13
+  and v14.
+* **FlexForm** — the `ds` shape differs per core version, and no version
+  tolerates another's.
+* **Plugin registration** — the `addPlugin()` signature changed, and what makes
+  a `CType` selectable is not what makes it render.
+* **API availability** — a class, method or attribute used by the change may
+  simply not exist on TYPO3 v12.
+* **PHP syntax** — branch `2` still compiles against PHP 8.1, so readonly
+  classes, constants in traits and disjunctive normal form types are not
+  available there.
+
+Any one of those turns a clean-applying cherry-pick into a fatal error at
+runtime, which no amount of "it merged without conflicts" will reveal.
+
+## But check before adapting
+
+The mistake in the other direction is more common and more expensive: assuming
+the branches differ and rewriting a patch that did not need it. In practice a
+large share of the files are **byte-identical** across the two branches. A
+survey of `packages/fgtclb/academic-jobs/Classes/` finds 16 of 19 files
+identical between `origin/2` and `origin/main`.
+
+So the first step is always measurement, and it takes three commands. None of
+them needs a checkout, a worktree or a stash — they read the branches straight
+out of the object database.
+
+### 1. Diff every touched file
+
+For each file the change on `main` touches:
+
+```bash
+git diff --stat origin/2 origin/main -- packages/fgtclb/academic-jobs/Classes/Controller/JobController.php
+```
+
+Empty output means the file is identical on both branches and the hunk will
+apply as-is. Anything else is the amount of adaptation actually required, and
+its size is the estimate:
+
+```
+ .../Classes/Controller/JobController.php | 155 +++++++++++++++++----
+ 1 file changed, 125 insertions(+), 30 deletions(-)
+```
+
+Do this per file rather than for the whole change, because one heavily diverged
+file among five identical ones is a very different job from five moderately
+diverged ones.
+
+### 2. Grep for every API the change uses
+
+For each class, method, attribute or constant the patch introduces:
+
+```bash
+git grep -l "FileUploadConfiguration" origin/2 -- 'packages/*'
+```
+
+No output (exit code 1) means nothing on branch `2` uses that API — which is a
+strong hint that it is not available there, and always a prompt to check the
+core version rather than to assume. Run the same grep against `origin/main` to
+see whether the API arrives with this change or was already established — and
+when the answer decides the backport, confirm it against the vendor tree of the
+older core version rather than against the packages.
+
+### 3. Check test-harness parity
+
+```bash
+git ls-tree -r --name-only origin/2 -- packages/fgtclb/academic-jobs/Tests/
+git ls-tree -r --name-only origin/main -- packages/fgtclb/academic-jobs/Tests/
+```
+
+Compare the two listings. The tests that come with the change need a place to
+live, and that place does not always exist — see the next section.
+
+Only after these three does the adaptation get planned. Often the plan is "apply
+unchanged".
+
+## What actually differs, in practice
+
+| Area                     | `main`                           | `2`                              |
+|--------------------------|----------------------------------|----------------------------------|
+| TYPO3                    | v13 + v14                        | v12 + v13                        |
+| `runTests.sh -t` default | `13`                             | `12`                             |
+| `COMPOSER_ROOT_VERSION`  | `3.0.0-dev`                      | `2.4.0-dev`                      |
+| PHPStan configurations   | `Build/phpstan/Core13`, `Core14` | `Build/phpstan/Core12`, `Core13` |
+| XLF indentation          | two spaces                       | tabs                             |
+| Test-helper traits       | 7                                | 3                                |
+| phpunit group names      | `not-core-13`, `not-core-14`     | `not-core-12`, `not-core-13`     |
+| Changelog directory      | `Documentation/Changelog/3.0/`   | `Documentation/Changelog/2.4/`   |
+
+### XLF indentation
+
+Language files are indented with **tabs on branch `2`** and with **two spaces on
+`main`**. This is uniform: of the 50 `.xlf` files on each branch, all 50 on
+`origin/2` are tab-indented and none on `origin/main` is.
+
+```xml
+<!-- origin/main -->
+  <file
+    source-language="en"
+
+<!-- origin/2 -->
+	<file
+		source-language="en"
+```
+
+A label added on `main` and pasted into branch `2` therefore arrives with the
+wrong indentation, in a file where nothing else uses it. It is invisible in a
+rendered diff and obvious in the file. Re-indent the added lines to match their
+surroundings; do not reformat the file.
+
+### The test harness is not at parity
+
+`packages-dev/testing-helper/` — the shared functional-test traits — has grown
+on `main` and was not backported wholesale:
+
+| Trait                                  | `main` | `2` |
+|----------------------------------------|--------|-----|
+| `ExtensionsLoadedTestsTrait`           | yes    | yes |
+| `ExtensionCoreVersionCompatTestsTrait` | yes    | yes |
+| `TcaHelperMethodsTrait`                | yes    | yes |
+| `DeprecatedCoreLabelsTrait`            | yes    | no  |
+| `EnsureTtContentListTypeColumnTrait`   | yes    | no  |
+| `FrontendPluginRenderingTrait`         | yes    | no  |
+| `PluginFlexFormDataStructureTrait`     | yes    | no  |
+
+All seven live in
+`packages-dev/testing-helper/Classes/FunctionalTestCase/` on `main`; branch `2`
+has the first three.
+
+The consequence is concrete: a fix on `main` that comes with a frontend plugin
+rendering test has **no home on branch `2`**. The whole
+`packages/fgtclb/academic-jobs/Tests/Functional/Plugins/` tree exists only on
+`main`. Backporting such a change means one of three things, and the choice is
+worth stating in the pull request:
+
+1. backport the production fix without the test,
+2. backport the trait first, as its own change, then the fix with its test,
+3. write a different test on branch `2` that uses what is there.
+
+None of them is wrong; silently dropping the test without saying so is.
+
+### phpunit group names mean different things
+
+Both branches run `--exclude-group not-core-${CORE_VERSION}`, so a test tagged
+`not-core-13` is skipped when the suite runs against TYPO3 v13. But the *other*
+version of each branch is not the same version:
+
+| Attribute     | On `main` runs on | On `2` runs on |
+|---------------|-------------------|----------------|
+| `not-core-13` | v14 only          | v12 only       |
+| `not-core-14` | v13 only          | n/a            |
+| `not-core-12` | n/a               | v13 only       |
+
+A `#[Group('not-core-13')]` copied unchanged from `main` to `2` therefore flips
+its meaning from "v14 only" to "v12 only" — the test still runs, still passes or
+fails plausibly, and tests the opposite of what was intended. Both attributes
+are in active use: `main` carries seven `not-core-13` and one `not-core-14`,
+branch `2` four of each of its own two.
+
+Translate the intent, not the string: "the newer core version of this branch" is
+`not-core-13` on `main` and `not-core-12` on `2`.
+
+### Core-version-aware structure
+
+`main` has no `Core13/`/`Core14/` class folders at all; its two version
+differences are inline switches on
+`(new Typo3Version())->getMajorVersion()` in
+`packages/fgtclb/academic-base/Classes/TcaManipulator.php:137` and `:168`.
+Branch `2` does use the folder split, under
+`packages/fgtclb/academic-base/Classes/` as `Core12/Environment/` and
+`Core13/Environment/`.
+
+The same file can therefore need a different mechanism on each branch.
+`TcaManipulator.php` exists on both and is nearly 100 lines longer on `main`
+(282 lines versus 185), almost entirely because of the v14 handling — a change
+to it is never a straight copy.
+
+### The changelog entry moves
+
+A user-facing backport needs its own changelog entry on the target branch, in
+that branch's version directory: `Documentation/Changelog/2.4/` on branch `2`,
+not the `3.0/` the entry was written into on `main`. The text usually needs
+adapting too, because "removed in 3.0" is not what happened on the `2.x` line.
+See [Changelog and documentation](changelog-and-documentation.md).
+
+## Verify on the target branch, not by analogy
+
+`-t` selects configuration only; it does not reinstall dependencies. Before
+running anything on the backport branch:
+
+```bash
+Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate
+Build/Scripts/runTests.sh -t 12 -p 8.1 -s cgl -n
+Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstan
+Build/Scripts/runTests.sh -t 12 -p 8.1 -s unit
+Build/Scripts/runTests.sh -t 12 -p 8.1 -s functional
+```
+
+…and then the same series with `-t 13`, the branch's other core version, each
+time starting with `composerUpdate`. A vendor tree installed for one core
+version silently answers questions about the other one wrongly. `-p` needs the
+same treatment: the PHP version is part of the install, not only of the run.
+
+Run the functional suite against a real DBMS (`-d mysql`, `-d postgres`) for
+anything that writes. SQLite accepts several constructs the other systems
+reject, so the default run is the one least likely to show a database defect —
+and branch `2` reaches one TYPO3 major version further back, where the core's
+own schema handling differs.
+
+## Commit messages
+
+A backport is a **new commit**: same subject, same issue reference, different
+hash. `ACE-358` is `8b5557037` on `main` and `1dd253043` on branch `2`, both
+titled `[BUGFIX] ACE-358: Drop the defaults on TEXT columns`.
+
+The body is expected to differ, because the facts differ. The `main` message
+says the failure "is not reachable on this branch" and explains why the change
+belongs there anyway; the branch `2` message describes the failure actually
+occurring on TYPO3 v12 with MySQL, and names the CI jobs that see it. Copying
+either message onto the other branch would have made it wrong.
+
+**Never silently rewrite another author's commit message.** Adapting the body
+to the target branch is required work, but when the original is somebody else's,
+it is done with them and not behind them: keep their authorship, keep their
+reasoning, and raise the parts that no longer hold rather than quietly deleting
+them. A message that claims something untrue about the branch it sits on is
+worse than one that is merely terse.
+
+## See also
+
+- [Changelog and documentation](changelog-and-documentation.md) — where the
+  entry for a backport goes.
+- [Releasing](releasing.md) — each branch releases on its own version line.
+- [Commit messages](commit-messages.md) — the subject and reference a backport
+  keeps.
+- [Pull requests](pull-requests.md) — a backport is a pull request like any
+  other.
+- [Development environment](../development/environment.md) — `-t`, `-p`, `-d`
+  and why `composerUpdate` is not optional.
+- `AGENTS.md` in the repository root — the backport policy in its short form.
+- `README.md`, section "Repository version support" — the per-extension support
+  matrix.
+- `packages-dev/monorepo-shared/composer.json` — the TYPO3 constraints that
+  define what each branch has to work against.

--- a/docs/workflow/changelog-and-documentation.md
+++ b/docs/workflow/changelog-and-documentation.md
@@ -1,0 +1,317 @@
+# Changelog and documentation
+
+Documentation in this repository has two audiences, and they never share a file.
+The split is the same one every TYPO3 extension makes — a shipped manual and
+notes for the people who work on the code — but a mono repository moves the
+first half **into each package** and keeps only the second half at the root:
+
+| Location                               | Audience                   | Format   | Scope           |
+|----------------------------------------|----------------------------|----------|-----------------|
+| `packages/fgtclb/<ext>/Documentation/` | users and integrators      | reST     | per extension   |
+| `docs/`                                | developers and maintainers | Markdown | repository wide |
+
+That is the important difference from a single-extension repository. There is no
+one manual for "the academic extensions": there are twelve, one per package, and
+each is split out to its own read-only repository and published on its own. A
+sentence about `academic_jobs` belongs in
+`packages/fgtclb/academic-jobs/Documentation/`, not in a shared place, because a
+reader of the split repository would never see the shared place.
+
+`docs/` is the opposite: it describes the repository — the harness, the branch
+model, the release chain — none of which survives the split, and none of which a
+site integrator needs.
+
+Both are written as part of the change that makes them necessary. A changelog
+entry added a week later is a changelog entry written from memory.
+
+## What a package manual looks like
+
+Every package under `packages/fgtclb/` ships the same skeleton
+(`packages/fgtclb/academic-base/Documentation/` is the reference):
+
+| File or folder                                     | Purpose                                                              |
+|----------------------------------------------------|----------------------------------------------------------------------|
+| `Index.rst`                                        | Entry page: extension key, package name, release, license, card grid |
+| `guides.xml`                                       | Renderer configuration: theme, project title and release, edit links |
+| `Changelog/`                                       | The per-version changelog tree, see below                            |
+| `Introduction/`, `Installation/`, `KnownProblems/` | The narrative sections                                               |
+| `Sitemap.rst`                                      | Generated sitemap page                                               |
+
+`guides.xml` carries the version too, as `<project title="…" release="3.0.0"/>`
+(`packages/fgtclb/academic-base/Documentation/guides.xml:16`). It is written by
+`tailor set-version`, which `bin/set-version` runs for every package that has a
+`Documentation/` folder — so it is not maintained by hand. See
+[Releasing](releasing.md).
+
+The extension key is not always the directory name: `academic-contact4pages`
+ships `academic_contacts4pages`. The manual's `Index.rst` states the key, the
+directory does not.
+
+## Rendering the manual
+
+Rendering goes through the harness like every other check, so it uses the same
+image locally and in CI:
+
+```bash
+Build/Scripts/runTests.sh -s checkRstRenderingAll                    # all 12 packages
+Build/Scripts/runTests.sh -s checkRstRenderingSingle academic-jobs   # one package
+Build/Scripts/runTests.sh -s openDocumentation academic-jobs         # open the result
+```
+
+The image is `ghcr.io/typo3-documentation/render-guides:latest`
+(`Build/Scripts/runTests.sh:531`). Neither `-t` nor `-p` matters here: the
+renderer is a self-contained container and needs no vendor tree, which is why
+`composerUpdate` is not a precondition for a documentation change.
+
+The argument to `checkRstRenderingSingle` and `openDocumentation` is the
+**directory** below `packages/fgtclb/`, not the extension key — the script
+checks `packages/fgtclb/${extensionKey}` for existence
+(`Build/Scripts/runTests.sh:626-631`) despite the variable's name. For
+`academic_contacts4pages` the argument is therefore `academic-contact4pages`.
+
+### Where the output lands
+
+`executeRstRendering()` (`Build/Scripts/runTests.sh:213-227`) mounts one package
+into the container and runs the renderer with the package as both configuration
+and input directory:
+
+```
+--fail-on-log --fail-on-error --no-progress --config=Documentation Documentation
+```
+
+The renderer writes into the package itself, at
+`packages/fgtclb/<ext>/Documentation-GENERATED-temp/`, which every package's
+`.gitignore` excludes (`packages/fgtclb/academic-base/.gitignore:9`). The script
+then copies that tree to
+`documentation-rendered/<ext>/Documentation-GENERATED-temp/`
+(`Build/Scripts/runTests.sh:223-225`), which is ignored at the root
+(`.gitignore:56`).
+
+Two locations for one result is deliberate. The per-package one is where the
+renderer has to write, because it renders one package at a time with that
+package as its root. The collected one is what makes a whole-repository run
+useful: after `checkRstRenderingAll`, `documentation-rendered/` holds one folder
+per extension, and that single directory is what CI uploads as an artifact.
+
+`openDocumentation` reads only the collected copy and opens
+`documentation-rendered/<ext>/Documentation-GENERATED-temp/Index.html` with
+`xdg-open`. It renders nothing itself: without a preceding render it prints the
+two commands to run first (`Build/Scripts/runTests.sh:229-244`). It is
+Linux-only, which the script marks with a `@todo`.
+
+There is no watch mode in this repository. The loop is edit, render the single
+package, reopen.
+
+## The render is a gate, not an artifact producer
+
+The `documentation` job of the CI workflow
+(`.github/workflows/ci.yml:294-339`) runs exactly the command above:
+
+```yaml
+- name: "Render documentation of all extensions"
+  run: "Build/Scripts/runTests.sh -b docker -s checkRstRenderingAll"
+```
+
+Because `executeRstRendering()` passes **`--fail-on-log --fail-on-error`**, the
+renderer exits non-zero on a warning, not only on a hard error, and the job
+fails. A broken cross-reference, an unknown directive or a malformed table is
+therefore a red pull request, not a cosmetic remark. The comment above the step
+says so in the workflow itself (`.github/workflows/ci.yml:322-326`).
+
+The job is independent of the source gates — it has no `needs:` — so a
+documentation-only change gets its answer without waiting for `cgl`, `phpstan`,
+`lint`, `unit` and the functional matrix. It also runs no `composerUpdate`,
+consistent with the renderer needing no vendor tree.
+
+## The rendered documentation on the pull request
+
+`.github/workflows/pr-comment.yml` posts one comment per pull request linking
+the `documentation` artifact of the run, and updates that same comment on every
+push instead of adding a new one (it finds its own comment by the marker
+`<!-- rendered-documentation -->`, `.github/workflows/pr-comment.yml:84`).
+
+It is a **separate workflow on the `workflow_run` event**, and that is not an
+accident:
+
+* A pull request from a **fork** gets a read-only `GITHUB_TOKEN` and no secrets.
+  Commenting needs `pull-requests: write`, so a comment step inside `ci.yml`
+  would work for branches in this repository and silently fail for exactly the
+  external contributors it is meant to serve.
+* `workflow_run` fires when `ci.yml` finishes and runs in the context of the
+  **default branch** of this repository, not the fork. Its token can write even
+  though the token of the run that triggered it could not, and no code from the
+  pull request is checked out — which is what makes granting write permission
+  safe (`.github/workflows/pr-comment.yml:6-22`, `39-43`).
+* `pull_request_target` is deliberately **not** used. It also carries a write
+  token, but running the pull request's own code under it is a documented way to
+  leak write access and secrets.
+
+Two consequences follow, and both surprise people:
+
+1. **This file only takes effect once it is on the default branch.** Changing
+   `pr-comment.yml` inside a pull request does not change the behaviour of that
+   pull request — the run that comments is the one on `main`. Test a change to
+   it by merging it, not by pushing it.
+2. `github.event.workflow_run.pull_requests` is empty for a fork, so the pull
+   request number cannot be read from the event. `ci.yml` writes it into a
+   `pull-request-context` artifact *before* rendering
+   (`.github/workflows/ci.yml:307-320`), so the comment lands on the right pull
+   request even when the rendering failed.
+
+## Changelog entries
+
+Each package keeps its own changelog under
+`packages/fgtclb/<ext>/Documentation/Changelog/<version>/`. All twelve currently
+carry `2.0`, `2.1`, `2.2`, `2.3`, `2.4` and `3.0` — the version directory is the
+**minor** line, so a `3.0.1` fix is documented in `3.0/`.
+
+There are four kinds, distinguished by the file name prefix:
+
+| File pattern        | Use for                                                       | Entries today |
+|---------------------|---------------------------------------------------------------|---------------|
+| `Breaking-*.rst`    | Changes requiring action from users of the extension          | 49            |
+| `Deprecation-*.rst` | Functionality marked for removal, together with the migration | 1             |
+| `Feature-*.rst`     | New functionality                                             | 30            |
+| `Important-*.rst`   | Notable changes that are none of the above                    | 43            |
+
+Templates for all four live in `Build/Documentation/Templates/`
+(`Changelog-Breaking.rst`, `Changelog-Deprecation.rst`, `Changelog-Feature.rst`,
+`Changelog-Important.rst`). Copy the matching one, rename it, replace the
+placeholder text.
+
+Two deviations from the template are the actual house style, so follow the
+existing entries rather than the template file:
+
+* **Drop the `.. include:: /Includes.rst.txt` line.** The templates open with
+  it; no shipped entry uses it, and there is no `Includes.rst.txt` anywhere in
+  the repository.
+* **Give the anchor a real name.** The template's `.. _feature-0000000000:` is a
+  placeholder. Two shapes occur in the tree: a numeric one
+  (`.. _important-1785874800:`, a timestamp) and a slug derived from the title
+  (`.. _breaking-removed-file-upload-converter:`). The numeric shape is the more
+  common one. A file name may additionally carry a reference number when the
+  entry documents a foreign issue, as in
+  `Important-88886-StrictLanguageFallbackForSelectedProfiles.rst`.
+
+The body follows the template's section order: `Description`, `Impact`, and for
+a breaking change additionally `Affected Installations` and `Migration`. A
+trailing `.. index::` line closes the entry.
+`packages/fgtclb/academic-base/Documentation/Changelog/3.0/Breaking-RemovedFileUploadConverter.rst`
+is a full worked example, including a `list-table` mapping old options to their
+replacements.
+
+### The index files, and why nothing has to be registered
+
+Adding an entry means adding one file. Nothing lists it:
+
+* `Changelog/<version>/Index.rst` carries four `toctree` directives with
+  `:glob:` over `Breaking-*`, `Feature-*`, `Deprecation-*` and `Important-*`
+  (`packages/fgtclb/academic-base/Documentation/Changelog/3.0/Index.rst:13-51`).
+  A hand-maintained list would go stale the first time somebody forgot it; a
+  glob cannot.
+* `Changelog/Changelog-<major>.rst` is the per-major landing page. It links the
+  minor `Index` files by hand (`3.0/Index`) — this one **does** need an edit,
+  once, when a new minor directory is created.
+* `Changelog/Changelog-<major>-combined.rst` is the same set of entries grouped
+  by kind instead of by version, again through `:glob:` patterns
+  (`Changelog/3.*/Breaking-*` and so on), and is linked from
+  `Changelog-<major>.rst` as "Also available".
+
+So the full cost of a new entry is one file; the full cost of a new minor
+version is one directory, an `Index.rst` copied from the previous one, and one
+line in `Changelog-<major>.rst`.
+
+## Section adornments must match the title exactly
+
+This is the one reST rule that has cost this repository time, so it gets its own
+section.
+
+A reST section title is delimited by an over/underline of punctuation
+characters. Written correctly, the adornment is exactly as long as the title:
+
+```rst
+=======================================
+Breaking: Removed `FileUploadConverter`
+=======================================
+```
+
+An adornment that is **longer** than its title is not a reST error. The renderer
+accepts it and the page comes out looking right, so nothing in the pipeline
+objects — `--fail-on-log --fail-on-error` cannot fail on something the parser
+never complains about. What it produces is a file that disagrees with itself,
+which is then copied as the template for the next entry, and the drift spreads.
+
+It happens for a boring reason: the title gets edited after the adornment was
+typed, and a shortened title leaves an over-long ruler behind.
+
+There is no gate for this, so check it before committing. Every `.rst` file in
+every package is currently consistent, and this keeps it that way:
+
+```bash
+find packages/fgtclb -path '*/Documentation/*' -name '*.rst' -exec awk '
+  /^[=~^-]+$/ && length($0) >= 3 && prev != "" && prev !~ /^[=~^-]+$/ &&
+  length(prev) != length($0) {
+      printf "%s:%d: title %d, adornment %d\n", FILENAME, FNR, length(prev), length($0)
+  }
+  { prev = $0 }' {} +
+```
+
+It compares every underline with the title directly above it — the shape the
+mistake takes in practice — and prints nothing when they all match. The
+character class covers the three adornment characters actually used here (`=`,
+`^`, `-`). An overline is not checked by it, but an overline has to be identical
+to its underline, which is visible at a glance in the same three lines.
+
+Restrict the `find` to the package you touched while writing.
+
+## When a change needs a changelog entry
+
+The test is not "did PHP change" — it is **can a user or integrator notice**.
+Everything a project can override, configure or depend on is user facing, which
+in a TYPO3 extension is considerably more than the public PHP API:
+
+| Change                                                        | Entry | Kind                      |
+|---------------------------------------------------------------|-------|---------------------------|
+| Public PHP API added, changed or removed                      | yes   | `Feature` / `Breaking`    |
+| A **Fluid template, layout or partial** changed or removed    | yes   | `Breaking` or `Important` |
+| An **asset path** changed (`Resources/Public/…`)              | yes   | `Breaking` or `Important` |
+| TCA, FlexForm or plugin registration changed                  | yes   | usually `Breaking`        |
+| A database column changed, requiring a schema update          | yes   | `Important`               |
+| TypoScript or extension configuration option added or removed | yes   | `Feature` / `Breaking`    |
+| A new or raised dependency                                    | yes   | `Important`               |
+| Internal refactoring with identical behaviour                 | no    | —                         |
+| Tests, CI, the harness, `docs/`                               | no    | —                         |
+
+The two rows in bold type are the ones that get forgotten. **A template change
+is user facing.** Projects copy partials into their site package and override
+them, so a renamed partial, a changed variable name or a restructured section is
+a breaking change for every project that did — even though no PHP signature
+moved. The repository has documented exactly this repeatedly:
+
+* `academic-contact4pages/Documentation/Changelog/2.1/Breaking-RemovedPartials.rst`
+  (and the same entry in `academic-persons`, `academic-programs`,
+  `academic-partners`, `academic-projects`)
+* `academic-persons-edit/Documentation/Changelog/2.4/Important-AdaptedProfileImagePartial.rst`
+* `academic-persons-edit/Documentation/Changelog/3.0/Breaking-AdaptedFrontendEditingFluidFiles.rst`
+
+**A changed asset path is user facing** for the same reason: a project may
+reference the file from its own TypoScript, its own template or its build.
+
+When in doubt, write the entry. An `Important` entry that nobody needed costs a
+paragraph; a missing `Breaking` entry costs somebody an afternoon after an
+update.
+
+## See also
+
+- [Releasing](releasing.md) — how the version reaches `guides.xml`, and the
+  three-step publishing chain.
+- [Backporting](backporting.md) — where the changelog entry for a backport goes.
+- [Commit messages](commit-messages.md) — the message that accompanies the entry.
+- [Pull requests](pull-requests.md) — the gates a documentation change passes.
+- [Development environment](../development/environment.md) — the harness the
+  renderer runs in.
+- `Build/Scripts/runTests.sh` — `executeRstRendering()` and the
+  `checkRstRendering*` and `openDocumentation` suites.
+- `.github/workflows/ci.yml` — the `documentation` job.
+- `.github/workflows/pr-comment.yml` — the artifact link comment.
+- `Build/Documentation/Templates/` — the four changelog entry templates.

--- a/docs/workflow/commit-messages.md
+++ b/docs/workflow/commit-messages.md
@@ -1,0 +1,228 @@
+# Commit messages
+
+This repository follows the TYPO3 Core commit message rules, with the two
+adjustments an extension mono repository needs: there is no forge issue, and
+there is no Gerrit. Everything below is derived from the actual history of this
+repository, not from a generic template — the counts quoted were taken from
+`git log` at the time of writing and can be reproduced.
+
+The reason the rules are enforced at all is that the history is read far more
+often than it is written. `git log --oneline` is the index of this repository:
+it is how a defect is traced back to the change that introduced it, how a
+backport candidate is found, and how a release changelog is assembled. A subject
+that does not say what changed, or that is cut off by the terminal, costs that
+every time.
+
+## Format
+
+```
+[TAG] ACE-NNN: Imperative subject line
+
+Body: what changed and why, wrapped at 72 characters. Separate
+paragraphs with a blank line.
+```
+
+The issue reference sits **inside the subject**, directly after the tag and
+before the description, separated by a colon. It is not a footer here. 83 of the
+last 100 commits carry an `ACE-NNN` key in that position. The 17 that do not are
+documentation fixes and the TYPO3 v14 support series, which was carried out as a
+sequence of steps rather than per issue. Release commits carry no reference
+either.
+
+## Subject line
+
+| Rule            | Value                                           |
+|-----------------|-------------------------------------------------|
+| Target length   | 52 characters, tag and issue reference included |
+| Hard cap        | 72 characters                                   |
+| Mood            | Imperative — "Add", "Fix", "Drop", "Cover"      |
+| First word      | Capitalized                                     |
+| Trailing period | None                                            |
+
+What the repository actually does: 95 of the last 100 subjects are within 52
+characters. The five that are not run to 53–63 characters. Older history is
+looser — across the last 600 commits only 330 stay within 52, and the longest
+subject on record is 83 characters, from March 2026. The 52 character target is
+the current standard; the drift is history, not licence.
+
+The budget is tighter than it looks. `[BUGFIX] ACE-358: ` alone is 18
+characters, so the description itself has about 34 left. A subject that does not
+fit is usually a commit that does two things.
+
+## Body
+
+The body is wrapped at **72 characters** and separated from the subject by a
+blank line. It is required for anything that is not trivially self-explaining,
+and in practice that is nearly everything: the recent history has substantial
+bodies on almost every commit.
+
+Verified over the last 60 commits: the longest body line is at or below 72
+characters in most of them, with a handful of lines running one to three
+characters over. The clear exceptions are literal shell commands, which are left
+unwrapped on purpose — a wrapped command cannot be copied and pasted, and that
+is the entire point of putting it in the message.
+
+Write what changed and **why**, not how. The bodies that have proved useful in
+this repository consistently contain four things:
+
+- the behaviour before the change, concretely enough to recognize it,
+- the cause, named at the level of the class or the API involved,
+- the alternative that was rejected and the reason it was rejected,
+- how the change was verified, including which core version it was measured on.
+
+## Tags
+
+Taken from the last 600 commits rather than from a generic list. The counts are
+what is in use; a tag that does not appear here is not established practice in
+this repository.
+
+| Tag              | Count | Use                                             | Example commit                                                        |
+|------------------|-------|-------------------------------------------------|-----------------------------------------------------------------------|
+| `[TASK]`         | 175   | Refactoring, tests, CI, dependencies, tooling   | `94c7aedc5` `[TASK] ACE-382: Cache only composer's dist archives`     |
+| `[BUGFIX]`       | 95    | Fixes incorrect behaviour                       | `8b5557037` `[BUGFIX] ACE-358: Drop the defaults on TEXT columns`     |
+| `[DOCS]`         | 74    | Documentation only, shipped or developer facing | `7d139a44f` `[DOCS] ACE-294: Record the TYPO3 v15 blockers`           |
+| `[FEATURE]`      | 22    | New, user-facing functionality                  | `4264cfe4b` `[FEATURE] ACE-236: Select the displayed address records` |
+| `[!!!][TASK]`    | 18    | Breaking change, marker first                   | `63fd7b099` `[!!!][TASK] ACE-306: Remove the profile switcher`        |
+| `[RELEASE]`      | 9     | Release commits, maintainers only               | `1f5334422` `[RELEASE] 2.3.4`                                         |
+| `[!!!][FEATURE]` | 5     | Breaking new functionality                      | `[!!!][FEATURE] ACE-304: Replace a profile image`                     |
+
+The `[!!!]` marker always comes first and is combined with the tag that
+describes the nature of the change, never used alone.
+
+`[RELEASE]` commits are the one deliberate exception to the rules above: they
+carry no issue reference, and their body is the literal, unwrapped command
+sequence the release was produced with, so a release can be reproduced or
+audited later.
+
+## Complete examples
+
+Two messages from the history, verbatim. Both are ordinary commits, not
+showcases — this is the expected level of detail.
+
+`bbc4ea33e`, a `[TASK]` that renames tests and explains why the old names were
+wrong, which alternative was rejected and on which core versions the result was
+measured:
+
+```
+[TASK] ACE-381: Fix the language overlay test names
+
+Four functional tests were named "_fallbackMode" but configured
+"fallbackType: 'content_fallback'", which is not a fallback type
+TYPO3 knows. LanguageAspectFactory lands anything unknown in its
+default branch, which means "OVERLAYS_OFF" and, less obviously,
+throws the configured fallback chain away and replaces it with [0].
+The repositories then lift "OVERLAYS_OFF" to
+"OVERLAYS_ON_WITH_FLOATING" (ACE-341), so these tests ran strict
+overlay semantics under a name promising the opposite - which is
+why they failed next to the strict ones when v14.3.6 started
+honouring the requested overlay type.
+
+They now configure "free", the real type that produces the same
+"OVERLAYS_OFF", and are named "_freeMode". Nothing about their
+behaviour changes: both repositories build the LanguageAspect with
+three arguments, so its "fallbackChain" defaults to empty and the
+site's chain never reaches the query - the only thing that
+separated the two values. Measured on v14.3.6, before and after:
+7 tests, 26 assertions, 2 skipped either way.
+
+Switching them to a real "fallback" instead was rejected: it would
+have removed the only coverage of "OVERLAYS_OFF" with an
+untranslated selected record. That combination is reachable in
+production through "fallbackType: free", and the sole other free
+test uses a fully localized fixture whose overlay never has to
+decide anything.
+
+Genuine fallback mode is covered by two new tests instead. It maps
+to "OVERLAYS_MIXED", which the repositories leave alone, so the
+untranslated selected record is kept and rendered in the default
+language. That holds before and after the fix for forge #88886,
+because the requested type is already the one the fix honours, so
+these two need no core version guard - verified green on 13.4.34
+and on 14.3.6.
+```
+
+`7860c783`, a `[BUGFIX]` that names the cause, why the defect stayed invisible,
+why the shipped templates were unaffected, and what the added tests prove:
+
+```
+[BUGFIX] ACE-345: Resolve category types in Fluid
+
+`CategoryCollection::offsetExists()` answered from `$typeSortedCollection`,
+the grouped view the collection builds lazily. That array stays empty
+until `getAllCategoriesByType()` has been called once on the instance, so
+a registered category type was reported as absent while `offsetGet()`,
+which resolves through `getCategoriesByTypeName()`, answered from the
+start.
+
+Fluid resolves a path segment on an `ArrayAccess` subject through
+`offsetExists()` and reads the offset only when that returned `true`, so
+`{categories.researchField}` rendered nothing - without an exception or a
+log entry - until something else had computed the grouping first. The
+partials shipped here were unaffected by accident: they iterate
+`{categories.allCategoriesByType}` before reaching a type by name.
+
+`offsetExists()` now answers from the registered type identifiers, the
+same source the lookup it guards resolves against, which is what
+`FilterCollection::offsetExists()` already did.
+
+The added tests assert both accessors agree on an untouched collection,
+and drive the template expression through Fluid's variable provider so
+the reason for the defect is covered, not just its symptom.
+```
+
+Note that the two differ in how they quote identifiers — backticks in one,
+double quotes in the other. That is not standardized; readability is.
+
+## Footers
+
+`Resolves:` and `Releases:` come from the TYPO3 Core workflow, where they drive
+forge and the cherry-pick targets. Neither exists here, and both **may be
+skipped**. The issue reference goes into the subject instead, as described
+above.
+
+That is also what the history shows: across the last 600 commits only four carry
+a `Resolves:` or `Related:` footer, all four repeat a reference that is already
+in their subject, and the most recent of them is from March 2026.
+
+`Change-Id:` is a Gerrit artefact and never appears here — review happens on
+GitHub.
+
+## Issue references
+
+Two trackers are involved, and they are not interchangeable.
+
+| Reference | Tracker  | Where it appears                                         |
+|-----------|----------|----------------------------------------------------------|
+| `ACE-NNN` | YouTrack | Commit subjects, pull request titles, changelog entries  |
+| `#NNN`    | GitHub   | Pull requests and issues on `fgtclb/academic-extensions` |
+
+`ACE-NNN` are **YouTrack** keys. The public issue and pull request tracker is
+**GitHub**, `fgtclb/academic-extensions` — that is what every package's
+`composer.json` points `support.issues` at, and it is where external reports
+arrive. A GitHub number is therefore never written as an `ACE` key and an `ACE`
+key never as `#NNN`.
+
+An issue reference is **verified before it is written into a commit**, never
+assumed. `ACE-` plus a plausible number always looks right and is wrong often
+enough to matter: a transposed digit points at a real but unrelated issue, and
+that wrong link then survives in the history, in the changelog and in the
+release notes. Look the key up and confirm it describes the change in hand
+before committing.
+
+## Attribution
+
+Contributions are attributed to the person who submits them. Whoever submits a
+change is responsible for it in full, regardless of which tools were used to
+produce it, and tooling is never credited as an author: no `Co-authored-by:`
+trailer for a tool, no `AI-assisted:` trailer, no "Generated with …" notice —
+not in a commit, a pull request, an issue or a file. `Co-authored-by:` is used
+only for an actual human co-author. Commit messages, pull request texts and
+documentation are written in the author's own voice.
+
+## See also
+
+- [Pull requests](pull-requests.md) — branch naming, the rebase merge model and
+  the pre-flight gates.
+- `AGENTS.md` in the repository root — the working rules this page's
+  attribution section restates, plus the quality gates and the backport targets.
+- `README.md` — the branch and extension support matrix.

--- a/docs/workflow/pull-requests.md
+++ b/docs/workflow/pull-requests.md
@@ -1,0 +1,225 @@
+# Pull requests
+
+Every change reaches a maintained branch through a pull request on GitHub,
+`fgtclb/academic-extensions`. There is no second route: the branches that
+matter are covered by a repository ruleset that requires one, and direct pushes
+to them are rejected.
+
+## Branch naming
+
+The established pattern is derived from the merged history and from the branches
+that currently exist on the remote:
+
+| Purpose               | Pattern                | Real example                     |
+|-----------------------|------------------------|----------------------------------|
+| Work on `main`        | `ace-<nnn>-<slug>`     | `ace-358-text-column-defaults`   |
+| Backport to `2`       | `ace-<nnn>-backport-2` | `ace-236-backport-2`             |
+| Backport to `2`, alt. | `ace-<nnn>-<slug>-2`   | `ace-358-text-column-defaults-2` |
+| Documentation work    | `ace-<nnn>-<slug>`     | `ace-389-docs`                   |
+
+All lowercase, words separated by hyphens, the issue number written in full and
+in the same order as in the commit subject. The slug describes the change, not
+the file it touches, so a branch name is recognizable next to the commit it
+carries.
+
+Both backport spellings are in active use — `-backport-2` and a plain `-2`
+suffix. Either is fine; what matters is that the target branch is visible in the
+name, because a pull request against `2` looks exactly like one against `main`
+in a notification.
+
+Older branches on the remote use a `task/<slug>` prefix, for example
+`task/image-fallback-metadata` and
+`task/ace-109-extbase-propertymapper-bases-extension-settings`. That prefix is
+history and is not used for new work.
+
+## One change, two pull requests
+
+A change that applies to both maintained branches is **two** pull requests, not
+one with two commits. The pull request against `main` goes first and is merged
+first; the backport follows. The merged history shows the pairs consistently —
+`#453` on `main` and `#455` on `2` for ACE-236, `#451` and `#452` for ACE-382,
+each pair minutes apart and in that order.
+
+The order is not cosmetic. `main` is where the change is reviewed on its merits;
+the backport is reviewed as an adaptation of something already accepted, and its
+description says what had to differ. Merging the backport first inverts that and
+leaves no record of what the change originally was.
+
+## Rebase merges only
+
+The repository is configured for a linear history, and the settings back that
+up. From the repository configuration:
+
+| Setting                  | Value   |
+|--------------------------|---------|
+| `allow_merge_commit`     | `false` |
+| `allow_squash_merge`     | `false` |
+| `allow_rebase_merge`     | `true`  |
+| `delete_branch_on_merge` | `true`  |
+| Default branch           | `main`  |
+
+A ruleset named `linear-history` additionally enforces `required_linear_history`
+on **all** branches, with no bypass actors at all. The result is visible in the
+history: there is not a single merge commit in the last 300 commits on `main`.
+
+Two consequences follow, and both bite in day-to-day work.
+
+**Every commit lands on its own.** Nothing is squashed, so each commit in a pull
+request becomes a commit on the target branch with its own message. Each one
+therefore has to be a complete, meaningful change with a message that stands
+alone, and ideally each one is green by itself — a bisect that lands on a commit
+which only works together with the next one is a lost afternoon.
+
+**A merged branch is no longer recognizable by SHA.** Rebasing rewrites every
+commit the branch carried, so the commits on the target branch have different
+SHAs than the ones that were pushed. Git's ancestry check then says the local
+branch is not merged, and `git branch -d` refuses to delete it — correctly, by
+its own definition, and uselessly, by yours. Containment has to be checked by
+content instead:
+
+```bash
+git fetch origin
+git diff origin/main..<branch>   # empty output: the branch adds nothing new
+git branch -D <branch>           # then delete it forcefully
+```
+
+The remote branch is gone already — `delete_branch_on_merge` removes it when the
+pull request is merged — so this is local cleanup only. Use the target the pull
+request actually went to, `origin/2` for a backport.
+
+## Rules on the maintained branches
+
+Verified through `gh api repos/fgtclb/academic-extensions/rulesets`. Note that
+`gh api repos/fgtclb/academic-extensions/branches/main/protection` answers
+`404 Branch not protected`: the repository uses **rulesets**, not classic branch
+protection, so the classic endpoint being empty says nothing.
+
+The ruleset `version-branches` is active and applies to the default branch plus
+`refs/heads/1`, `refs/heads/1.*`, `refs/heads/2` and `refs/heads/2.*`:
+
+| Rule                                       | Effect                                                  |
+|--------------------------------------------|---------------------------------------------------------|
+| `pull_request`                             | A pull request is required; direct pushes are rejected  |
+| `required_approving_review_count`          | 1 approving review                                      |
+| `dismiss_stale_reviews_on_push`            | A new push drops existing approvals                     |
+| `require_last_push_approval`               | The most recent push must be approved by someone else   |
+| `required_review_thread_resolution`        | All review threads must be resolved                     |
+| `allowed_merge_methods`                    | `rebase` only                                           |
+| `required_linear_history`                  | No merge commits                                        |
+| `creation`, `deletion`, `non_fast_forward` | The branches cannot be created, deleted or force-pushed |
+
+Bypass is granted to organization admins and to one repository role, in
+`always` mode. That is an escape hatch for a maintainer, not a workflow.
+
+**There is no required status checks rule in either ruleset.** CI is therefore
+not a mechanical merge blocker — GitHub will let a pull request with a red
+pipeline be merged by someone with the approval. Reading the pipeline result
+before merging is a discipline here, not a guard rail, which is exactly why the
+next two sections exist.
+
+## Pre-flight, before pushing
+
+Run the gates locally first. The harness is containerized, so a local run and a
+CI run execute the same commands in the same image — the difference is only how
+much of the matrix is covered.
+
+The rule that is easiest to get wrong: `-t` selects configuration, it does
+**not** install dependencies. Each core version needs its own `composerUpdate`
+before its gates, and a run for one version against the other version's vendor
+tree fails in ways that look like real defects.
+
+```bash
+# TYPO3 v13
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s lintPhp
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+# TYPO3 v14 — its own composerUpdate first
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s composerUpdate
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s lintPhp
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 14 -p 8.2 -s functional
+```
+
+Notes on the individual gates:
+
+- `cgl -n` reports without modifying, which is what CI runs. Drop the `-n` to
+  let it fix.
+- `phpstan` is the only source gate that genuinely differs per core version — it
+  analyses against the installed core through `Build/phpstan/Core13` and
+  `Build/phpstan/Core14`.
+- `lintPhp` needs neither `-t` nor a prepared vendor tree; running it once is
+  enough.
+- A change that touches shipped documentation adds
+  `Build/Scripts/runTests.sh -s checkRstRenderingAll`. It is a real gate in CI,
+  run with `--fail-on-log --fail-on-error`.
+- Anything that writes to the database deserves one run on a real DBMS before
+  the pipeline finds it: `-d postgres` is the strictest of the four and catches
+  what SQLite silently accepts.
+
+On branch `2` the two core versions are v12 and v13, so the same sequence is run
+with `-t 12` and `-t 13`.
+
+## Watch the pipeline
+
+Push, then watch the pull request pipeline. A green local run is **not** a
+substitute, for three reasons that are all structural rather than occasional:
+
+- **PHP versions.** Local runs use one version, usually the 8.2 default. CI
+  lints on 8.2, 8.3, 8.4 and 8.5, and runs unit and functional tests on the
+  edges 8.2 and 8.5.
+- **Database systems.** The local default is SQLite, which accepts constructs
+  MariaDB, MySQL and PostgreSQL reject. CI runs the functional suite on MySQL
+  8.0, MariaDB 10.4, MariaDB 10.6 and PostgreSQL 10 as well.
+- **Core versions.** It is easy to run the full sequence for one core version
+  and only part of it for the other. CI does not forget.
+
+The `ci.yml` workflow is staged so that a defect is reported cheaply:
+
+```
+cgl     ─┐
+phpstan ─┼─> unit ─> functional (SQLite) ─> functional (MySQL, MariaDB, Postgres)
+lint    ─┘
+documentation   (independent)
+```
+
+The 16-job DBMS matrix only starts once the same functional tests passed on
+SQLite for both core versions and both edge PHP versions. A defect that is not
+DBMS specific is therefore reported by four jobs instead of twenty — but it also
+means a red pipeline can still have most of its work ahead of it, and "the DBMS
+jobs did not run" is not the same as "the DBMS jobs passed".
+
+The `documentation` job uploads the rendered documentation as an artifact, and a
+separate `pr-comment.yml` workflow posts the link as a pull request comment that
+is updated in place. That second workflow runs on `workflow_run` on purpose, so
+that pull requests from forks — which get a read-only token — get the comment
+too. Its consequence for anyone editing it: changes to `pr-comment.yml` only
+take effect once they are on the default branch, never within the pull request
+that changes them.
+
+## Backport targets
+
+**The only maintained backport targets are `main` and `2`.**
+
+Branch `2.2` is no longer maintained and branch `1` is legacy. Neither is
+proposed as a backport target — not even when it demonstrably carries the same
+defect. Stating factually which branches contain a defect is useful; opening a
+pull request against `2.2` or `1`, or suggesting one, is not, unless it has been
+explicitly requested for that specific change.
+
+Note that the `version-branches` ruleset covers `refs/heads/1`, `refs/heads/1.*`
+and `refs/heads/2.*` as well. Those branches being protected is a leftover of
+when they were maintained; it is not an invitation.
+
+## See also
+
+- [Commit messages](commit-messages.md) — the format of what ends up on the
+  target branch, one commit at a time.
+- `AGENTS.md` in the repository root — the quality gates, the backport policy
+  and the `runTests.sh` flag reference in full.
+- `.github/workflows/ci.yml` — the authoritative job list, matrices and staging.

--- a/docs/workflow/releasing.md
+++ b/docs/workflow/releasing.md
@@ -1,0 +1,301 @@
+# Releasing
+
+A release of this repository is a release of **fourteen packages at once**:
+twelve TYPO3 extensions under `packages/fgtclb/` and the two meta packages under
+`packages-dev/`. They share a single version number, they are tagged together,
+and twelve of them end up in the TER — but never from here. The repository root
+is a composer `project`, not an extension, and has nothing to publish.
+
+Two scripts do the work, and neither of them is optional knowledge: `bin/set-version`
+writes the version everywhere, `bin/release` drives git and GitHub around it.
+
+## Where the version lives
+
+Every package carries its own version. There is no central version file, and —
+since the path repositories were reworked — no version map anywhere either:
+
+| File                                                  | Value today | Written by           |
+|-------------------------------------------------------|-------------|----------------------|
+| `composer.json` → `extra.typo3/cms.version`           | `3.0.0-dev` | `composer config`    |
+| `VERSION`                                             | `3.0.0-dev` | plain write          |
+| `ext_emconf.php` → `version`                          | `3.0.0`     | `pkw extemconf:set`  |
+| `Documentation/guides.xml` → `release`                | `3.0.0`     | `tailor set-version` |
+| `Build/Scripts/runTests.sh` → `COMPOSER_ROOT_VERSION` | `3.0.0-dev` | `sed`, root only     |
+
+The `-dev` suffix appears in the composer-facing files and not in the two TYPO3
+facing ones, because `ext_emconf.php` and `guides.xml` express a released
+version, not a range.
+
+The two `packages-dev/*` meta packages are **not** an exception:
+`fgtclb/academics-monorepo-shared` and
+`fgtclb/academics-monorepo-testing-helper` both carry
+`extra.typo3/cms.version` and a `VERSION` file, both at `3.0.0-dev`. They have
+no `ext_emconf.php`, are not extensions, and are never published — but they are
+path packages, so their version has to be right for the same reason.
+
+**Why this matters:** every `composer.json` in this repository that declares a
+`path` repository requires the composer plugin `sbuerk/extended-path-repository`,
+which derives the version of a path package **from the package itself** — from
+exactly those three places. Before it, each consuming `composer.json` carried a
+`repositories.*.options.versions` map naming the version of every path package,
+and every bump had to be mirrored into every map. Those maps are gone. Write the
+version on the package and it is correct in the root project, in the sibling
+extensions, in the `packages-dev` meta packages and in the `core-13`/`core-14`
+development instances.
+
+## `bin/set-version` — apply a version across the repository
+
+```shell
+bin/set-version <version> <type> [--source-branch=<name>] [--dry-run]
+```
+
+It edits working-tree files and does **nothing else**: no git, no network
+(`bin/set-version:40-41`). That separation is what makes it safe to run and
+inspect on its own.
+
+`<version>` is always a bare `MAJOR.MINOR.PATCH`; the `-dev` suffixes are
+derived, never passed. `<type>` decides how:
+
+| Type           | Package version | `ext_emconf` | Academic dependency constraint | Branch alias |
+|----------------|-----------------|--------------|--------------------------------|--------------|
+| `release`      | `X.Y.Z`         | `X.Y.Z`      | `X.Y.Z@dev`                    | not written  |
+| `post-release` | `X.Y.Z-dev`     | `X.Y.Z`      | `~X.Y.Z@dev`                   | `X.Y.x-dev`  |
+| `dev`          | `X.Y.Z-dev`     | `X.Y.Z`      | `~X.Y.Z@dev`                   | `X.Y.x-dev`  |
+
+`post-release` and `dev` share one derivation (`bin/set-version:173-186`); `dev`
+is the thin variant used for branching and forced minor or major bumps.
+`post-release` does **not** increment anything — the version passed is already
+the next one.
+
+What one run rewrites, in order (`bin/set-version:311-403`):
+
+1. `Build/Scripts/runTests.sh` → `COMPOSER_ROOT_VERSION`
+2. every split extension → academic composer dependencies,
+   `extra.typo3/cms.version`, branch alias, `tailor set-version`, `VERSION`
+3. functional-test fixture extensions → composer dependencies only
+4. every `ext_emconf.php` (splits **and** fixtures) → `version`, plus the
+   `depends`/`suggests` constraints for each academic extension key
+5. `packages-dev/*` → academic dependencies, `extra.typo3/cms.version`, `VERSION`
+6. `core-*/` development instances → the `academics-monorepo-shared` requirement
+7. root `composer.json` → the `academics-monorepo-shared` requirement and the
+   branch alias
+
+Nothing in that list is hardcoded. The package set is discovered by looking for
+directories under `packages/fgtclb/*/` that carry both a `composer.json` and an
+`ext_emconf.php` (`bin/set-version:204-215`); the extension key is read from
+`extra.typo3/cms.extension-key`, never guessed from the directory name; fixture
+extensions are found under `Tests/Functional/Fixtures/Extensions`
+(`bin/set-version:220-225`); the meta packages and the development instances are
+discovered by path. A thirteenth extension or a `core-15` instance is picked up
+by existing, which is precisely what the previously hardcoded instance list
+failed to do.
+
+`--dry-run` prints every change without touching a file and is the way to
+rehearse a bump. `--source-branch=<name>` only selects which
+`extra.branch-alias.dev-<branch>` key is written; it defaults to `main`, so a
+release on branch `2` must pass `--source-branch=2`.
+
+## `bin/release` — orchestrate the release
+
+```shell
+bin/release <release-version> [--source-branch=<name>] [--dry-run|--execute]
+```
+
+It owns git and `gh` and delegates all version rewriting to `bin/set-version`
+(`bin/release:20-21`). One invocation runs two phases:
+
+**Phase 1 — release** (`bin/release:211-232`)
+
+1. `git checkout -b release-X.Y.Z <source-branch>`
+2. `bin/set-version X.Y.Z release`
+3. commit `[RELEASE] X.Y.Z`, push, `gh pr create --fill`
+4. `gh pr checks --watch --interval 10 --fail-fast`
+5. `gh pr merge --rebase --delete-branch --admin`
+6. back on the refreshed source branch: `git tag X.Y.Z` and push the tag
+
+**Phase 2 — post-release** (`bin/release:234-251`), with `W = Z + 1`
+
+1. `git checkout -b set-version-X.Y.W <source-branch>`
+2. `bin/set-version X.Y.W post-release`
+3. commit `[TASK] Set version X.Y.W`, push, PR, checks, admin rebase-merge
+
+The next development version is derived as patch + 1 (`bin/release:144`). A
+minor or major bump afterwards is a separate `bin/set-version … dev` run, not
+something `bin/release` decides.
+
+### Two independent safety gates
+
+| Invocation  | Local steps (branch, set-version, commit) | Remote and irreversible steps (push, PR, merge, tag) |
+|-------------|-------------------------------------------|------------------------------------------------------|
+| *(bare)*    | executed                                  | **only printed**                                     |
+| `--dry-run` | printed                                   | printed                                              |
+| `--execute` | executed                                  | executed                                             |
+
+A bare run can therefore never mutate the remote or create a tag
+(`bin/release:76-89`). The two flags are mutually exclusive
+(`bin/release:129-131`). This matters more than it looks: the failure mode of a
+release script is not a wrong file, it is a pushed tag that cannot be taken
+back.
+
+### What it refuses to do
+
+Pre-flight (`bin/release:178-200`):
+
+* not inside a git work tree → abort,
+* the tag `X.Y.Z` already exists locally → abort, always, in every mode
+  ("refusing to re-release"),
+* the working tree is dirty → fatal for `--execute`, a warning otherwise, so the
+  flow stays rehearsable,
+* a version that is not `MAJOR.MINOR.PATCH` → abort.
+
+Tooling is resolved and verified up front, before anything changes:
+`bin/set-version` needs `composer`, `php`, `tailor`, `pkw`, `jq` and `sed` on
+`PATH` (`bin/set-version:133-139`); `bin/release` additionally needs `git` and an
+authenticated `gh` (`bin/release:154-162`).
+
+## The tag has to match `ext_emconf.php`
+
+The root `publish` workflow builds the TER artifacts with
+`tailor create-artefact <version> <extension-key>`
+(`.github/workflows/publish.yml:69-80`), and **that command fails when the
+version does not match the extension's `ext_emconf.php`**. This is a feature, not
+an obstacle: it makes it impossible for a release to disagree with the extension
+metadata that TYPO3 and the TER read.
+
+`bin/set-version` is what keeps the two in sync — step 4 above writes
+`ext_emconf.php` in the same run that writes everything else. All twelve
+extensions currently declare `'version' => '3.0.0'`, so the tag for the next
+release is `3.0.0`.
+
+The workflow additionally rejects a tag that is not a bare
+`MAJOR.MINOR.PATCH` before doing any work
+(`.github/workflows/publish.yml:47-52`). There is no `v` prefix — `bin/release`
+creates `3.0.0`, not `v3.0.0`.
+
+## The three-step publishing chain
+
+```
+tag X.Y.Z pushed to fgtclb/academic-extensions
+  |
+  |  1. this repository, .github/workflows/publish.yml
+  |     tailor create-artefact, once per extension  ->  GitHub release
+  |     no TER upload
+  v
+  |  2. external splitter
+  |     mirrors the tagged state into the twelve read-only split
+  |     repositories, tag included
+  v
+  |  3. each split repository, its own .github/workflows/publish.yml
+  |     tailor create-artefact  ->  GitHub release  ->  tailor ter:publish
+  v
+ published on extensions.typo3.org, one extension at a time
+```
+
+**Step 1 — here.** `.github/workflows/publish.yml` triggers on any pushed tag,
+verifies its shape, installs `typo3/tailor`, then loops over
+`packages/fgtclb/*`, reads each extension key from that package's
+`composer.json` at runtime, and builds one artifact per extension. The keys are
+read rather than derived from the directory name because they differ:
+`academic-contact4pages` ships `academic_contacts4pages`
+(`.github/workflows/publish.yml:21-23`). Finally
+`softprops/action-gh-release` creates the release `[RELEASE] <version>` with
+generated notes and attaches all artifacts plus `LICENSE`, failing on an
+unmatched file.
+
+This workflow contains **no** `ter:publish` step, and that is deliberate
+(`.github/workflows/publish.yml:3-13`). There is no `academic_extensions`
+extension to publish.
+
+A documentation-rendering step exists in the file but is commented out
+(`.github/workflows/publish.yml:82-88`); the rendered manual is currently
+produced only by the CI workflow on pull requests, see
+[Changelog and documentation](changelog-and-documentation.md).
+
+**Step 2 — the splitter.** An external splitting setup mirrors this
+repository's packages into their standalone read-only repositories
+(`fgtclb/academic-persons`, `fgtclb/typo3-category-types`, …), tags included.
+The split repositories are never a source of truth and are never committed to
+directly.
+
+**Step 3 — per extension.** Each package ships its own publish workflow at
+`packages/fgtclb/<pkg>/.github/workflows/publish.yml` — all twelve have one.
+When the tag arrives in the split repository, that workflow builds the single
+artifact for its extension, creates the release there, and runs:
+
+```yaml
+tailor ter:publish --comment "<link to the GitHub release>" <version> \
+  --artefact=tailor-version-artefact/<key>_<version>.zip
+```
+
+Because it lives inside the package, it is **split out with the package**. That
+is the whole point: TER publishing is maintained here and never edited
+downstream — a change made in a split repository would be overwritten by the
+next split. The reference copy for new packages is
+`Build/templates/extensions/.github/workflows/publish.yml`, which the shipped
+copies currently differ from only in the `actions/checkout` version (`v6` in the
+packages, `v4` in the template).
+
+Both publish workflows declare the `TYPO3_API_TOKEN` secret and grant
+`contents: write`; only the per-package one actually spends the token, in
+`ter:publish`.
+
+## Pre-release checklist
+
+Everything the scripts check themselves is listed as such — the point of the
+list is the handful of things they do *not* check.
+
+**Checked by the scripts (they will stop you):**
+
+- [ ] Version is `MAJOR.MINOR.PATCH`, no `v`, no suffix.
+- [ ] `composer`, `php`, `tailor`, `pkw`, `jq`, `sed`, `git` and an
+      authenticated `gh` are on `PATH`.
+- [ ] The working tree is clean (fatal for `--execute`).
+- [ ] No **local** tag with that version exists — the check is
+      `git rev-parse refs/tags/X.Y.Z`, so fetch first, or a tag that only exists
+      on the remote will not be seen.
+- [ ] CI is green — `bin/release` waits for it with
+      `gh pr checks --watch --fail-fast` and stops at the first failure.
+- [ ] The tag matches every `ext_emconf.php` — guaranteed by the `release` run
+      of `bin/set-version`, enforced by `tailor create-artefact`.
+
+**Not checked — verify by hand before starting:**
+
+- [ ] **The right branch.** A release is cut from the branch owning that version
+      line: `main` for `3.x`, `2` for `2.x`. Releasing `2.4.0` needs
+      `--source-branch=2`; the default is `main` and would write the wrong
+      branch alias.
+- [ ] **Changelog entries are complete** for the version, in every package that
+      changed. Nothing enforces this, and after the tag it is too late — see
+      [Changelog and documentation](changelog-and-documentation.md).
+- [ ] **The changelog version directory exists** for the line being released
+      (`Documentation/Changelog/<minor>/`), and its `Index.rst` is linked from
+      `Changelog-<major>.rst`.
+- [ ] **A dry run was read**, not just executed:
+      `bin/set-version X.Y.Z release --dry-run` prints every file it would
+      touch, and `bin/release X.Y.Z --dry-run` prints the whole plan.
+- [ ] **`TYPO3_API_TOKEN` is present in the split repositories.** It is what
+      `ter:publish` spends, and a missing one surfaces only in step 3, after the
+      tag exists. The root workflow declares the same secret but never uses it.
+- [ ] **The rendered documentation was looked at** for anything with
+      user-visible documentation changes.
+
+After the release, `bin/release` phase 2 leaves the source branch on
+`X.Y.(Z+1)-dev`. A minor or major bump is a deliberate, separate
+`bin/set-version <next> dev` run.
+
+## See also
+
+- [Changelog and documentation](changelog-and-documentation.md) — what has to be
+  written before the tag.
+- [Backporting](backporting.md) — the second maintained branch releases on its
+  own version line.
+- [Commit messages](commit-messages.md) — the `[RELEASE]` and `[TASK]` subjects
+  the scripts generate.
+- [Pull requests](pull-requests.md) — both release phases go through one.
+- `README.md`, section "Releasing (maintainers)" — the contributor-facing
+  summary of the same process.
+- `bin/set-version`, `bin/release` — the scripts, both self-documenting via
+  `--help`.
+- `.github/workflows/publish.yml` — step 1 of the chain.
+- `Build/templates/extensions/.github/workflows/publish.yml` — the reference for
+  step 3.


### PR DESCRIPTION
Adds a `docs/` tree for developer and maintainer documentation, on the shape
used in `sbuerk/extension-skeleton` and adapted to a mono repository.

> **Stacked on #457.** The base of this pull request is `ace-388-agents-md`, so
> the diff shows only this change. GitHub retargets it to `main` once #457
> merges.

## What this is

Eighteen pages plus five `Index.md` files, 5 552 lines, in four sections:

| Section | Pages |
|---|---|
| `development/` | environment, monorepo layout, dual core setup, quality gates |
| `architecture/` | core version aware code, dependency injection, class design, database queries |
| `testing/` | phpunit configuration, unit tests, functional tests, fixture extensions, testing helper |
| `workflow/` | commit messages, pull requests, backporting, changelog and documentation, releasing |

It sits at the repository root, outside every package, so it never reaches a
split repository and needs no `export-ignore`. The per-extension
`Documentation/` keeps its own audience: users and integrators, in reST,
rendered to docs.typo3.org.

Conventions, stated in `docs/Index.md` and followed by every page: an `Index.md`
per directory, a `See also` section per page, documenting *why* rather than only
*what*, and formatted tables.

## Four corrections to `AGENTS.md`

Writing the pages meant verifying what the instruction file claims. Four claims
did not survive:

| Claim | Reality |
|---|---|
| "no `--` passthrough to phpunit" | The separator **does** reach the suite command. `-s unit -- --filter ZzNoSuchTestName` reports "No tests executed!" where a plain run executes 225. Only `-e` is absent. |
| Five testing helper traits | The package ships **seven**. Replaced with a pointer so the list cannot go stale again. |
| Extensions configure DI in `Services.php` | **Eleven of twelve** use `Services.yaml`. The one `Services.php` holds only `registerForAutoconfiguration()` calls, and TYPO3's DI attributes are already used in production code. |
| A core version folder must be added to the phpstan `paths` | The two `phpstan.neon` files are **byte-identical** and analyse `../../../packages` wholesale. Such a folder is already covered; a split would need an `excludePaths` entry instead. |

## One correction that did not happen

An early draft flagged `TYPO3\CMS\Install\Updates\*` as removed on v14 — nine
upgrade wizards across five extensions import it. It is **not** removed. The
classes live in `cms-core/DeprecatedClasses/ext-install/`, autoloaded through
`"classmap"` in `cms-core/composer.json`, each a shim extending the new
`Core\Upgrades\*` and marked `@deprecated since v14.0, will be removed in
v15.0`. Searching only `cms-install/Classes/` is what made them look gone. The
page now records both the fact and the way to check it, because the same trap
applies to `Extbase\Annotation\*` and `FlexFormService` — and the generated
alias map lowercases its keys, so a naive grep of it also finds nothing.

`AGENTS.md` was right about the blockers all along.

## Verification

* Every page states what was verified. Where a claim could not be checked from a
  single checkout — v12 behaviour, for instance, since this branch installs v13
  and v14 — the page says so rather than repeating it as fact.
* All relative links resolve, every page has a `See also`, no trailing
  whitespace, and every table is padded — checked mechanically.
* `README.md` also has unaligned tables. Deliberately left alone; it belongs to
  ACE-390.

## Follow-ups

* ACE-390 streamlines `README.md` and `CONTRIBUTING.md` to link here instead of
  saying nothing. It will also fix a broken link label in the `README.md`
  package table (`fgtclb/fgtclb/typo3-category-types`).
* The table-alignment convention has no gate yet, so it will rot. Worth a
  `checkMarkdownTables` suite later.
* `docs/testing/testing-helper.md` describes the traits as they are on `main`;
  one sentence needs updating when #456 lands.
