### PR TITLE
[TASK] ACE-390: Link the documentation together

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,189 @@
 # Contributing
 
-This is the central place to work on all `academic-*` extensions.
+Contributions are welcome. This is the central place to work on all `academic-*`
+extensions and `category_types`: use this repository to report issues or to
+contribute changes to the code or the documentation.
 
-Use this repository to report issues or contribute changes to the documentation or code.
+**Never send a change to a split repository.** Every extension is mirrored out
+to its own read-only GitHub repository, and those mirrors are not a source of
+truth — a change made there is lost on the next split.
+
+This document is the entry point. It covers what you need to get started and
+links to the detailed developer documentation in [`docs/`](docs/Index.md)
+instead of repeating it.
+
+## Table of contents
+
+- [Getting started](#getting-started)
+- [Quality gates](#quality-gates)
+- [Running tests](#running-tests)
+- [Code rules](#code-rules)
+- [Commit messages](#commit-messages)
+- [Pull request checklist](#pull-request-checklist)
+- [Backporting](#backporting)
+- [Documentation](#documentation)
+- [Releasing](#releasing)
+- [AI-assisted contributions](#ai-assisted-contributions)
+
+## Getting started
+
+Everything runs in containers through `Build/Scripts/runTests.sh`. The only
+requirement on the host is **podman** (preferred) or **docker** — no PHP, no
+composer, no node.
+
+```bash
+git clone git@github.com:fgtclb/academic-extensions.git
+cd academic-extensions
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+```
+
+> **Important:** `-t` selects configuration only, it does **not** reinstall
+> dependencies, and `-p` needs a `composerUpdate` just as much. Running a gate
+> for one core version while the other one's dependency set is installed fails
+> in confusing ways.
+
+→ [Development environment](docs/development/environment.md) ·
+[Monorepo layout](docs/development/monorepo-layout.md) ·
+[Dual core setup](docs/development/dual-core-setup.md)
+
+## Quality gates
+
+The same gates run locally and in the GitHub Actions workflow, for every TYPO3
+version the branch supports:
+
+```bash
+Build/Scripts/runTests.sh -s cgl -n      # coding guidelines, omit "-n" to fix
+Build/Scripts/runTests.sh -s phpstan     # static analysis, per core version
+Build/Scripts/runTests.sh -s lintPhp     # PHP linting
+```
+
+PHPStan is configured per core version and has a baseline per core version. A
+growing baseline is a defect — prefer fixing the finding.
+
+→ [Quality gates](docs/development/quality-gates.md)
+
+## Running tests
+
+```bash
+Build/Scripts/runTests.sh -s unit
+Build/Scripts/runTests.sh -s functional                 # SQLite, the default
+Build/Scripts/runTests.sh -s functional -d postgres     # anything that writes
+```
+
+Both suites are **hard breaking**: deprecations, notices, warnings and risky
+tests all fail the run. Never silence one to get a run green — fix the cause.
+
+A test without an assertion still passes, so prove a new test can fail: break
+what it covers, watch it go red, restore.
+
+SQLite is the default and is not sufficient. Several defects here were invisible
+on SQLite and only appeared on MySQL, MariaDB or PostgreSQL.
+
+→ [Testing](docs/testing/Index.md) ·
+[Unit tests](docs/testing/unit-tests.md) ·
+[Functional tests](docs/testing/functional-tests.md) ·
+[Testing helper](docs/testing/testing-helper.md)
+
+## Code rules
+
+- **A core version difference is a switch while it is one or two lines**, and a
+  class split only when a whole class has to differ.
+  → [Core version aware code](docs/architecture/core-version-aware-code.md)
+- **Services are stateless.** New services must be; existing ones must not gain
+  state. → [Dependency injection](docs/architecture/dependency-injection.md)
+- **Never hand a raw array to `in()` or `notIn()`**, and build a constraint on
+  the query builder that executes it. Both rules come from defects that reached
+  a release. → [Database queries](docs/architecture/database-queries.md)
+- Match the surrounding extension's existing style rather than introducing a
+  second one alongside it. → [Class design](docs/architecture/class-design.md)
+
+## Commit messages
+
+TYPO3 Core conventions: `[TAG] ACE-NNN: Subject`, subject within 52 characters,
+body wrapped at 72.
+
+The `ACE-NNN` keys are YouTrack issues while the public issue and pull request
+tracker is GitHub. **An issue reference is verified before it is written into a
+commit**, never assumed.
+
+→ [Commit messages](docs/workflow/commit-messages.md)
+
+## Pull request checklist
+
+Before opening a pull request, run every gate above and both test suites for
+**each** TYPO3 version the branch supports, every one of them after its own
+`composerUpdate`.
+
+A green local run is not a substitute for the pipeline — watch it after pushing.
+
+→ [Pull requests](docs/workflow/pull-requests.md)
+
+## Backporting
+
+The only maintained targets are `main` and `2`. Branch `2.2` is no longer
+maintained and branch `1` is legacy; neither is a backport target.
+
+A backport is **analysed, not cherry-picked** — the branches support different
+TYPO3 versions. But check before adapting: diff each touched file between the
+branches first, because they are frequently identical.
+
+→ [Backporting](docs/workflow/backporting.md)
+
+## Documentation
+
+Two audiences, two places — both updated in the same commit as the change:
+
+| Location                                     | Audience                   | Format   | Scope           |
+|----------------------------------------------|----------------------------|----------|-----------------|
+| `packages/fgtclb/<extension>/Documentation/` | Users and integrators      | reST     | per extension   |
+| [`docs/`](docs/Index.md)                     | Developers and maintainers | Markdown | repository wide |
+
+```bash
+# Render every extension's manual, as CI does. Must pass without errors.
+Build/Scripts/runTests.sh -s checkRstRenderingAll
+
+# Render one, then open it.
+Build/Scripts/runTests.sh -s checkRstRenderingSingle academic-persons
+Build/Scripts/runTests.sh -s openDocumentation academic-persons
+```
+
+User facing changes need a changelog entry below the extension's
+`Documentation/Changelog/<version>/` — `Breaking-*.rst`, `Deprecation-*.rst`,
+`Feature-*.rst` or `Important-*.rst`. Templates are in
+`Build/Documentation/Templates/`.
+
+Two formatting rules that are easy to get wrong and are not caught by a gate:
+a reST section over- or underline must match its title length **exactly**, and
+Markdown tables are always padded so the pipes line up.
+
+→ [Changelog and documentation](docs/workflow/changelog-and-documentation.md)
+
+## Releasing
+
+Maintainers only. Every package carries its own version, and a release is
+applied across the repository with `bin/set-version` and orchestrated with
+`bin/release`. Publishing to the TER happens per extension, one step later in
+the chain, from the split repositories.
+
+→ [Releasing](docs/workflow/releasing.md)
+
+## AI-assisted contributions
+
+Whoever submits a change is responsible for it in full, exactly as if every line
+had been typed by hand. The quality bar does not move: every gate applies
+unchanged, and code that has only been reasoned about is not code that has been
+run.
+
+Tools are not authors. A change is never attributed to one — no
+`Co-authored-by:` trailer for a model or a tool, no `AI-assisted:` trailer, no
+"Generated with …" notice, in a commit, a pull request, an issue or a file.
+Everything is written in the maintainer's voice.
+
+[`AGENTS.md`](AGENTS.md) is the instruction file for AI coding agents, with
+`CLAUDE.md`, `GEMINI.md` and `.github/copilot-instructions.md` as symlinks to
+it. It links into this document and into [`docs/`](docs/Index.md) rather than
+repeating them, and adds what applies to agent work: the above, scratch files
+below the git-ignored `.agent/`, and the gate matrix including the dual core
+rule.
+
+→ [Agent instructions](AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,27 @@
 which may depend on others. To keep the maintenance burden across the set of extension small while
 increasing the cross-over development and testing experience.
 
+## Documentation
+
+| For                        | Where                                                                     |
+|----------------------------|---------------------------------------------------------------------------|
+| Users and integrators      | The `Documentation/` folder of each extension, rendered to docs.typo3.org |
+| Developers and maintainers | [`docs/`](docs/Index.md)                                                  |
+| Contributors, entry point  | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                      |
+| AI coding agents           | [`AGENTS.md`](AGENTS.md)                                                  |
+
+Each extension ships its own manual — there is no repository-wide one, because
+each extension is released and published on its own. [`docs/`](docs/Index.md) is
+the counterpart for the repository itself: the harness, the rules the code
+follows, and how a release is cut.
+
 ## Repository version support
 
-| Branch | Version       | TYPO3     | PHP                                          |
-|--------|---------------|-----------|----------------------------------------------|
-| main   | ^3, 3.x-dev   | v13 + v14 | 8.2, 8.3, 8.4, 8.5                           |
-| 2, 2.x | ^2, 2.x-dev   | v12 + v13 | 8.1, 8.2, 8.3, 8.4, 8.5 (depending on TYPO3) |
-| 1      | ^1, 1.x-dev   | v11 + v12 | 8.1, 8.2, 8.3, 8.4 (depending on TYPO3)      |
+| Branch | Version     | TYPO3     | PHP                                          |
+|--------|-------------|-----------|----------------------------------------------|
+| main   | ^3, 3.x-dev | v13 + v14 | 8.2, 8.3, 8.4, 8.5                           |
+| 2, 2.x | ^2, 2.x-dev | v12 + v13 | 8.1, 8.2, 8.3, 8.4, 8.5 (depending on TYPO3) |
+| 1      | ^1, 1.x-dev | v11 + v12 | 8.1, 8.2, 8.3, 8.4 (depending on TYPO3)      |
 
 **Testing 3.x.x extension version in projects (composer mode)**
 
@@ -78,30 +92,62 @@ implemented and verified for every extension above by the `TYPO3 v13` and
 
 ## List of TYPO3 extension and the split repositories (READ ONLY)
 
-| Composer                       | TYPO3                   | Path                                                                                       | Split Repository                                                                     |
-|--------------------------------|-------------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| fgtclb/academic-base           | academic_base           | [packages/fgtclb/academic-base](packages/fgtclb/academic-base/README.md)                   | [fgtclb/academic-base](https://github.com/fgtclb/academic-base)                      |
-| fgtclb/academic-bite-jobs      | academic_bite_jobs      | [packages/fgtclb/academic-bite-jobs](packages/fgtclb/academic-bite-jobs/README.md)         | [fgtclb/academic-bite-jobs](https://github.com/fgtclb/academic-bite-jobs)            |
-| fgtclb/academic-contacts4pages | academic_contacts4pages | [packages/fgtclb/academic-contact4pages](packages/fgtclb/academic-contact4pages/README.md) | [fgtclb/academic-contact4pages](https://github.com/fgtclb/academic-contact4pages)    |
-| fgtclb/academic-study-plan     | academic_study_plan     | [packages/fgtclb/academic-study-plan](packages/fgtclb/academic-study-plan/README.md)       | [fgtclb/academic-study-plan](https://github.com/fgtclb/academic-study-plan)          |
-| fgtclb/academic-jobs           | academic_jobs           | [packages/fgtclb/academic-jobs](packages/fgtclb/academic-jobs/README.md)                   | [fgtclb/academic-jobs](https://github.com/fgtclb/academic-jobs)                      |
-| fgtclb/academic-partners       | academic_partners       | [packages/fgtclb/academic-partners](packages/fgtclb/academic-partners/README.md)           | [fgtclb/academic-partners](https://github.com/fgtclb/academic-partners)              |
-| fgtclb/academic-persons        | academic_persons        | [packages/fgtclb/academic-persons](packages/fgtclb/academic-persons/README.md)             | [fgtclb/academic-persons](https://github.com/fgtclb/academic-persons)                |
-| fgtclb/academic-persons-edit   | academic_persons_edit   | [packages/fgtclb/academic-persons-edit](packages/fgtclb/academic-persons-edit/README.md)   | [fgtclb/academic-persons-edit](https://github.com/fgtclb/academic-persons-edit)      |
-| fgtclb/academic-persons-sync   | academic_persons_sync   | [packages/fgtclb/academic-persons-sync](packages/fgtclb/academic-persons-sync/README.md)   | [fgtclb/academic-persons-sync](https://github.com/fgtclb/academic-persons-sync)      |
-| fgtclb/academic-programs       | academic_programs       | [packages/fgtclb/academic-programs](packages/fgtclb/academic-programs/README.md)           | [fgtclb/academic-programs](https://github.com/fgtclb/academic-programs)              |
-| fgtclb/academic-projects       | academic_projects       | [packages/fgtclb/academic-projects](packages/fgtclb/academic-projects/README.md)           | [fgtclb/academic-projects](https://github.com/fgtclb/academic-projects)              |
-| fgtclb/category-types          | category_types          | [packages/fgtclb/typo3-category-types](packages/fgtclb/typo3-category-types/README.md)     | [fgtclb/fgtclb/typo3-category-types](https://github.com/fgtclb/typo3-category-types) |
+| Composer                       | TYPO3                   | Path                                                                                       | Split Repository                                                                  |
+|--------------------------------|-------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| fgtclb/academic-base           | academic_base           | [packages/fgtclb/academic-base](packages/fgtclb/academic-base/README.md)                   | [fgtclb/academic-base](https://github.com/fgtclb/academic-base)                   |
+| fgtclb/academic-bite-jobs      | academic_bite_jobs      | [packages/fgtclb/academic-bite-jobs](packages/fgtclb/academic-bite-jobs/README.md)         | [fgtclb/academic-bite-jobs](https://github.com/fgtclb/academic-bite-jobs)         |
+| fgtclb/academic-contacts4pages | academic_contacts4pages | [packages/fgtclb/academic-contact4pages](packages/fgtclb/academic-contact4pages/README.md) | [fgtclb/academic-contact4pages](https://github.com/fgtclb/academic-contact4pages) |
+| fgtclb/academic-study-plan     | academic_study_plan     | [packages/fgtclb/academic-study-plan](packages/fgtclb/academic-study-plan/README.md)       | [fgtclb/academic-study-plan](https://github.com/fgtclb/academic-study-plan)       |
+| fgtclb/academic-jobs           | academic_jobs           | [packages/fgtclb/academic-jobs](packages/fgtclb/academic-jobs/README.md)                   | [fgtclb/academic-jobs](https://github.com/fgtclb/academic-jobs)                   |
+| fgtclb/academic-partners       | academic_partners       | [packages/fgtclb/academic-partners](packages/fgtclb/academic-partners/README.md)           | [fgtclb/academic-partners](https://github.com/fgtclb/academic-partners)           |
+| fgtclb/academic-persons        | academic_persons        | [packages/fgtclb/academic-persons](packages/fgtclb/academic-persons/README.md)             | [fgtclb/academic-persons](https://github.com/fgtclb/academic-persons)             |
+| fgtclb/academic-persons-edit   | academic_persons_edit   | [packages/fgtclb/academic-persons-edit](packages/fgtclb/academic-persons-edit/README.md)   | [fgtclb/academic-persons-edit](https://github.com/fgtclb/academic-persons-edit)   |
+| fgtclb/academic-persons-sync   | academic_persons_sync   | [packages/fgtclb/academic-persons-sync](packages/fgtclb/academic-persons-sync/README.md)   | [fgtclb/academic-persons-sync](https://github.com/fgtclb/academic-persons-sync)   |
+| fgtclb/academic-programs       | academic_programs       | [packages/fgtclb/academic-programs](packages/fgtclb/academic-programs/README.md)           | [fgtclb/academic-programs](https://github.com/fgtclb/academic-programs)           |
+| fgtclb/academic-projects       | academic_projects       | [packages/fgtclb/academic-projects](packages/fgtclb/academic-projects/README.md)           | [fgtclb/academic-projects](https://github.com/fgtclb/academic-projects)           |
+| fgtclb/category-types          | category_types          | [packages/fgtclb/typo3-category-types](packages/fgtclb/typo3-category-types/README.md)     | [fgtclb/typo3-category-types](https://github.com/fgtclb/typo3-category-types)     |
+
+## Development
+
+Every test and quality tool runs in a container through the
+[`Build/Scripts/runTests.sh`](Build/Scripts/runTests.sh) wrapper. The only
+requirement on the host is a container runtime — **podman** (preferred) or
+**docker**.
+
+```bash
+# Install dependencies for the core version and PHP version you will test.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
+
+# Quality gates.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s cgl -n
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstan
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s lintPhp
+
+# Tests.
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
+Build/Scripts/runTests.sh -t 13 -p 8.2 -s functional
+
+# All available options.
+Build/Scripts/runTests.sh -h
+```
+
+`-t` selects configuration only, it does **not** reinstall dependencies.
+Everything has to pass for **both** TYPO3 versions this branch supports, each
+after its own `composerUpdate` — see
+[Dual core setup](docs/development/dual-core-setup.md).
+
+→ [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow ·
+[`docs/`](docs/Index.md) for the full developer documentation
 
 ## Development instances
 
 Two ready-to-start TYPO3 instances live at the repository root, one per supported
 core version:
 
-| Folder     | TYPO3 | DDEV project           | Seeded demo content |
-|------------|-------|------------------------|---------------------|
-| `core-13/` | v13   | `core13-academics-v3`  | styleguide          |
-| `core-14/` | v14   | `core14-academics-v3`  | camino              |
+| Folder     | TYPO3 | DDEV project          | Seeded demo content |
+|------------|-------|-----------------------|---------------------|
+| `core-13/` | v13   | `core13-academics-v3` | styleguide          |
+| `core-14/` | v14   | `core14-academics-v3` | camino              |
 
 Both run on **SQLite** — no database container is started (`omit_containers: [db]`).
 Each instance is seeded on first start from the committed template in
@@ -182,12 +228,12 @@ A release is always cut from the branch owning that version line (see the
 `bin/`. All extensions of the mono repository are released together, sharing one
 version number.
 
-| Branch | Release line | Example version | Release tooling                             |
-|--------|--------------|-----------------|---------------------------------------------|
-| main   | `3.x`        | `3.0.0`         | `bin/release`, `bin/set-version`            |
-| 2      | `2.x`        | `2.4.0`         | `bin/release`, `bin/set-version`            |
-| 2.2    | `2.2.x`      | `2.2.2`         | `bin/release`, `bin/set-version`            |
-| 1      | `1.x`        | -               | none — that branch has no `bin/` scripts    |
+| Branch | Release line | Example version | Release tooling                          |
+|--------|--------------|-----------------|------------------------------------------|
+| main   | `3.x`        | `3.0.0`         | `bin/release`, `bin/set-version`         |
+| 2      | `2.x`        | `2.4.0`         | `bin/release`, `bin/set-version`         |
+| 2.2    | `2.2.x`      | `2.2.2`         | `bin/release`, `bin/set-version`         |
+| 1      | `1.x`        | -               | none — that branch has no `bin/` scripts |
 
 Both scripts are kept as the *same* implementation on every branch. Only two
 things legitimately differ per branch: the `--source-branch` default (which
@@ -209,11 +255,11 @@ bin/set-version <version> <type> [--source-branch=<name>] [--dry-run]
 
 `<type>` selects how the version is written:
 
-| Type           | Result                                                                   |
-|----------------|--------------------------------------------------------------------------|
-| `release`      | tag/release version — `X.Y.Z`, academic deps `X.Y.Z@dev`                  |
+| Type           | Result                                                                                                                                          |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `release`      | tag/release version — `X.Y.Z`, academic deps `X.Y.Z@dev`                                                                                        |
 | `post-release` | next dev version — `X.Y.W-dev`, deps `~X.Y.W@dev`, branch-alias `X.Y.x-dev`; the version passed is *already* the next one, no `+1` happens here |
-| `dev`          | force a plain dev version everywhere (`X.Y.Z-dev`); thin variant of `post-release`, used for branching and forced minor/major bumps |
+| `dev`          | force a plain dev version everywhere (`X.Y.Z-dev`); thin variant of `post-release`, used for branching and forced minor/major bumps             |
 
 It rewrites, in one pass:
 
@@ -252,11 +298,11 @@ It runs two phases, delegating all version rewriting to `bin/set-version`:
 
 Two independent safety gates control how far a run goes:
 
-| Invocation  | Local steps | Remote/irreversible steps (push, PR, merge, tag) |
-|-------------|-------------|--------------------------------------------------|
+| Invocation  | Local steps | Remote/irreversible steps (push, PR, merge, tag)                          |
+|-------------|-------------|---------------------------------------------------------------------------|
 | *(bare)*    | executed    | **only printed** — a bare run can never mutate the remote or create a tag |
-| `--dry-run` | printed     | printed                                          |
-| `--execute` | executed    | executed                                         |
+| `--dry-run` | printed     | printed                                                                   |
+| `--execute` | executed    | executed                                                                  |
 
 `--dry-run` and `--execute` are mutually exclusive. Pre-flight checks refuse to
 run outside a git work tree or when the target tag already exists; a dirty


### PR DESCRIPTION
Makes `README.md` and `CONTRIBUTING.md` link the documentation together instead
of each ignoring the other.

> **Stacked on #458**, which is stacked on #457. The base of this pull request is
> `ace-389-docs`, so the diff shows only this change. GitHub retargets it as the
> ones below it merge.

## The state this fixes

* `CONTRIBUTING.md` was **four lines**. No workflow, no harness, no release
  process, no mention of the agent instructions.
* `README.md` is 296 lines and mentioned `runTests.sh` exactly twice, both times
  in passing inside the release section. It never mentioned contributing,
  `AGENTS.md`, or how to run a single test.

The consequence: the entire build and test harness was documented only inside
the agent instruction file, which is the one file a human contributor has no
reason to open.

## What changes

`README.md`

* A `## Documentation` table naming the four audiences — users to the
  per-extension `Documentation/`, developers to `docs/`, contributors to
  `CONTRIBUTING.md`, agents to `AGENTS.md`.
* A `## Development` section with the harness quick start, including the trap
  that `-t` selects configuration but installs nothing.
* Everything else is untouched.

`CONTRIBUTING.md` becomes the entry point it claimed to be: getting started,
quality gates, running tests, code rules, commit messages, the pull request
checklist, backporting, documentation, releasing. Each section is a summary and
a `→` link into `docs/` — no duplicated content.

It also states something the stub never did: **a change sent to a split
repository is lost on the next split.** That is the single most expensive thing
a new contributor can get wrong here.

## Two fixes in passing

* The `category_types` split repository link was labelled
  `fgtclb/fgtclb/typo3-category-types`. The URL was always right.
* The `README.md` tables were not padded. They are now, matching the convention
  `docs/Index.md` states.

## Verified

* Every relative link in both files resolves.
* `-s checkRstRenderingSingle` and `-s openDocumentation` take the **directory**
  name under `packages/fgtclb/`, not the extension key — the script's variable
  is named `extensionKey`, which is misleading. The examples use
  `academic-persons` accordingly.
* `bin/set-version` and `bin/release` exist as named.
