### PR TITLE
[TASK] ACE-391: Add the frontend asset build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ name: "CI"
 #   phpstan ─┼─> unit ─> functional (SQLite) ─> functional (MySQL, MariaDB, …)
 #   lint    ─┘
 #
-#   documentation  (independent, for fast feedback on documentation changes)
+#   documentation     (independent, for fast feedback on documentation changes)
+#   frontend assets   (independent, core version agnostic, no composerUpdate)
 #
 # The DBMS matrix is the expensive part — 16 jobs, each starting a database
 # container — so it only runs once the same tests have passed on SQLite for both
@@ -290,6 +291,39 @@ jobs:
 
       - name: "Execute functional tests with ${{ matrix.dbms.name }} ${{ matrix.dbms.version }}"
         run: "Build/Scripts/runTests.sh -b docker -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d ${{ matrix.dbms.name }} -i ${{ matrix.dbms.version }} -s functional"
+
+  frontend-assets:
+    name: "frontend assets"
+    runs-on: ubuntu-latest
+    # No matrix. These suites run in a node container and never touch PHP or the
+    # installed core, so repeating them per PHP and core version would check the
+    # same sources four times. They also need no "composerUpdate" — nothing here
+    # reads ".Build/".
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Cache npm downloads"
+        uses: actions/cache@v6
+        with:
+          path: ".cache/npm"
+          key: "npm-${{ hashFiles('Build/package-lock.json') }}"
+          restore-keys: "npm-"
+
+      - name: "Lint TypeScript"
+        run: "Build/Scripts/runTests.sh -b docker -s lintTypescript -n"
+
+      - name: "Type check"
+        run: "Build/Scripts/runTests.sh -b docker -s typecheckJs"
+
+      # Last, and the one that matters most: the compiled assets are committed,
+      # because neither composer nor a TER upload runs a node build. That makes
+      # it possible to change a source and forget to rebuild, which nothing else
+      # would notice — the artifact would simply go on serving the previous
+      # behaviour.
+      - name: "Ensure the committed assets match their sources"
+        run: "Build/Scripts/runTests.sh -b docker -s checkJsBuildClean"
 
   documentation:
     name: "documentation"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@
 # because "runTests.sh -s composerUpdate" starts with "rm -rf .Build" and would
 # otherwise throw the cache away on every dependency install.
 /.cache/
+
+# Dependency tree of the frontend asset build. The compiled artifacts below the
+# packages' "Resources/Public/" are committed, this is not: neither composer nor
+# a TER upload runs a node build, so the result has to ship while its sources and
+# tooling do not. The npm cache lands in "/.cache/npm", ignored above.
+/Build/node_modules
+
 /composer.json.orig
 /composer.json.testing
 /composer.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,20 +12,21 @@ handful of things that are easy to get wrong and expensive to discover later.
 
 ## Read this before changing code
 
-| Topic                                                | Page                                                                    |
-|------------------------------------------------------|-------------------------------------------------------------------------|
-| Container based tooling, every suite and option      | [Development environment](docs/development/environment.md)              |
-| What lives where, extension keys, split repositories | [Monorepo layout](docs/development/monorepo-layout.md)                  |
-| **Dual core setup — read this first**                | [Dual core setup](docs/development/dual-core-setup.md)                  |
-| The gates and what they check                        | [Quality gates](docs/development/quality-gates.md)                      |
-| Version differences, and the v15 blockers            | [Core version aware code](docs/architecture/core-version-aware-code.md) |
-| Service configuration and stateless services         | [Dependency injection](docs/architecture/dependency-injection.md)       |
-| `final`, `readonly`, injection, data objects         | [Class design](docs/architecture/class-design.md)                       |
-| **Quoting value lists and binding parameters**       | [Database queries](docs/architecture/database-queries.md)               |
-| Both suites, their strictness and their conventions  | [Testing](docs/testing/Index.md)                                        |
-| The shared functional test traits                    | [Testing helper](docs/testing/testing-helper.md)                        |
-| Commit message conventions                           | [Commit messages](docs/workflow/commit-messages.md)                     |
-| Analysing a backport instead of cherry-picking it    | [Backporting](docs/workflow/backporting.md)                             |
+| Topic                                                   | Page                                                                    |
+|---------------------------------------------------------|-------------------------------------------------------------------------|
+| Container based tooling, every suite and option         | [Development environment](docs/development/environment.md)              |
+| What lives where, extension keys, split repositories    | [Monorepo layout](docs/development/monorepo-layout.md)                  |
+| **Dual core setup — read this first**                   | [Dual core setup](docs/development/dual-core-setup.md)                  |
+| The gates and what they check                           | [Quality gates](docs/development/quality-gates.md)                      |
+| The TypeScript and SCSS build, and its committed output | [Frontend assets](docs/development/frontend-assets.md)                  |
+| Version differences, and the v15 blockers               | [Core version aware code](docs/architecture/core-version-aware-code.md) |
+| Service configuration and stateless services            | [Dependency injection](docs/architecture/dependency-injection.md)       |
+| `final`, `readonly`, injection, data objects            | [Class design](docs/architecture/class-design.md)                       |
+| **Quoting value lists and binding parameters**          | [Database queries](docs/architecture/database-queries.md)               |
+| Both suites, their strictness and their conventions     | [Testing](docs/testing/Index.md)                                        |
+| The shared functional test traits                       | [Testing helper](docs/testing/testing-helper.md)                        |
+| Commit message conventions                              | [Commit messages](docs/workflow/commit-messages.md)                     |
+| Analysing a backport instead of cherry-picking it       | [Backporting](docs/workflow/backporting.md)                             |
 
 ## Local additions and overrides
 
@@ -179,10 +180,19 @@ Build/Scripts/runTests.sh -t 13 -s unit packages/fgtclb/academic-persons/Tests/U
 wrong vendor tree and fails in confusing ways — always `composerUpdate` for the
 version you are about to test.
 
-The complete suite list is `cgl`, `cglHeader`, `checkRstRenderingAll`,
-`checkRstRenderingSingle`, `composer` (dispatch an arbitrary composer command),
-`composerUpdate`, `functional`, `lintPhp`, `openDocumentation`, `phpstan`,
-`phpstanGenerateBaseline`, `unit`, `unitRandom`; plus `help` and `update`.
+The complete suite list is `buildJs`, `cgl`, `cglHeader`, `checkJsBuildClean`,
+`checkRstRenderingAll`, `checkRstRenderingSingle`, `cleanJs`, `composer`
+(dispatch an arbitrary composer command), `composerUpdate`, `functional`,
+`lintPhp`, `lintTypescript`, `npm` (dispatch an arbitrary npm command),
+`openDocumentation`, `phpstan`, `phpstanGenerateBaseline`, `typecheckJs`,
+`unit`, `unitRandom`; plus `help` and `update`.
+
+The six frontend suites — `buildJs`, `checkJsBuildClean`, `cleanJs`,
+`lintTypescript`, `npm` and `typecheckJs` — are **core version independent**.
+They look at the sources and the committed artifacts, never at the installed
+core, so `-t` changes nothing for them and they need no `composerUpdate`. That
+makes them the only suites safe to run while the other core version's dependency
+set is installed.
 
 Test discovery: phpunit globs `packages/*/*/Tests/Unit/` and
 `packages/*/*/Tests/Functional/` across **all** extensions at once

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -210,6 +210,16 @@ cleanRenderedDocumentationFiles() {
     echo "done"
 }
 
+cleanJsFiles() {
+    # Intermediates of the frontend asset build only. The compiled artifacts
+    # below the packages are committed files and are never removed here - use
+    # "checkJsBuildClean", which deletes and rebuilds them on purpose.
+    echo -n "Clean frontend build related files ... "
+    rm -rf \
+        Build/node_modules
+    echo "done"
+}
+
 executeRstRendering() {
     local extensionFolderName="$1"
     local extensionFolder="packages/fgtclb/${extensionFolderName}"
@@ -255,18 +265,32 @@ Usage: $0 [options] [file]
 Options:
     -s <...>
         Specifies which test suite to run
+            - buildJs: compile the frontend sources of every extension into its Resources/Public/
             - cgl: test and fix all core php files
             - cglHeader: test and fix file header for all core php files
+            - checkJsBuildClean: check the committed frontend artifacts match their sources
             - checkRstRenderingAll: Test all extension .rst files for rendering errors
             - checkRstRenderingSingle: Test specified system extension .rst files for rendering errors
+            - cleanJs: clean up frontend build related files and folders (Build/node_modules)
             - composer: "composer" with all remaining arguments dispatched.
             - composerUpdate: "composer update", handy if host has no PHP
+            - functional: PHP functional tests
             - lintPhp: PHP linting
+            - lintTypescript: eslint over the TypeScript sources, fixes by default, "-n" to only check
+            - npm: "npm" with all remaining arguments dispatched, run in Build/
             - openDocumentation: Open a rendered extension documentation in the browser (only linux for now)
             - phpstan: phpstan tests
             - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
+            - typecheckJs: "tsc --noEmit" over the TypeScript sources, which the build does not do
             - unit (default): PHP unit tests
             - unitRandom: PHP unit tests in random order, "-- --random-order-seed=<number>" to use specific seed
+
+        The frontend suites - buildJs, checkJsBuildClean, lintTypescript, npm and
+        typecheckJs - run in a node container, and cleanJs runs on the host. All six are
+        core version independent: they look at the sources and the committed artifacts and
+        never at the installed core, so "-t" does not change what they do. They also need
+        no composerUpdate, which makes them the only suites that are safe to run while the
+        other core version's dependency set is installed.
 
     -b <docker|podman>
         Container environment:
@@ -377,6 +401,15 @@ Examples:
 
     # Run functional tests on postgres 16
     ./Build/Scripts/runTests.sh -s functional -d postgres -i 16
+
+    # Compile the frontend assets after a change below an extension's Resources/Private/
+    ./Build/Scripts/runTests.sh -s buildJs
+
+    # Prove the committed artifacts still match their sources, as CI does
+    ./Build/Scripts/runTests.sh -s checkJsBuildClean
+
+    # Add or update a node dependency, arguments after "--"
+    ./Build/Scripts/runTests.sh -s npm -- install --save-dev sass@latest
 EOF
 }
 
@@ -529,6 +562,12 @@ IMAGE_MARIADB="docker.io/mariadb:${DBMS_VERSION}"
 IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"
 IMAGE_RSTRENDERING="ghcr.io/typo3-documentation/render-guides:latest"
+# The image TYPO3 core itself uses for its JavaScript suites. It carries node 24
+# and npm 11, which match the "engines" range of Build/package.json, and it ships
+# git, which "checkJsBuildClean" needs. Pinned rather than ":latest", the way core
+# pins it - a node major changing under a committed build artifact is exactly the
+# kind of surprise that gate exists to catch, not to produce.
+IMAGE_NODEJS="ghcr.io/typo3/core-testing-nodejs24:1.1"
 
 # Detect arm64 and use a seleniarm image.
 # In a perfect world selenium would have a arm64 integrated, but that is not on the horizon.
@@ -587,6 +626,52 @@ fi
 
 # Suite execution
 case ${TEST_SUITE} in
+    buildJs)
+        COMMAND="cd Build && npm ci --no-audit --no-fund && npm run build"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name build-js-${SUFFIX} -e npm_config_cache=${ROOT_DIR}/.cache/npm ${IMAGE_NODEJS} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    checkJsBuildClean)
+        # The gate that makes committed build artifacts trustworthy. The compiled
+        # files below "Resources/Public/" are tracked because neither composer nor
+        # a TER upload runs a node build, and an artifact that no longer matches
+        # its source passes every review, ships to every installation and is only
+        # noticed when someone wonders why a fix had no effect.
+        #
+        # Only the files the build produces are deleted, not the output folders:
+        # those also hold vendored files that have no source - a minified library
+        # and its images - and deleting them would report a permanently dirty tree.
+        # "--list-outputs" derives that set from the same discovery the build uses,
+        # so a source file that stopped producing an output is caught as well, as
+        # a deletion in "git status".
+        #
+        # "safe.directory" is passed as environment rather than written to a config
+        # file: in CI the container runs against a checkout owned by another user,
+        # and git refuses to operate in a repository owned by someone else.
+        COMMAND="export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*'; \
+            cd Build && npm ci --no-audit --no-fund || exit 1; \
+            cd ${ROOT_DIR} || exit 1; \
+            (cd Build && npm run outputs --silent) | while read -r ARTIFACT; do rm -rf \"\${ARTIFACT}\"; done; \
+            (cd Build && npm run build) || exit 1; \
+            CHANGED=\$(git status --porcelain --untracked-files=all -- 'packages/*/*/Resources/Public/*' 'packages-dev/*/Resources/Public/*'); \
+            if [ -n \"\${CHANGED}\" ]; then \
+                echo ''; \
+                echo 'The committed frontend artifacts do not match their sources:'; \
+                echo \"\${CHANGED}\"; \
+                echo ''; \
+                git --no-pager diff -- 'packages/*/*/Resources/Public/*' 'packages-dev/*/Resources/Public/*'; \
+                echo ''; \
+                echo 'Run \"Build/Scripts/runTests.sh -s buildJs\" and commit the result.'; \
+                exit 1; \
+            fi; \
+            echo 'The committed frontend artifacts match their sources.'"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name check-js-build-clean-${SUFFIX} -e npm_config_cache=${ROOT_DIR}/.cache/npm ${IMAGE_NODEJS} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    cleanJs)
+        cleanJsFiles
+        SUITE_EXIT_CODE=$?
+        ;;
     cgl)
         # Active dry-run for cgl needs not "-n" but specific options
         CSFIXER_DRYRUN=""""
@@ -715,8 +800,36 @@ case ${TEST_SUITE} in
         # AGENTS.md). It holds drafts and partial snippets that are none of this
         # repository's business, and a snippet that does not parse would turn
         # this gate red for a file that is not part of the code base.
-        COMMAND="find . -name \\*.php ! -path "./.Build/\\*" ! -path "./.agent/\\*" ! -path "./core-1\\*/vendor/\\*" ! -path "./core-1\\*/public/\\*" ! -path "./core-1\\*/var/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
+        #
+        # "Build/node_modules" is the frontend build's dependency tree, and npm
+        # packages do ship PHP - "flatted" carries a PHP port of itself.
+        COMMAND="find . -name \\*.php ! -path "./.Build/\\*" ! -path "./.agent/\\*" ! -path "./Build/node_modules/\\*" ! -path "./core-1\\*/vendor/\\*" ! -path "./core-1\\*/public/\\*" ! -path "./core-1\\*/var/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name lint-php-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    lintTypescript)
+        # Mirrors "cgl": it fixes in place, and only checks when "-n" is given.
+        NPM_LINT_SCRIPT="lint:fix"
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            NPM_LINT_SCRIPT="lint"
+        fi
+        COMMAND="cd Build && npm ci --no-audit --no-fund && npm run ${NPM_LINT_SCRIPT}"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name lint-typescript-${SUFFIX} -e npm_config_cache=${ROOT_DIR}/.cache/npm ${IMAGE_NODEJS} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    npm)
+        # Escape hatch, mirroring the "composer" suite:
+        #   ./Build/Scripts/runTests.sh -s npm -- install --save-dev sass@latest
+        # The working directory is overridden to Build/, where package.json lives.
+        COMMAND=(npm "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} -w ${ROOT_DIR}/Build --name npm-${SUFFIX} -e npm_config_cache=${ROOT_DIR}/.cache/npm ${IMAGE_NODEJS} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    typecheckJs)
+        # Its own suite precisely because esbuild does not type check: without
+        # this the build succeeds on TypeScript that does not compile.
+        COMMAND="cd Build && npm ci --no-audit --no-fund && npm run typecheck"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name typecheck-js-${SUFFIX} -e npm_config_cache=${ROOT_DIR}/.cache/npm ${IMAGE_NODEJS} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     openDocumentation)

--- a/Build/esbuild.mjs
+++ b/Build/esbuild.mjs
@@ -1,0 +1,259 @@
+/**
+ * The frontend asset build of every extension in this mono repository.
+ *
+ *   node esbuild.mjs                 the build, and what is committed
+ *   node esbuild.mjs --dev           same, with an inline source map
+ *   node esbuild.mjs --list-outputs  print the files the build would write
+ *
+ * Called through "Build/Scripts/runTests.sh -s buildJs", which runs it in a
+ * container so nothing has to be installed on the host.
+ *
+ * It does not type check — esbuild never does. "typecheckJs" is the type gate
+ * and runs as its own suite.
+ *
+ * See "docs/development/frontend-assets.md".
+ */
+import { build } from 'esbuild';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as sass from 'sass';
+
+const buildRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(buildRoot, '..');
+const development = process.argv.slice(2).includes('--dev');
+const listOutputs = process.argv.slice(2).includes('--list-outputs');
+
+/**
+ * The browser floor. TYPO3 no longer polyfills the import map mechanism on
+ * either supported core version, so targeting anything older would emit
+ * transpiled output for browsers that cannot resolve the module anyway.
+ */
+const target = ['chrome89', 'firefox108', 'safari16.4'];
+
+/**
+ * Where a package keeps its sources, and where the result belongs. Both are
+ * optional: a package that has neither directory contributes nothing, and
+ * adding one is picked up without touching any configuration.
+ */
+const passes = [
+    { sources: 'Resources/Private/TypeScript', output: 'Resources/Public/JavaScript', extensions: ['.ts'] },
+    { sources: 'Resources/Private/Scss', output: 'Resources/Public/Css', extensions: ['.scss', '.css'] },
+];
+
+/**
+ * Every extension in the repository, found rather than listed.
+ *
+ * A directory counts when it declares an extension key, which is what makes it
+ * a TYPO3 extension with a "Resources/" tree — and hands over the key for the
+ * import map prefix in the same step.
+ */
+const extensions = () => {
+    const candidates = [];
+    for (const group of ['packages', 'packages-dev']) {
+        const groupPath = resolve(repositoryRoot, group);
+        if (!existsSync(groupPath)) {
+            continue;
+        }
+        for (const entry of readdirSync(groupPath, { withFileTypes: true })) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            // "packages/" nests one level deeper, by vendor.
+            const path = join(groupPath, entry.name);
+            const nested = group === 'packages'
+                ? readdirSync(path, { withFileTypes: true })
+                    .filter((child) => child.isDirectory())
+                    .map((child) => join(path, child.name))
+                : [path];
+            candidates.push(...nested);
+        }
+    }
+
+    return candidates
+        .map((path) => {
+            const manifest = join(path, 'composer.json');
+            if (!existsSync(manifest)) {
+                return null;
+            }
+            const key = JSON.parse(readFileSync(manifest, 'utf8'))?.extra?.['typo3/cms']?.['extension-key'];
+            return key ? { path, key } : null;
+        })
+        .filter(Boolean)
+        .sort((one, other) => one.path.localeCompare(other.path));
+};
+
+/**
+ * Every source file below a directory, recursively.
+ *
+ * A file whose name starts with an underscore is a partial: it is reached
+ * through "@use" from an entry point and never becomes one itself. That is the
+ * sass convention, and applying it to TypeScript as well costs nothing.
+ */
+const entryPointsIn = (directory, allowed) => {
+    const found = [];
+    const walk = (current) => {
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            const path = join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(path);
+            } else if (allowed.includes(extname(entry.name)) && !entry.name.startsWith('_')) {
+                found.push(path);
+            }
+        }
+    };
+    walk(directory);
+
+    return found.sort();
+};
+
+/**
+ * Hands the SCSS to dart-sass and the result back to esbuild as CSS, so that
+ * "@use", partials and the url() rewriting all happen in the tool that is good
+ * at each of them.
+ *
+ * "resolveDir" is what makes a relative url() in a partial resolve against the
+ * file that wrote it rather than against the entry point.
+ */
+const sassPlugin = {
+    name: 'sass',
+    setup(pluginBuild) {
+        pluginBuild.onLoad({ filter: /\.scss$/ }, (arguments_) => {
+            const compiled = sass.compile(arguments_.path, {
+                loadPaths: [dirname(arguments_.path)],
+                style: 'expanded',
+                quietDeps: true,
+            });
+
+            return {
+                contents: compiled.css,
+                loader: 'css',
+                resolveDir: dirname(arguments_.path),
+                watchFiles: compiled.loadedUrls
+                    .filter((url) => url.protocol === 'file:')
+                    .map((url) => fileURLToPath(url)),
+            };
+        });
+    },
+};
+
+const shared = {
+    target,
+    // esbuild writes the path of each input into the bundled CSS as a comment,
+    // relative to its working directory. Pinning that to the repository root
+    // makes the emitted bytes the same whether the build was started from
+    // "Build/" or from the root — which a gate comparing committed artifacts
+    // against a fresh build depends on.
+    absWorkingDir: repositoryRoot,
+    // Never minified. The emitted files are meant to be readable, and nothing
+    // here is large enough for the size to be worth the loss.
+    minify: false,
+    // Source maps are never committed. The development build carries an inline
+    // one instead, so no ".map" file exists to be ignored or shipped.
+    sourcemap: development ? 'inline' : false,
+    legalComments: 'none',
+    logLevel: listOutputs ? 'silent' : 'info',
+    // Anything a stylesheet or module refers to is emitted next to the result,
+    // so a relative reference keeps working in a composer installation where
+    // "Resources/Public/" is published.
+    loader: {
+        '.png': 'file',
+        '.jpg': 'file',
+        '.jpeg': 'file',
+        '.gif': 'file',
+        '.svg': 'file',
+        '.webp': 'file',
+        '.avif': 'file',
+        '.woff': 'file',
+        '.woff2': 'file',
+    },
+    assetNames: 'assets/[name]-[hash]',
+};
+
+/**
+ * What the build writes, derived from the sources without running it.
+ *
+ * "checkJsBuildClean" deletes exactly this set before rebuilding. It cannot
+ * simply delete the output directories: they also hold vendored files that have
+ * no source — a minified library and its images — and those must survive.
+ *
+ * Assets emitted through the loaders above are not listed, because their name
+ * carries a content hash that is only known after the build. They live below
+ * "assets/", which the gate removes wholesale.
+ */
+const outputsFor = (extension) => {
+    const outputs = [];
+    for (const pass of passes) {
+        const sourceRoot = join(extension.path, pass.sources);
+        if (!existsSync(sourceRoot)) {
+            continue;
+        }
+        for (const entryPoint of entryPointsIn(sourceRoot, pass.extensions)) {
+            const stem = relative(sourceRoot, entryPoint).replace(/\.[^.]+$/, '');
+            const suffix = pass.extensions.includes('.ts') ? '.js' : '.css';
+            outputs.push(join(extension.path, pass.output, stem + suffix));
+        }
+    }
+
+    return outputs;
+};
+
+const found = extensions();
+
+if (listOutputs) {
+    for (const extension of found) {
+        for (const output of outputsFor(extension)) {
+            process.stdout.write(relative(repositoryRoot, output) + '\n');
+        }
+        for (const pass of passes) {
+            const assets = join(extension.path, pass.output, 'assets');
+            if (existsSync(assets)) {
+                process.stdout.write(relative(repositoryRoot, assets) + '\n');
+            }
+        }
+    }
+    process.exit(0);
+}
+
+let built = 0;
+for (const extension of found) {
+    for (const pass of passes) {
+        const sourceRoot = join(extension.path, pass.sources);
+        if (!existsSync(sourceRoot)) {
+            continue;
+        }
+        const entryPoints = entryPointsIn(sourceRoot, pass.extensions);
+        if (entryPoints.length === 0) {
+            continue;
+        }
+
+        const isScript = pass.extensions.includes('.ts');
+        await build({
+            ...shared,
+            entryPoints,
+            outbase: sourceRoot,
+            outdir: join(extension.path, pass.output),
+            // Scripts are emitted one module per source module, so every import
+            // survives as written and is resolved in the browser through the
+            // TYPO3 import map — which is what gives each one its "?bust="
+            // cache key. Stylesheets are bundled, because "@use" and url() have
+            // to be resolved at build time.
+            bundle: !isScript,
+            ...(isScript ? { format: 'esm', platform: 'browser', tsconfig: resolve(buildRoot, 'tsconfig.json') } : {}),
+            ...(isScript ? {} : { plugins: [sassPlugin] }),
+            banner: isScript
+                ? { js: `/* Generated from ${pass.sources} — do not edit. */` }
+                : { css: `/* Generated from ${pass.sources} — do not edit. */` },
+        });
+        built += entryPoints.length;
+    }
+}
+
+if (built === 0) {
+    process.stdout.write(
+        'No frontend sources found. Add a file below "Resources/Private/TypeScript/"\n' +
+        'or "Resources/Private/Scss/" of an extension and it is picked up here.\n',
+    );
+} else {
+    process.stdout.write(`\nBuilt ${built} entry point(s) across ${found.length} extension(s).\n`);
+}

--- a/Build/eslint.config.mjs
+++ b/Build/eslint.config.mjs
@@ -1,0 +1,78 @@
+/**
+ * eslint 9 flat configuration.
+ *
+ *   Build/Scripts/runTests.sh -s lintTypescript        fix in place
+ *   Build/Scripts/runTests.sh -s lintTypescript -n     check only, as CI does
+ *
+ * Type aware linting is deliberately not enabled. "tsc --noEmit" is the type
+ * gate and runs as its own suite, so the rules here are the ones a compiler
+ * does not have.
+ *
+ * ## Every path below is relative to the repository root, not to this file
+ *
+ * eslint refuses to lint a file above the base path of its configuration, and
+ * the sources live in the packages while this file lives in "Build/" — so a
+ * configuration rooted here could never reach them. The base path is the
+ * directory eslint was started in **whenever the configuration is named with
+ * "--config"**, and the directory of the configuration file only when it was
+ * found by searching upwards.
+ *
+ * The "lint" script of "Build/package.json" therefore changes into the
+ * repository root and names this file explicitly. Moving the file up there
+ * instead would have been the obvious alternative and does not work: its plugin
+ * imports resolve through "node_modules" directories above *it*, and the only
+ * manifest in this repository is the one next to it.
+ *
+ * See "docs/development/frontend-assets.md".
+ */
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+/**
+ * The house rules, applied to every source tree alike. Extracted only so the
+ * blocks below cannot drift apart.
+ */
+const houseRules = {
+    '@typescript-eslint/explicit-function-return-type': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    eqeqeq: 'error',
+    'no-console': 'error',
+    'prefer-const': 'error',
+};
+
+export default tseslint.config(
+    {
+        // Not ours: the vendor trees, the development instances, the generated
+        // artifacts, and the agent working tree.
+        ignores: [
+            '**/node_modules/**',
+            '.Build/**',
+            '.agent/**',
+            'core-*/**',
+            'documentation-rendered/**',
+            '**/Documentation-GENERATED-temp/**',
+            '**/Resources/Public/**',
+        ],
+    },
+    js.configs.recommended,
+    tseslint.configs.recommended,
+    {
+        // The frontend and backend sources of every extension.
+        files: [
+            'packages/*/*/Resources/Private/TypeScript/**/*.ts',
+            'packages-dev/*/Resources/Private/TypeScript/**/*.ts',
+        ],
+        languageOptions: {
+            globals: globals.browser,
+        },
+        rules: houseRules,
+    },
+    {
+        // The build configuration itself runs in node, not in a browser.
+        files: ['Build/*.mjs'],
+        languageOptions: {
+            globals: globals.nodeBuiltin,
+        },
+    },
+);

--- a/Build/package-lock.json
+++ b/Build/package-lock.json
@@ -1,0 +1,2409 @@
+{
+    "name": "academic-extensions",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "academic-extensions",
+            "license": "GPL-2.0-or-later",
+            "devDependencies": {
+                "@eslint/js": "^9.39.0",
+                "@types/node": "^24.10.1",
+                "esbuild": "^0.25.11",
+                "eslint": "^9.39.0",
+                "globals": "^16.5.0",
+                "sass": "^1.93.2",
+                "typescript": "^5.9.3",
+                "typescript-eslint": "^8.46.2"
+            },
+            "engines": {
+                "node": ">=24",
+                "npm": ">=11"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.3.0",
+                "minimatch": "^3.1.5",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@parcel/watcher": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3",
+                "is-glob": "^4.0.3",
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.18.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+            "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/type-utils": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "ignore": "^7.0.5",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.67.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+            "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.8"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.67.0",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.5",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/immutable": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/sass": {
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+            "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^5.0.0",
+                "immutable": "^5.1.5",
+                "source-map-js": ">=0.6.2 <2.0.0"
+            },
+            "bin": {
+                "sass": "sass.js"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher": "^2.4.1"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/ts-api-utils": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+            "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.67.0",
+                "@typescript-eslint/parser": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/Build/package.json
+++ b/Build/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "academic-extensions",
+    "description": "Frontend asset build of the fgtclb/academic-extensions TYPO3 extensions.",
+    "license": "GPL-2.0-or-later",
+    "private": true,
+    "type": "module",
+    "engines": {
+        "node": ">=24",
+        "npm": ">=11"
+    },
+    "scripts": {
+        "build": "node esbuild.mjs",
+        "build:dev": "node esbuild.mjs --dev",
+        "outputs": "node esbuild.mjs --list-outputs",
+        "lint": "cd .. && eslint --no-error-on-unmatched-pattern --config Build/eslint.config.mjs .",
+        "lint:fix": "npm run lint -- --fix",
+        "typecheck": "node typecheck.mjs"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.39.0",
+        "@types/node": "^24.10.1",
+        "esbuild": "^0.25.11",
+        "eslint": "^9.39.0",
+        "globals": "^16.5.0",
+        "sass": "^1.93.2",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.46.2"
+    }
+}

--- a/Build/tsconfig.json
+++ b/Build/tsconfig.json
@@ -1,0 +1,54 @@
+// TypeScript is installed for "tsc --noEmit" only: esbuild performs the emit and
+// does not type check, which is why "typecheckJs" is a suite of its own — a build
+// that is green and a type check that is red have to be distinguishable.
+//
+// One project covers every extension. The sources of the extensions do not
+// import each other, so there is nothing a per-extension project would isolate
+// that this one does not.
+//
+// tsconfig.json is JSONC, and both TypeScript and esbuild read the comments.
+{
+    "compilerOptions": {
+        "target": "es2022",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "es2022",
+            "dom",
+            "dom.iterable"
+        ],
+        // No ambient @types packages. These sources run in a browser, not in node.
+        "types": [],
+
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitOverride": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "skipLibCheck": true,
+
+        "noEmit": true,
+
+        // A module that imports another module of the same extension does so by
+        // the bare specifier the TYPO3 import map resolves in the browser, never
+        // relatively — only a specifier that goes through the map receives the
+        // "?bust=" cache key, and a relative one could pair a fresh module with
+        // a stale cached dependency.
+        //
+        // TypeScript has to be told where those specifiers live. Add an entry
+        // here when an extension gains a module that is imported by another;
+        // an extension whose modules are standalone needs none.
+        //
+        // No "baseUrl": with "moduleResolution": "bundler" the targets resolve
+        // relative to this file, and a "baseUrl" would additionally make every
+        // directory below it importable as a bare specifier.
+        "paths": {}
+    },
+    "include": [
+        "../packages/*/*/Resources/Private/TypeScript/**/*.ts",
+        "../packages-dev/*/Resources/Private/TypeScript/**/*.ts"
+    ]
+}

--- a/Build/typecheck.mjs
+++ b/Build/typecheck.mjs
@@ -1,0 +1,47 @@
+/**
+ * The type gate, which esbuild does not provide: it transpiles TypeScript
+ * without ever checking it, so a build can be green on code that does not
+ * compile.
+ *
+ *   node typecheck.mjs        as "npm run typecheck", and as the "typecheckJs" suite
+ *
+ * This exists as a wrapper rather than a plain "tsc --noEmit" for one reason:
+ * an extension is not required to ship TypeScript, and today none does. With
+ * nothing to check, "tsc" aborts with TS18003 "No inputs were found in config
+ * file", which is a configuration error rather than a type error — and would
+ * make the suite red for a repository that is perfectly fine.
+ *
+ * The source list comes from the build itself, so the two cannot disagree about
+ * what counts as a source.
+ *
+ * See "docs/development/frontend-assets.md".
+ */
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const buildRoot = dirname(fileURLToPath(import.meta.url));
+
+const outputs = spawnSync(process.execPath, [resolve(buildRoot, 'esbuild.mjs'), '--list-outputs'], {
+    cwd: buildRoot,
+    encoding: 'utf8',
+});
+
+if (outputs.status !== 0) {
+    process.stderr.write(outputs.stderr ?? 'Could not determine the frontend sources.\n');
+    process.exit(1);
+}
+
+const scripts = outputs.stdout.split('\n').filter((line) => line.endsWith('.js'));
+
+if (scripts.length === 0) {
+    process.stdout.write('No TypeScript sources to check.\n');
+    process.exit(0);
+}
+
+const result = spawnSync(resolve(buildRoot, 'node_modules/.bin/tsc'), ['--noEmit'], {
+    cwd: buildRoot,
+    stdio: 'inherit',
+});
+
+process.exit(result.status ?? 1);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,29 @@ growing baseline is a defect — prefer fixing the finding.
 
 → [Quality gates](docs/development/quality-gates.md)
 
+## Frontend assets
+
+TypeScript and SCSS sources live in the extension they belong to, below
+`Resources/Private/TypeScript/` and `Resources/Private/Scss/`, and compile into
+its `Resources/Public/`. Neither directory has to exist; adding one is picked up
+without any configuration change.
+
+```bash
+Build/Scripts/runTests.sh -s buildJs             # compile, then commit the result
+Build/Scripts/runTests.sh -s checkJsBuildClean   # prove the artifacts match, as CI does
+Build/Scripts/runTests.sh -s lintTypescript -n   # eslint, omit "-n" to fix
+Build/Scripts/runTests.sh -s typecheckJs         # tsc --noEmit
+```
+
+The compiled files are **committed**, because neither composer nor a TER upload
+runs a node build. That makes it possible to change a source and forget to
+rebuild, which nothing else would notice — so `checkJsBuildClean` is a required
+gate rather than a convenience.
+
+These suites are core version independent: no `-t`, no `composerUpdate`.
+
+→ [Frontend assets](docs/development/frontend-assets.md)
+
 ## Running tests
 
 ```bash

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -22,6 +22,7 @@ such manual per extension; this tree is the single, repository-wide counterpart.
 | [Monorepo layout](development/monorepo-layout.md)     | What each directory is, the packages and their split repositories, extension keys, path package versions. |
 | [Dual core setup](development/dual-core-setup.md)     | Running against TYPO3 v13 and v14, and the rule that avoids false positives.                              |
 | [Quality gates](development/quality-gates.md)         | Every gate and its configuration, PHPStan per core version, continuous integration.                       |
+| [Frontend assets](development/frontend-assets.md)     | The TypeScript and SCSS build, and why the compiled result is committed.                                  |
 
 ## [Architecture](architecture/Index.md)
 

--- a/docs/development/Index.md
+++ b/docs/development/Index.md
@@ -36,6 +36,7 @@ Everything has to pass for **both** supported core versions, each after its own
 | [Monorepo layout](monorepo-layout.md)     | What each directory is for, the twelve extensions and their split repositories, extension keys, how a path package gets its version. |
 | [Dual core setup](dual-core-setup.md)     | Why the installed dependency set must match `-t`, how to check which core is installed, and how tests are scoped per version.        |
 | [Quality gates](quality-gates.md)         | Each gate and what it actually runs, PHPStan per core version, and how continuous integration stages them.                           |
+| [Frontend assets](frontend-assets.md)     | The TypeScript and SCSS build, where sources live, how the result is loaded, and why the committed artifacts need a gate.            |
 
 ## See also
 

--- a/docs/development/frontend-assets.md
+++ b/docs/development/frontend-assets.md
@@ -1,0 +1,182 @@
+# Frontend assets
+
+TypeScript and SCSS sources live in the extension they belong to, are compiled
+by one build for the whole repository, and the result is committed.
+
+## Layout
+
+Sources sit below `Resources/Private/`, which TYPO3 does not serve, and compile
+into the sibling `Resources/Public/`:
+
+```
+packages/fgtclb/<extension>/
+  Resources/Private/TypeScript/{backend,frontend}/**.ts
+  Resources/Private/Scss/{backend,frontend}/**.scss
+        ->  Resources/Public/JavaScript/{backend,frontend}/**.js
+        ->  Resources/Public/Css/{backend,frontend}/**.css
+```
+
+The same applies to `packages-dev/*`. Nothing is required to exist: an extension
+without those directories contributes nothing to the build, and adding one is
+picked up without touching any configuration.
+
+The `backend/` and `frontend/` split is a convention rather than a mechanism —
+the build mirrors whatever directory structure it finds. Keeping the two apart
+matters because a TYPO3 import map maps a prefix, so a backend module can be
+kept off a frontend page by mapping only the `frontend/` prefix.
+
+A file whose name starts with an underscore is a **partial**: it is reached
+through `@use` and never becomes an entry point of its own. That is the sass
+convention, and the build applies it to TypeScript as well.
+
+## The build
+
+One script, `Build/esbuild.mjs`, driven by npm scripts and run in a container:
+
+| Suite               | Runs                                                      | Purpose                                                                                  |
+|---------------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------|
+| `buildJs`           | `npm ci && npm run build`                                 | Compiles every extension's sources. Run after a source change, and commit the result.    |
+| `checkJsBuildClean` | delete the outputs, rebuild, assert `git status` is empty | The gate that makes committed artifacts trustworthy. Runs in CI.                         |
+| `lintTypescript`    | `npm run lint:fix`, or `lint` with `-n`                   | eslint 9 with typescript-eslint. Mirrors `cgl`: fixes by default, checks only with `-n`. |
+| `typecheckJs`       | `npm run typecheck`                                       | `tsc --noEmit`, which the build does not do.                                             |
+| `npm`               | `npm "$@"` with the working directory set to `Build/`     | Escape hatch, mirroring the `composer` suite.                                            |
+| `cleanJs`           | `rm -rf Build/node_modules`                               | Intermediates only. It never removes a compiled artifact — those are committed files.    |
+
+```bash
+Build/Scripts/runTests.sh -s buildJs
+Build/Scripts/runTests.sh -s checkJsBuildClean
+Build/Scripts/runTests.sh -s lintTypescript -n
+Build/Scripts/runTests.sh -s typecheckJs
+Build/Scripts/runTests.sh -s npm -- install --save-dev sass@latest
+```
+
+All six are **core version independent**. They look at the sources and the
+committed artifacts and never at the installed core, so `-t` does not change
+what they do and no `composerUpdate` is needed. That makes them the only suites
+that are safe to run while the other core version's dependency set is installed.
+
+The image is pinned: `ghcr.io/typo3/core-testing-nodejs24:1.1`, the one TYPO3
+core uses for its own JavaScript suites. It carries node 24 and npm 11, matching
+the `engines` range of `Build/package.json`, and it ships git, which
+`checkJsBuildClean` needs. Pinned rather than `:latest` on purpose — a node
+major changing under a committed artifact is the kind of surprise the gate
+exists to catch, not to produce.
+
+The npm cache lands in `.cache/npm`, next to the composer cache and for the same
+reason: `composerUpdate` starts with `rm -rf .Build`, so a cache inside `.Build/`
+would be discarded on every dependency install.
+
+## What the build does
+
+**Scripts** are emitted one module per source module, unbundled, as ES modules.
+Every import survives into the output exactly as written and is resolved in the
+browser by the TYPO3 import map. That is what gives each module its `?bust=`
+cache key: only a specifier that goes through the map receives one, while a
+relative specifier resolves against the URL of the importing module and drops
+the query string — so a deploy could pair a fresh entry module with a stale
+cached dependency. Modules of one extension therefore import each other by their
+bare specifier, never relatively.
+
+**Stylesheets** are bundled, because `@use` and `url()` have to be resolved at
+build time. dart-sass compiles the SCSS and hands the result to esbuild as CSS,
+so each tool does the part it is good at.
+
+**Referenced files** — images, icons, fonts — are emitted into
+`Resources/Public/Css/assets/<name>-<hash>.<ext>` and the `url()` is rewritten to
+point at them relatively. That is what keeps a stylesheet working in a composer
+installation, where only `Resources/Public/` is published.
+
+Nothing is minified: the emitted files are meant to be readable, and nothing here
+is large enough for the size to be worth the loss. Source maps are never
+committed; `npm run build:dev` carries an inline one instead, and differs from
+the committed build in nothing else.
+
+## Loading the result
+
+The compiled JavaScript is an ES module, which a classic `<script src>` cannot
+execute. There is **no TypoScript key that loads an ES module** — the frontend
+request handler only knows `includeJSLibs`, `includeJSFooterlibs`, `includeJS`
+and `includeJSFooter`, all of which emit a classic script tag.
+
+So an extension shipping TypeScript declares its prefix:
+
+```php
+// packages/fgtclb/<extension>/Configuration/JavaScriptModules.php
+return [
+    'dependencies' => ['core'],
+    'imports' => [
+        '@fgtclb/<extension>/' => 'EXT:<extension_key>/Resources/Public/JavaScript/',
+    ],
+];
+```
+
+and its templates load a module rather than a script:
+
+```html
+<f:asset.module identifier="@fgtclb/<extension>/frontend/example.js" />
+```
+
+CSS is unaffected and keeps loading through `f:asset.css` or
+`page.includeCSS`.
+
+Verified present on TYPO3 13.4.34 and 14.3.6: the `f:asset.module` ViewHelper,
+`AssetCollector::addJavaScriptModule()`, and `ImportMap` reading
+`Configuration/JavaScriptModules.php` from every package.
+
+## Artifacts are committed, and that makes a gate mandatory
+
+`Resources/Public/JavaScript/**` and `Resources/Public/Css/**` are tracked files.
+This is not a preference:
+
+- **Composer distribution requires it.** `composer require` runs no node build.
+- **TER requires it.** A TER upload is an archive of the working tree; there is
+  no build hook.
+- **Core does the same** — its shipped JavaScript is tracked and only the
+  intermediates are ignored.
+
+The sources stay out of the distributed package instead: every package's
+`.gitattributes` marks `Resources/Private/Scss` and `Resources/Private/TypeScript`
+as `export-ignore`, so they are absent from the archive composer downloads for a
+`dist` install, while `Resources/Private/Language` and the rest still ship.
+
+The consequence has to be stated plainly: **a committed artifact that no longer
+matches its source is a silent defect.** It passes every review, ships to every
+installation, and is only noticed when someone wonders why a fix had no effect.
+`checkJsBuildClean` is therefore mandatory, not optional.
+
+That gate cannot simply delete the output directories the way a single-extension
+repository can. `academic_partners` keeps vendored files there that have no
+source — a minified mapping library, its plugin, their stylesheets and their
+images — and deleting them would report a permanently dirty tree. So
+`node esbuild.mjs --list-outputs` derives the exact set of files the build would
+write, from the same discovery the build itself uses, and the gate removes only
+those. A source that stopped producing an output is still caught, as a deletion
+in `git status`.
+
+## Things that were got wrong once already
+
+- **The build must not depend on the working directory.** esbuild writes the
+  path of each input into the bundled CSS as a comment, relative to its working
+  directory, so a build started from the repository root produced different
+  bytes than one started from `Build/` — and the clean gate would have gone red
+  for no reason. `absWorkingDir` is pinned to the repository root.
+- **A git pathspec containing a wildcard must match the whole path.**
+  `git status -- 'packages/*/*/Resources/Public'` matches nothing, because the
+  leading-directory shortcut does not apply once a pattern contains a wildcard.
+  The gate uses `'packages/*/*/Resources/Public/*'`.
+- **`tsc` fails when it has nothing to check.** With no TypeScript anywhere it
+  aborts with TS18003, a configuration error rather than a type error, which
+  would make the suite red for a repository that is perfectly fine.
+  `Build/typecheck.mjs` asks the build for the source list first and skips when
+  it is empty.
+- **npm packages ship PHP.** `flatted` carries a PHP port of itself, so
+  `Build/node_modules` is excluded from `lintPhp`.
+
+## See also
+
+- [Development environment](environment.md) — the harness these suites run in.
+- [Quality gates](quality-gates.md) — where they sit among the other gates.
+- [Monorepo layout](monorepo-layout.md) — the packages and their
+  `.gitattributes`.
+- [Changelog and documentation](../workflow/changelog-and-documentation.md) —
+  a changed asset path is user facing and needs an entry.

--- a/packages/fgtclb/academic-base/.gitattributes
+++ b/packages/fgtclb/academic-base/.gitattributes
@@ -14,3 +14,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-bite-jobs/.gitattributes
+++ b/packages/fgtclb/academic-bite-jobs/.gitattributes
@@ -14,3 +14,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-contact4pages/.gitattributes
+++ b/packages/fgtclb/academic-contact4pages/.gitattributes
@@ -33,3 +33,8 @@ docker-compose.yaml export-ignore
 *.txt text eol=lf
 *.typoscript text eol=lf
 *.tsconfig text eol=lf
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss/ export-ignore
+/Resources/Private/TypeScript/ export-ignore

--- a/packages/fgtclb/academic-jobs/.gitattributes
+++ b/packages/fgtclb/academic-jobs/.gitattributes
@@ -14,3 +14,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-partners/.gitattributes
+++ b/packages/fgtclb/academic-partners/.gitattributes
@@ -35,3 +35,8 @@ docker-compose.yaml export-ignore
 *.txt text eol=lf
 *.typoscript text eol=lf
 *.tsconfig text eol=lf
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss/ export-ignore
+/Resources/Private/TypeScript/ export-ignore

--- a/packages/fgtclb/academic-persons-edit/.gitattributes
+++ b/packages/fgtclb/academic-persons-edit/.gitattributes
@@ -13,3 +13,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-persons-sync/.gitattributes
+++ b/packages/fgtclb/academic-persons-sync/.gitattributes
@@ -9,3 +9,8 @@
 /.ddev export-ignore
 /.gitlab export-ignore
 /config export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-persons/.gitattributes
+++ b/packages/fgtclb/academic-persons/.gitattributes
@@ -15,3 +15,8 @@
 /patches export-ignore
 /Tests export-ignore
 /Build export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-programs/.gitattributes
+++ b/packages/fgtclb/academic-programs/.gitattributes
@@ -35,3 +35,8 @@ docker-compose.yaml export-ignore
 *.txt text eol=lf
 *.typoscript text eol=lf
 *.tsconfig text eol=lf
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss/ export-ignore
+/Resources/Private/TypeScript/ export-ignore

--- a/packages/fgtclb/academic-projects/.gitattributes
+++ b/packages/fgtclb/academic-projects/.gitattributes
@@ -14,3 +14,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/academic-study-plan/.gitattributes
+++ b/packages/fgtclb/academic-study-plan/.gitattributes
@@ -14,3 +14,8 @@
 /Migrations export-ignore
 /patches export-ignore
 /Tests export-ignore
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss export-ignore
+/Resources/Private/TypeScript export-ignore

--- a/packages/fgtclb/typo3-category-types/.gitattributes
+++ b/packages/fgtclb/typo3-category-types/.gitattributes
@@ -35,3 +35,8 @@ docker-compose.yaml export-ignore
 *.txt text eol=lf
 *.typoscript text eol=lf
 *.tsconfig text eol=lf
+
+# Frontend build sources. They are compiled into "Resources/Public/",
+# which ships; the sources themselves do not.
+/Resources/Private/Scss/ export-ignore
+/Resources/Private/TypeScript/ export-ignore


### PR DESCRIPTION
Adds a TypeScript and SCSS build for the whole mono repository, adapted from
`sbuerk/extension-skeleton`.

> **Stacked on #459**, which is stacked on #458 and #457. The base of this pull
> request is `ace-390-readme-contributing`. GitHub retargets it as the ones below
> it merge.

## Sources stay in the extension

```
packages/fgtclb/<extension>/Resources/Private/TypeScript/{backend,frontend}/**.ts
packages/fgtclb/<extension>/Resources/Private/Scss/{backend,frontend}/**.scss
        ->  …/Resources/Public/JavaScript/{backend,frontend}/**.js
        ->  …/Resources/Public/Css/{backend,frontend}/**.css
```

Neither directory has to exist. The build discovers extensions by their
`extra.typo3/cms.extension-key`, so an extension without sources contributes
nothing and adding a folder is picked up with no configuration change. Works for
`packages/` and `packages-dev/` alike. A file starting with `_` is a partial and
never an entry point.

**This pull request adds no sources** — ACE-392 migrates the existing assets. So
the build currently reports "No frontend sources found", which is a state it has
to handle, and does.

## Decisions

* **sass**, via a small esbuild plugin. The skeleton has no SCSS at all; this is
  an addition rather than an adoption.
* **ES modules**, unbundled, one emitted module per source module — so every
  import keeps its `?bust=` cache key through the TYPO3 import map.
* Referenced images/fonts are emitted to `Resources/Public/Css/assets/` with the
  `url()` rewritten relatively, which is what keeps a stylesheet working in a
  composer installation.
* Nothing minified, no committed source maps.

## Six suites, all core version independent

`buildJs`, `checkJsBuildClean`, `lintTypescript`, `npm`, `typecheckJs`, `cleanJs`.
They look at sources and artifacts, never at the installed core — no `-t`, no
`composerUpdate`. CI runs them in one job with no matrix. Image pinned to
`ghcr.io/typo3/core-testing-nodejs24:1.1`; npm cache in `.cache/npm`.

## The gate, and why it is not the skeleton's

Compiled files are committed, because neither composer nor a TER upload runs a
node build — so an artifact that drifts from its source is a silent defect.

The skeleton's gate deletes `Resources/Public/JavaScript` and `Css` wholesale
and rebuilds. Here that would delete `academic_partners`' vendored Leaflet,
markerCluster, their stylesheets and their images — none of which has a source —
and report a permanently dirty tree. So `esbuild.mjs --list-outputs` derives the
exact set the build would write, from the same discovery the build uses, and the
gate removes only that. A source that stopped producing an output is still
caught, as a deletion.

## Three defects found and fixed while building it

| Symptom | Cause | Fix |
|---|---|---|
| A build from the repo root produced different bytes than one from `Build/` | esbuild writes each input's path into the bundled CSS as a **cwd-relative** comment | `absWorkingDir` pinned to the repository root |
| The gate reported success with a demonstrably stale artifact | a git pathspec **containing a wildcard must match the whole path**, so `packages/*/*/Resources/Public` matched nothing | `packages/*/*/Resources/Public/*` |
| `typecheckJs` failed on a clean repository | `tsc` treats "no inputs" as error TS18003 — a configuration error, not a type error | `Build/typecheck.mjs` asks the build for the source list and skips when empty |

Also: `Build/node_modules/flatted/php/flatted.php` exists, so `node_modules` is
now excluded from `lintPhp`.

## Verified, not assumed

Every claim below was executed, not reasoned about.

* **The build works.** A temporary fixture with a SCSS partial, `&` nesting, a
  variable and a `url()` image produced the expected CSS, resolved the partial,
  and emitted `assets/dot-TDKIDFE5.png` with the `url()` rewritten to
  `../assets/dot-TDKIDFE5.png`.
* **Determinism.** Same fixture built from `Build/` and from the repository root
  → identical md5 (`f8d174da…`).
* **The gate fails when it should.** Changed `_tokens.scss`, ran
  `checkJsBuildClean` → exit **1** with a diff. Restored → exit **0**.
* **The type gate fails when it should.** Type error → FAILURE; valid source →
  SUCCESS; no sources → SUCCESS with "No TypeScript sources to check."
* **The lint gate fails when it should.** A function without a return type →
  `@typescript-eslint/explicit-function-return-type`, 1 problem.
* **`export-ignore` works.** Staged a tree containing
  `Resources/Private/Scss/frontend/probe.scss` and `…/TypeScript/frontend/probe.ts`,
  then `git archive` on that tree: both absent, all four
  `Resources/Private/Language/*.xlf` present.

Local gates on v13/PHP 8.2, all SUCCESS: `cgl -n`, `lintPhp`, `phpstan`,
`buildJs`, `checkJsBuildClean`, `lintTypescript -n`, `typecheckJs`.

## Follow-ups

* **ACE-392** migrates the five hand-written assets and switches their loading to
  `f:asset.module`, with a `Breaking-*.rst` per affected extension.
* **ACE-394** backports to branch `2`.
