### PR TITLE
[TASK] ACE-395: Correct the attribute guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,17 @@ unless it is explicitly requested for that specific change. Branch `1` is legacy
 and is treated the same way. Stating factually which branches contain a defect is
 fine; proposing work on `2.2` is not.
 
+**A backport starts by reading the target branch's own `AGENTS.md` and `docs/`.**
+They are not copies of these: each branch supports a different pair of TYPO3
+versions, so the instructions differ, and several of them differ by being
+*inverted* rather than merely absent. `not-core-13` excludes a test from v13
+here and means v12-only on `2`. The phpstan configurations are byte-identical
+here and differ there. `TYPO3\CMS\Core\Attribute\AsEventListener` exists here and
+does not exist on v12 at all. Applying a rule from this file to branch `2`
+without checking its copy first is how a change lands that is confidently wrong.
+
+→ [Backporting](docs/workflow/backporting.md) for the file-level diff recipe.
+
 ## Build / test / lint — `Build/Scripts/runTests.sh`
 
 All checks run through the containerized harness (docker or podman, auto-selected;
@@ -397,11 +408,20 @@ runs on v14 only. Examples:
 Note: the DI style here is **not** what a fresh extension would use. Eleven of
 the twelve extensions configure services in `Configuration/Services.yaml`; only
 `academic-persons` also has a `Configuration/Services.php`, and that file holds
-nothing but `registerForAutoconfiguration()` calls. TYPO3's DI attributes are
-already in use in production code — `#[Autoconfigure]`, `#[Autowire]`,
-`#[AsAlias]`, `#[Exclude]` — so the two styles coexist. Match the surrounding
-extension when editing it, and see
-[Dependency injection](docs/architecture/dependency-injection.md).
+nothing but `registerForAutoconfiguration()` calls. Attributes are already in use
+in production code alongside it, so the two styles coexist.
+
+Keep the two vendors apart when you use them. `#[Autoconfigure]`, `#[Autowire]`,
+`#[AsAlias]` and `#[Exclude]` are **Symfony's**, from
+`Symfony\Component\DependencyInjection\Attribute`. The only **TYPO3** attribute
+in use here is `Install\Attribute\UpgradeWizard`. That distinction is what the
+`#[AsEventListener]` rule above turns on — TYPO3 ships its own, Symfony's must
+never stand in for it, and Symfony's fails silently rather than loudly: it
+registers nothing, so the listener simply never fires.
+
+Match the surrounding extension when editing it, and see
+[Dependency injection](docs/architecture/dependency-injection.md) for the counts
+— they are measured there, and are deliberately not repeated here.
 
 ## TYPO3 v15 blockers — do not migrate these yet
 


### PR DESCRIPTION
Corrects the dependency injection guidance in `AGENTS.md`, and records the
backport lesson from the ACE-388 … ACE-394 round.

## The wording

`AGENTS.md` claimed *"TYPO3's DI attributes are already in use in production
code — `#[Autoconfigure]`, `#[Autowire]`, `#[AsAlias]`, `#[Exclude]`"*. All four
are **Symfony's**:

```
13  use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 8  use Symfony\Component\DependencyInjection\Attribute\Autowire;
 3  use Symfony\Component\DependencyInjection\Attribute\Exclude;
 2  use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 9  use TYPO3\CMS\Install\Attribute\UpgradeWizard;
```

The only TYPO3 attribute in use is `Install\Attribute\UpgradeWizard`.

**Why it is worth a change rather than a shrug.** Twenty-five lines above, the
same file says *"never use Symfony's own `#[AsEventListener]`, always TYPO3's"* —
a rule that depends entirely on the reader telling the two vendors apart. The
later sentence then told them the Symfony attributes were TYPO3's, so the rule
reads as if it did not apply. And the mistake it invites fails **silently**:
Symfony's `#[AsEventListener]` registers nothing in TYPO3, so the listener never
fires and nothing complains.

The counts leave with it. They are measured in
`docs/architecture/dependency-injection.md`, and a number kept in two places goes
stale in one of them. (Mine already disagreed with that page — 13 vs 9 — because
one counts imports and the other usages. Both correct, which is the point.)

## The backport rule

The `Backport targets` section gains a paragraph: a backport starts by reading
the target branch's own `AGENTS.md` and `docs/`, because the instructions
themselves differ per branch — and several differ by being **inverted** rather
than absent:

* `not-core-13` excludes a test from v13 here; on `2` it means v12-only.
* The two phpstan configurations are byte-identical here; on `2` they differ.
* `Core\Attribute\AsEventListener` exists here; on v12 it does not exist at all.

The ACE-388 … ACE-394 round found seven such claims. This change is an eighth.

## Branch `2` needs a different fix — see the companion PR

Branch `2` already names the vendors correctly. What is wrong there is the
`#[AsEventListener]` rule itself: on a branch supporting v12 it **cannot be
followed**, because the TYPO3 attribute does not exist there. Its own
`docs/architecture/dependency-injection.md` already says the attribute has zero
sites and the three listeners use `event.listener` YAML tags — only the agent
instructions still demanded the impossible.

That is exactly the failure mode this pull request adds a rule about, which is
why the two branches get different patches rather than a cherry-pick.

## Verified

`lintPhp` SUCCESS. Links, tables and `See also` sections checked across 27 files
— 0 problems. No PHP or configuration is touched; this is `AGENTS.md` only.
