### PR TITLE
[TASK] ACE-396: Correct the runTests.sh help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,8 @@ override with `-b docker|podman`). It mirrors the TYPO3 Core `runTests.sh`. Key 
 - Trailing `[file]` — restrict phpunit to a path.
 
 There is **no `-e` option**. Everything after a `--` separator is appended to the
-suite's command, so `-s unit -- --filter Foo` does reach phpunit — but that is
-undocumented in the script's own help, so prefer restricting a run with the
-trailing path.
+suite's command, so `-s unit -- --filter Foo` reaches phpunit. Prefer restricting
+a run with the trailing path, and `-o` for the random order seed.
 
 Typical workflow — **always prepare deps first** for the target core version:
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -256,18 +256,25 @@ openDocumentation() {
 loadHelp() {
     # Load help text into $HELP
     read -r -d '' HELP <<EOF
-TYPO3 core test runner. Execute acceptance, unit, functional and other test suites in
-a container based test environment. Handles execution of single test files, sending
-xdebug information to a local IDE and more.
+Test runner of fgtclb/academic-extensions. Executes the unit, functional, linting,
+static analysis, documentation and frontend suites in a container based environment,
+so nothing but docker or podman has to be installed on the host. Handles execution of
+single test files, sending xdebug information to a local IDE and more.
 
-Usage: $0 [options] [file]
+Usage: $0 [options] [file] [-- <arguments>]
+
+A trailing file or directory restricts the phpunit based suites to it. Everything
+after a "--" separator is appended to the command the suite runs, which is how
+options are handed to phpunit, composer and npm:
+
+    ./Build/Scripts/runTests.sh -s unit -- --filter SomeTest
 
 Options:
     -s <...>
         Specifies which test suite to run
             - buildJs: compile the frontend sources of every extension into its Resources/Public/
-            - cgl: test and fix all core php files
-            - cglHeader: test and fix file header for all core php files
+            - cgl: test and fix all php files, "-n" to only check
+            - cglHeader: test and fix the file header of all php files, "-n" to only check
             - checkJsBuildClean: check the committed frontend artifacts match their sources
             - checkRstRenderingAll: Test all extension .rst files for rendering errors
             - checkRstRenderingSingle: Test specified system extension .rst files for rendering errors
@@ -283,7 +290,9 @@ Options:
             - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
             - typecheckJs: "tsc --noEmit" over the TypeScript sources, which the build does not do
             - unit (default): PHP unit tests
-            - unitRandom: PHP unit tests in random order, "-- --random-order-seed=<number>" to use specific seed
+            - unitRandom: PHP unit tests in random order, "-o <number>" to use a specific seed
+            - update: update the typo3/core-testing-* images, same as "-u"
+            - help: show this help, the default when "-s" is not given
 
         The frontend suites - buildJs, checkJsBuildClean, lintTypescript, npm and
         typecheckJs - run in a node container, and cleanJs runs on the host. All six are
@@ -300,7 +309,7 @@ Options:
         If not specified, podman will be used if available. Otherwise, docker is used.
 
     -a <mysqli|pdo_mysql>
-        Only with -s functional|functionalDeprecated
+        Only with -s functional
         Specifies to use another driver, following combinations are available:
             - mysql
                 - mysqli (default)
@@ -310,7 +319,7 @@ Options:
                 - pdo_mysql
 
     -d <sqlite|mariadb|mysql|postgres>
-        Only with -s functional|functionalDeprecated|acceptance|acceptanceInstall
+        Only with -s functional
         Specifies on which DBMS tests are performed
             - sqlite: (default): use sqlite
             - mariadb: use mariadb
@@ -349,9 +358,16 @@ Options:
             - 16    maintained until 2028-11-09
 
     -t <13|14>
-        Only with -s composerInstall|composerInstallMin|composerInstallMax
-        Specifies the TYPO3 CORE Version to be used
+        Only with -s composerUpdate|functional|phpstan|phpstanGenerateBaseline|unit|unitRandom
+        Specifies the TYPO3 core version to be used
             - 13: (default) use TYPO3 v13
+            - 14: use TYPO3 v14
+
+        It selects configuration only and does not install anything: composerUpdate
+        resolves against it, phpstan picks Build/phpstan/Core<version>/phpstan.neon,
+        and the test suites exclude the group "not-core-<version>". Running a suite
+        for one version while the other one's dependencies are installed fails in
+        confusing ways, so run composerUpdate for the version to be tested first.
 
     -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
@@ -370,9 +386,14 @@ Options:
         Send xdebug information to a different port than default 9003 if an IDE like PhpStorm
         is not listening on default port.
 
+    -o <number>
+        Only with -s unitRandom
+        Set the random order seed, so a failing random order run can be repeated:
+        "--random-order-seed=<number>" is passed on to phpunit.
+
     -n
-        Only with -s cgl|cglGit|cglHeader|cglHeaderGit
-        Activate dry-run in CGL check that does not actively change files and only prints broken ones.
+        Only with -s cgl|cglHeader|lintTypescript
+        Activate dry-run, which does not change files and only reports the broken ones.
 
     -u
         Update existing typo3/core-testing-*:latest container images and remove dangling local volumes.
@@ -383,14 +404,20 @@ Options:
         Show this help.
 
 Examples:
-    # Run all core unit tests using PHP 8.2
+    # Install the dependencies of a core version, which every PHP suite needs first
+    ./Build/Scripts/runTests.sh -s composerUpdate -t 14 -p 8.3
+
+    # Run all unit tests using PHP 8.2
     ./Build/Scripts/runTests.sh -s unit
     ./Build/Scripts/runTests.sh -s unit -p 8.2
 
-    # Run all core unit tests using PHP 8.3
-    ./Build/Scripts/runTests.sh -s unit -p 8.3
+    # Run all unit tests against TYPO3 v14 using PHP 8.3
+    ./Build/Scripts/runTests.sh -s unit -t 14 -p 8.3
 
-    # Run all core units tests and enable xdebug (have a PhpStorm listening on port 9003!)
+    # Repeat a failing random order unit run with the seed it reported
+    ./Build/Scripts/runTests.sh -s unitRandom -o 1234
+
+    # Run all unit tests and enable xdebug (have a PhpStorm listening on port 9003!)
     ./Build/Scripts/runTests.sh -x
 
     # Run the unit tests of a single test file with xdebug on PHP 8.3

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -66,7 +66,7 @@ optional trailing argument.
 | `-d <dbms>`       | DBMS for functional tests: `sqlite`, `mariadb`, `mysql`, `postgres`.                | `sqlite`            |
 | `-i <version>`    | DBMS version, only with `-d mariadb\|mysql\|postgres`.                              | per DBMS, see below |
 | `-a <driver>`     | Database driver, only with `-d mariadb\|mysql`: `mysqli` or `pdo_mysql`.            | `mysqli`            |
-| `-n`              | Dry run for `cgl` and `cglHeader`: report offending files, change nothing.          | off                 |
+| `-n`              | Dry run for `cgl`, `cglHeader` and `lintTypescript`: report, change nothing.        | off                 |
 | `-x`              | Enable Xdebug and send debugging information to the host IDE.                       | off                 |
 | `-y <port>`       | Xdebug client port on the host, when the IDE does not listen on the default.        | `9003`              |
 | `-o <seed>`       | Random order seed for `unitRandom`, to replay a specific order.                     | none                |
@@ -116,14 +116,19 @@ the **extension folder name** below `packages/fgtclb/`
 (`Build/Scripts/runTests.sh:624`, `723`). For `composer` it is the composer
 command with its arguments (`Build/Scripts/runTests.sh:642`).
 
-> [!NOTE]
-> A `--` separator does technically end the wrapper's own option parsing, and
-> the remainder then reaches the dispatched tool, because every one of those
-> suites appends `"$@"`. It is neither documented in `-h` nor used by the
-> workflows, and the single mention of a separator in the help text — under
-> `unitRandom`, `Build/Scripts/runTests.sh:269` — points at what `-o` already
-> does. Use `-o` for the seed and the trailing path for everything else; do not
-> build tooling on the separator.
+A `--` separator ends the wrapper's own option parsing, and the remainder
+reaches the dispatched tool, because every one of those suites appends `"$@"`.
+It is the supported way to hand an option to phpunit, composer or npm, and it
+is documented in `-h` since ACE-396:
+
+```bash
+Build/Scripts/runTests.sh -s unit -- --filter SomeTest
+Build/Scripts/runTests.sh -s npm -- install --save-dev sass@latest
+```
+
+For the two cases that have a dedicated option, prefer it: `-o` for the random
+order seed and the trailing path for restricting a phpunit run. Neither
+workflow in `.github/workflows/` uses the separator.
 
 ## Suites
 
@@ -151,28 +156,27 @@ is the authority — the help text is not complete, see below.
 Anything else prints the help and exits non-zero
 (`Build/Scripts/runTests.sh:776-782`).
 
-### Where the help text and the script disagree
+### The help text
 
-`-h` renders a text block maintained by hand in `loadHelp()`
-(`Build/Scripts/runTests.sh:246-381`), and it has drifted from the `case`
-statement. Read the script when in doubt:
+`-h` renders a text block maintained by hand in `loadHelp()`. It had drifted
+from the `case` statement, because the wrapper started as a copy of the TYPO3
+Core runner and inherited its help: `-t` was documented for
+`composerInstall|composerInstallMin|composerInstallMax`, `-n` for
+`cglGit|cglHeaderGit`, `-a` and `-d` for `functionalDeprecated` and the
+acceptance suites, and `-o` was not documented at all — none of those suites
+exists here. That was corrected in ACE-396, and the help now names the suites
+and options this script really has.
 
-* **`functional` is missing from the help text entirely**, although it is a
-  suite (`Build/Scripts/runTests.sh:657`), is described under `-d` and `-a`,
-  and appears in the examples. `update` and `help` are missing as well.
-* `-o` is not listed as an option at all, even though it is parsed
-  (`Build/Scripts/runTests.sh:447-449`).
-* `-t` is documented as being usable only with the suites `composerInstall`,
-  `composerInstallMin` and `composerInstallMax`. None of those three exists
-  here, and `-t` in fact also selects the PHPStan configuration and the
-  excluded PHPUnit group.
-* `-n` is documented for `cgl|cglGit|cglHeader|cglHeaderGit`; the `*Git`
-  variants do not exist.
-* The `-i` lists carry TYPO3 Core's maintenance annotations, which are dated
-  and say nothing about this repository.
+Two things are deliberately not derived from the script and can still go stale,
+so read the `case` statement and the `getopts` string when a claim matters:
 
-Correcting the help text is worthwhile; until then, the `case` statement and
-the `getopts` string are the specification.
+* The suite list and the option descriptions are prose. A new suite has to be
+  added to both the `case` statement and `loadHelp()`.
+* The `-i` lists carry TYPO3 Core's maintenance annotations for the DBMS
+  versions. They describe the products, not this repository, and are as dated
+  as the day they were copied. The values themselves are checked against the
+  regular expressions in `handleDbmsOptions()`, so an unsupported one is
+  rejected rather than silently used.
 
 ## Quick start
 


### PR DESCRIPTION
`Build/Scripts/runTests.sh` started as a copy of the TYPO3 Core test runner, and its help text came along with it. Suites that never existed in this repository were still documented, and two options that this script does parse were not documented at all — so `-h`, which is what someone reads before running anything, was the first thing that misled them.

Corrected against the `case` statement and the `getopts` string:

* `-t` claimed "Only with -s composerInstall|composerInstallMin|composerInstallMax". None of the three exists. It drives `composerUpdate`, the PHPStan configuration and the `--exclude-group not-core-<version>` of the test suites, and it selects configuration only — which is now spelled out, because running a suite while the other core version's dependency set is installed is the most common way to lose an afternoon here.
* `-n` claimed "Only with -s cgl|cglGit|cglHeader|cglHeaderGit". The two `*Git` variants do not exist, and `lintTypescript` — which honours `-n` — was not named.
* `-a` and `-d` named `functionalDeprecated`, `acceptance` and `acceptanceInstall`.
* `-o` is parsed by `getopts` and was not documented at all, which made the seed of a failing random-order run look unrepeatable.
* Everything after a `--` separator is appended to the dispatched command. That is the supported way to hand an option to phpunit, composer or npm, and it appeared only inside a single example.
* `update` and `help` were missing from the suite list, and the preamble still offered acceptance tests, which this repository does not have.

Both passthrough behaviours were verified rather than reasoned about:

```
$ Build/Scripts/runTests.sh -s unit -- --filter TcaManipulator
OK (6 tests, 6 assertions)

$ Build/Scripts/runTests.sh -s unitRandom -o 4711 -- --filter TcaManipulator
Random Seed:   4711
OK (6 tests, 6 assertions)
```

`docs/development/environment.md` carried a section titled *Where the help text and the script disagree* that enumerated exactly these defects. It is replaced by what is still hand-maintained and can therefore still rot — the suite list itself, and the DBMS maintenance annotations inherited from Core — and the note calling the `--` passthrough undocumented is dropped from it and from `AGENTS.md`.

No PHP is touched.

Backport to branch `2` follows: the same defects are there, plus three examples using an `-e "…"` option that branch does not implement, `typo3/sysext/core/Tests/…` paths, a `-k` that is `-i` here, and a `-p` default documented as 8.1 where it is 8.2.

Issue: ACE-396
