### PR TITLE
[TASK] ACE-398: Add an aggregating CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,3 +386,43 @@ jobs:
           retention-days: 5
           include-hidden-files: true
           overwrite: true
+
+  # One job whose name never changes, so a branch ruleset can require it without
+  # pinning the matrix. Every leaf job here carries its core, PHP and DBMS values
+  # in its name — "unit (v13, PHP 8.2)", "functional mysql 8.0 (v14, PHP 8.5)" —
+  # and requiring those by name would move the matrix into a repository setting
+  # that lives outside the branch, where the two maintained branches do not have
+  # the same one.
+  #
+  # "always()" is what makes it work: without it the job would be skipped as soon
+  # as anything it needs fails, and a skipped required check blocks a pull request
+  # forever instead of reporting a failure. With it the job always runs and decides
+  # for itself. A skipped dependency counts as a failure too, because a gate that
+  # did not run has not passed.
+  all-checks:
+    name: "all checks"
+    runs-on: ubuntu-latest
+    if: "always()"
+    needs:
+      - "cgl"
+      - "phpstan"
+      - "lint"
+      - "unit"
+      - "functional-sqlite"
+      - "functional-dbms"
+      - "frontend-assets"
+      - "markdown"
+      - "documentation"
+    steps:
+
+      # Through an environment variable, not interpolated into the command:
+      # the JSON is multi-line and quoted, and a "run" that inlines it is not
+      # valid shell.
+      - name: "Report the result of every job"
+        env:
+          NEEDS: "${{ toJSON(needs) }}"
+        run: 'echo "$NEEDS"'
+
+      - name: "Fail unless all of them succeeded"
+        if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')"
+        run: "exit 1"

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -388,10 +388,18 @@ frontend assets, markdown, documentation   (independent)
 | `frontend-assets`   | —                  | none                       |
 | `markdown`          | —                  | none                       |
 | `documentation`     | —                  | none                       |
+| `all checks`        | all of the above   | none                       |
 
-The last three carry no matrix because none of them reads the installed core:
-they look at sources and committed artifacts, so repeating them per core and
-PHP version would check the same files four times.
+`frontend-assets`, `markdown` and `documentation` carry no matrix because none
+of them reads the installed core: they look at sources and committed artifacts,
+so repeating them per core and PHP version would check the same files four
+times.
+
+`all checks` runs no gate of its own. It exists so that a branch ruleset has one
+check to require whose name does not move with the matrix — see
+[Pull requests](../workflow/pull-requests.md). It needs every other job, runs
+with `if: always()` so that it reports rather than being skipped, and treats a
+skipped dependency as a failure.
 
 The DBMS matrix is the expensive part — sixteen jobs, each starting a database
 container. It runs only after the same tests passed on SQLite for both core

--- a/docs/workflow/pull-requests.md
+++ b/docs/workflow/pull-requests.md
@@ -117,6 +117,32 @@ pipeline be merged by someone with the approval. Reading the pipeline result
 before merging is a discipline here, not a guard rail, which is exactly why the
 next two sections exist.
 
+### The check to require, once that is wanted
+
+Requiring the leaf jobs by name does not work here: nearly all of them carry
+their matrix values in the name — `unit (v13, PHP 8.2)`,
+`functional mysql 8.0 (v14, PHP 8.5)` — so the ruleset would pin the matrix of
+a branch in a repository setting that lives outside that branch, and the two
+maintained branches do not have the same matrix.
+
+`ci.yml` therefore ends in an aggregating job named **`all checks`** (ACE-398).
+It needs every other job, runs with `if: always()` and fails when any of them
+reported `failure`, `cancelled` or `skipped`. Its name never changes, so it is
+the one check a ruleset should require:
+
+```bash
+gh api repos/fgtclb/academic-extensions/rulesets/4151166   # inspect first
+```
+
+The `always()` is the load-bearing part. Without it the job would be *skipped*
+as soon as anything it needs fails, and a skipped required check blocks a pull
+request indefinitely rather than reporting a failure. Treating a skipped
+dependency as a failure follows from the same reasoning: a gate that did not
+run has not passed.
+
+Adding the rule itself is a repository setting and affects every contributor,
+so it is deliberately not part of that change.
+
 ## Pre-flight, before pushing
 
 Run the gates locally first. The harness is containerized, so a local run and a


### PR DESCRIPTION
Neither `linear-history` nor `version-branches` defines a `required_status_checks` rule — verified with `gh api repos/fgtclb/academic-extensions/rulesets`. A pull request with a red pipeline is therefore mergeable by anyone with the approval, and a merge queue would gate on nothing, which is why one was never configured.

Requiring the leaf jobs by name is not the way out. Almost all of them carry their matrix values in the name — `unit (v13, PHP 8.2)`, `functional mysql 8.0 (v14, PHP 8.5)` — so the ruleset would pin a branch's matrix into a repository setting that lives outside that branch, and `main` and `2` do not have the same matrix.

`ci.yml` now ends in a job named **`all checks`**: it needs every other job and fails when any of them reported `failure`, `cancelled` or `skipped`. Its name never changes, so it is the single check a ruleset can require.

`if: always()` is the load-bearing part. Without it the job would be *skipped* as soon as anything it needs fails, and a skipped required check blocks a pull request indefinitely instead of reporting a failure. A skipped dependency counts as a failure for the same reason: a gate that did not run has not passed.

## What this pull request deliberately does not do

**It does not add the rule to the ruleset.** That is a repository setting, it takes effect for every contributor at once, and it is not something a pull request can carry. Once this is merged and `all checks` has appeared on a run, it is one call:

```bash
gh api repos/fgtclb/academic-extensions/rulesets/4151166   # read it first
```

…adding a `required_status_checks` rule with the single context `all checks`.

Both `docs/development/quality-gates.md` and `docs/workflow/pull-requests.md` are updated, including the sentence in the latter that used to state there is no such check to require.

Backport to branch `2` follows once this is merged — the job is workflow-only and its `needs` list differs there.

Issue: ACE-398

---

**First run: `all checks` failed, and the reason was itself worth having.** Not the gate step — the *reporting* step. `run: 'echo ${{ toJSON(needs) }}'` interpolates a multi-line, quoted JSON document straight into the shell command, which is not valid shell. It now travels through an environment variable, which is also the form that cannot be injected into. Everything else in that run was green, so the job proved it reports on itself.
