### PR TITLE
[TASK] ACE-398: Add an aggregating CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,3 +399,42 @@ jobs:
           retention-days: 5
           include-hidden-files: true
           overwrite: true
+  # One job whose name never changes, so a branch ruleset can require it without
+  # pinning the matrix. Every leaf job here carries its core, PHP and DBMS values
+  # in its name — "unit (v13, PHP 8.2)", "functional mysql 8.0 (v14, PHP 8.5)" —
+  # and requiring those by name would move the matrix into a repository setting
+  # that lives outside the branch, where the two maintained branches do not have
+  # the same one.
+  #
+  # "always()" is what makes it work: without it the job would be skipped as soon
+  # as anything it needs fails, and a skipped required check blocks a pull request
+  # forever instead of reporting a failure. With it the job always runs and decides
+  # for itself. A skipped dependency counts as a failure too, because a gate that
+  # did not run has not passed.
+  all-checks:
+    name: "all checks"
+    runs-on: ubuntu-latest
+    if: "always()"
+    needs:
+      - "cgl"
+      - "phpstan"
+      - "lint"
+      - "unit"
+      - "functional-sqlite"
+      - "functional-dbms"
+      - "frontend-assets"
+      - "markdown"
+      - "documentation"
+    steps:
+
+      # Through an environment variable, not interpolated into the command:
+      # the JSON is multi-line and quoted, and a "run" that inlines it is not
+      # valid shell.
+      - name: "Report the result of every job"
+        env:
+          NEEDS: "${{ toJSON(needs) }}"
+        run: 'echo "$NEEDS"'
+
+      - name: "Fail unless all of them succeeded"
+        if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')"
+        run: "exit 1"

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -405,10 +405,18 @@ frontend assets, markdown, documentation   (independent)
 | `frontend-assets`   | —                  | none                                  |
 | `markdown`          | —                  | none                                  |
 | `documentation`     | —                  | none                                  |
+| `all checks`        | all of the above   | none                                  |
 
-The last three carry no matrix because none of them reads the installed core:
-they look at sources and committed artifacts, so repeating them per core and
-PHP version would check the same files four times.
+`frontend-assets`, `markdown` and `documentation` carry no matrix because none
+of them reads the installed core: they look at sources and committed artifacts,
+so repeating them per core and PHP version would check the same files four
+times.
+
+`all checks` runs no gate of its own. It exists so that a branch ruleset has one
+check to require whose name does not move with the matrix — see
+[Pull requests](../workflow/pull-requests.md). It needs every other job, runs
+with `if: always()` so that it reports rather than being skipped, and treats a
+skipped dependency as a failure.
 
 The DBMS matrix is the expensive part — sixteen jobs, each starting a database
 container. It runs only after the same tests passed on SQLite for both core

--- a/docs/workflow/pull-requests.md
+++ b/docs/workflow/pull-requests.md
@@ -129,6 +129,36 @@ pipeline be merged by someone with the approval. Reading the pipeline result
 before merging is a discipline here, not a guard rail, which is exactly why the
 next two sections exist.
 
+### The check to require, once that is wanted
+
+Requiring the leaf jobs by name does not work here: nearly all of them carry
+their matrix values in the name — `unit (v12, PHP 8.1)`,
+`functional mysql 8.0 (v13, PHP 8.5)` — so the ruleset would pin the matrix of
+a branch in a repository setting that lives outside that branch, and the two
+maintained branches do not have the same matrix.
+
+`ci.yml` therefore ends in an aggregating job named **`all checks`** (ACE-398).
+It needs every other job, runs with `if: always()` and fails when any of them
+reported `failure`, `cancelled` or `skipped`. Its name never changes, so it is
+the one check a ruleset should require:
+
+```bash
+gh api repos/fgtclb/academic-extensions/rulesets/4151166   # inspect first
+```
+
+The `always()` is the load-bearing part. Without it the job would be *skipped*
+as soon as anything it needs fails, and a skipped required check blocks a pull
+request indefinitely rather than reporting a failure. Treating a skipped
+dependency as a failure follows from the same reasoning: a gate that did not
+run has not passed.
+
+`version-branches` is **one** ruleset covering the default branch, `1`, `1.*`,
+`2` and `2.*`, so the required context has to exist on every branch it covers
+before the rule is added — otherwise a pull request against a branch without
+that job waits for a status that is never reported. That is why this job is
+maintained on both `main` and `2`, and why the rule itself is a separate,
+repository-wide decision rather than part of the change that added the job.
+
 ## Pre-flight, before pushing
 
 Run the gates locally first. The harness is containerized, so a local run and a


### PR DESCRIPTION
Backport of #470. It is a **precondition** for enabling the rule, not a follow-up to it.

`version-branches` is a single ruleset covering `~DEFAULT_BRANCH`, `refs/heads/1`, `refs/heads/1.*`, `refs/heads/2` and `refs/heads/2.*`. A required status check is a context name, and GitHub waits for it: requiring `all checks` while this branch has no job of that name would leave every pull request against `2` stuck on *"Expected — waiting for status to be reported"*, indefinitely. So the job has to exist on every branch the ruleset covers **before** the rule is added.

The nine jobs are the same here, so the `needs` list carries over unchanged and the job block is byte-identical to `main`'s. What differs is the documentation around it — this branch's `docs/workflow/pull-requests.md` and `docs/development/quality-gates.md`, and the example job names in the explanation (`unit (v12, PHP 8.1)` rather than `unit (v13, PHP 8.2)`).

`docs/workflow/pull-requests.md` additionally spells out the one-ruleset-many-branches constraint, because it is the reason this change exists on two branches at once.

Verified locally: `lintMarkdown -n` green, and the workflow parses with all ten jobs and the expected `needs` list.

Still deliberately not done, on either branch: adding the `required_status_checks` rule itself. Note when it is added that the ruleset also covers `1`, `1.*` and `2.*`, which are unmaintained — a pull request against one of those would block on a job those branches do not have.

Issue: ACE-398
