### PR TITLE
[DOCS] ACE-400: Replace rotted line references

### DIFF
--- a/docs/architecture/database-queries.md
+++ b/docs/architecture/database-queries.md
@@ -360,9 +360,9 @@ route from "this does nothing" to "this is comparing the wrong two things".
 
 Both rules fail in the direction the default test run cannot see: rule 1 hides
 behind SQLite's tolerance of `IN ()` on v12, rule 2 hides behind three
-databases silently updating nothing. The functional suite defaults to SQLite
-(`Build/Scripts/runTests.sh:392`, `DBMS="sqlite"`), so a green local run proves
-less than it appears to.
+databases silently updating nothing. The functional suite defaults to SQLite —
+`DBMS="sqlite"` in `runTests.sh` — so a green local run proves less than it
+appears to.
 
 Three habits follow.
 
@@ -374,9 +374,9 @@ Build/Scripts/runTests.sh -t 13 -p 8.3 -s functional -d postgres \
     packages/fgtclb/academic-projects/Tests/Functional/Upgrades
 ```
 
-CI reaches the same coverage eventually — `functional-dbms` in
-`.github/workflows/ci.yml:250-265` runs MySQL 8.0, MariaDB 10.4, MariaDB 10.6
-and PostgreSQL 10 — but only after the SQLite jobs pass, so a defect of this
+CI reaches the same coverage eventually — the `functional-dbms` job runs MySQL
+8.0, MariaDB 10.4, MariaDB 10.6 and PostgreSQL 10 — but only after the SQLite
+jobs pass, so a defect of this
 kind is reported one stage late unless it was reproduced locally first.
 
 **Assert the effect, not the return value.** `executeStatement()` returning

--- a/docs/development/dual-core-setup.md
+++ b/docs/development/dual-core-setup.md
@@ -12,13 +12,11 @@ repository.
 > command is run with.
 
 `-t <13|14>` selects **configuration only**. It picks the phpstan config
-(`Build/phpstan/Core${CORE_VERSION}/phpstan.neon`,
-`Build/Scripts/runTests.sh:738`) and the phpunit exclude group
-(`--exclude-group not-core-${CORE_VERSION}`, `Build/Scripts/runTests.sh:659`
-and `:751`). It installs nothing.
+(`Build/phpstan/Core${CORE_VERSION}/phpstan.neon`, in the `phpstan` arm) and
+the phpunit exclude group (`--exclude-group not-core-${CORE_VERSION}`, in the
+`functional`, `unit` and `unitRandom` arms). It installs nothing.
 
-The only suite that changes what is in `.Build/` is `composerUpdate`
-(`Build/Scripts/runTests.sh:646-655`):
+The only suite that changes what is in `.Build/` is `composerUpdate`:
 
 ```bash
 rm -rf .Build composer.lock composer.json.orig
@@ -48,8 +46,8 @@ Running `-t 14` while the v13 set is installed does not fail with a useful
 message. It produces wrong answers: phpstan reports unknown classes for APIs
 that only exist in the other major and misses the errors it was supposed to
 find, and tests pass or fail for reasons that have nothing to do with the
-change under test. The default is `-t 13` (`Build/Scripts/runTests.sh:391`),
-so the trap is easiest to fall into right after finishing a v14 round and
+change under test. The default is `-t 13` — `CORE_VERSION="13"` — so the trap
+is easiest to fall into right after finishing a v14 round and
 omitting `-t` on the next command.
 
 Both `.Build/` and `composer.lock` are git-ignored, so nothing is lost by
@@ -62,9 +60,8 @@ reinstalling. The composer download cache lives in `.cache/composer`, outside
 overlook because a PHP version does not feel like a dependency.
 
 `composerUpdate` runs `composer` inside the container image selected by `-p`
-(`IMAGE_PHP="ghcr.io/typo3/core-testing-php${PHP_VERSION}"`,
-`Build/Scripts/runTests.sh:524`, used for the composer calls at
-`Build/Scripts/runTests.sh:649` and `:652`). The root `composer.json` sets no
+(`IMAGE_PHP="ghcr.io/typo3/core-testing-php${PHP_VERSION}"`, which is what both
+composer calls of that arm run in). The root `composer.json` sets no
 `config.platform`, so composer resolves against the PHP version it is actually
 running on. A tree resolved on 8.2 can therefore hold different package
 versions than one resolved on 8.5, and running the 8.5 image against a tree
@@ -73,10 +70,10 @@ test.
 
 `.github/workflows/ci.yml` follows this without exception: every job that runs
 a suite runs `composerUpdate` first with the same `-t` **and** `-p` values it
-then uses (`ci.yml:106/109`, `:149/152`, `:205/208`, `:245/248`, `:289/292`).
-The one job that does not is `lint`, which passes neither `-t` nor
-`composerUpdate` (`ci.yml:171`) because `lintPhp` only runs `php -l` over the
-sources and needs no vendor tree at all.
+then uses — its *Prepare dependencies for TYPO3 v…* step, present in `cgl`,
+`phpstan`, `unit`, `functional-sqlite` and `functional-dbms`. The one job that
+does not is `lint`, which passes neither `-t` nor `composerUpdate` because
+`lintPhp` only runs `php -l` over the sources and needs no vendor tree at all.
 
 Treat `-t` and `-p` together as the identity of the installed tree: change
 either, reinstall.
@@ -146,9 +143,8 @@ Not every test can run on both core versions. Two mechanisms exist and they are
 picked by scope, not by taste.
 
 `runTests.sh` always passes `--exclude-group not-core-${CORE_VERSION}` to
-phpunit — for `functional` (`Build/Scripts/runTests.sh:659`), `unit` (`:751`)
-and `unitRandom` (`:757`). The group therefore names the version the test must
-**not** run on:
+phpunit, in the `functional`, `unit` and `unitRandom` arms. The group therefore
+names the version the test must **not** run on:
 
 | Group         | Runs on     | Meaning                                     |
 |---------------|-------------|---------------------------------------------|
@@ -240,7 +236,7 @@ Notes on that loop:
   `-s unit packages/fgtclb/academic-base/Tests/Unit/TcaManipulatorTest.php`.
   The trailing path is the restriction mechanism; there is no dedicated flag
   for handing extra options to phpunit, apart from `-o <seed>` for
-  `unitRandom` (`Build/Scripts/runTests.sh:447-448`).
+  `unitRandom`.
 
 Run the unrestricted sequence once before pushing, no matter how narrow the
 change looked.

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -14,8 +14,7 @@ of problem that exists in this repository.
 ## Host requirements
 
 One container runtime, and nothing else. No PHP, no Composer, no PHPUnit on the
-host. The script refuses to start when neither runtime is installed
-(`Build/Scripts/runTests.sh:384-387`):
+host. The script refuses to start when neither runtime is installed:
 
 ```bash
 if ! type "docker" >/dev/null 2>&1 && ! type "podman" >/dev/null 2>&1; then
@@ -24,14 +23,14 @@ if ! type "docker" >/dev/null 2>&1 && ! type "podman" >/dev/null 2>&1; then
 fi
 ```
 
-**podman is preferred.** When `-b` is not given, the runtime is picked at
-`Build/Scripts/runTests.sh:516-522`: podman if it is on the `PATH`, docker
-otherwise. `-b docker|podman` overrides the choice, and an argument that is
-neither is rejected as an invalid option
-(`Build/Scripts/runTests.sh:414-419`).
+**podman is preferred.** When `-b` is not given, `CONTAINER_BIN` is resolved
+from the `PATH`: podman if it is there, docker otherwise. `-b docker|podman`
+overrides the choice, and the `b)` arm of the option parsing rejects anything
+else as an invalid option.
 
 The two runtimes are not interchangeable in their details, which is why the
-script branches on the selected one (`Build/Scripts/runTests.sh:549-578`):
+script branches on `CONTAINER_BIN` where it assembles
+`CONTAINER_COMMON_PARAMS`:
 
 * docker needs `--add-host host.docker.internal:host-gateway` for Xdebug to
   reach an IDE on the host; podman has `host.containers.internal` built in.
@@ -44,19 +43,18 @@ script branches on the selected one (`Build/Scripts/runTests.sh:549-578`):
 
 The GitHub workflows pass `-b docker` on every step. That is not a statement
 about which runtime is better — it works around a crun failure on hosted
-runners and is documented in `.github/workflows/ci.yml:44-52`. There is no
-reason to pass it locally.
+runners and is documented in the header comment of
+[`ci.yml`](../../.github/workflows/ci.yml). There is no reason to pass it
+locally.
 
-Each run creates its own container network named `academic-extensions-<random>`
-(`Build/Scripts/runTests.sh:545-547`) and removes it together with every
-attached container in `cleanUp()` (`Build/Scripts/runTests.sh:109-115`), so
-parallel runs on one machine do not collide.
+Each run creates its own container network — `NETWORK` is
+`academic-extensions-${SUFFIX}` — and `cleanUp()` removes it together with
+every attached container, so parallel runs on one machine do not collide.
 
 ## Options
 
-The wrapper parses exactly these options
-(`Build/Scripts/runTests.sh:409-468`); everything left over after them is the
-optional trailing argument.
+The wrapper parses exactly these options in its `while getopts` loop;
+everything left over after them is the optional trailing argument.
 
 | Option            | Meaning                                                                             | Default             |
 |-------------------|-------------------------------------------------------------------------------------|---------------------|
@@ -75,16 +73,15 @@ optional trailing argument.
 | `-h`              | Print the help text and exit.                                                       | —                   |
 | trailing `[file]` | Path passed on to the tool of the suite — for PHPUnit a test file or directory.     | none                |
 
-`-u` is not a modifier: it sets the suite to `update`
-(`Build/Scripts/runTests.sh:458-460`), so it cannot be combined with `-s`.
+`-u` is not a modifier: its `u)` arm sets `TEST_SUITE=update`, so it cannot be
+combined with `-s`.
 
-`-t` and `-p` are validated against a fixed list
-(`Build/Scripts/runTests.sh:431-440`); anything else aborts the run before a
-container is started.
+`-t` and `-p` are validated against a fixed list in their own `getopts` arms;
+anything else aborts the run before a container is started.
 
 The `-a`, `-d` and `-i` combinations are validated together in
-`handleDbmsOptions()` (`Build/Scripts/runTests.sh:117-188`), which also holds
-the per-DBMS defaults and the accepted version lists:
+`handleDbmsOptions()`, which also holds the per-DBMS defaults and the accepted
+version lists:
 
 | `-d`       | Default `-i` | Accepted `-i`                     | `-a`                              |
 |------------|--------------|-----------------------------------|-----------------------------------|
@@ -110,11 +107,10 @@ Build/Scripts/runTests.sh -t 13 -s unit \
 
 The trailing argument means different things per suite. For `unit`,
 `unitRandom`, `functional` and `phpstan` it is appended to the tool's command
-line (`Build/Scripts/runTests.sh:659`, `739`, `751`, `757`). For
-`checkRstRenderingSingle` and `openDocumentation` it is not a path at all but
-the **extension folder name** below `packages/fgtclb/`
-(`Build/Scripts/runTests.sh:624`, `723`). For `composer` it is the composer
-command with its arguments (`Build/Scripts/runTests.sh:642`).
+line, in each of those four `case` arms. For `checkRstRenderingSingle` and
+`openDocumentation` it is not a path at all but the **extension folder name**
+below `packages/fgtclb/`. For `composer` it is the composer command with its
+arguments.
 
 A `--` separator ends the wrapper's own option parsing, and the remainder
 reaches the dispatched tool, because every one of those suites appends `"$@"`.
@@ -132,8 +128,8 @@ workflow in `.github/workflows/` uses the separator.
 
 ## Suites
 
-Taken from the `case` statement at `Build/Scripts/runTests.sh:589-783`, which
-is the authority — the help text is not complete, see below.
+Taken from the `case ${TEST_SUITE} in` statement, which is the authority — the
+help text is prose and can drift, see below.
 
 | Suite                     | What it runs                                                                                        |
 |---------------------------|-----------------------------------------------------------------------------------------------------|
@@ -154,8 +150,7 @@ is the authority — the help text is not complete, see below.
 | `update`                  | Pulls newer `ghcr.io/typo3/core-testing-*` images and removes dangling ones. Also reached via `-u`. |
 | `help`                    | Prints the help text. This is the default when `-s` is omitted.                                     |
 
-Anything else prints the help and exits non-zero
-(`Build/Scripts/runTests.sh:776-782`).
+Anything else falls to the `*)` arm, which prints the help and exits non-zero.
 
 ### The help text
 
@@ -200,7 +195,7 @@ Build/Scripts/runTests.sh -t 14 -p 8.2 -s phpstan
 
 ## Dependencies: one tree, one core version, one PHP version
 
-`composerUpdate` (`Build/Scripts/runTests.sh:646-656`) does four things:
+The `composerUpdate` arm does four things:
 
 1. `rm -rf .Build composer.lock composer.json.orig` — the vendor tree is
    rebuilt from scratch, never patched.
@@ -230,15 +225,15 @@ Two consequences that cause most of the confusing local failures:
 
 The workflows follow this rule literally: every job that needs a vendor tree
 runs `composerUpdate` for its own `-t`/`-p` pair first, and the `lint` job,
-which needs no vendor tree, does not run it at all
-(`.github/workflows/ci.yml:154-171`).
+which needs no vendor tree, does not run it at all — see its `lint` job.
 
 ## Caches: `.cache/` at the repository root
 
 Composer downloads land in `.cache/composer` and the PHPStan result cache in
 `.cache/phpstan`. The directory is created before any container starts
-(`Build/Scripts/runTests.sh:502-503`), passed in as `COMPOSER_CACHE_DIR` on
-every composer-facing suite, and configured as PHPStan's `tmpDir`
+by an explicit `mkdir -p .cache/composer` before any container starts, passed
+in as `COMPOSER_CACHE_DIR` on every composer-facing suite, and configured as
+PHPStan's `tmpDir`
 (`Build/phpstan/Core13/phpstan.neon:11`).
 
 It sits **next to** `.Build/`, not inside it, and that placement is deliberate.
@@ -249,10 +244,9 @@ CI. The reasoning is recorded in `.gitignore:17-20`.
 The workflows cache only `.cache/composer/files` — the content-addressed dist
 archives — and never the `repo/` metadata next to it, because restoring stale
 packagist metadata makes the `restore-keys` fallback resolve against an old
-package list (`.github/workflows/ci.yml:88-103`).
+package list — see the *Cache composer downloads* step in `ci.yml`.
 
-`.cache` and `.php-cs-fixer.cache` are what `cleanCacheFiles()` removes
-(`Build/Scripts/runTests.sh:190-196`).
+`.cache` and `.php-cs-fixer.cache` are what `cleanCacheFiles()` removes.
 
 ## Container images
 
@@ -265,8 +259,8 @@ package list (`.github/workflows/ci.yml:88-103`).
 | PostgreSQL       | `docker.io/postgres:<-i>-alpine`                   |
 | Port wait helper | `docker.io/alpine:3.8`                             |
 
-Defined at `Build/Scripts/runTests.sh:524-531`. The `docker.io` images are
-pulled through `ensureImage()` (`Build/Scripts/runTests.sh:60-79`), which
+Defined in the `IMAGE_*` variables. The `docker.io` images are pulled through
+`ensureImage()`, which
 checks the local image first and retries a failed pull up to three times: an
 anonymous Docker Hub pull is rate limited per source IP, hosted runners share
 address space, and a single failed pull otherwise ends a job with exit 125
@@ -274,13 +268,14 @@ before a test has run. The `ghcr.io` images have never needed it, which is why
 only the Docker Hub ones are guarded.
 
 `-u` refreshes the PHP images that already exist locally and removes the
-dangling ones (`Build/Scripts/runTests.sh:761-770`). Run it when tests start
+dangling ones, in the `update` arm. Run it when tests start
 failing in ways that do not match the code.
 
 ## Xdebug
 
 `-x` switches the PHP container from `XDEBUG_MODE=off` to `debug` and points
-the client at the host (`Build/Scripts/runTests.sh:580-586`). The host address
+the client at the host through `XDEBUG_MODE` and `XDEBUG_CONFIG`. The host
+address
 differs per runtime — `host.docker.internal` for docker,
 `host.containers.internal` for podman — and the wrapper sets the right one.
 `-y <port>` changes the client port when the IDE does not listen on 9003.
@@ -301,8 +296,8 @@ extensions in a running backend and frontend.
 their own `composer.lock`, their own git-ignored `vendor/`, `public/` and
 `var/` trees, and they play no part in any suite. The single point of contact
 is negative: `lintPhp` explicitly excludes `./core-1*/vendor/`,
-`./core-1*/public/` and `./core-1*/var/` from the `find`
-(`Build/Scripts/runTests.sh:709-718`), because those are third-party trees —
+`./core-1*/public/` and `./core-1*/var/` from the `find` in its `case` arm, because those are
+third-party trees —
 `typo3/class-alias-loader` ships a template file that is deliberately not valid
 PHP. The instances' tracked `config/system/*.php` is still linted, on purpose.
 

--- a/docs/development/monorepo-layout.md
+++ b/docs/development/monorepo-layout.md
@@ -79,7 +79,7 @@ Both are covered in their own sections below.
 repository: every extension's `composer.json`, `ext_emconf.php`, `VERSION` file
 and tailor metadata, the functional-test fixture extensions, the `packages-dev`
 meta packages, the development instances, the root `composer.json` and the
-`COMPOSER_ROOT_VERSION` in `runTests.sh` (`Build/Scripts/runTests.sh:483`). It
+`COMPOSER_ROOT_VERSION` assignment in `runTests.sh`. It
 discovers the package list from the repository rather than carrying one, so a
 new extension needs no change there. It only edits files; it runs no git and no
 network operation.
@@ -123,7 +123,7 @@ at the moment and holds only a `.gitkeep` so git keeps the directory.
 is `.Build/vendor` (`composer.json:26-27`), and the TYPO3 web and app
 directories are `.Build/Web` and `.Build` (`composer.json:37-38`). It is
 git-ignored and disposable — `runTests.sh -s composerUpdate` starts by removing
-it (`Build/Scripts/runTests.sh:647`).
+it.
 
 `.cache/` holds the composer download cache and the phpstan result cache. It
 sits next to `.Build/` rather than inside it precisely because
@@ -133,8 +133,8 @@ phpstan configuration points its `tmpDir` at `../../../.cache/phpstan`
 (`Build/phpstan/Core13/phpstan.neon:11`).
 
 `documentation-rendered/` receives the output of `checkRstRenderingAll` and
-`checkRstRenderingSingle`, one folder per extension
-(`Build/Scripts/runTests.sh:223-225`). It is git-ignored and uploaded as a
+`checkRstRenderingSingle`, one folder per extension — the output directory is
+built in `executeRstRendering()`. It is git-ignored and uploaded as a
 continuous integration artifact.
 
 ## The extensions and their split repositories
@@ -180,7 +180,7 @@ turned into hyphens, which makes the two that are not easy to miss:
 The authoritative source is always `extra.typo3/cms.extension-key` in the
 package's `composer.json`. Anything that needs the key derives it from there
 rather than from the path — the release workflow reads it with `jq` at runtime
-for exactly this reason (`.github/workflows/publish.yml:76`), and
+for exactly this reason, in its TER artifact step, and
 `bin/set-version` discovers the mapping the same way.
 
 Note also that the split repository name follows the directory, not the package

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -31,10 +31,10 @@ Build/Scripts/runTests.sh -t 14 -p 8.2 -s composerUpdate
 
 ## Coding guidelines — `cgl`
 
-`Build/Scripts/runTests.sh:590-599` runs php-cs-fixer with
+The `cgl` arm of `runTests.sh` runs php-cs-fixer with
 [`Build/php-cs-fixer/config.php`](../../Build/php-cs-fixer/config.php). Without
 `-n` it **rewrites files in place**; with `-n` it adds `--dry-run --diff` and
-only reports, which is the form CI uses (`.github/workflows/ci.yml:108-109`).
+only reports, which is the form CI uses in its `cgl` job.
 
 The rule set is `@PER-CS1.0` plus `@DoctrineAnnotation` and some fifty
 individual rules (`Build/php-cs-fixer/config.php:64-133`), risky rules allowed.
@@ -78,15 +78,16 @@ carry a header: `*locallang*.php`, `ext_localconf.php`, `ext_tables.php`,
 > [!IMPORTANT]
 > **This gate is currently not enforced.** Its CI step is commented out with a
 > `@todo` — "Disabled until the correct file header has been determined for
-> extensions" (`.github/workflows/ci.yml:111-113`). Running it locally without
+> extensions" — the commented-out *CGL (header comments)* step of the `cgl`
+> job. Running it locally without
 > `-n` therefore rewrites headers across the code base and produces a diff
 > nobody asked for. Run it with `-n` if at all, until the header is settled.
 
 ## PHP linting — `lintPhp`
 
 `php -l` over every `*.php` in the repository, four processes in parallel, with
-Xdebug off (`Build/Scripts/runTests.sh:709-721`). It has no configuration file;
-the specification is the `find` invocation, and its exclusions are load-bearing:
+Xdebug off. It has no configuration file; the specification is the `find`
+invocation in its `case` arm, and its exclusions are load-bearing:
 
 * `./.Build/*` — the installed vendor tree.
 * `./.agent/*` — the git-ignored working tree for drafts and partial snippets;
@@ -98,8 +99,8 @@ the specification is the `find` invocation, and its exclusions are load-bearing:
 The instances' **tracked** `config/system/*.php` is deliberately still linted.
 
 This is the only gate that needs neither a vendor tree nor a core version,
-which is why CI runs it without `composerUpdate` and across all four PHP
-versions (`.github/workflows/ci.yml:154-171`). It is also the cheapest way to
+which is why the `lint` job runs it without `composerUpdate` and across all
+four PHP versions. It is also the cheapest way to
 find a syntax error that is specific to one PHP version.
 
 ## Static analysis — `phpstan`
@@ -112,13 +113,13 @@ included from the installed vendor tree: `bnf/phpstan-psr-container`,
 
 ### Why it is configured per core version
 
-`-t` selects `Build/phpstan/Core${CORE_VERSION}/phpstan.neon`
-(`Build/Scripts/runTests.sh:737-742`). PHPStan analyses the sources **against
+`-t` selects `Build/phpstan/Core${CORE_VERSION}/phpstan.neon` in the `phpstan`
+arm. PHPStan analyses the sources **against
 the core that is installed in `.Build/`**, so the same code produces different
 findings on v13 and on v14: a method that exists only in one of them, a
 signature that changed, a return type that was narrowed. Running the gate for
 one version would miss half of them. It is the only source gate CI runs per
-core version (`.github/workflows/ci.yml:115-125`).
+core version — its `phpstan` job has the core version as a matrix axis.
 
 The two `phpstan.neon` files are byte-identical today. The version specific
 part sits next to them:
@@ -149,7 +150,7 @@ Build/Scripts/runTests.sh -t 14 -s phpstanGenerateBaseline
 ```
 
 which writes `Build/phpstan/Core<version>/phpstan-baseline.neon` with
-`--allow-empty-baseline` (`Build/Scripts/runTests.sh:743-748`).
+`--allow-empty-baseline`, in the `phpstanGenerateBaseline` arm.
 
 **A growing baseline is a defect, not a configuration change.** Regenerating it
 to make a new finding disappear removes exactly the signal the gate exists for,
@@ -181,8 +182,8 @@ one slower run and never loses anything.
 `unit` and `unitRandom` use
 [`Build/phpunit/UnitTests.xml`](../../Build/phpunit/UnitTests.xml),
 `functional` uses
-[`Build/phpunit/FunctionalTests.xml`](../../Build/phpunit/FunctionalTests.xml)
-(`Build/Scripts/runTests.sh:749-760`, `657-708`). `unitRandom` adds
+[`Build/phpunit/FunctionalTests.xml`](../../Build/phpunit/FunctionalTests.xml),
+each named in its own `case` arm. `unitRandom` adds
 `--order-by=random` and the seed from `-o`, which is how an order dependency
 between tests is found and then replayed.
 
@@ -246,7 +247,7 @@ Build/Scripts/runTests.sh -t 13 -s functional \
 
 `functional` starts the database in its own container, waits for the port,
 hands the connection parameters to PHPUnit as environment variables and removes
-the container afterwards (`Build/Scripts/runTests.sh:657-708`). With the
+the container afterwards — all of it in the `functional` arm. With the
 default `-d sqlite` no container is started; the databases are created in a
 tmpfs below `.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/`.
 
@@ -258,8 +259,8 @@ in the DBMS matrix. Run PostgreSQL as well for anything that writes:
 Build/Scripts/runTests.sh -t 13 -s functional -d postgres -i 16
 ```
 
-`functional` also excludes the group `not-${DBMS}`
-(`Build/Scripts/runTests.sh:659`), so a test that cannot work on one DBMS can
+`functional` also excludes the group `not-${DBMS}`, so a test that cannot work
+on one DBMS can
 be tagged `#[Group('not-postgres')]` instead of being skipped at runtime. No
 test uses this at the moment; a DBMS difference has so far always been a defect
 in the query, not a property of the test.
@@ -267,7 +268,7 @@ in the query, not a property of the test.
 ## Core version aware tests: `not-core-13` and `not-core-14`
 
 Every PHPUnit suite is started with `--exclude-group not-core-${CORE_VERSION}`
-(`Build/Scripts/runTests.sh:659`, `751`, `757`). The name reads as an
+— the `functional`, `unit` and `unitRandom` arms. The name reads as an
 exclusion, so the effect is inverted from what it looks like:
 
 | Group attribute           | Runs on |
@@ -300,9 +301,8 @@ The user-facing manuals live per package in
 `packages/fgtclb/<extension>/Documentation/` and are reST, not Markdown.
 `checkRstRenderingAll` iterates over every extension folder that has a
 `Documentation/` directory — twelve today — and renders each one with the
-`ghcr.io/typo3-documentation/render-guides` image
-(`Build/Scripts/runTests.sh:610-622`, rendering in `executeRstRendering()` at
-`Build/Scripts/runTests.sh:213-227`).
+`ghcr.io/typo3-documentation/render-guides` image; the rendering itself is in
+`executeRstRendering()`.
 
 **This is a real gate, not an artifact producer.** The renderer is invoked with
 `--fail-on-log --fail-on-error`, so a warning fails the job. The results are
@@ -405,13 +405,13 @@ anybody. See [Pull requests](../workflow/pull-requests.md).
 The DBMS matrix is the expensive part — sixteen jobs, each starting a database
 container. It runs only after the same tests passed on SQLite for both core
 versions and both edge PHP versions, so a defect that is not DBMS specific is
-reported by four jobs instead of twenty
-(`.github/workflows/ci.yml:250-255`).
+reported by four jobs instead of twenty — `functional-dbms` needs
+`functional-sqlite`.
 
 ### Three PHP sets
 
-They are three, and they have to be changed together
-(`.github/workflows/ci.yml:26-36`):
+They are three, and they have to be changed together — the table in the header
+comment of `ci.yml` records which set each job uses:
 
 | Set    | PHP versions       | Used by              | Why                                            |
 |--------|--------------------|----------------------|------------------------------------------------|
@@ -427,7 +427,7 @@ A gate therefore cannot behave differently in CI than locally, and reproducing
 a red pipeline is a matter of copying the command from the log.
 
 The two deviations from a plain local run are both explained in the workflow
-itself: `-b docker` on every step (`.github/workflows/ci.yml:44-52`) and the
+itself: `-b docker` on every step, explained in its header comment, and the
 `composerUpdate` that precedes every job needing a vendor tree.
 
 ### Why the pull-request comment is a separate workflow
@@ -440,8 +440,7 @@ A pull request **from a fork** gets a read-only `GITHUB_TOKEN` and no secrets.
 Commenting needs `pull-requests: write`, so a comment step inside `ci.yml`
 would work for branches in this repository and silently fail for exactly the
 contributors it is meant to serve. `ci.yml` therefore declares
-`permissions: contents: read` and writes nothing at all
-(`.github/workflows/ci.yml:62-63`).
+`permissions: contents: read` and writes nothing at all.
 
 `workflow_run` fires when `ci.yml` finishes, runs in the context of the default
 branch rather than the fork, and its token can write. No code from the pull
@@ -456,9 +455,10 @@ Two consequences follow, and both have cost time before:
    it.
 2. `github.event.workflow_run.pull_requests` is empty for a fork, so the pull
    request number cannot be read from the event. `ci.yml` writes it into the
-   `pull-request-context` artifact before rendering, so the comment lands on
-   the right pull request even when the rendering fails
-   (`.github/workflows/ci.yml:302-320`).
+   `pull-request-context` artifact before rendering — the *Record the pull
+   request number* and *Upload the pull request context* steps of its
+   `documentation` job — so the comment lands on the right pull request even
+   when the rendering fails.
 
 ## Before pushing
 

--- a/docs/testing/functional-tests.md
+++ b/docs/testing/functional-tests.md
@@ -56,14 +56,14 @@ As with the unit suite, the trailing path is the only way to narrow a run;
 | `-i`   | a version of the selected DBMS           | see below | Rejected for `-d sqlite`.                                                 |
 | `-a`   | `mysqli`, `pdo_mysql`                    | `mysqli`  | Only for `-d mysql` and `-d mariadb`; rejected for SQLite and PostgreSQL. |
 
-Defaults and accepted versions are validated in `handleDbmsOptions()`,
-[`Build/Scripts/runTests.sh:117`](../../Build/Scripts/runTests.sh#L117) onwards:
+Defaults and accepted versions are validated in `handleDbmsOptions()` of
+[`Build/Scripts/runTests.sh`](../../Build/Scripts/runTests.sh):
 MariaDB `10.4`, MySQL `8.0`, PostgreSQL `10`. An invalid combination is refused
 before a container starts, with the offending pair echoed.
 
 SQLite needs no container: the script creates
-`.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/` and mounts it as tmpfs
-([`runTests.sh:693-706`](../../Build/Scripts/runTests.sh#L693-L706)). The other
+`.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/` and mounts it as tmpfs,
+in the `sqlite)` branch of the `functional` arm. The other
 three start a database container, wait for its port, and pass the connection
 through `typo3Database*` environment variables. That is the whole reason SQLite
 is the default — it is the fastest loop, and it needs the least of the host.
@@ -131,8 +131,7 @@ DBMS specific is therefore reported by 4 jobs instead of 20.
 
 ## The `not-<dbms>` group
 
-`runTests.sh` always appends **two** exclusions to the functional PHPUnit call
-([`runTests.sh:659`](../../Build/Scripts/runTests.sh#L659)):
+`runTests.sh` always appends **two** exclusions to the functional PHPUnit call:
 
 ```bash
 COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} --exclude-group not-core-${CORE_VERSION} "$@")

--- a/docs/testing/phpunit-configuration.md
+++ b/docs/testing/phpunit-configuration.md
@@ -11,12 +11,10 @@ of every other tool:
 | [`Build/phpunit/FunctionalTests.xml`](../../Build/phpunit/FunctionalTests.xml)                   | 49    | PHPUnit configuration of the functional suite. |
 | [`Build/phpunit/FunctionalTestsBootstrap.php`](../../Build/phpunit/FunctionalTestsBootstrap.php) | 60    | Bootstrap referenced by `FunctionalTests.xml`. |
 
-Nothing selects them implicitly. `Build/Scripts/runTests.sh` passes the matching
-file with `-c` for every suite it starts — see
-[`Build/Scripts/runTests.sh:658`](../../Build/Scripts/runTests.sh#L658) for the
-functional suite and
-[`Build/Scripts/runTests.sh:750`](../../Build/Scripts/runTests.sh#L750) and
-[`:756`](../../Build/Scripts/runTests.sh#L756) for `unit` and `unitRandom`.
+Nothing selects them implicitly.
+[`Build/Scripts/runTests.sh`](../../Build/Scripts/runTests.sh) sets
+`PHPUNIT_CONFIG_FILE` and passes it with `-c` in each of the `functional`,
+`unit` and `unitRandom` arms.
 
 The installed PHPUnit is `phpunit/phpunit` 11.5.56, against
 `typo3/testing-framework` 9.6.1.

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -29,24 +29,23 @@ Build/Scripts/runTests.sh -t 13 -p 8.3 -s unit
 | `runTests.sh -s unit packages/fgtclb/academic-persons/Tests/Unit`                            | Restricted to one extension.                                            |
 | `runTests.sh -s unit packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/EmailTest.php` | Restricted to one file.                                                 |
 
-The trailing path is the **only** way to narrow a run. `runTests.sh` has no
-argument passthrough to PHPUnit — no `-e`, no `--`. Anything else (a
-`--filter`, a `--group`) has to be added to the `COMMAND` array in the script
-itself, which is not how a normal run works.
+The trailing path is the usual way to narrow a run, and there is no `-e`
+option. Anything else — a `--filter`, a `--group` — goes after a `--`
+separator, which every phpunit suite appends to its command:
 
-`-o` is parsed at
-[`Build/Scripts/runTests.sh:447-449`](../../Build/Scripts/runTests.sh#L447-L449)
-and turns into `--random-order-seed=<seed>`. It only has an effect together with
-`-s unitRandom`; the `unit` suite does not pass `PHPUNIT_RANDOM` on. Note that
-the built-in help text still documents the TYPO3 Core spelling
-`-- --random-order-seed=<number>`
-([`runTests.sh:269`](../../Build/Scripts/runTests.sh#L269)) — that form does not
-work here, use `-o`.
+```bash
+Build/Scripts/runTests.sh -s unit -- --filter EmailTest
+```
 
-`unitRandom` is not decoration. CI runs it right after `unit` in the same job
-([`.github/workflows/ci.yml:210-211`](../../.github/workflows/ci.yml#L210-L211)),
-because ordering dependencies between tests are exactly the kind of defect a
-fixed order hides.
+`-o` is parsed in its own `getopts` arm and turns into
+`--random-order-seed=<seed>`. It only has an effect together with
+`-s unitRandom`; the `unit` suite does not pass `PHPUNIT_RANDOM` on. Prefer it
+over `-- --random-order-seed=<number>`, which reaches phpunit as well but says
+the same thing twice as long.
+
+`unitRandom` is not decoration. CI runs it right after `unit` in the same job —
+the *Execute unit tests in random order* step — because ordering dependencies
+between tests are exactly the kind of defect a fixed order hides.
 
 ## Discovery
 
@@ -163,10 +162,8 @@ will not catch one for you.
 ## Core-version-aware unit tests
 
 `runTests.sh` always appends `--exclude-group not-core-${CORE_VERSION}` to the
-PHPUnit call — for `unit` at
-[`runTests.sh:751`](../../Build/Scripts/runTests.sh#L751) and for `unitRandom`
-at [`:757`](../../Build/Scripts/runTests.sh#L757). The group names read as what
-they exclude:
+PHPUnit call, in both the `unit` and the `unitRandom` arm. The group names read
+as what they exclude:
 
 | Group         | Runs on | Meaning                      |
 |---------------|---------|------------------------------|

--- a/docs/workflow/changelog-and-documentation.md
+++ b/docs/workflow/changelog-and-documentation.md
@@ -59,21 +59,20 @@ Build/Scripts/runTests.sh -s openDocumentation academic-jobs         # open the 
 ```
 
 The image is `ghcr.io/typo3-documentation/render-guides:latest`
-(`Build/Scripts/runTests.sh:531`). Neither `-t` nor `-p` matters here: the
+(`IMAGE_RSTRENDERING`). Neither `-t` nor `-p` matters here: the
 renderer is a self-contained container and needs no vendor tree, which is why
 `composerUpdate` is not a precondition for a documentation change.
 
 The argument to `checkRstRenderingSingle` and `openDocumentation` is the
 **directory** below `packages/fgtclb/`, not the extension key — the script
-checks `packages/fgtclb/${extensionKey}` for existence
-(`Build/Scripts/runTests.sh:626-631`) despite the variable's name. For
+checks `packages/fgtclb/${extensionKey}` for existence, in the
+`checkRstRenderingSingle` arm, despite the variable's name. For
 `academic_contacts4pages` the argument is therefore `academic-contact4pages`.
 
 ### Where the output lands
 
-`executeRstRendering()` (`Build/Scripts/runTests.sh:213-227`) mounts one package
-into the container and runs the renderer with the package as both configuration
-and input directory:
+`executeRstRendering()` mounts one package into the container and runs the
+renderer with the package as both configuration and input directory:
 
 ```
 --fail-on-log --fail-on-error --no-progress --config=Documentation Documentation
@@ -83,9 +82,8 @@ The renderer writes into the package itself, at
 `packages/fgtclb/<ext>/Documentation-GENERATED-temp/`, which every package's
 `.gitignore` excludes (`packages/fgtclb/academic-base/.gitignore:9`). The script
 then copies that tree to
-`documentation-rendered/<ext>/Documentation-GENERATED-temp/`
-(`Build/Scripts/runTests.sh:223-225`), which is ignored at the root
-(`.gitignore:56`).
+`documentation-rendered/<ext>/Documentation-GENERATED-temp/`, which is ignored
+at the root.
 
 Two locations for one result is deliberate. The per-package one is where the
 renderer has to write, because it renders one package at a time with that
@@ -96,7 +94,7 @@ per extension, and that single directory is what CI uploads as an artifact.
 `openDocumentation` reads only the collected copy and opens
 `documentation-rendered/<ext>/Documentation-GENERATED-temp/Index.html` with
 `xdg-open`. It renders nothing itself: without a preceding render it prints the
-two commands to run first (`Build/Scripts/runTests.sh:229-244`). It is
+two commands to run first, in `openDocumentation()`. It is
 Linux-only, which the script marks with a `@todo`.
 
 There is no watch mode in this repository. The loop is edit, render the single
@@ -104,8 +102,7 @@ package, reopen.
 
 ## The render is a gate, not an artifact producer
 
-The `documentation` job of the CI workflow
-(`.github/workflows/ci.yml:294-339`) runs exactly the command above:
+The `documentation` job of the CI workflow runs exactly the command above:
 
 ```yaml
 - name: "Render documentation of all extensions"
@@ -116,7 +113,7 @@ Because `executeRstRendering()` passes **`--fail-on-log --fail-on-error`**, the
 renderer exits non-zero on a warning, not only on a hard error, and the job
 fails. A broken cross-reference, an unknown directive or a malformed table is
 therefore a red pull request, not a cosmetic remark. The comment above the step
-says so in the workflow itself (`.github/workflows/ci.yml:322-326`).
+says so in the workflow itself.
 
 The job is independent of the source gates — it has no `needs:` — so a
 documentation-only change gets its answer without waiting for `cgl`, `phpstan`,
@@ -128,7 +125,7 @@ consistent with the renderer needing no vendor tree.
 `.github/workflows/pr-comment.yml` posts one comment per pull request linking
 the `documentation` artifact of the run, and updates that same comment on every
 push instead of adding a new one (it finds its own comment by the marker
-`<!-- rendered-documentation -->`, `.github/workflows/pr-comment.yml:84`).
+`<!-- rendered-documentation -->`).
 
 It is a **separate workflow on the `workflow_run` event**, and that is not an
 accident:
@@ -141,7 +138,7 @@ accident:
   **default branch** of this repository, not the fork. Its token can write even
   though the token of the run that triggered it could not, and no code from the
   pull request is checked out — which is what makes granting write permission
-  safe (`.github/workflows/pr-comment.yml:6-22`, `39-43`).
+  safe — see its `on:` block and its `permissions:`.
 * `pull_request_target` is deliberately **not** used. It also carries a write
   token, but running the pull request's own code under it is a documented way to
   leak write access and secrets.
@@ -154,9 +151,9 @@ Two consequences follow, and both surprise people:
    it by merging it, not by pushing it.
 2. `github.event.workflow_run.pull_requests` is empty for a fork, so the pull
    request number cannot be read from the event. `ci.yml` writes it into a
-   `pull-request-context` artifact *before* rendering
-   (`.github/workflows/ci.yml:307-320`), so the comment lands on the right pull
-   request even when the rendering failed.
+   `pull-request-context` artifact *before* rendering, in the *Record the pull
+   request number* and *Upload the pull request context* steps, so the comment
+   lands on the right pull request even when the rendering failed.
 
 ## Changelog entries
 

--- a/docs/workflow/releasing.md
+++ b/docs/workflow/releasing.md
@@ -156,8 +156,8 @@ authenticated `gh` (`bin/release:154-162`).
 ## The tag has to match `ext_emconf.php`
 
 The root `publish` workflow builds the TER artifacts with
-`tailor create-artefact <version> <extension-key>`
-(`.github/workflows/publish.yml:69-80`), and **that command fails when the
+`tailor create-artefact <version> <extension-key>` in its *Create local TER
+package upload artifact* step, and **that command fails when the
 version does not match the extension's `ext_emconf.php`**. This is a feature, not
 an obstacle: it makes it impossible for a release to disagree with the extension
 metadata that TYPO3 and the TER read.
@@ -168,8 +168,8 @@ extensions currently declare `'version' => '3.0.0'`, so the tag for the next
 release is `3.0.0`.
 
 The workflow additionally rejects a tag that is not a bare
-`MAJOR.MINOR.PATCH` before doing any work
-(`.github/workflows/publish.yml:47-52`). There is no `v` prefix — `bin/release`
+`MAJOR.MINOR.PATCH` before doing any work, in its *Verify tag* step. There is
+no `v` prefix — `bin/release`
 creates `3.0.0`, not `v3.0.0`.
 
 ## The three-step publishing chain
@@ -196,18 +196,17 @@ verifies its shape, installs `typo3/tailor`, then loops over
 `packages/fgtclb/*`, reads each extension key from that package's
 `composer.json` at runtime, and builds one artifact per extension. The keys are
 read rather than derived from the directory name because they differ:
-`academic-contact4pages` ships `academic_contacts4pages`
-(`.github/workflows/publish.yml:21-23`). Finally
+`academic-contact4pages` ships `academic_contacts4pages`. Finally
 `softprops/action-gh-release` creates the release `[RELEASE] <version>` with
 generated notes and attaches all artifacts plus `LICENSE`, failing on an
 unmatched file.
 
-This workflow contains **no** `ter:publish` step, and that is deliberate
-(`.github/workflows/publish.yml:3-13`). There is no `academic_extensions`
+This workflow contains **no** `ter:publish` step, and that is deliberate; the
+header comment of the file says why. There is no `academic_extensions`
 extension to publish.
 
-A documentation-rendering step exists in the file but is commented out
-(`.github/workflows/publish.yml:82-88`); the rendered manual is currently
+A *Render documentation of all academic extensions* step exists in the file but
+is commented out; the rendered manual is currently
 produced only by the CI workflow on pull requests, see
 [Changelog and documentation](changelog-and-documentation.md).
 


### PR DESCRIPTION
`docs/` cited its sources by line number. Every edit to a cited file shifted them silently, and nothing reported it — so they had drifted far enough to be actively misleading rather than merely imprecise:

| Reference | Claimed | Actually was |
|---|---|---|
| `runTests.sh:213-227` | `executeRstRendering()` | `cleanJsFiles()` |
| `runTests.sh:391` | the `-t` default | `-o <number>` |
| `runTests.sh:659` | the functional phpunit call | a `checkJsBuildClean` echo |
| `ci.yml:294-339` | the `documentation` job | `frontend-assets` |

**All 85 references into the two files this repository edits most** — `Build/Scripts/runTests.sh` and `.github/workflows/*.yml` — now name the thing instead: the shell function, the `case` arm, the variable, the CI job, the step. Those names change when the thing itself changes, which is exactly when the sentence around them needs rewriting anyway.

```diff
-`-t` selects `Build/phpstan/Core${CORE_VERSION}/phpstan.neon`
-(`Build/Scripts/runTests.sh:737-742`).
+`-t` selects `Build/phpstan/Core${CORE_VERSION}/phpstan.neon` in the `phpstan`
+arm.
```

No gate can catch this — a drifted line number still points at a line that exists — so removing the construct is the only durable fix, not a check.

## Four sentences were stale beyond their reference

Fixed with them, since correcting the citation and leaving the claim wrong would be worse than either:

* `docs/testing/unit-tests.md` stated *"The trailing path is the **only** way to narrow a run. `runTests.sh` has no argument passthrough to PHPUnit — no `-e`, no `--`. Anything else has to be added to the `COMMAND` array in the script itself."* The `--` separator has always worked and has been documented since ACE-396. Verified rather than assumed:

  ```
  $ Build/Scripts/runTests.sh -s unit -- --filter EmailTest
  OK (5 tests, 4 assertions)
  ```

* The same page called `-- --random-order-seed=<number>` a form that "does not work here". It does; `-o` is simply shorter.

Every named anchor was checked against the file. The CI step names come from the workflow (`Prepare dependencies for TYPO3 v…` is in exactly `cgl`, `phpstan`, `unit`, `functional-sqlite`, `functional-dbms` — confirmed by parsing `ci.yml`), and `publish.yml`'s steps are cited by their real names (`Verify tag`, `Create local TER package upload artifact`) rather than the invented ones I first wrote.

## What was deliberately left

96 line references remain, into extension classes, phpunit/phpstan configuration and the installed core. Two reasons:

1. They are **correct today** — the resolvable ones were checked, and they point at what the prose says.
2. The core ones are **pinned to the version they were read at** — `QueryBuilder.php:1145-1158` "(v13.4.34)", `ExpressionBuilder.php:227-234` "on v13.4.34, `:223-230` on v14.3.6". That is what makes a line number legitimate: a citation of a fixed third-party artifact, not a pointer into a file we edit. `docs/architecture/database-queries.md` was already doing this correctly and is left alone.

Documentation only. `lintMarkdown` green. Backport to `2` follows.

Issue: ACE-400
