### PR TITLE
[BUGFIX] ACE-401: Checkpoint the SQLite snapshot

### DIFF
--- a/Build/Scripts/sqliteSnapshot.php
+++ b/Build/Scripts/sqliteSnapshot.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the fgtclb/academic extension collection.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Copies the SQLite database of a development instance to or from its committed
+ * template.
+ *
+ * Invoked through the "sqlite:backup" and "sqlite:apply" composer scripts of
+ * "core-13/" and "core-14/", so the working directory is the instance directory
+ * and both paths are relative to it:
+ *
+ *   php ../Build/Scripts/sqliteSnapshot.php backup  var/sqlite/core-13.sqlite ../sqlite-databases/core-13.sqlite
+ *   php ../Build/Scripts/sqliteSnapshot.php restore ../sqlite-databases/core-13.sqlite var/sqlite/core-13.sqlite
+ *
+ * Why this is not a plain "cp".
+ *
+ * SQLite may run in write ahead logging mode, and then the database file on
+ * disk is not the database: the most recent transactions live in a "-wal"
+ * sidecar until a checkpoint folds them back in. That checkpoint happens when
+ * the last connection closes - and a backup is taken while the instance is
+ * running, so there usually is one. Copying the main file alone then produces a
+ * template that is silently missing the newest writes, or one that cannot be
+ * opened at all.
+ *
+ * So a backup checkpoints first, and both directions remove the sidecars of the
+ * target, which belong to the database being replaced and never to its
+ * replacement. The checkpoint is harmless when the database is in any other
+ * journal mode; the pragma then simply reports that there was nothing to do.
+ *
+ * The copy is verified by opening it and counting its tables, because a
+ * truncated or half written template is worth less than no template at all.
+ *
+ * Requires nothing but PHP with pdo_sqlite: it is called from an instance whose
+ * dependencies may not be installed yet.
+ */
+const SIDECAR_SUFFIXES = ['-wal', '-shm'];
+
+/**
+ * @param string[] $argv
+ */
+function main(array $argv): int
+{
+    $mode = $argv[1] ?? '';
+    $source = $argv[2] ?? '';
+    $target = $argv[3] ?? '';
+
+    if (!in_array($mode, ['backup', 'restore'], true) || $source === '' || $target === '') {
+        fwrite(STDERR, "Usage: sqliteSnapshot.php <backup|restore> <source> <target>\n");
+        return 1;
+    }
+
+    if (!extension_loaded('pdo_sqlite')) {
+        fwrite(STDERR, "The pdo_sqlite extension is not available.\n");
+        return 1;
+    }
+
+    if (!is_file($source)) {
+        fwrite(STDERR, sprintf(
+            "There is no database at \"%s\".\n%s\n",
+            $source,
+            $mode === 'restore'
+                ? 'Nothing has been committed as a template yet, so there is nothing to restore from.'
+                : 'Start the instance and set it up before backing it up.',
+        ));
+        return 1;
+    }
+
+    // Only a backup reads a live database. A restore reads a template that
+    // nothing is writing to, and checkpointing it would only touch a file that
+    // is about to be copied verbatim anyway.
+    if ($mode === 'backup' && !checkpoint($source)) {
+        return 1;
+    }
+
+    $targetDirectory = dirname($target);
+    if (!is_dir($targetDirectory) && !mkdir($targetDirectory, 0775, true) && !is_dir($targetDirectory)) {
+        fwrite(STDERR, sprintf("Could not create \"%s\".\n", $targetDirectory));
+        return 1;
+    }
+
+    foreach (SIDECAR_SUFFIXES as $suffix) {
+        $sidecar = $target . $suffix;
+        if (is_file($sidecar) && !unlink($sidecar)) {
+            fwrite(STDERR, sprintf("Could not remove the stale sidecar \"%s\".\n", $sidecar));
+            return 1;
+        }
+    }
+
+    if (!copy($source, $target)) {
+        fwrite(STDERR, sprintf("Could not copy \"%s\" to \"%s\".\n", $source, $target));
+        return 1;
+    }
+
+    $tables = countTables($target);
+    if ($tables === null) {
+        fwrite(STDERR, sprintf("The copy at \"%s\" could not be opened as a database.\n", $target));
+        return 1;
+    }
+
+    printf(
+        "%s %s -> %s (%d tables, %s)\n",
+        $mode === 'backup' ? 'Backed up' : 'Restored',
+        $source,
+        $target,
+        $tables,
+        formatSize((int)filesize($target)),
+    );
+
+    return 0;
+}
+
+function checkpoint(string $database): bool
+{
+    try {
+        $connection = new PDO('sqlite:' . $database, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        // TRUNCATE folds the write ahead log back into the database and empties
+        // it, so the file that is copied afterwards is complete on its own.
+        $connection->query('PRAGMA wal_checkpoint(TRUNCATE)');
+        unset($connection);
+    } catch (PDOException $exception) {
+        fwrite(STDERR, sprintf("Could not checkpoint \"%s\": %s\n", $database, $exception->getMessage()));
+        return false;
+    }
+
+    return true;
+}
+
+function countTables(string $database): ?int
+{
+    try {
+        $connection = new PDO('sqlite:' . $database, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $count = $connection->query("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'")?->fetchColumn();
+        unset($connection);
+    } catch (PDOException) {
+        return null;
+    }
+
+    return is_numeric($count) ? (int)$count : null;
+}
+
+function formatSize(int $bytes): string
+{
+    if ($bytes >= 1048576) {
+        return sprintf('%.1f MB', $bytes / 1048576);
+    }
+
+    return sprintf('%.1f kB', $bytes / 1024);
+}
+
+exit(main($argv));

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ ddev composer system:refresh   # flush + warm caches, update languages, extensio
 `sqlite:backup` rewrites a multi-megabyte binary that git cannot delta-compress,
 so commit it when the demo content genuinely changed, not on every run.
 
+Both directions go through `Build/Scripts/sqliteSnapshot.php` rather than `cp`,
+because a running instance keeps its newest writes in a SQLite write ahead log
+that a plain copy leaves behind — see
+[Development environment](docs/development/environment.md#snapshotting-an-instance-database-is-not-a-copy).
+
 ### Teardown
 
 ```shell

--- a/core-13/.ddev/docker-compose.mounts.yaml
+++ b/core-13/.ddev/docker-compose.mounts.yaml
@@ -1,6 +1,17 @@
+# Makes the parts of the repository the instance refers to reachable under the
+# same relative paths inside the container as on the host.
+#
+# The instance itself is mounted at "/var/www/html", so ".." inside the
+# container is "/var/www". Each mount below recreates one directory the
+# instance sees one level up on the host, which is what lets a single
+# "composer.json" serve DDEV and a plain host stack.
+#
+# The sources are resolved by DDEV relative to this ".ddev" directory, hence
+# "../..".
 services:
   web:
     volumes:
+      - "../../Build:/var/www/Build"
       - "../../packages:/var/www/packages"
       - "../../packages-dev:/var/www/packages-dev"
       - "../../sqlite-databases:/var/www/sqlite-databases"

--- a/core-13/composer.json
+++ b/core-13/composer.json
@@ -71,13 +71,13 @@
     "homepage": "https://www.fgtclb.com/",
     "scripts": {
         "sqlite:apply": [
-            "\\cp -Rvf ../sqlite-databases/core-13.sqlite var/sqlite/core-13.sqlite",
+            "@php ../Build/Scripts/sqliteSnapshot.php restore ../sqlite-databases/core-13.sqlite var/sqlite/core-13.sqlite",
             "@php vendor/bin/typo3 cache:flush",
             "@php vendor/bin/typo3 cache:warmup"
         ],
         "sqlite:backup": [
             "@php vendor/bin/typo3 cache:flush",
-            "\\cp -Rvf var/sqlite/core-13.sqlite ../sqlite-databases/core-13.sqlite",
+            "@php ../Build/Scripts/sqliteSnapshot.php backup var/sqlite/core-13.sqlite ../sqlite-databases/core-13.sqlite",
             "@php vendor/bin/typo3 cache:warmup"
         ],
         "system:refresh": [

--- a/core-14/.ddev/docker-compose.mounts.yaml
+++ b/core-14/.ddev/docker-compose.mounts.yaml
@@ -1,6 +1,17 @@
+# Makes the parts of the repository the instance refers to reachable under the
+# same relative paths inside the container as on the host.
+#
+# The instance itself is mounted at "/var/www/html", so ".." inside the
+# container is "/var/www". Each mount below recreates one directory the
+# instance sees one level up on the host, which is what lets a single
+# "composer.json" serve DDEV and a plain host stack.
+#
+# The sources are resolved by DDEV relative to this ".ddev" directory, hence
+# "../..".
 services:
   web:
     volumes:
+      - "../../Build:/var/www/Build"
       - "../../packages:/var/www/packages"
       - "../../packages-dev:/var/www/packages-dev"
       - "../../sqlite-databases:/var/www/sqlite-databases"

--- a/core-14/composer.json
+++ b/core-14/composer.json
@@ -72,13 +72,13 @@
     "homepage": "https://www.fgtclb.com/",
     "scripts": {
         "sqlite:apply": [
-            "\\cp -Rvf ../sqlite-databases/core-14.sqlite var/sqlite/core-14.sqlite",
+            "@php ../Build/Scripts/sqliteSnapshot.php restore ../sqlite-databases/core-14.sqlite var/sqlite/core-14.sqlite",
             "@php vendor/bin/typo3 cache:flush",
             "@php vendor/bin/typo3 cache:warmup"
         ],
         "sqlite:backup": [
             "@php vendor/bin/typo3 cache:flush",
-            "\\cp -Rvf var/sqlite/core-14.sqlite ../sqlite-databases/core-14.sqlite",
+            "@php ../Build/Scripts/sqliteSnapshot.php backup var/sqlite/core-14.sqlite ../sqlite-databases/core-14.sqlite",
             "@php vendor/bin/typo3 cache:warmup"
         ],
         "system:refresh": [

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -304,9 +304,50 @@ PHP. The instances' tracked `config/system/*.php` is still linted, on purpose.
 Do not run a gate expecting an instance to be updated, and do not fix a failing
 instance by running `composerUpdate` — that installs the root project's
 dependency tree into `.Build/`, which is a different thing entirely. Instance
-handling, DDEV project names, the SQLite backup/restore scripts and the branch
-switching collision are described in
+handling, DDEV project names and the branch switching collision are described in
 [`README.md`](../../README.md#development-instances).
+
+### Snapshotting an instance database is not a copy
+
+Both directions of the snapshot — `ddev composer sqlite:backup` and
+`ddev composer sqlite:apply` — go through
+[`Build/Scripts/sqliteSnapshot.php`](../../Build/Scripts/sqliteSnapshot.php)
+rather than `cp`. That is not a refinement. A plain copy is **wrong** here, and
+it fails silently.
+
+SQLite in write ahead logging mode keeps the newest transactions in a `-wal`
+sidecar until a checkpoint folds them back into the main file. The checkpoint
+happens when the *last* connection closes — and a backup is taken while the
+instance is running, so php-fpm is holding one. Until it closes, the main file
+can be almost empty.
+
+Measured on PHP 8.2 with `pdo_sqlite`, 500 rows written in WAL mode with the
+writer deliberately kept open:
+
+| File              | Size    |
+|-------------------|---------|
+| `live.sqlite`     | 4 kB    |
+| `live.sqlite-wal` | 2076 kB |
+
+The plain copy of the main file opened, and then reported `no such table` for
+every table the database had. That is the shape of the defect: not an error at
+backup time, but a committed template that turns out to be empty the next time
+somebody restores from it. The `cache:flush` that `sqlite:backup` runs first
+does not help — it flushes TYPO3 caches, not the write ahead log.
+
+The helper therefore checkpoints the source with `PRAGMA wal_checkpoint(TRUNCATE)`
+before copying, removes the `-wal` and `-shm` sidecars of the file it replaces
+— they belong to the database being overwritten, never to its replacement — and
+verifies the result by opening it and counting its tables. It exits non-zero
+with a readable message when the source is missing or the copy cannot be opened.
+
+The checkpoint is harmless in any other journal mode; the pragma then reports
+that there was nothing to do, which is why the helper needs no journal mode
+detection. It uses nothing but PHP with `pdo_sqlite`, because it is called from
+an instance whose dependencies may not be installed yet — and it is reachable at
+the same relative path on both sides, because each instance bind-mounts the
+repository's `Build/` into its container
+(`core-*/.ddev/docker-compose.mounts.yaml`).
 
 ## See also
 

--- a/docs/development/monorepo-layout.md
+++ b/docs/development/monorepo-layout.md
@@ -109,7 +109,10 @@ no test run depends on them.
 `sqlite-databases/core-13.sqlite` and `sqlite-databases/core-14.sqlite` are the
 committed database templates. Each instance restores from and backs up to its
 own file through the composer scripts `sqlite:apply` and `sqlite:backup`
-declared in `core-13/composer.json` and `core-14/composer.json`.
+declared in `core-13/composer.json` and `core-14/composer.json`. Both call
+`Build/Scripts/sqliteSnapshot.php` rather than copying the file — see
+[Development environment](environment.md#snapshotting-an-instance-database-is-not-a-copy)
+for why a copy is wrong.
 
 `patches/` is the shared pool for `vaimo/composer-patches`. Both instances
 require that plugin and declare `"patches-search": "patches/"`


### PR DESCRIPTION
Resolves ACE-401 on `main`.

## The defect

`core-13/composer.json` and `core-14/composer.json` copied the instance database
with a plain `cp`, in both directions:

```
"\\cp -Rvf var/sqlite/core-13.sqlite ../sqlite-databases/core-13.sqlite"
```

SQLite in write ahead logging mode keeps the newest transactions in a `-wal`
sidecar until a checkpoint folds them back into the main file, and that
checkpoint only happens when the **last** connection closes. A backup is taken
while the instance is running, so php-fpm is still holding one.

Measured on PHP 8.2 with `pdo_sqlite`, 500 rows written in WAL mode with the
writer deliberately kept open:

| File              | Size    |
|-------------------|---------|
| `live.sqlite`     | 4 kB    |
| `live.sqlite-wal` | 2076 kB |

The plain copy of the main file *opened* — and then reported `no such table` for
every table the database had. That is what makes this worth fixing: nothing goes
wrong at backup time. It goes wrong much later, when somebody restores from a
committed template that turns out to be empty.

The `cache:flush` that `sqlite:backup` runs first does not help — it flushes
TYPO3 caches, not the write ahead log.

Secondary, smaller: `sqlite:apply` left the `-wal` and `-shm` sidecars of the
file it overwrote in place. Those belong to the database being replaced, never
to its replacement.

## The fix

Both directions go through the new `Build/Scripts/sqliteSnapshot.php`:

1. for a backup, opens the source and runs `PRAGMA wal_checkpoint(TRUNCATE)`
2. removes `<target>-wal` and `<target>-shm` if present
3. copies
4. verifies the copy by opening it and counting the `table` rows in
   `sqlite_master`, failing loudly when it cannot be opened

The checkpoint is harmless in any other journal mode — the pragma reports that
there was nothing to do — so no journal mode detection is needed. The helper
requires nothing but PHP with `pdo_sqlite`, because it runs from an instance
whose dependencies may not be installed yet.

`core-*/.ddev/docker-compose.mounts.yaml` gains a `Build/` bind mount, so
`../Build/Scripts/sqliteSnapshot.php` resolves to the same file inside DDEV as on
a host stack — which is the point of the relative paths in those `composer.json`
scripts.

Adapted from `sbuerk/theme-extension-development`, which is where the problem was
diagnosed.

## Verification

The reproduction and every error path were run, not reasoned about:

| Case                                        | Result                                            |
|---------------------------------------------|---------------------------------------------------|
| plain `cp` of a live WAL database           | copy opens, `no such table: demo`                 |
| helper on the same database                 | 500 rows, 2.0 MB template, exit 0                 |
| no arguments / unknown mode                 | usage on stderr, exit 1                           |
| missing source, `backup` vs `restore`       | exit 1, and a message that fits the direction     |
| source that is not a database               | "could not be opened as a database", exit 1       |
| target directory does not exist             | created, exit 0                                   |
| stale `-wal`/`-shm` next to the target      | both removed                                      |
| source in rollback journal mode             | exit 0 — the checkpoint is a no-op                |
| real `core-13`/`core-14` databases and both templates, both directions, run from the instance directory | exit 0, 172/146/62 tables |

Gates, each after its own `composerUpdate`:

| Suite          | v13 / 8.2 | v14 / 8.2 |
|----------------|-----------|-----------|
| `lintPhp`      | SUCCESS   | SUCCESS   |
| `cgl -n`       | SUCCESS   | SUCCESS   |
| `phpstan`      | SUCCESS   | SUCCESS   |
| `unit`         | SUCCESS   | SUCCESS   |
| `lintMarkdown -n` | SUCCESS (core version independent) ||

`cgl` and `cglHeader` were both shown to *cover* the new file rather than merely
pass over it: an `array()` plus double quotes made `cgl` red, and removing the
licence header made `cglHeader` red.

## Not done, and why

- **No `Documentation/Changelog/` entry.** This touches the development
  instances and the repository's own tooling. It is neither user nor integrator
  facing, and no extension changes.
- **`cglHeader` is red repository-wide** — 423 of 424 files, on `main` without
  this change too. The job is commented out in `ci.yml`. Pre-existing, out of
  scope here, and the new file is the one file that passes it.
- **No functional run.** No extension runtime code is touched. CI runs it anyway.
- The dangling `fileadmin/` files behind the committed `sys_file` rows, noted at
  the end of the issue, are deliberately left for their own issue.

A backport to branch `2` follows, where the same two scripts exist in `core-12/`
and `core-13/`.
