### PR TITLE
[BUGFIX] ACE-383: Allocate a TTY only for a terminal

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -573,6 +573,16 @@ if [ "${CI}" == "true" ]; then
     IS_CORE_CI=1
     IMAGE_PREFIX=""
     CONTAINER_INTERACTIVE=""
+elif [ ! -t 0 ] || [ ! -t 1 ]; then
+    # If stdin or stdout is not a TTY (e.g. a script runner, pipe, or non-interactive shell),
+    # drop the interactive "-it" flags automatically to avoid podman warning "The input device
+    # is not a TTY." and docker failure, and to keep redirected output free of TTY control characters.
+    # Keep "--init" so the PID 1 init process still forwards signals (e.g. ctrl-c) to the test process.
+    #
+    # It also stops a scripted run from hanging forever: with a pseudo TTY every tool inside the
+    # container believes it may ask a question, and composer does - it asks whether a plugin missing
+    # from "allow-plugins" is trusted, and then waits for an answer nobody is there to give (ACE-383).
+    CONTAINER_INTERACTIVE="--init"
 fi
 
 # determine default container binary to use: 1. podman 2. docker

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -51,6 +51,45 @@ Each run creates its own container network — `NETWORK` is
 `academic-extensions-${SUFFIX}` — and `cleanUp()` removes it together with
 every attached container, so parallel runs on one machine do not collide.
 
+### A pseudo TTY only when there is a terminal
+
+`CONTAINER_INTERACTIVE` is `-it --init` by default, and drops to `--init` when
+stdin **or** stdout is not a terminal — a script runner, a pipe, a redirect, a
+non-interactive shell. `CI=true` clears it entirely, as before. That distinction
+is load-bearing rather than cosmetic.
+
+`-t` makes the runtime allocate a pseudo TTY inside the container, and every tool
+started there then believes it may ask a question. Composer does. When a plugin
+is missing from `config.allow-plugins` it asks whether the plugin is trusted —
+and in a scripted run nobody answers, so the whole invocation **hangs with no
+output at all**. Measured: a root `-s composer` command with one `allow-plugins`
+entry removed was still waiting when it was killed at 45 seconds; with the entry
+restored the same command returns in seconds.
+
+Nothing about it points at composer. It looks exactly like a stuck image pull or
+a broken container runtime, which is why it cost the time it did (ACE-383).
+
+Without the TTY the same run fails immediately and says what is wrong:
+
+```
+In PluginManager.php line 821:
+  sbuerk/extended-path-repository contains a Composer plugin which is blocked
+  by your allow-plugins config. You may add it to the list if you consider it safe.
+  You can run "composer config --no-plugins allow-plugins.… [true|false]" to enable it
+```
+
+An interactive run keeps `-t`, so colours and progress bars are unchanged when a
+person is watching. The `input device is not a TTY` warning that used to prefix
+every scripted run is gone with it.
+
+Checking stdout as well as stdin is not redundancy: `runTests.sh -s unit > log`
+from a real terminal has a terminal on stdin and a file on stdout, and with `-t`
+the container writes TTY control characters into that file.
+
+The condition and its comment are taken verbatim from
+`web-vision/a11y-by-default`, the one harness in the portfolio that already had
+them, so the two do not drift apart.
+
 ## Options
 
 The wrapper parses exactly these options in its `while getopts` loop;


### PR DESCRIPTION
Resolves ACE-383 on branch `2` — the backport of #480, and the branch the hang was reported on.

## It was never a root-versus-subdirectory bug in the harness

The issue reports that `-s composer` hangs at the repository root on branch `2`,
works in a subdirectory, and works at the root on `main`. That reads like a
harness defect. It is not one — the `composer)` case, `CONTAINER_SIMPLE_PARAMS`
and `CONTAINER_INTERACTIVE` are **byte-identical** on both branches, and diffing
the whole script leaves exactly two differences, neither related:

```
< COMPOSER_ROOT_VERSION="3.0.0-dev"
> COMPOSER_ROOT_VERSION="2.4.0-dev"
<     ./Build/Scripts/runTests.sh -s composerUpdate -t 14 -p 8.3
>     ./Build/Scripts/runTests.sh -s composerUpdate -t 13 -p 8.3
```

**Composer was waiting for an answer.** The command in the report —
`composer config allow-plugins.sbuerk/extended-path-repository true` — is the fix
for the very prompt that was blocking it. Branch `2`'s **root** `composer.json`
did not list that plugin at the time, while `core-12/`, `core-13/` and
`packages-dev/monorepo-shared/` already did. Root prompts, subdirectories do not,
`main` does not. `-- --version` returned because it never builds a `Composer`
instance and so never reaches the plugin manager.

Reproduced on a current checkout, same command, same session:

| Root `composer.json`                                      | Result                          |
|-----------------------------------------------------------|---------------------------------|
| as committed                                              | returns in seconds, `SUCCESS`   |
| one `config.allow-plugins` entry removed                  | **hangs**, killed at 45 s (`rc=143`) |

## The trigger is gone, the trap is not

Both branches list all five plugins today, so the reported command no longer
hangs. What remains is that the harness turns **any** such prompt into a silent,
indefinite wait: `CONTAINER_INTERACTIVE="-it --init"` was unconditional locally
and only cleared for `CI=true`. `-t` gives the container a pseudo TTY, so every
tool started inside believes it may ask a question.

Nothing about the symptom points at composer. It looks exactly like a stuck image
pull or a broken container runtime, which is what it was mistaken for — and what
it cost.

So allocate a TTY only when there is a terminal on **both** stdin and stdout,
as an `elif` of the existing `CI=true` branch:

```bash
elif [ ! -t 0 ] || [ ! -t 1 ]; then
    CONTAINER_INTERACTIVE="--init"
fi
```

Checking stdout as well is not redundancy: `runTests.sh -s unit > log` from a
real terminal has a terminal on stdin and a file on stdout, and with `-t` the
container writes TTY control characters into that file.

**This condition and its comment are taken verbatim from
`web-vision/a11y-by-default`**, which turned out to be the one harness in the
portfolio that already had them. Adopting it rather than inventing a second
variant is the point — see the last section.

## Verification

Run on this branch, A/B against the same broken state — one
`config.allow-plugins` entry removed from the root `composer.json`:

| Case                                                            | Before                          | After                                     |
|------------------------------------------------------------------|---------------------------------|-------------------------------------------|
| the issue's own command, `config allow-plugins.… true`           | **hung**, killed at 45 s (`rc=124`), entry never written | **1 s**, `rc=0`, entry written |
| a read-only command, `show --self`                               | **hung**, killed at 45 s (`rc=124`) | **1 s**, `FAILURE` with the message below |
| scripted `-s composer` at the root, healthy repository            | works                           | works                                     |
| real terminal on stdin and stdout (`script -qec …`)               | `-it --init`                    | `-it --init` — unchanged                  |
| terminal on stdin, redirect on stdout                             | `-it --init`                    | `--init` — the case the stdout check adds |
| `CI=true`                                                         | `""`                            | `""` — unchanged                          |

Worth noting from the first row: composer lets `config` through even when a
plugin is not allowed — it has to, or the setting could never be fixed. So the
reported command was *never* rejected, it was only ever waiting to be answered.
That is why it looked like an infrastructure problem rather than a composer one.

What the non-interactive run says now instead of hanging:

```
In PluginManager.php line 821:
  sbuerk/extended-path-repository contains a Composer plugin which is blocked
  by your allow-plugins config. You may add it to the list if you consider it safe.
  You can run "composer config --no-plugins allow-plugins.sbuerk/extended-path-repository [true|false]"
  to enable it (true) or disable it explicitly and suppress this exception (false)
  See https://getcomposer.org/allow-plugins
```

Gates, each after its own `composerUpdate`:

| Suite             | v12 / 8.1                          | v13 / 8.2          |
|-------------------|------------------------------------|--------------------|
| `lintPhp`         | SUCCESS                            | SUCCESS            |
| `cgl -n`          | SUCCESS                            | SUCCESS            |
| `phpstan`         | SUCCESS                            | SUCCESS            |
| `unit`            | SUCCESS                            | SUCCESS            |
| `functional`      | SUCCESS (SQLite)                   | SUCCESS (PostgreSQL) |
| `lintMarkdown -n` | SUCCESS (core version independent) |                    |

`functional` was run against a real DBMS container as well, deliberately: this
changes how *every* container in the harness is started, and the database
containers are the part a `-t` change could plausibly disturb.

## Side effect, and one behaviour change

The `The input device is not a TTY` warning that prefixed every scripted run is
gone — it was the runtimes complaining about exactly this `-t`.

The behaviour change worth naming: a **scripted** run now loses colour, because
phpunit and php-cs-fixer detect the absent TTY. An interactive run is unchanged,
and CI never had it, since `CI=true` already cleared the variable.

## What the branch comparison turned up

The patched block and the documentation section are **byte-identical** to #480 —
`diff` on both reports no difference. The only thing around them that differs is
`COMPOSER_ROOT_VERSION`, which this change does not touch.

The issue was filed as `[2.x]` and has been corrected to `[3.x][2.x]`: the defect
is in `main`'s copy of the script just as much, branch `2` merely had the missing
`allow-plugins` entry that exposed it.

## Beyond this repository

Every sibling harness was checked **at its current remote state**, not from the
local checkouts — which were stale and gave a wrong answer the first time.

`web-vision/a11y-by-default@main` is the only one that already has the guard, and
this change adopts its wording. Every other maintained branch of every other
harness is affected: `deepltranslate-core` (`main`, `5`), `deepltranslate-glossary`
(`main`, `5`), `deepltranslate-mass`, `deepltranslate-auto-renew` and
`deepltranslate-assets` (`main`, `2` each), `environment-state-manager`
(`main`, `1`), `his-connector` (`main`) and `t3oodle` (`master`, `1`).

`deepltranslate-core@3.0` is end of life and runs an older harness generation
with no `CONTAINER_INTERACTIVE` at all — not affected.

Those are tracked as issues in their own repositories rather than fixed here.
