### PR TITLE
[TASK] ACE-403: Cover the projects demand and enums

### DIFF
--- a/packages/fgtclb/academic-projects/Tests/Unit/Domain/Model/Dto/ActiveStateTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Unit/Domain/Model/Dto/ActiveStateTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicProjects\Domain\Model\Dto\ActiveState;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `ActiveState` decides which projects a list plugin shows: all of them, the running
+ * ones, or the finished ones. The value arrives from a FlexForm, so it is a string
+ * from outside and `tryFromDefault()` is what stands between that string and the
+ * repository.
+ */
+final class ActiveStateTest extends UnitTestCase
+{
+    #[Test]
+    public function allIsTheDefault(): void
+    {
+        $this->assertSame(ActiveState::ALL, ActiveState::default());
+    }
+
+    #[Test]
+    #[DataProvider('knownValues')]
+    public function aKnownValueResolvesToItsCase(string $value, ActiveState $expected): void
+    {
+        $this->assertSame($expected, ActiveState::tryFromDefault($value));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: ActiveState}>
+     */
+    public static function knownValues(): \Generator
+    {
+        yield 'all' => ['all', ActiveState::ALL];
+        yield 'active' => ['active', ActiveState::ACTIVE];
+        yield 'completed' => ['completed', ActiveState::COMPLETED];
+    }
+
+    /**
+     * The point of `tryFromDefault()` over `from()`: an unusable value must not reach
+     * the repository as an exception, it has to fall back. A FlexForm that was saved
+     * before an option was renamed still holds the old string.
+     */
+    #[Test]
+    #[DataProvider('unknownValues')]
+    public function anUnknownValueFallsBackToAll(string $value): void
+    {
+        $this->assertSame(ActiveState::ALL, ActiveState::tryFromDefault($value));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function unknownValues(): \Generator
+    {
+        yield 'empty string' => [''];
+        yield 'unknown option' => ['pending'];
+        yield 'wrong case' => ['ACTIVE'];
+        yield 'padded' => [' active '];
+        yield 'the case name instead of its value' => ['COMPLETED'];
+    }
+
+    /**
+     * `ProjectDemand::getPossibleActiveStates()` hands this list to the FlexForm item
+     * list, so the order is what an editor sees.
+     */
+    #[Test]
+    public function valuesAreTheCaseValuesInDeclarationOrder(): void
+    {
+        $this->assertSame(['all', 'active', 'completed'], ActiveState::values());
+    }
+
+    /**
+     * Guards the pair above against drifting apart: every value the enum offers has to
+     * be resolvable again, or `values()` would advertise something `tryFrom()` rejects.
+     */
+    #[Test]
+    public function everyAdvertisedValueResolvesBack(): void
+    {
+        foreach (ActiveState::values() as $value) {
+            $this->assertNotNull(ActiveState::tryFrom($value), sprintf('Value "%s" does not resolve', $value));
+        }
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Unit/Domain/Model/Dto/ProjectDemandTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Unit/Domain/Model/Dto/ProjectDemandTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicProjects\Domain\Model\Dto\ActiveState;
+use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
+use FGTCLB\AcademicProjects\Enumeration\SortingOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `ProjectDemand` is assembled from FlexForm settings and request arguments and then
+ * handed to `ProjectRepository::findByDemand()`. Everything it accepts reaches a query,
+ * so what it rejects matters as much as what it stores.
+ *
+ * The sorting handling is the interesting part: `setSorting()` validates against
+ * `SortingOptions::getConstants()` and keeps the previous value when the given one is
+ * unknown, while `setSortingField()` and `setSortingDirection()` reassemble a full
+ * option and go through the same validation.
+ */
+final class ProjectDemandTest extends UnitTestCase
+{
+    #[Test]
+    public function aFreshDemandSortsByTheDefaultOption(): void
+    {
+        $subject = new ProjectDemand();
+
+        $this->assertSame(SortingOptions::__default, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame('asc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function aFreshDemandShowsEveryProjectOfNoPage(): void
+    {
+        $subject = new ProjectDemand();
+
+        $this->assertSame([], $subject->getPages());
+        $this->assertSame(ActiveState::ALL->value, $subject->getActiveState());
+        $this->assertFalse($subject->getShowSelected());
+        $this->assertFalse($subject->getShowHiddenRecords());
+        $this->assertNull($subject->getFilterCollection());
+    }
+
+    #[Test]
+    #[DataProvider('knownSortingOptions')]
+    public function aKnownOptionIsSplitIntoFieldAndDirection(string $option, string $field, string $direction): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setSorting($option);
+
+        $this->assertSame($option, $subject->getSorting());
+        $this->assertSame($field, $subject->getSortingField());
+        $this->assertSame($direction, $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function knownSortingOptions(): \Generator
+    {
+        yield 'title descending' => [SortingOptions::SORT_BY_TITLE_DESC, 'title', 'desc'];
+        yield 'last updated ascending' => [SortingOptions::SORT_BY_LASTUPDATED_ASC, 'lastUpdated', 'asc'];
+        yield 'backend sorting' => [SortingOptions::SORT_BY_SORTING_ASC, 'sorting', 'asc'];
+        yield 'a prefixed column' => [SortingOptions::SORT_BY_BUDGET_DESC, 'tx_academicprojects_budget', 'desc'];
+    }
+
+    /**
+     * An unknown option leaves the demand as it was rather than clearing the ordering.
+     * A stored FlexForm value that refers to a since-renamed option therefore falls back
+     * to the previous sorting instead of reaching Extbase as an empty `ORDER BY`.
+     */
+    #[Test]
+    #[DataProvider('unusableSortingValues')]
+    public function anUnknownOptionIsIgnored(string $value): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_BUDGET_ASC);
+
+        $subject->setSorting($value);
+
+        $this->assertSame(SortingOptions::SORT_BY_BUDGET_ASC, $subject->getSorting());
+        $this->assertSame('tx_academicprojects_budget', $subject->getSortingField());
+        $this->assertSame('asc', $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function unusableSortingValues(): \Generator
+    {
+        yield 'empty' => [''];
+        yield 'field without direction' => ['title'];
+        yield 'unknown field' => ['uid asc'];
+        yield 'unknown direction' => ['title sideways'];
+        yield 'wrong case' => ['TITLE ASC'];
+        yield 'constant name instead of value' => ['SORT_BY_TITLE_ASC'];
+        yield 'sql injected into the ordering' => ['title asc; DROP TABLE pages'];
+    }
+
+    /**
+     * The direction is kept, so switching the column in a list view does not silently
+     * flip the order back to ascending.
+     */
+    #[Test]
+    public function changingTheFieldKeepsTheDirection(): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_DESC);
+
+        $subject->setSortingField('lastUpdated');
+
+        $this->assertSame(SortingOptions::SORT_BY_LASTUPDATED_DESC, $subject->getSorting());
+        $this->assertSame('lastUpdated', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function changingTheDirectionKeepsTheField(): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_BUDGET_ASC);
+
+        $subject->setSortingDirection('desc');
+
+        $this->assertSame(SortingOptions::SORT_BY_BUDGET_DESC, $subject->getSorting());
+        $this->assertSame('tx_academicprojects_budget', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    /**
+     * Both setters reassemble a full option and hand it to `setSorting()`, so a
+     * combination that is not offered is rejected there. `tx_academicprojects_start_date`
+     * exists in both directions, `budget` only in the two it declares - asking for a
+     * field the current direction has no option for changes nothing.
+     */
+    #[Test]
+    public function aFieldWithoutAnOptionForTheCurrentDirectionIsIgnored(): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_ASC);
+
+        $subject->setSortingField('nonexistentColumn');
+
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+    }
+
+    /**
+     * There is no option without a direction, so the direction cannot be cleared. Worth
+     * pinning: it means `getSortingDirection()` never returns an empty string once the
+     * constructor has run.
+     */
+    #[Test]
+    public function theDirectionCannotBeCleared(): void
+    {
+        $subject = new ProjectDemand();
+
+        $subject->setSortingDirection('');
+
+        $this->assertSame('asc', $subject->getSortingDirection());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, $subject->getSorting());
+    }
+
+    #[Test]
+    #[DataProvider('activeStates')]
+    public function aKnownActiveStateIsStored(string $value): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setActiveState($value);
+
+        $this->assertSame($value, $subject->getActiveState());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function activeStates(): \Generator
+    {
+        foreach (ActiveState::values() as $value) {
+            yield $value => [$value];
+        }
+    }
+
+    /**
+     * Unlike the sorting, an unusable active state throws rather than falling back -
+     * it is set from the controller, not from a stored FlexForm value, so a wrong value
+     * there is a programming error and has to be loud.
+     */
+    #[Test]
+    public function anUnknownActiveStateIsRejected(): void
+    {
+        $subject = new ProjectDemand();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1743627158);
+
+        $subject->setActiveState('pending');
+    }
+
+    #[Test]
+    public function theRejectedStateIsNamedInTheMessage(): void
+    {
+        $subject = new ProjectDemand();
+
+        try {
+            $subject->setActiveState('pending');
+            $this->fail('Expected an \InvalidArgumentException');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString('pending', $exception->getMessage());
+            $this->assertStringContainsString('all, active, completed', $exception->getMessage());
+        }
+    }
+
+    #[Test]
+    public function theOfferedActiveStatesAreTheOnesTheSetterAccepts(): void
+    {
+        $this->assertSame(ActiveState::values(), (new ProjectDemand())->getPossibleActiveStates());
+    }
+
+    /**
+     * The pages list reaches `findByDemand()` as an uid list for an `IN` constraint, and
+     * an empty one is valid there since ACE-349 - so the demand must not invent a value.
+     */
+    #[Test]
+    public function thePageListIsStoredAsGiven(): void
+    {
+        $subject = new ProjectDemand();
+        $subject->setPages([12, 34]);
+
+        $this->assertSame([12, 34], $subject->getPages());
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Unit/Enumeration/SortingOptionsTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Unit/Enumeration/SortingOptionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Unit\Enumeration;
+
+use FGTCLB\AcademicProjects\Enumeration\SortingOptions;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The values are used verbatim as Extbase ordering strings, and `getConstants()` is
+ * what `ProjectDemand::setSorting()` validates against - so a value that drops out of
+ * this list stops being selectable without anything failing.
+ */
+final class SortingOptionsTest extends UnitTestCase
+{
+    /**
+     * The full set, asserted as a whole rather than by counting: a renamed constant or
+     * a changed ordering string has to show up here, since both are part of what a
+     * stored FlexForm value refers to.
+     */
+    #[Test]
+    public function everySortingOptionIsOffered(): void
+    {
+        $this->assertSame(
+            [
+                'SORT_BY_TITLE_ASC' => 'title asc',
+                'SORT_BY_TITLE_DESC' => 'title desc',
+                'SORT_BY_LASTUPDATED_ASC' => 'lastUpdated asc',
+                'SORT_BY_LASTUPDATED_DESC' => 'lastUpdated desc',
+                'SORT_BY_SORTING_ASC' => 'sorting asc',
+                'SORT_BY_SORTING_DESC' => 'sorting desc',
+                'SORT_BY_BUDGET_ASC' => 'tx_academicprojects_budget asc',
+                'SORT_BY_BUDGET_DESC' => 'tx_academicprojects_budget desc',
+                'SORT_BY_STARTDATE_ASC' => 'tx_academicprojects_start_date asc',
+                'SORT_BY_STARTDATE_desc' => 'tx_academicprojects_start_date desc',
+            ],
+            SortingOptions::getConstants(),
+        );
+    }
+
+    /**
+     * `__default` is an alias of an option that is already in the list, so offering it
+     * would present the same ordering twice.
+     */
+    #[Test]
+    public function theDefaultAliasIsNotAnOptionOfItsOwn(): void
+    {
+        $this->assertArrayNotHasKey('__default', SortingOptions::getConstants());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, SortingOptions::__default);
+    }
+
+    /**
+     * `ProjectDemand` splits an option on the first space into field and direction, so
+     * an option that carries neither, or carries more than one space, would reach the
+     * query builder as an ordering it cannot use.
+     */
+    #[Test]
+    public function everyOptionIsAFieldAndADirection(): void
+    {
+        foreach (SortingOptions::getConstants() as $name => $value) {
+            $this->assertMatchesRegularExpression(
+                '/^[a-zA-Z0-9_]+ (asc|desc)$/',
+                $value,
+                sprintf('%s is not a "<field> <asc|desc>" pair', $name),
+            );
+        }
+    }
+
+    /**
+     * Two constants sharing a value would make the option list ambiguous - the FlexForm
+     * stores the value, not the constant name, so the second one could never be selected.
+     */
+    #[Test]
+    public function noOrderingIsOfferedTwice(): void
+    {
+        $values = array_values(SortingOptions::getConstants());
+        $this->assertSame($values, array_values(array_unique($values)));
+    }
+}


### PR DESCRIPTION
Resolves ACE-403 on `main`. First unit of the test coverage round tracked under
ACE-10.

## Why these three classes

`EXT:academic_projects` had **one** unit test, `VersionCompatTest`, and 11
functional ones. None of the three classes that decide what its list plugin
queries were covered:

| Class | Coverage before |
|---|---|
| `Domain\Model\Dto\ProjectDemand` | none |
| `Domain\Model\Dto\ActiveState` | none |
| `Enumeration\SortingOptions` | none |

`ProjectDemand` is assembled from FlexForm settings and request arguments and
handed straight to `ProjectRepository::findByDemand()`, so **everything it
accepts reaches a query** — which makes what it *rejects* the interesting part.

## What is now pinned

**The sorting is validated, and an unknown value is kept out silently.**
`setSorting()` checks against `SortingOptions::getConstants()` and leaves the
demand as it was when the value is not an offered option. That is what makes a
stored FlexForm value referring to a since-renamed option fall back to the
previous sorting instead of reaching Extbase as an empty `ORDER BY`. Covered
with a provider: empty, field without direction, unknown field, unknown
direction, wrong case, the constant *name* instead of its value, and an ordering
with SQL appended.

**The two partial setters reassemble and re-validate.** Changing the column
keeps the direction, changing the direction keeps the column, and a combination
that is not offered changes nothing. Also pinned: the direction *cannot* be
cleared, so `getSortingDirection()` never returns an empty string once the
constructor has run.

**`setActiveState()` is the opposite case and is covered as such.** It throws
`\InvalidArgumentException` 1743627158 rather than falling back, because it is
set from the controller — a wrong value there is a programming error and has to
be loud. The message naming both the rejected value and the accepted ones is
asserted too.

**`ActiveState::tryFromDefault()`** is the reason that FlexForm path is safe at
all, so its fallback is covered over five unusable inputs, and `values()` is
pinned against `tryFrom()` so the list it advertises cannot drift from what
resolves.

**`SortingOptions::getConstants()`** is asserted as a whole set rather than by
counting — a renamed constant or a changed ordering string is exactly what a
stored FlexForm value refers to. Plus three structural properties: `__default`
is not offered as an option of its own, every option is a `<field> <asc|desc>`
pair (which is what the demand's split assumes), and no ordering is offered
twice.

## Proof the tests can fail

A test-only change has no production change whose absence proves it, so each
covered behaviour was broken on purpose:

| Mutation | Failures |
|---|---|
| `tryFromDefault()` falls back to `ACTIVE` instead of `ALL` | 5 |
| `getConstants()` stops skipping the `__default` alias | 3 |
| `setSorting()`'s `in_array()` guard removed | 9 |
| `setActiveState()`'s exception removed | 2 |

Restored afterwards, control run green at 41 tests.

## Verification

| Suite | v13 / 8.2 | v14 / 8.2 |
|---|---|---|
| `lintPhp` | SUCCESS | SUCCESS |
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | SUCCESS | SUCCESS |
| `unit` | SUCCESS | SUCCESS |

Each after its own `composerUpdate`. No `functional` run — no production code is
touched and no runtime behaviour can change; CI runs it regardless.

## Scope

**No production code is changed.** Tests over plain accessors are deliberately
left out: `Build/phpunit/UnitTests.xml` sets
`beStrictAboutTestsThatDoNotTestAnything` to `false`, so a test that sets a
property and reads it back passes while asserting that PHP works. `Project` and
the two `PageTypes`/`Utility` classes are accessor-only and stay uncovered here.

One thing noticed and **not** changed: `SortingOptions::SORT_BY_STARTDATE_desc`
is the only constant with a lower-case suffix. It is public API and referenced
from the FlexForm item list, so renaming it belongs in its own issue rather than
in a test-only change. The test asserts the name as it is.

A backport to branch `2` follows: `ProjectDemand` and `ActiveState` are
byte-identical there, and `SortingOptions` differs only by still extending the
`TYPO3\CMS\Core\Type\Enumeration` that v14 removed — whose `getConstants()` has
the same contract, so the tests apply unchanged.
