### PR TITLE
[TASK] ACE-404: Cover the programs demand and sorting

### DIFF
--- a/packages/fgtclb/academic-programs/Tests/Unit/Domain/Model/Dto/ProgramDemandTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Unit/Domain/Model/Dto/ProgramDemandTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPrograms\Domain\Model\Dto\ProgramDemand;
+use FGTCLB\AcademicPrograms\Enumeration\SortingOptions;
+use FGTCLB\CategoryTypes\Collection\FilterCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `ProgramDemand` is assembled from FlexForm settings and request arguments and then
+ * handed to `ProgramRepository::findByDemand()`. Everything it accepts reaches a query,
+ * so what it rejects matters as much as what it stores.
+ */
+final class ProgramDemandTest extends UnitTestCase
+{
+    #[Test]
+    public function aFreshDemandSortsByTheDefaultOption(): void
+    {
+        $subject = new ProgramDemand();
+
+        $this->assertSame(SortingOptions::__default, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame('asc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function aFreshDemandSelectsNoPageAndNoFilter(): void
+    {
+        $subject = new ProgramDemand();
+
+        $this->assertSame([], $subject->getPages());
+        $this->assertNull($subject->getFilterCollection());
+        $this->assertFalse($subject->getShowHiddenRecords());
+    }
+
+    #[Test]
+    #[DataProvider('knownSortingOptions')]
+    public function aKnownOptionIsSplitIntoFieldAndDirection(string $option, string $field, string $direction): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setSorting($option);
+
+        $this->assertSame($option, $subject->getSorting());
+        $this->assertSame($field, $subject->getSortingField());
+        $this->assertSame($direction, $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function knownSortingOptions(): \Generator
+    {
+        yield 'title ascending' => [SortingOptions::SORT_BY_TITLE_ASC, 'title', 'asc'];
+        yield 'title descending' => [SortingOptions::SORT_BY_TITLE_DESC, 'title', 'desc'];
+        yield 'last updated ascending' => [SortingOptions::SORT_BY_LASTUPDATED_ASC, 'lastUpdated', 'asc'];
+        yield 'last updated descending' => [SortingOptions::SORT_BY_LASTUPDATED_DESC, 'lastUpdated', 'desc'];
+        yield 'backend sorting' => [SortingOptions::SORT_BY_SORTING_ASC, 'sorting', 'asc'];
+    }
+
+    /**
+     * An unknown option leaves the demand as it was rather than clearing the ordering.
+     * A stored FlexForm value that refers to a since-renamed option therefore falls back
+     * to the previous sorting instead of reaching Extbase as an empty `ORDER BY`.
+     */
+    #[Test]
+    #[DataProvider('unusableSortingValues')]
+    public function anUnknownOptionIsIgnored(string $value): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_LASTUPDATED_DESC);
+
+        $subject->setSorting($value);
+
+        $this->assertSame(SortingOptions::SORT_BY_LASTUPDATED_DESC, $subject->getSorting());
+        $this->assertSame('lastUpdated', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function unusableSortingValues(): \Generator
+    {
+        yield 'empty' => [''];
+        yield 'field without direction' => ['title'];
+        yield 'unknown field' => ['uid asc'];
+        yield 'unknown direction' => ['title sideways'];
+        yield 'wrong case' => ['TITLE ASC'];
+        yield 'constant name instead of value' => ['SORT_BY_TITLE_ASC'];
+        yield 'sql injected into the ordering' => ['title asc; DROP TABLE pages'];
+    }
+
+    /**
+     * The direction is kept, so switching the column in a list view does not silently
+     * flip the order back to ascending.
+     */
+    #[Test]
+    public function changingTheFieldKeepsTheDirection(): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_DESC);
+
+        $subject->setSortingField('lastUpdated');
+
+        $this->assertSame(SortingOptions::SORT_BY_LASTUPDATED_DESC, $subject->getSorting());
+        $this->assertSame('lastUpdated', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function changingTheDirectionKeepsTheField(): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_ASC);
+
+        $subject->setSortingDirection('desc');
+
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_DESC, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    /**
+     * `sorting` is the one field offered ascending only, so asking for it descending
+     * reassembles to an option that does not exist and is dropped. The demand keeps
+     * the ordering it had - it does not end up sorting by `sorting asc` either.
+     *
+     * This is the asymmetry `SortingOptionsTest` points at, and it is what a list
+     * plugin offering "backend order, reversed" would silently run into.
+     */
+    #[Test]
+    public function aFieldOfferedInOneDirectionOnlyRejectsTheOther(): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_SORTING_ASC);
+
+        $subject->setSortingDirection('desc');
+
+        $this->assertSame(SortingOptions::SORT_BY_SORTING_ASC, $subject->getSorting());
+        $this->assertSame('sorting', $subject->getSortingField());
+        $this->assertSame('asc', $subject->getSortingDirection());
+    }
+
+    /**
+     * There is no option without a direction, so the direction cannot be cleared. Worth
+     * pinning: it means `getSortingDirection()` never returns an empty string once the
+     * constructor has run.
+     */
+    #[Test]
+    public function theDirectionCannotBeCleared(): void
+    {
+        $subject = new ProgramDemand();
+
+        $subject->setSortingDirection('');
+
+        $this->assertSame('asc', $subject->getSortingDirection());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, $subject->getSorting());
+    }
+
+    /**
+     * The pages list reaches `findByDemand()` as an uid list for an `IN` constraint, and
+     * an empty one is valid there since ACE-349 - so the demand must not invent a value.
+     */
+    #[Test]
+    public function thePageListIsStoredAsGiven(): void
+    {
+        $subject = new ProgramDemand();
+        $subject->setPages([12, 34]);
+
+        $this->assertSame([12, 34], $subject->getPages());
+    }
+
+    /**
+     * The category filter is optional, and clearing it has to be possible - the
+     * repository branches on `null` to skip the category join entirely.
+     */
+    #[Test]
+    public function theFilterCollectionCanBeSetAndClearedAgain(): void
+    {
+        $subject = new ProgramDemand();
+        $filterCollection = new FilterCollection();
+
+        $subject->setFilterCollection($filterCollection);
+        $this->assertSame($filterCollection, $subject->getFilterCollection());
+
+        $subject->setFilterCollection(null);
+        $this->assertNull($subject->getFilterCollection());
+    }
+}

--- a/packages/fgtclb/academic-programs/Tests/Unit/Enumeration/SortingOptionsTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Unit/Enumeration/SortingOptionsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Unit\Enumeration;
+
+use FGTCLB\AcademicPrograms\Enumeration\SortingOptions;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The values are used verbatim as Extbase ordering strings, and `getConstants()` is
+ * what `ProgramDemand::setSorting()` validates against - so a value that drops out of
+ * this list stops being selectable without anything failing.
+ */
+final class SortingOptionsTest extends UnitTestCase
+{
+    /**
+     * The full set, asserted as a whole rather than by counting: a renamed constant or
+     * a changed ordering string has to show up here, since both are part of what a
+     * stored FlexForm value refers to.
+     *
+     * Note the asymmetry - `sorting` is offered ascending only, unlike the two other
+     * fields. `ProgramDemandTest` covers what that means for `setSortingDirection()`.
+     */
+    #[Test]
+    public function everySortingOptionIsOffered(): void
+    {
+        $this->assertSame(
+            [
+                'SORT_BY_TITLE_ASC' => 'title asc',
+                'SORT_BY_TITLE_DESC' => 'title desc',
+                'SORT_BY_LASTUPDATED_ASC' => 'lastUpdated asc',
+                'SORT_BY_LASTUPDATED_DESC' => 'lastUpdated desc',
+                'SORT_BY_SORTING_ASC' => 'sorting asc',
+            ],
+            SortingOptions::getConstants(),
+        );
+    }
+
+    /**
+     * `__default` is an alias of an option that is already in the list, so offering it
+     * would present the same ordering twice.
+     */
+    #[Test]
+    public function theDefaultAliasIsNotAnOptionOfItsOwn(): void
+    {
+        $this->assertArrayNotHasKey('__default', SortingOptions::getConstants());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, SortingOptions::__default);
+    }
+
+    /**
+     * `ProgramDemand::setSorting()` splits an accepted option with a plain
+     * `explode(' ', $sorting)` into exactly two variables, so an option carrying no
+     * space - or more than one - would raise "Undefined array key 1" instead of
+     * sorting. The suite runs with `failOnNotice`, so that would be a failure rather
+     * than a warning, but only if an option like that ever reached the list. This
+     * asserts it cannot.
+     */
+    #[Test]
+    public function everyOptionIsExactlyAFieldAndADirection(): void
+    {
+        foreach (SortingOptions::getConstants() as $name => $value) {
+            $this->assertMatchesRegularExpression(
+                '/^[a-zA-Z0-9_]+ (asc|desc)$/',
+                $value,
+                sprintf('%s is not a "<field> <asc|desc>" pair', $name),
+            );
+        }
+    }
+
+    /**
+     * Two constants sharing a value would make the option list ambiguous - the FlexForm
+     * stores the value, not the constant name, so the second one could never be selected.
+     */
+    #[Test]
+    public function noOrderingIsOfferedTwice(): void
+    {
+        $values = array_values(SortingOptions::getConstants());
+        $this->assertSame($values, array_values(array_unique($values)));
+    }
+}


### PR DESCRIPTION
Resolves ACE-404 on `main`. Second unit of the test coverage round tracked under ACE-10.

## Why these two classes

`EXT:academic_programs` had **one** unit test, `VersionCompatTest`. Neither class deciding what its list plugin queries was covered:

| Class | Coverage before |
|---|---|
| `Domain\Model\Dto\ProgramDemand` | none |
| `Enumeration\SortingOptions` | none |

`ProgramDemand` is assembled from FlexForm settings and request arguments and handed straight to `ProgramRepository::findByDemand()`, so everything it accepts reaches a query.

## What is now pinned

**Sorting is validated, and an unknown value is kept out silently** — a stored FlexForm value referring to a since-renamed option falls back to the previous sorting instead of reaching Extbase as an empty `ORDER BY`. Covered with a provider: empty, field without direction, unknown field, unknown direction, wrong case, the constant *name* instead of its value, and an ordering with SQL appended.

**The two partial setters reassemble and re-validate**, so changing the column keeps the direction and vice versa, and the direction cannot be cleared.

**One case is specific to this extension.** `sorting` is offered **ascending only** — there is no `SORT_BY_SORTING_DESC`, unlike the `academic_projects` twin — so asking for that field descending reassembles an option that does not exist and is dropped. The demand keeps the ordering it had, and does not silently fall back to `sorting asc` either.

## Two latent differences from the projects twin, named not fixed

Neither is a defect today, both are one edit away from being one:

1. `setSorting()` uses `in_array()` **without** the strict flag. No behavioural difference while every value is a non-numeric string.
2. It destructures `explode(' ', $sorting)` with **no limit and no `array_pad()`**, where the projects twin has both. Safe only because every current option has exactly one space — an option without one would raise `Undefined array key 1`, which `failOnNotice` turns into a failing test.

That second one is not hypothetical: removing the validation guard in the mutation run below produced exactly that warning. So the precondition is now asserted where it can actually be guaranteed — on the option list itself, via `everyOptionIsExactlyAFieldAndADirection()`.

## Proof the tests can fail

| Mutation | Result |
|---|---|
| `setSorting()`'s `in_array()` guard removed | 3 errors, 6 failures, 1 warning |
| `initializeObject()` no longer sets the default sorting | 2 failures |
| `setSortingField()` assembles direction and field the wrong way round | 1 failure |
| `getConstants()` stops skipping the `__default` alias | 3 failures |
| a `SORT_BY_SORTING_DESC` added, removing the asymmetry | 2 failures |

Restored afterwards, control run green at 26 tests.

## Scope

**No production code is changed.** Tests over plain accessors are deliberately left out — `beStrictAboutTestsThatDoNotTestAnything` is `false` here, so they pass while asserting that PHP works.

A backport to branch `2` follows: `ProgramDemand` is byte-identical there, and `SortingOptions` differs only by still extending the `TYPO3\CMS\Core\Type\Enumeration` that v14 removed, whose `getConstants()` has the same contract.
