### PR TITLE
[TASK] ACE-418: Cover the job settings and validator

### DIFF
--- a/packages/fgtclb/academic-jobs/Tests/Functional/Domain/Validator/JobValidatorTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Domain/Validator/JobValidatorTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Domain\Validator;
+
+use FGTCLB\AcademicJobs\Domain\Model\Job;
+use FGTCLB\AcademicJobs\Domain\Validator\JobValidator;
+use FGTCLB\AcademicJobs\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\CMS\Extbase\Validation\ValidatorResolver;
+
+/**
+ * Covers `JobValidator`, the validator `JobController::initializeCreateAction()` adds to
+ * the `job` argument of the public new-job form. What it rejects is what a visitor cannot
+ * submit, so both directions matter: a job that must be refused, and a job that must not
+ * be refused for the wrong reason.
+ *
+ * The validator is built the way the controller builds it —
+ * `ValidatorResolver::createValidator()`, i.e. `GeneralUtility::makeInstance()` through
+ * the container — because `injectSettingsRegistry()` is a dependency injection setter. A
+ * validator constructed with `new` has no registry and fails on an uninitialized typed
+ * property, so the container round trip is a load-bearing part of what is asserted here,
+ * not a convenience.
+ *
+ * The rules themselves come from the shipped
+ * `Configuration/AcademicJobs/Settings.yaml` via `AcademicJobsSettingsRegistry` — see
+ * `Tests/Functional/Registry/AcademicJobsSettingsRegistryTest` for the mapping from
+ * keyword to validator class.
+ */
+final class JobValidatorTest extends AbstractAcademicJobsTestCase
+{
+    /**
+     * A job carrying every value the shipped settings mark as required passes. Without
+     * this the "rejects everything" mistake would be indistinguishable from a working
+     * validator.
+     */
+    #[Test]
+    public function aFullyFilledJobIsAccepted(): void
+    {
+        $result = $this->subject()->validate($this->createValidJob());
+
+        $this->assertFalse($result->hasErrors());
+        $this->assertSame([], $result->getFlattenedErrors());
+    }
+
+    /**
+     * The four string and date properties that are really empty on a fresh model are
+     * reported, each on its own property path so the Fluid form can show the message at
+     * the field.
+     *
+     * Note what is *not* in this list: `type` and `employmentType` are configured
+     * `required` too, but they are `int` properties defaulting to `0`, and
+     * `NotEmptyValidator` treats `0` as a value. An unselected job type therefore passes
+     * this validator — the assertion is written as a whole list so that the gap is stated
+     * rather than merely unnoticed.
+     */
+    #[Test]
+    public function anEmptyJobReportsEveryRequiredPropertyThatIsActuallyEmpty(): void
+    {
+        $result = $this->subject()->validate(new Job());
+
+        $this->assertTrue($result->hasErrors());
+        $this->assertSame(
+            ['title', 'companyName', 'employmentStartDate', 'description'],
+            array_keys($result->getFlattenedErrors()),
+        );
+    }
+
+    /**
+     * `NotEmptyValidator` distinguishes a `null` from an empty string by error code. Pinning
+     * the codes proves the errors come from the mapped validator and not from some other
+     * part of the chain, and that the unset date really arrives as `null`.
+     */
+    #[Test]
+    public function requiredPropertiesReportTheNotEmptyValidatorCodes(): void
+    {
+        $result = $this->subject()->validate(new Job());
+
+        $this->assertSame(1221560718, $this->firstErrorCode($result, 'title'));
+        $this->assertSame(1221560910, $this->firstErrorCode($result, 'employmentStartDate'));
+    }
+
+    /**
+     * A zeroed integer is not empty. Setting both integer properties to a real value must
+     * therefore change nothing — which is the same statement as above, made from the other
+     * side, and it is what pins the behaviour if the mapping for those two ever changes.
+     */
+    #[Test]
+    public function selectingAJobTypeChangesNothingBecauseZeroWasAlreadyAccepted(): void
+    {
+        $job = new Job();
+        $job->setType(3);
+        $job->setEmploymentType(2);
+
+        $result = $this->subject()->validate($job);
+
+        $this->assertSame(
+            ['title', 'companyName', 'employmentStartDate', 'description'],
+            array_keys($result->getFlattenedErrors()),
+        );
+    }
+
+    #[Test]
+    public function anInvalidContactEmailIsReportedOnItsOwnProperty(): void
+    {
+        $job = $this->createValidJob();
+        $job->setContactEmail('not-an-email');
+
+        $result = $this->subject()->validate($job);
+
+        $this->assertSame(['contactEmail'], array_keys($result->getFlattenedErrors()));
+        $this->assertSame(1221559976, $this->firstErrorCode($result, 'contactEmail'));
+    }
+
+    /**
+     * `contactEmail` is configured `email`, not `required`, and `EmailAddressValidator`
+     * accepts empty values. Leaving the field blank must stay possible — the new-job form
+     * offers it as optional.
+     */
+    #[Test]
+    public function anEmptyContactEmailIsAccepted(): void
+    {
+        $job = $this->createValidJob();
+        $job->setContactEmail('');
+
+        $this->assertFalse($this->subject()->validate($job)->hasErrors());
+    }
+
+    #[Test]
+    public function anInvalidLinkIsReportedOnItsOwnProperty(): void
+    {
+        $job = $this->createValidJob();
+        $job->setLink('not a url');
+
+        $result = $this->subject()->validate($job);
+
+        $this->assertSame(['link'], array_keys($result->getFlattenedErrors()));
+        $this->assertSame(1238108078, $this->firstErrorCode($result, 'link'));
+    }
+
+    #[Test]
+    public function anAbsoluteLinkIsAccepted(): void
+    {
+        $job = $this->createValidJob();
+        $job->setLink('https://www.acme.com/jobs/42');
+
+        $this->assertFalse($this->subject()->validate($job)->hasErrors());
+    }
+
+    #[Test]
+    public function anEmptyLinkIsAccepted(): void
+    {
+        $job = $this->createValidJob();
+        $job->setLink('');
+
+        $this->assertFalse($this->subject()->validate($job)->hasErrors());
+    }
+
+    /**
+     * `contactPhone` is configured `number` in the shipped settings, and the registry maps
+     * no validator class for that keyword. Nothing therefore checks the value here, no
+     * matter what is submitted. The frontend reader hands `number` to the template, so the
+     * form may well mark the field — the server side does not.
+     */
+    #[Test]
+    public function contactPhoneIsNotValidatedAtAll(): void
+    {
+        $job = $this->createValidJob();
+        $job->setContactPhone('definitely not a number');
+
+        $this->assertFalse($this->subject()->validate($job)->hasErrors());
+    }
+
+    /**
+     * Every configured property is checked in one pass, not up to the first failure — the
+     * form has to be able to mark all offending fields at once.
+     */
+    #[Test]
+    public function allViolationsOfOneSubmissionAreCollected(): void
+    {
+        $job = new Job();
+        $job->setLink('not a url');
+        $job->setContactEmail('not-an-email');
+
+        $result = $this->subject()->validate($job);
+
+        $this->assertSame(
+            ['title', 'companyName', 'employmentStartDate', 'description', 'link', 'contactEmail'],
+            array_keys($result->getFlattenedErrors()),
+        );
+    }
+
+    /**
+     * `AbstractValidator::validate()` starts a fresh `Result` on every call. Reusing one
+     * validator instance for a second submission must not carry the first one's errors
+     * over — the controller keeps the validator on the argument across a re-displayed
+     * form.
+     */
+    #[Test]
+    public function aSecondValidationDoesNotInheritTheErrorsOfTheFirst(): void
+    {
+        $subject = $this->subject();
+        $subject->validate(new Job());
+
+        $this->assertFalse($subject->validate($this->createValidJob())->hasErrors());
+    }
+
+    /**
+     * The type guard. It is a hard failure rather than a validation error, because a
+     * non-`Job` argument on the `job` argument is a programming mistake, not visitor input.
+     */
+    #[Test]
+    public function validatingSomethingThatIsNotAJobThrows(): void
+    {
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1753702412);
+
+        $this->subject()->validate(new \stdClass());
+    }
+
+    /**
+     * The guard is only reached for values `AbstractValidator` considers non-empty, and
+     * `null` is not one of them: `isValid()` is never called, so a `null` job is reported
+     * as valid rather than as unsuitable. That is core behaviour, and it is the reason
+     * `JobController::createAction()` still has to handle `$job === null` itself.
+     */
+    #[Test]
+    public function validatingNullIsAcceptedWithoutReachingTheTypeGuard(): void
+    {
+        $result = $this->subject()->validate(null);
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * The same for the empty string — while any other string does reach the guard and
+     * throws. Both are pinned together because the pair is what makes the asymmetry
+     * visible.
+     */
+    #[Test]
+    public function validatingAnEmptyStringIsAcceptedWhileAnyOtherStringThrows(): void
+    {
+        $this->assertFalse($this->subject()->validate('')->hasErrors());
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->subject()->validate('some string');
+    }
+
+    /**
+     * `processValidations()` is public and takes the identifier, so it is usable for
+     * something other than a job. An identifier the settings do not configure validates
+     * anything without complaint instead of failing.
+     *
+     * Note that this only holds for an identifier without configuration. The method writes
+     * to `$this->result`, which `AbstractValidator::validate()` creates — calling it
+     * standalone with a configured identifier fatals on the uninitialized property, so it
+     * is public but not usable on its own.
+     */
+    #[Test]
+    public function processValidationsForAnUnconfiguredIdentifierReportsNothing(): void
+    {
+        $subject = $this->subject();
+        $subject->processValidations(new Job(), 'unknown');
+
+        $this->assertFalse($subject->validate($this->createValidJob())->hasErrors());
+    }
+
+    private function createValidJob(): Job
+    {
+        $job = new Job();
+        $job->setTitle('Research Assistant');
+        $job->setCompanyName('ACME University');
+        $job->setDescription('<p>A description of the position.</p>');
+        $job->setEmploymentStartDate(new \DateTime('2026-10-01'));
+        $job->setType(1);
+        $job->setEmploymentType(1);
+        $job->setLink('https://www.acme.com/jobs/1');
+        $job->setContactEmail('editor@acme.com');
+        $job->setContactPhone('+49 123 456789');
+
+        return $job;
+    }
+
+    private function firstErrorCode(Result $result, string $propertyPath): int
+    {
+        $errors = $result->forProperty($propertyPath)->getErrors();
+        $this->assertNotSame([], $errors);
+
+        return $errors[0]->getCode();
+    }
+
+    private function subject(): JobValidator
+    {
+        $validator = $this->get(ValidatorResolver::class)->createValidator(JobValidator::class);
+        $this->assertInstanceOf(JobValidator::class, $validator);
+
+        return $validator;
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Loader/AcademicJobsSettingsLoaderTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Loader/AcademicJobsSettingsLoaderTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Loader;
+
+use FGTCLB\AcademicJobs\Loader\AcademicJobsSettingsLoader;
+use FGTCLB\AcademicJobs\Registry\AcademicJobsSettingsRegistry;
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\CMS\Core\Package\PackageManager;
+
+/**
+ * Covers `AcademicJobsSettingsLoader`, which is the only producer of
+ * `AcademicJobsSettingsRegistry` — `Configuration/Services.yaml` declares the registry
+ * with this class as its factory. Everything the new-job form offers and everything
+ * `JobValidator` rejects therefore starts here.
+ *
+ * The loader is exercised against the real `PackageManager` and the real `core` cache of
+ * the test instance rather than against doubles: the interesting part is not the
+ * branching but that a `Configuration/AcademicJobs/Settings.yaml` shipped by an active
+ * package is found at all, and that the cached round trip returns the same thing the YAML
+ * round trip returns.
+ *
+ * The `core` cache is a `PhpFrontend` backed by the file system in a functional test
+ * instance — the testing framework nulls `hash`, `imagesizes`, `pages` and `rootline`,
+ * but not `core` — and it survives between test methods of this class. Every method
+ * therefore starts from a known cache state, and `tearDown()` removes the entry again so
+ * a doctored value cannot reach the next test class through the instance.
+ */
+final class AcademicJobsSettingsLoaderTest extends AbstractAcademicJobsTestCase
+{
+    private const CACHE_IDENTIFIER = 'AcademicJobs_Settings';
+
+    /**
+     * The settings `EXT:academic_jobs` ships in `Configuration/AcademicJobs/Settings.yaml`.
+     * It is the only `Settings.yaml` in the mono repository, so it is also the complete
+     * expected result of a load.
+     *
+     * @var array<string, mixed>
+     */
+    private const SHIPPED_SETTINGS = [
+        'validations' => [
+            'job' => [
+                'title' => ['required'],
+                'employmentType' => ['required'],
+                'type' => ['required'],
+                'companyName' => ['required'],
+                'employmentStartDate' => ['required'],
+                'description' => ['required'],
+                'link' => ['url'],
+                'contactEmail' => ['email'],
+                'contactPhone' => ['number'],
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->coreCache()->remove(self::CACHE_IDENTIFIER);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->coreCache()->remove(self::CACHE_IDENTIFIER);
+        parent::tearDown();
+    }
+
+    /**
+     * The uncached path is what fills the cache on a cold boot, so its result is the
+     * definition of what the extension offers. Asserted as a whole rather than key by key:
+     * a property silently dropping out of the YAML is exactly the defect this guards.
+     */
+    #[Test]
+    public function uncachedLoadCollectsTheSettingsYamlOfEveryActivePackage(): void
+    {
+        $this->assertSame(self::SHIPPED_SETTINGS, $this->subject()->loadUncached());
+    }
+
+    #[Test]
+    public function loadReturnsARegistryCarryingTheShippedSettings(): void
+    {
+        $registry = $this->subject()->load();
+
+        $this->assertInstanceOf(AcademicJobsSettingsRegistry::class, $registry);
+        $this->assertSame(self::SHIPPED_SETTINGS, $registry->getSettings());
+    }
+
+    /**
+     * The loader memoizes its registry. That matters because the registry is a mutable
+     * object with a public `attach()`: a caller that attaches to the registry it received
+     * changes what every later caller of the same loader sees.
+     */
+    #[Test]
+    public function loadReturnsTheSameRegistryInstanceOnEveryCall(): void
+    {
+        $subject = $this->subject();
+
+        $this->assertSame($subject->load(), $subject->load());
+    }
+
+    /**
+     * Two loaders are two registries — the memoization above is per instance, not global.
+     * The single shared instance applications see comes from the container, not from here.
+     */
+    #[Test]
+    public function twoLoadersProduceTwoRegistries(): void
+    {
+        $this->assertNotSame($this->subject()->load(), $this->subject()->load());
+    }
+
+    /**
+     * A cold `load()` has to leave the cache populated, otherwise every request re-reads
+     * and re-parses one YAML file per active package.
+     */
+    #[Test]
+    public function loadWritesTheCollectedSettingsToTheCoreCache(): void
+    {
+        $this->assertFalse($this->coreCache()->has(self::CACHE_IDENTIFIER));
+
+        $this->subject()->load();
+
+        $this->assertTrue($this->coreCache()->has(self::CACHE_IDENTIFIER));
+        $this->assertSame(self::SHIPPED_SETTINGS, $this->coreCache()->require(self::CACHE_IDENTIFIER));
+    }
+
+    /**
+     * The warm path wins unconditionally: the YAML files are not consulted at all when the
+     * cache holds an array. That is the intended behaviour, and it is also the reason a
+     * changed `Settings.yaml` does not reach a running installation before the core cache
+     * is flushed — which is why this is pinned with a value the YAML could never produce.
+     */
+    #[Test]
+    public function cachedSettingsAreUsedInsteadOfTheSettingsYaml(): void
+    {
+        $cachedSettings = ['validations' => ['job' => ['title' => ['email']]]];
+        $this->writeCacheEntry($cachedSettings);
+
+        $this->assertSame($cachedSettings, $this->subject()->load()->getSettings());
+    }
+
+    /**
+     * `getFromCache()` guards the required value with `is_array()`. A cache entry that
+     * returns something else — a leftover from an older format, a `false` from a truncated
+     * file — must fall back to the YAML files rather than propagate into the registry.
+     */
+    #[Test]
+    public function aCacheEntryThatIsNotAnArrayIsIgnoredAndTheYamlIsReadAgain(): void
+    {
+        $this->coreCache()->set(self::CACHE_IDENTIFIER, 'return \'not an array\';');
+
+        $this->assertSame(self::SHIPPED_SETTINGS, $this->subject()->load()->getSettings());
+    }
+
+    /**
+     * An empty settings array is a legitimate cached state — no active package shipping a
+     * `Settings.yaml` produces it. It is an array, so it must be honoured and must not be
+     * mistaken for a cache miss.
+     */
+    #[Test]
+    public function anEmptyCachedSettingsArrayIsHonouredAsACacheHit(): void
+    {
+        $this->writeCacheEntry([]);
+
+        $this->assertSame([], $this->subject()->load()->getSettings());
+    }
+
+    /**
+     * The registry published by the container is the one the loader built, which is what
+     * `Configuration/Services.yaml` expresses with its `factory` entry. Without this the
+     * controller and `JobValidator` would receive an empty registry and silently validate
+     * nothing.
+     */
+    #[Test]
+    public function containerPublishesTheRegistryProducedByTheLoader(): void
+    {
+        $registry = $this->get(AcademicJobsSettingsRegistry::class);
+
+        $this->assertInstanceOf(AcademicJobsSettingsRegistry::class, $registry);
+        $this->assertSame(self::SHIPPED_SETTINGS, $registry->getSettings());
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function writeCacheEntry(array $settings): void
+    {
+        $this->coreCache()->set(self::CACHE_IDENTIFIER, 'return ' . var_export($settings, true) . ';');
+    }
+
+    private function coreCache(): PhpFrontend
+    {
+        $cache = $this->get(CacheManager::class)->getCache('core');
+        $this->assertInstanceOf(PhpFrontend::class, $cache);
+        return $cache;
+    }
+
+    private function subject(): AcademicJobsSettingsLoader
+    {
+        return new AcademicJobsSettingsLoader(
+            $this->coreCache(),
+            $this->get(PackageManager::class),
+        );
+    }
+}

--- a/packages/fgtclb/academic-jobs/Tests/Functional/Registry/AcademicJobsSettingsRegistryTest.php
+++ b/packages/fgtclb/academic-jobs/Tests/Functional/Registry/AcademicJobsSettingsRegistryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicJobs\Tests\Functional\Registry;
+
+use FGTCLB\AcademicJobs\Registry\AcademicJobsSettingsRegistry;
+use FGTCLB\AcademicJobs\Tests\Functional\AbstractAcademicJobsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Validation\Validator\EmailAddressValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\UrlValidator;
+
+/**
+ * Covers the three readers of `AcademicJobsSettingsRegistry` against the registry the
+ * container publishes — that is, against the settings `EXT:academic_jobs` really ships in
+ * `Configuration/AcademicJobs/Settings.yaml`, not against a hand-built array.
+ *
+ * That is the point of doing this functionally. The three readers translate one YAML
+ * section into three different vocabularies — the Fluid form, the Extbase validator and
+ * TCA — and they do not support the same keywords. Feeding them the shipped configuration
+ * is what shows which of the nine configured properties actually arrive in each of the
+ * three, and where a keyword falls through unnoticed.
+ *
+ * The pure array mechanics of `attach()` and the `getSettings()` accessor need no
+ * container and are covered by the unit suite.
+ */
+final class AcademicJobsSettingsRegistryTest extends AbstractAcademicJobsTestCase
+{
+    /**
+     * What the new-job form template receives. It is handed out verbatim, so it is the
+     * YAML section unchanged — including `number`, which neither of the other two readers
+     * understands.
+     */
+    #[Test]
+    public function frontendValidationsForJobAreTheShippedYamlSectionUnchanged(): void
+    {
+        $this->assertSame(
+            [
+                'title' => ['required'],
+                'employmentType' => ['required'],
+                'type' => ['required'],
+                'companyName' => ['required'],
+                'employmentStartDate' => ['required'],
+                'description' => ['required'],
+                'link' => ['url'],
+                'contactEmail' => ['email'],
+                'contactPhone' => ['number'],
+            ],
+            $this->subject()->getValidationsForFrontend('job'),
+        );
+    }
+
+    /**
+     * `JobController::newAction()` assigns this for every plugin, so an identifier without
+     * configuration has to answer with an empty array rather than a missing index notice —
+     * the suite fails on notices.
+     */
+    #[Test]
+    public function frontendValidationsForAnUnconfiguredObjectAreEmpty(): void
+    {
+        $this->assertSame([], $this->subject()->getValidationsForFrontend('unknown'));
+    }
+
+    /**
+     * The map `JobValidator` walks. Three of the four keywords in use are mapped;
+     * `number` is not, so `contactPhone` has no entry here at all and a submitted phone
+     * number is never validated by the Extbase side. Asserted as a whole so that the
+     * missing property is visible rather than merely unasserted.
+     */
+    #[Test]
+    public function validatorMapForJobResolvesOnlyTheKeywordsItKnows(): void
+    {
+        $this->assertSame(
+            [
+                'title' => [NotEmptyValidator::class],
+                'employmentType' => [NotEmptyValidator::class],
+                'type' => [NotEmptyValidator::class],
+                'companyName' => [NotEmptyValidator::class],
+                'employmentStartDate' => [NotEmptyValidator::class],
+                'description' => [NotEmptyValidator::class],
+                'link' => [UrlValidator::class],
+                'contactEmail' => [EmailAddressValidator::class],
+            ],
+            $this->subject()->getValidationsForValidator('job'),
+        );
+    }
+
+    #[Test]
+    public function validatorMapForAnUnconfiguredObjectIsEmpty(): void
+    {
+        $this->assertSame([], $this->subject()->getValidationsForValidator('unknown'));
+    }
+
+    /**
+     * The TCA reader is the third vocabulary and it knows a different keyword set again:
+     * `required`, `email` and `number` produce configuration, `url` produces none — so
+     * `link` is absent here while `contactPhone` is present, the exact inverse of the
+     * validator map above.
+     *
+     * The property names are underscored on the way, because TCA column names are, and the
+     * result is nested below a `columns` key ready to be merged into a table definition.
+     */
+    #[Test]
+    public function tcaMapForJobUsesUnderscoredColumnNamesAndItsOwnKeywordSet(): void
+    {
+        $this->assertSame(
+            [
+                'columns' => [
+                    'title' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'employment_type' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'type' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'company_name' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'employment_start_date' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'description' => ['config' => ['required' => true, 'minitems' => 1]],
+                    'contact_email' => ['config' => ['type' => 'email']],
+                    'contact_phone' => ['config' => ['type' => 'number']],
+                ],
+            ],
+            $this->subject()->getValidationsForTca('job'),
+        );
+    }
+
+    #[Test]
+    public function tcaMapForAnUnconfiguredObjectIsEmpty(): void
+    {
+        $this->assertSame([], $this->subject()->getValidationsForTca('unknown'));
+    }
+
+    /**
+     * Nothing in this repository consumes `getValidationsForTca()` — it is the only one of
+     * the three readers without a caller. It is public API of a published extension
+     * nonetheless, and the shape it returns is the part an integrator would merge into
+     * `$GLOBALS['TCA']`, so it is pinned rather than left to drift.
+     */
+    #[Test]
+    public function tcaMapIsShapedForMergingIntoATableDefinition(): void
+    {
+        $tcaMap = $this->subject()->getValidationsForTca('job');
+
+        $this->assertArrayHasKey('columns', $tcaMap);
+        $this->assertArrayNotHasKey('link', $tcaMap['columns']);
+        $this->assertArrayNotHasKey('ctrl', $tcaMap);
+    }
+
+    private function subject(): AcademicJobsSettingsRegistry
+    {
+        return $this->get(AcademicJobsSettingsRegistry::class);
+    }
+}


### PR DESCRIPTION
Resolves ACE-418 on `main`. Part of the test coverage round tracked under ACE-10.

## Why

`Loader\AcademicJobsSettingsLoader`, `Registry\AcademicJobsSettingsRegistry` and `Domain\Validator\JobValidator` decide what the **public-facing** new-job form offers and what it rejects. None of the three had a test.

## Covered through the real wiring, not around it

`Configuration/Services.yaml` declares the registry `public: true` with `AcademicJobsSettingsLoader::load` as its **factory**, and `ServiceProvider` instantiates it on `BootCompletedEvent`. So:

* the registry tests resolve `$this->get(AcademicJobsSettingsRegistry::class)` — the container-built object fed by the real `Settings.yaml` — rather than a hand-built array;
* the loader tests use the real `PackageManager` and the real `core` cache;
* `JobValidator` is built the way `JobController::initializeCreateAction()` builds it, through `ValidatorResolver::createValidator()`. That round trip is load-bearing: `injectSettingsRegistry()` is a DI setter, so a plain `new JobValidator()` fatals on the uninitialized typed property.

**No fixtures.** None of the three touches the database — the loader reads the package's `Settings.yaml`, the registry is a pure translator, the validator works on in-memory `Job` objects. A CSV would have been decoration.

## Four things the tests document rather than fix

1. **`required` does nothing for `type` and `employmentType`.** Both are `protected int … = 0` on `Job`, and `NotEmptyValidator` treats `0` as a value — so **a job with neither selected passes server-side validation.** Pinned by two tests.
2. **`contactPhone` is never validated.** It is configured `number`, and `getValidationsForValidator()` has no `case 'number'`, so nothing is mapped — while `getValidationsForFrontend()` *does* hand `number` to the template, so the form may mark the field while the server accepts anything.
3. **The three readers understand three different keyword sets, and the two mismatches are inverse.** `url` produces a validator but no TCA configuration; `number` produces TCA configuration but no validator. `disabled` and `readonly`, documented in the YAML comment, are understood by none of the three.
4. **`UnknownValidatorException` (1753702335) is unreachable.** The guard is `method_exists($validator, 'validate')`, and every class the registry can return implements `ValidatorInterface`.

Smaller ones: `processValidations()` is public but not callable on its own (it writes to `$this->result`, which only `AbstractValidator::validate()` creates); the `instanceof Job` guard never sees `null` or `''`, because `AbstractValidator::validate()` skips `isValid()` for empty values; and the cross-package settings merge is a top-level `array_merge`, so a second package shipping `Configuration/AcademicJobs/Settings.yaml` would *replace* the whole `validations` key rather than merge into it.

## Proof the tests can fail

| Mutation | Result |
|---|---|
| `Settings.yaml` renamed to `Settings.yml` | 5 + 4 + 6 failures across the three classes |
| memoization early return dropped / `setCache()` dropped / cache never read | 1 / 1 / 2 failures |
| both `is_array()` guards dropped | 6 errors |
| registry: `required` remapped, snake-casing dropped, frontend reader emptied | 3 + 13 failures |
| registry: unknown identifiers return a fallback; `url` produces TCA `link` | 6 failures |
| validator: guard returns instead of throwing / `addError()` not per property | 2 / 6 failures |
| validator: `acceptsEmptyValues = false` / identifier hardcoded | 2 errors / 1 error |

One assertion was **removed rather than shipped unproven**: `shared: false` on the registry service did not change the identity `$this->get()` returns, so the test could not be made to fail. (The mechanism itself was verified — renaming the factory method in the same file did turn the suite red, so the container is genuinely rebuilt.) `Services.yaml` was restored.

## Scope

No production code is changed. The array mechanics of `attach()`/`getSettings()` are left to the unit suite. The cross-package merge above is untested — a second fixture extension needs a `composerUpdate`, and adding a `Settings.yaml` to the existing `test_jobcontact_schema` would change the environment of `ContactTcaUpgradeWizardTest`.
