### PR TITLE
[TASK] ACE-420: Cover the programs factory and collection

### DIFF
--- a/packages/fgtclb/academic-programs/Tests/Functional/Collection/FileReferenceCollectionTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Collection/FileReferenceCollectionTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Collection;
+
+use FGTCLB\AcademicPrograms\Collection\FileReferenceCollection;
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Resource\FileReference;
+
+/**
+ * `FileReferenceCollection::getCollectionByPageIdAndField()` reads `sys_file_reference`
+ * by hand instead of going through `FileRepository::findByRelation()`, so the three
+ * constraints of the relation - the record uid, the table and the field - are its own
+ * code and are what is pinned down here.
+ *
+ * The near misses in the fixture are the point: uid 3 is referenced from the same page
+ * through another field and from `tt_content` uid 1 through the same field name. Both
+ * would come back if one of the three conditions were dropped.
+ *
+ * The collection carries the **core** `TYPO3\CMS\Core\Resource\FileReference`, not the
+ * Extbase one, so its metadata getters resolve rather than returning empty strings -
+ * `getTitle()` reads the reference's own value and falls back to the file metadata when
+ * the reference leaves it `NULL`. That fallback is the behaviour a caller gets for free
+ * here and would not get from the Extbase model.
+ *
+ * Not asserted: the order of the collection. The query carries no `ORDER BY`, so
+ * `sorting_foreign` is ignored and the order is whatever the DBMS returns - see the
+ * report on the method rather than a test that only passes on SQLite.
+ */
+final class FileReferenceCollectionTest extends AbstractAcademicProgramsTestCase
+{
+    private const PAGE_WITH_MEDIA = 1;
+    private const PAGE_WITHOUT_MEDIA = 2;
+    private const PAGE_WITH_REMOVED_MEDIA = 3;
+    private const PAGE_WITH_TRANSLATED_MEDIA = 4;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FileReferenceCollection/fileReferences.csv');
+    }
+
+    #[Test]
+    public function countReportsTheNumberOfMatchingReferences(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $this->assertCount(2, $collection);
+        $this->assertSame(2, $collection->count());
+    }
+
+    #[Test]
+    public function everyMatchingReferenceIsPartOfTheCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $this->assertSame([1, 2], $this->referenceUids($collection));
+    }
+
+    /**
+     * The collection hands out reference objects, not file objects: the uid of the
+     * reference and the uid of the file it points at are different numbers, and a caller
+     * rendering the image needs the second one.
+     */
+    #[Test]
+    public function eachReferencePointsAtItsOriginalFile(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $names = [];
+        foreach ($collection as $reference) {
+            $this->assertInstanceOf(FileReference::class, $reference);
+            $names[$reference->getOriginalFile()->getUid()] = $reference->getName();
+        }
+        ksort($names);
+
+        $this->assertSame([1 => 'program-flyer.png', 2 => 'campus.png'], $names);
+    }
+
+    /**
+     * The same page references uid 3 through `og_image`. Without the `fieldname`
+     * condition every file attached to the page anywhere would end up in the collection.
+     */
+    #[Test]
+    public function referencesOfAnotherFieldOfTheSamePageAreNotPartOfTheCollection(): void
+    {
+        $this->assertSame([1, 2], $this->referenceUids(
+            FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media')
+        ));
+        $this->assertSame([3], $this->referenceUids(
+            FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'og_image')
+        ));
+    }
+
+    /**
+     * `uid_foreign` is only unique per table, so a `tt_content` record that happens to
+     * carry the same uid as the page would leak into the result without the
+     * `tablenames = 'pages'` condition - which is exactly what the fixture sets up.
+     */
+    #[Test]
+    public function referencesOfAnotherTableAreNotPartOfTheCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $this->assertNotContains(4, $this->referenceUids($collection));
+    }
+
+    #[Test]
+    public function aFieldWithoutAnyReferenceYieldsAnEmptyCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'teaser_image');
+
+        $this->assertCount(0, $collection);
+        $this->assertSame([], $this->referenceUids($collection));
+    }
+
+    #[Test]
+    public function anUnknownPageIdYieldsAnEmptyCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(999, 'media');
+
+        $this->assertCount(0, $collection);
+    }
+
+    #[Test]
+    public function aPageWithoutAnyReferenceYieldsAnEmptyCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITHOUT_MEDIA, 'media');
+
+        $this->assertCount(0, $collection);
+    }
+
+    /**
+     * The query builder comes from the connection pool and therefore carries the default
+     * restrictions. `sys_file_reference` declares both `deleted` and `hidden`, so an
+     * editor removing or disabling a reference takes it out of the collection - without a
+     * single line in this class saying so, which is why it is worth a test.
+     */
+    #[Test]
+    public function deletedAndHiddenReferencesAreNotPartOfTheCollection(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_REMOVED_MEDIA, 'media');
+
+        $this->assertCount(0, $collection);
+    }
+
+    /**
+     * An empty collection has to survive being asked for its current entry: `current()`
+     * on an empty array is `false`, which is what `valid()` reports on and what stops a
+     * `foreach` before its first iteration.
+     */
+    #[Test]
+    public function anEmptyCollectionIsNotValidAndHasNoCurrentEntry(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITHOUT_MEDIA, 'media');
+
+        $this->assertFalse($collection->valid());
+        $this->assertFalse($collection->current());
+        $this->assertNull($collection->key());
+
+        $seen = 0;
+        foreach ($collection as $unused) {
+            $seen++;
+        }
+        $this->assertSame(0, $seen);
+    }
+
+    /**
+     * The iterator is the internal array pointer, so a second pass only works because
+     * `rewind()` resets it. A template that lists the references twice - once as a
+     * gallery, once as a download list - is the ordinary case for that.
+     */
+    #[Test]
+    public function theCollectionCanBeIteratedMoreThanOnce(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $firstPass = $this->referenceUids($collection);
+        $secondPass = $this->referenceUids($collection);
+
+        $this->assertSame([1, 2], $firstPass);
+        $this->assertSame($firstPass, $secondPass);
+    }
+
+    /**
+     * The keys are the positions of the internal list, not the reference uids - a
+     * template addressing an entry by index gets the position.
+     */
+    #[Test]
+    public function iterationYieldsTheSequentialArrayPositionsAsKeys(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media');
+
+        $this->assertSame([0, 1], array_keys(iterator_to_array($collection)));
+    }
+
+    /**
+     * What a file reference exists for: the values entered on the relation win over the
+     * metadata of the file they point at.
+     */
+    #[Test]
+    public function aReferenceOverridesTheMetadataOfItsFile(): void
+    {
+        $reference = $this->referenceWithUid(1);
+
+        $this->assertSame('Flyer title from the reference', $reference->getTitle());
+        $this->assertSame('Flyer alternative from the reference', $reference->getAlternative());
+    }
+
+    /**
+     * Reference uid 2 leaves title, alternative and description `NULL`, which is what the
+     * backend stores for an untouched field, so the values of `sys_file_metadata` show
+     * through. Reading this off the Extbase `FileReference` would yield empty strings
+     * instead - the core object is what makes the fallback observable.
+     */
+    #[Test]
+    public function aReferenceWithoutOwnMetadataFallsBackToTheFileMetadata(): void
+    {
+        $reference = $this->referenceWithUid(2);
+
+        $this->assertSame('Campus from the file metadata', $reference->getTitle());
+        $this->assertSame('Campus alternative from the file metadata', $reference->getAlternative());
+        $this->assertSame('Campus description from the file metadata', $reference->getDescription());
+    }
+
+    /**
+     * The query constrains neither `sys_language_uid` nor `l10n_parent`, so the
+     * translated reference of page 4 is returned next to its default language original.
+     * A caller therefore has to pass the uid of the translated page, not the uid of the
+     * default language one - the method does no overlay of any kind.
+     */
+    #[Test]
+    public function referencesAreNotFilteredByLanguage(): void
+    {
+        $collection = FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_TRANSLATED_MEDIA, 'media');
+
+        $this->assertSame([7, 8], $this->referenceUids($collection));
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function referenceUids(FileReferenceCollection $collection): array
+    {
+        $uids = [];
+        foreach ($collection as $reference) {
+            $uids[] = $reference->getUid();
+        }
+        sort($uids);
+
+        return $uids;
+    }
+
+    private function referenceWithUid(int $uid): FileReference
+    {
+        foreach (FileReferenceCollection::getCollectionByPageIdAndField(self::PAGE_WITH_MEDIA, 'media') as $reference) {
+            if ($reference->getUid() === $uid) {
+                return $reference;
+            }
+        }
+        $this->fail(sprintf('No file reference with uid %d in the collection.', $uid));
+    }
+}

--- a/packages/fgtclb/academic-programs/Tests/Functional/Collection/Fixtures/FileReferenceCollection/fileReferences.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Collection/Fixtures/FileReferenceCollection/fileReferences.csv
@@ -1,0 +1,27 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,20,0,0,0,0,"/program-with-media","Program with media"
+,2,0,20,0,0,0,0,"/program-without-media","Program without media"
+,3,0,20,0,0,0,0,"/program-with-removed-media","Program with removed media"
+,4,0,20,0,0,0,0,"/translated-program","Translated program"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","CType","header"
+,1,1,0,0,0,"textmedia","Content element on the program page"
+"sys_file",
+,"uid","pid","storage","type","mime_type","missing","extension","name","identifier","identifier_hash","folder_hash","sha1","size","creation_date","modification_date"
+,1,0,1,2,"image/png",0,"png","program-flyer.png","/images/program-flyer.png","d82b65d423fe4a234ed73529a68b8262c1f763dc","ca306f2df2823c083069873158fd3b91fd4ebe01","0f4c7ac72a6360b0be1b82c2a9bc5837fafddd6c",1024,1700000000,1700000000
+,2,0,1,2,"image/png",0,"png","campus.png","/images/campus.png","cc166139799b16b634fd8a3afa35ac4bca188fbe","ca306f2df2823c083069873158fd3b91fd4ebe01","cace595ea1f5c0b2311e7e88ffeb21025d7c7d5c",2048,1700000000,1700000000
+,3,0,1,5,"application/pdf",0,"pdf","module-handbook.pdf","/documents/module-handbook.pdf","5820bffb7c2cec7a2ab205a36b83004df574df80","52eb14154f48adc08e24efe6370add6d331d6038","179bd5eee4540325b85aa2fddc40966070ed4e56",4096,1700000000,1700000000
+"sys_file_metadata",
+,"uid","pid","file","sys_language_uid","l10n_parent","title","alternative","description"
+,1,0,2,0,0,"Campus from the file metadata","Campus alternative from the file metadata","Campus description from the file metadata"
+"sys_file_reference",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","uid_local","uid_foreign","tablenames","fieldname","sorting_foreign","title","alternative","description","link"
+,1,1,0,0,0,0,1,1,"pages","media",2,"Flyer title from the reference","Flyer alternative from the reference","",""
+,2,1,0,0,0,0,2,1,"pages","media",1,\NULL,\NULL,\NULL,""
+,3,1,0,0,0,0,3,1,"pages","og_image",1,"Same page, other field","","",""
+,4,1,0,0,0,0,3,1,"tt_content","media",1,"Other table, same field","","",""
+,5,3,1,0,0,0,1,3,"pages","media",1,"Deleted reference","","",""
+,6,3,0,1,0,0,2,3,"pages","media",2,"Hidden reference","","",""
+,7,4,0,0,0,0,1,4,"pages","media",1,"Default language reference","","",""
+,8,4,0,0,1,7,2,4,"pages","media",1,"Translated reference","","",""

--- a/packages/fgtclb/academic-programs/Tests/Functional/Factory/Fixtures/ProgramDataFactory/programPages.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Factory/Fixtures/ProgramDataFactory/programPages.csv
@@ -1,0 +1,14 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title","subtitle","abstract","credit_points","job_profile","performance_scope","prerequisites","categories"
+,5,0,1,0,0,0,0,"/programs","Programs","","",\NULL,\NULL,\NULL,\NULL,0
+,1,5,20,0,0,0,0,"/programs/applied-physics","Applied Physics","Bachelor of Science","Optics, photonics and applied quantum mechanics.",180,"<p>Research and development in industry.</p>","<p>Six semesters, 30 credit points each.</p>","<p>General qualification for university entrance.</p>",2
+,2,5,20,0,0,0,0,"/programs/untouched","Untouched Program","","",\NULL,\NULL,\NULL,\NULL,0
+,3,5,1,0,0,0,0,"/programs/regular-page","Regular Page","","",\NULL,\NULL,\NULL,\NULL,0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,5,0,0,0,"admission_restriction","Restricted admission",0,0
+,2,5,0,0,0,"application_period","Winter term",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,1,"pages","categories",0,1
+,2,1,"pages","categories",0,2

--- a/packages/fgtclb/academic-programs/Tests/Functional/Factory/ProgramDataFactoryTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Factory/ProgramDataFactoryTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Factory;
+
+use FGTCLB\AcademicPrograms\Domain\Model\ProgramData;
+use FGTCLB\AcademicPrograms\Factory\ProgramDataFactory;
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * `ProgramDataFactory::get()` is the only thing standing between the raw `pages` row and
+ * the `{program}` variable of a program page template - `ProgramDataProcessor` passes
+ * `$processedData['data']` straight into it.
+ *
+ * It is a mapper, so a unit test can cover the assignments; what it cannot cover is the
+ * two things the row actually brings with it. First, the value types: a database row is
+ * strings on some drivers and integers on others, and every getter of `ProgramData` is
+ * typed, so the casts in the factory are the only reason the model can be built at all.
+ * Second, the columns of this extension are nullable (`credit_points`, `job_profile`,
+ * `performance_scope`, `prerequisites`), so an untouched program page carries `NULL`
+ * rather than an empty string. Both are asserted here against rows read back from the
+ * database, not against a hand written array.
+ *
+ * The categories are part of it because `setUid()` is the only reason the uid is mapped:
+ * `ProgramData::getCategories()` resolves them from it at render time. A factory writing
+ * the pid there would produce a model that looks right and lists the wrong categories.
+ */
+final class ProgramDataFactoryTest extends AbstractAcademicProgramsTestCase
+{
+    private const PROGRAM_PAGE = 1;
+    private const UNTOUCHED_PROGRAM_PAGE = 2;
+    private const REGULAR_PAGE = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProgramDataFactory/programPages.csv');
+    }
+
+    #[Test]
+    public function everyProgramPropertyIsTakenFromThePageRecord(): void
+    {
+        $program = $this->programOfPage(self::PROGRAM_PAGE);
+
+        $this->assertSame(1, $program->getUid());
+        $this->assertSame(5, $program->getPid());
+        $this->assertSame(20, $program->getDoktype());
+        $this->assertSame('Applied Physics', $program->getTitle());
+        $this->assertSame('Bachelor of Science', $program->getSubtitle());
+        $this->assertSame('Optics, photonics and applied quantum mechanics.', $program->getAbstract());
+        $this->assertSame(180, $program->getCreditPoints());
+        $this->assertSame('<p>Research and development in industry.</p>', $program->getJobProfile());
+        $this->assertSame('<p>Six semesters, 30 credit points each.</p>', $program->getPerformanceScope());
+        $this->assertSame('<p>General qualification for university entrance.</p>', $program->getPrerequisites());
+    }
+
+    /**
+     * The four columns this extension adds to `pages` are nullable, so a program page
+     * nobody filled in hands the factory `NULL` for each of them. Without the casts the
+     * typed setters of `ProgramData` would raise a `TypeError` on the first program page
+     * created in the backend.
+     */
+    #[Test]
+    public function nullColumnsBecomeAnEmptyStringOrZero(): void
+    {
+        $program = $this->programOfPage(self::UNTOUCHED_PROGRAM_PAGE);
+
+        $this->assertSame(0, $program->getCreditPoints());
+        $this->assertSame('', $program->getJobProfile());
+        $this->assertSame('', $program->getPerformanceScope());
+        $this->assertSame('', $program->getPrerequisites());
+        $this->assertSame('Untouched Program', $program->getTitle());
+    }
+
+    /**
+     * A `TypoScript` misconfiguration pointing the data processor at an ordinary page is
+     * not rejected: the factory maps whatever row it is given and reports the doktype it
+     * found. A template can therefore branch on `{program.doktype}`, but it will not be
+     * told by an exception.
+     */
+    #[Test]
+    public function aPageOfAnotherDoktypeIsMappedJustTheSame(): void
+    {
+        $program = $this->programOfPage(self::REGULAR_PAGE);
+
+        $this->assertSame(3, $program->getUid());
+        $this->assertSame(1, $program->getDoktype());
+        $this->assertSame('Regular Page', $program->getTitle());
+    }
+
+    /**
+     * `ProgramData::getCategories()` looks the categories up by the uid the factory set,
+     * which is what makes the mapped uid load bearing rather than decorative.
+     */
+    #[Test]
+    public function theCategoriesOfTheProgramAreResolvedFromTheMappedUid(): void
+    {
+        $categories = $this->programOfPage(self::PROGRAM_PAGE)->getCategories();
+
+        $this->assertNotNull($categories);
+        $titles = [];
+        foreach ($categories as $category) {
+            $titles[] = $category->getTitle();
+        }
+        sort($titles);
+
+        $this->assertSame(['Restricted admission', 'Winter term'], $titles);
+    }
+
+    /**
+     * A program page without categories still renders, so the collection is empty rather
+     * than `null` - a template iterating over `{program.categories}` must not have to
+     * guard against it.
+     */
+    #[Test]
+    public function aProgramWithoutCategoriesYieldsAnEmptyCollection(): void
+    {
+        $categories = $this->programOfPage(self::UNTOUCHED_PROGRAM_PAGE)->getCategories();
+
+        $this->assertNotNull($categories);
+        $this->assertCount(0, $categories);
+    }
+
+    /**
+     * The model is built with `GeneralUtility::makeInstance()`, which returns a shared
+     * instance for a `SingletonInterface`. `ProgramData` is not one - and must not become
+     * one, because a second `get()` call would then overwrite the first program.
+     */
+    #[Test]
+    public function everyCallReturnsItsOwnModel(): void
+    {
+        $first = $this->programOfPage(self::PROGRAM_PAGE);
+        $second = $this->programOfPage(self::UNTOUCHED_PROGRAM_PAGE);
+
+        $this->assertNotSame($first, $second);
+        $this->assertSame('Applied Physics', $first->getTitle());
+        $this->assertSame('Untouched Program', $second->getTitle());
+    }
+
+    private function programOfPage(int $pageId): ProgramData
+    {
+        // Obtained the way `ProgramDataProcessor` obtains it - the factory is not a
+        // public service, so `$this->get()` cannot be used here.
+        return GeneralUtility::makeInstance(ProgramDataFactory::class)->get($this->pageRecord($pageId));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pageRecord(int $pageId): array
+    {
+        $record = $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->select(['*'], 'pages', ['uid' => $pageId])
+            ->fetchAssociative();
+
+        $this->assertIsArray($record, sprintf('Page %d is missing in the fixture.', $pageId));
+
+        return $record;
+    }
+}


### PR DESCRIPTION
Resolves ACE-420 on `main`. Part of the test coverage round tracked under ACE-10.

## Why

`Factory\ProgramDataFactory` had no test, and `Collection\FileReferenceCollection::getCollectionByPageIdAndField()` queries `sys_file_reference` directly and had none either.

The collection fixture carries the near misses that matter, not just the happy path: a reference of another **table**, one of another **field**, one of another **page**, plus a deleted, a hidden and a translated row. Iteration is covered twice over, so `rewind()` correctness is pinned rather than assumed.

**Both are green on SQLite *and* PostgreSQL.** That is not decoration here — the collection has no `ORDER BY`, so a second DBMS is the only way to show the tests do not lean on one engine's incidental row order.

## Three things the tests document rather than fix

1. **No `ORDER BY`.** `sorting_foreign` is selected and never used, so a page's media come back in whatever order the database returns. Core's `FileRepository::findByRelation()` orders by it. For a gallery that is user-visible.
2. **No language handling.** Neither `sys_language_uid` nor `l10n_parent` is constrained and no overlay happens, so a caller must pass the uid of the *translated* page. Pinned by `referencesAreNotFilteredByLanguage`.
3. **The class has no caller.** Grepping `packages/` and `packages-dev/` outside `Tests/`, the only hits are the class itself — dead public API, duplicating `FileRepository::findByRelation()`, which does the same three-condition lookup **plus** ordering, workspace and language handling and the reference cache.

Smaller: `buildQueryBuilder(string $tableName = 'sys_file_reference')` is never passed an argument and the `FROM` hardcodes the table anyway; the `@throws` and import name `Doctrine\DBAL\Driver\Exception` where `executeQuery()` throws `Doctrine\DBAL\Exception`.

**The collection order is deliberately not asserted.** Pinning today's row order would encode one DBMS's behaviour as a contract. The absence of the `ORDER BY` is stated in the class docblock instead.

## Reported, not pinnable

`ProgramDataFactory::get()` reads **ten array keys unguarded** — no `??` anywhere. It survives a real program page only because the four extension columns are nullable and the casts absorb `NULL`. A row lacking a key yields eight `Undefined array key` warnings and a `ProgramData` full of zeros instead of a clear failure. `failOnWarning` means there is no way to pin that without silencing something. Related: `ProgramDataProcessor`'s `$processedData['page']->getPageRecord() ?? []` guards the wrong thing — it assumes `page` exists and is an object.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| drop the `tablenames = 'pages'` condition | 7 |
| drop the `fieldname` condition | 7 |
| drop the `uid_foreign` condition | 10 |
| `rewind()` made a no-op | 1 |
| `select('uid', 'uid_local')` instead of `sys_file_reference.*` | 1 |
| coerce `NULL` reference columns to `''` | 1 |
| `ProgramDataFactory`: uid taken from `pid` | 3 |
| drop the `(int)`/`(string)` casts | 4 (`TypeError`) |
| `setSubtitle()` fed `title` | 1 |

All run on `-d postgres`, which was the stable engine while the rest of this round was running.

## Scope

No production code is changed. `DemandFactory` was examined and **not** extended: the two branches its existing test does not reach are already exercised end to end by six tests of `AcademicProgramsPluginTest`, so duplicating them would add files without adding coverage.
