### PR TITLE
[TASK] ACE-407: Cover the profile demand and context

### DIFF
--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/Dto/ProfileDemandTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/Dto/ProfileDemandTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\Dto\ProfileDemand;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `ProfileDemand` is mapped by Extbase straight from request arguments in
+ * `ProfileController::listAction()` and handed to `ProfileRepository::findByDemand()`.
+ * It holds no logic of its own - what it does hold is the state a request that carries
+ * no demand at all ends up querying with, and `findByDemand()` branches on exactly that
+ * state. Those defaults are the contract, and they are what this test pins.
+ */
+final class ProfileDemandTest extends UnitTestCase
+{
+    /**
+     * `ProfileRepository::getOrderingsFromDemand()` only accepts a `sortBy` that is
+     * listed in the `demand/allowedSortByValues` extension configuration and a direction
+     * of `asc` or `desc`. A default that is not in that list leaves the query without any
+     * `ORDER BY`, and a profile list would come out in database order.
+     */
+    #[Test]
+    public function aFreshDemandSortsByLastNameAscending(): void
+    {
+        $subject = new ProfileDemand();
+
+        $this->assertSame('lastName', $subject->getSortBy());
+        $this->assertSame('asc', $subject->getSortByDirection());
+        $this->assertSame('', $subject->getGroupBy());
+    }
+
+    /**
+     * Every filter is off and the paginator starts at the first page. A `currentPage` of
+     * 0 would reach `SlidingWindowPagination` as an out-of-range page, and a non-empty
+     * `alphabetFilter` would put a `last_name LIKE` constraint on a plugin that never
+     * asked for one.
+     */
+    #[Test]
+    public function aFreshDemandFiltersNothingAndStartsOnTheFirstPage(): void
+    {
+        $subject = new ProfileDemand();
+
+        $this->assertSame(1, $subject->getCurrentPage());
+        $this->assertSame('', $subject->getAlphabetFilter());
+        $this->assertSame('', $subject->getProfileList());
+        $this->assertSame([], $subject->getFunctionTypes());
+        $this->assertSame([], $subject->getOrganisationalUnits());
+    }
+
+    /**
+     * The three values that are deliberately not on `DemandInterface` and are only ever
+     * set by the controller from plugin settings. Their defaults are the safe end of each
+     * branch in `ProfileRepository::applyDemandSettings()`: an empty `storagePages` turns
+     * the storage page restriction off instead of restricting to page 0, a fallback other
+     * than 1 leaves the language aspect as the site configured it, and `showHiddenRecords`
+     * false keeps the enable fields in effect - a default of true would publish every
+     * hidden profile of an installation on the next request.
+     */
+    #[Test]
+    public function aFreshDemandTransportsNoPluginOverrides(): void
+    {
+        $subject = new ProfileDemand();
+
+        $this->assertSame('', $subject->getStoragePages());
+        $this->assertSame(0, $subject->getFallbackForNonTranslated());
+        $this->assertFalse($subject->getShowHiddenRecords());
+    }
+
+    /**
+     * Every setter returns the demand itself, not a copy. `ProfileController` and the
+     * `ModifyProfileDemandEvent` listeners mutate the instance they were handed and hand
+     * the same one on - a setter returning a clone would drop everything set before it
+     * from the object that actually reaches the repository.
+     */
+    #[Test]
+    public function theSettersReturnTheSameInstanceSoTheyCanBeChained(): void
+    {
+        $subject = new ProfileDemand();
+
+        $result = $subject
+            ->setGroupBy('contracts.organisationalUnit')
+            ->setSortBy('firstName')
+            ->setSortByDirection('desc')
+            ->setCurrentPage(3)
+            ->setAlphabetFilter('B')
+            ->setProfileList('12,34')
+            ->setFunctionTypes([5, 8])
+            ->setOrganisationalUnits([13])
+            ->setStoragePages('7,9')
+            ->setFallbackForNonTranslated(1)
+            ->setShowHiddenRecords(true);
+
+        $this->assertSame($subject, $result);
+        $this->assertSame('contracts.organisationalUnit', $subject->getGroupBy());
+        $this->assertSame('firstName', $subject->getSortBy());
+        $this->assertSame('desc', $subject->getSortByDirection());
+        $this->assertSame(3, $subject->getCurrentPage());
+        $this->assertSame('B', $subject->getAlphabetFilter());
+        $this->assertSame('12,34', $subject->getProfileList());
+        $this->assertSame([5, 8], $subject->getFunctionTypes());
+        $this->assertSame([13], $subject->getOrganisationalUnits());
+        $this->assertSame('7,9', $subject->getStoragePages());
+        $this->assertSame(1, $subject->getFallbackForNonTranslated());
+        $this->assertTrue($subject->getShowHiddenRecords());
+    }
+
+    /**
+     * The documented "overrules all other filter options" of `getProfileList()` is a
+     * decision `ProfileRepository::applyDemandForQuery()` takes when it reads the demand,
+     * not something the DTO enforces. Pinning that: a `ModifyProfileDemandEvent` listener
+     * that clears the profile list again gets the previous filters back rather than an
+     * emptied demand, and `ProfileController::adoptSettings()` may set both in any order.
+     */
+    #[Test]
+    public function aProfileListDoesNotClearTheOtherFilters(): void
+    {
+        $subject = new ProfileDemand();
+        $subject->setFunctionTypes([5]);
+        $subject->setOrganisationalUnits([8]);
+        $subject->setAlphabetFilter('B');
+        $subject->setSortBy('firstName');
+
+        $subject->setProfileList('12,34');
+
+        $this->assertSame('12,34', $subject->getProfileList());
+        $this->assertSame([5], $subject->getFunctionTypes());
+        $this->assertSame([8], $subject->getOrganisationalUnits());
+        $this->assertSame('B', $subject->getAlphabetFilter());
+        $this->assertSame('firstName', $subject->getSortBy());
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/Dto/Syncronizer/SynchronizerContextTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Domain/Model/Dto/Syncronizer/SynchronizerContextTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Domain\Model\Dto\Syncronizer;
+
+use FGTCLB\AcademicPersons\Domain\Model\Dto\Syncronizer\SynchronizerContext;
+use FGTCLB\AcademicPersons\Service\RecordSynchronizerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `SynchronizerContext::create()` is the only place that turns the configured language
+ * id list of `EXT:academic_persons_edit` (`profile/allowedLanguages`, an
+ * integrator-maintained comma separated string) into site languages.
+ * `RecordSynchronizer::synchronizeRecord()` then loops over exactly that list and writes
+ * a translation per entry, so every id that survives here becomes a database write.
+ */
+final class SynchronizerContextTest extends UnitTestCase
+{
+    /**
+     * The site languages are carried as objects, not ids: the synchronizer needs
+     * `getLanguageId()` off them, and resolving them once is what makes the unknown ones
+     * detectable at all.
+     */
+    #[Test]
+    public function everyConfiguredLanguageIsResolvedToItsSiteLanguage(): void
+    {
+        $site = $this->site();
+
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $site,
+            [1, 2],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame([1, 2], $subject->getAllowedLanguageIds());
+        $this->assertSame($site->getLanguageById(1), $subject->allowedSiteLanguages[1]);
+        $this->assertSame($site->getLanguageById(2), $subject->allowedSiteLanguages[2]);
+    }
+
+    /**
+     * The ids reach the factory from an extension configuration string. They are already
+     * `intExplode()`d by `ProfileTranslator::getAllowedLanguageIds()` today, but the
+     * signature accepts strings and a second caller may not cast - a `'2'` must select
+     * language 2, not fall over the `<= 0` guard.
+     */
+    #[Test]
+    public function languageIdsAreAcceptedAsStrings(): void
+    {
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $this->site(),
+            ['1', '2'],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame([1, 2], $subject->getAllowedLanguageIds());
+    }
+
+    /**
+     * Language 0 is the source of the synchronization. Were it kept, the synchronizer
+     * would look for a "translation" of the default language record, not find one, and
+     * create a duplicate of the record it is copying from. `-1` ("all languages") has no
+     * site language either, and anything non numeric casts to 0.
+     *
+     * @param array<int, string|int> $allowedLanguageIds
+     */
+    #[Test]
+    #[DataProvider('languageIdsWithoutATranslationTarget')]
+    public function anIdThatIsNoTranslationTargetIsDropped(array $allowedLanguageIds): void
+    {
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $this->site(),
+            $allowedLanguageIds,
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame([], $subject->getAllowedLanguageIds());
+        $this->assertSame([], $subject->allowedSiteLanguages);
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<int, string|int>}>
+     */
+    public static function languageIdsWithoutATranslationTarget(): \Generator
+    {
+        yield 'nothing configured' => [[]];
+        yield 'the default language' => [[0]];
+        yield 'the default language as string' => [['0']];
+        yield 'all languages' => [[-1]];
+        yield 'an empty string' => [['']];
+        yield 'a non numeric value' => [['default']];
+    }
+
+    /**
+     * An integrator keeps `profile/allowedLanguages` per installation while a site
+     * configuration may drop a language at any time. That must stay a skipped
+     * translation, not an uncaught `\InvalidArgumentException` out of a DataHandler hook.
+     */
+    #[Test]
+    public function aLanguageTheSiteDoesNotConfigureIsDropped(): void
+    {
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $this->site(),
+            [1, 99, 2],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame([1, 2], $subject->getAllowedLanguageIds());
+    }
+
+    /**
+     * The list is keyed by language id, so a duplicated entry in the configuration
+     * string cannot make the synchronizer write the same translation twice.
+     */
+    #[Test]
+    public function theSameLanguageIsCollectedOnce(): void
+    {
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $this->site(),
+            [2, '2', 2],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame([2], $subject->getAllowedLanguageIds());
+    }
+
+    /**
+     * Only exception code 1522960188 - `Site::getLanguageById()` on an unknown id - is
+     * the expected one. Catching `\InvalidArgumentException` wholesale would otherwise
+     * turn an unrelated defect into a silently shortened language list, and the
+     * synchronization would report success while having translated nothing.
+     */
+    #[Test]
+    public function anUnexpectedSiteFailureIsNotSwallowed(): void
+    {
+        $configuration = [
+            'base' => 'https://example.com/',
+            'languages' => [
+                ['languageId' => 0, 'locale' => 'en_US.UTF-8', 'title' => 'English', 'base' => '/'],
+            ],
+        ];
+        $site = new class ('failing-site', 1, $configuration) extends Site {
+            public function getLanguageById(int $languageId): SiteLanguage
+            {
+                throw new \InvalidArgumentException('Something else went wrong.', 1234567890);
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1234567890);
+
+        SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $site,
+            [1],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+    }
+
+    /**
+     * The default language is what the synchronizer reads the source record in. Taking it
+     * from the site rather than from the caller is what keeps it consistent with the
+     * languages resolved next to it.
+     */
+    #[Test]
+    public function theDefaultLanguageIsTakenFromTheSite(): void
+    {
+        $site = $this->site();
+
+        $subject = SynchronizerContext::create(
+            $this->createMock(RecordSynchronizerInterface::class),
+            $site,
+            [1],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $this->assertSame($site->getDefaultLanguage(), $subject->defaultLanguage);
+        $this->assertSame(0, $subject->defaultLanguage->getLanguageId());
+    }
+
+    /**
+     * `RecordSynchronizer` recurses into inline children with `withRecord()` while it is
+     * iterating the parent's languages. A mutating implementation would rewrite the
+     * context under that loop and continue the parent's work on the child's table.
+     */
+    #[Test]
+    public function withRecordDescendsToAnotherRecordWithoutTouchingTheOriginal(): void
+    {
+        $recordSynchronizer = $this->createMock(RecordSynchronizerInterface::class);
+        $site = $this->site();
+        $subject = SynchronizerContext::create(
+            $recordSynchronizer,
+            $site,
+            [1, 2],
+            'tx_academicpersons_domain_model_profile',
+            42,
+        );
+
+        $child = $subject->withRecord('tx_academicpersons_domain_model_profile_email', 7);
+
+        $this->assertNotSame($subject, $child);
+        $this->assertSame('tx_academicpersons_domain_model_profile_email', $child->tableName);
+        $this->assertSame(7, $child->uid);
+        $this->assertSame('tx_academicpersons_domain_model_profile', $subject->tableName);
+        $this->assertSame(42, $subject->uid);
+
+        $this->assertSame($recordSynchronizer, $child->recordSyncronizer);
+        $this->assertSame($site, $child->site);
+        $this->assertSame($subject->defaultLanguage, $child->defaultLanguage);
+        $this->assertSame($subject->allowedSiteLanguages, $child->allowedSiteLanguages);
+    }
+
+    /**
+     * A site with a default language and two translations, which is what the
+     * synchronization is written for.
+     */
+    private function site(): Site
+    {
+        return new Site('academic-persons', 1, [
+            'base' => 'https://example.com/',
+            'languages' => [
+                ['languageId' => 0, 'locale' => 'en_US.UTF-8', 'title' => 'English', 'base' => '/'],
+                ['languageId' => 1, 'locale' => 'de_DE.UTF-8', 'title' => 'German', 'base' => '/de/'],
+                ['languageId' => 2, 'locale' => 'fr_FR.UTF-8', 'title' => 'French', 'base' => '/fr/'],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Resolves ACE-407 on `main`. Part of the test coverage round tracked under ACE-10.

## What is covered

`Domain\Model\Dto\ProfileDemand` is 244 lines and had no unit test. `Domain\Model\Dto\Syncronizer\SynchronizerContext` had none either.

**For `ProfileDemand`, the defaults** — the sort field and direction, the current page, the storage pages, the translation fallback and the hidden-record flag. They are what a controller inherits when it sets nothing, so a silent change to any of them changes what every plugin queries.

**For `SynchronizerContext`**, the guard that decides which languages are synchronized, the keying of the language list, and the rethrow path. The `<= 0` guard doubles as the rule that *the default language is never a synchronization target* — nothing said so, and the tests now name that intent, so a later "fix" to `< 0` fails here instead of silently writing onto the source record.

## An asymmetry worth naming

The demand's **validation is deliberately not pinned here, because it does not live in the DTO.** `ProfileRepository::getOrderingsFromDemand()` requires `sortBy` *and* `sortByDirection` to both validate, and drops the `ORDER BY` **entirely** when one does not — so an uppercase `DESC` from a FlexForm loses the ordering altogether.

`ProgramDemand` in `EXT:academic_programs` (see #483) validates in its setter and keeps the previous ordering. **The same bad input produces opposite behaviour in the two extensions.** Reported here rather than changed; pinning it would mean pinning it in the repository, which is a different unit.

## Two more findings, reported not changed

* **A shipped namespace typo.** `Domain\Model\Dto\Syncronizer\` and the promoted property `$recordSyncronizer` both misspell "synchronizer", while the interface they hold — `RecordSynchronizerInterface` — spells it correctly. The tests mirror the typo; renaming is breaking.
* **`SynchronizerContext::create()` assumes the site's first language is the default.** It takes `defaultLanguage` from `Site::getDefaultLanguage()`, which core implements as `reset($languages)` — the first *configured* language, not necessarily `languageId: 0`. A site listing a translation first would have the synchronizer read the source record in that language. Core's behaviour, inherited silently.

Also noticed: `ProfileDemand` mixes `private` (`storagePages`, `fallbackForNonTranslated`, `showHiddenRecords`) and `protected` on a non-`final` class explicitly designed to be subclassed through `DemandInterface`, so a subclass cannot reach those three; and its setter return types alternate between `self` and `ProfileDemand` with no rule.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| all six `ProfileDemand` defaults flipped | 3 |
| `setSortBy()` returns a clone; `setProfileList()` clears `functionTypes` | 2 |
| `create()`: guard `<= 0` → `< 0`, list appended instead of keyed by language id, rethrow disabled | 9 |
| `create()` takes the default language from the first *allowed* language; `withRecord()` returns `$this` | 2 |

## Scope

`ProfileCreateCommandDto` and `ProfileUpdateCommandDto` are **deliberately left uncovered**: each is two promoted `readonly array` properties defaulting to `[]` and nothing else, and the two are byte-identical apart from the class name. A test there would assert that PHP constructor promotion works.

No production code is changed. All three covered classes are byte-identical on branch `2`.
