### PR TITLE
[TASK] ACE-408: Cover the persons types and settings

### DIFF
--- a/packages/fgtclb/academic-persons/Tests/Unit/DemandValues/AbstractDemandValuesTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/DemandValues/AbstractDemandValuesTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\DemandValues;
+
+use FGTCLB\AcademicPersons\DemandValues\AbstractDemandValues;
+use FGTCLB\AcademicPersons\DemandValues\SortByValues;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `AbstractDemandValues` parses one extension configuration string into the FlexForm
+ * item list of the `groupBy` and `sortBy` fields. The keys of that list are more than
+ * labels: `Domain\Repository\ProfileRepository::getOrderingsFromDemand()` uses them as
+ * the allow list a submitted demand is checked against, and then as the Extbase
+ * property name it orders by. A key that is not a property of `Domain\Model\Profile`
+ * therefore reaches the persistence layer.
+ *
+ * The parser is the whole class - the two subclasses only name a configuration path -
+ * so it is covered here through `SortByValues`, and the paths in `DemandValuesTest`.
+ */
+final class AbstractDemandValuesTest extends UnitTestCase
+{
+    /**
+     * @param array<string, string> $expected
+     */
+    #[Test]
+    #[DataProvider('configuredValueStrings')]
+    public function aConfigurationStringBecomesAnItemList(string $configured, array $expected): void
+    {
+        $this->assertSame($expected, $this->subject($configured)->getAll());
+    }
+
+    /**
+     * The last three cases are not what an integrator means to configure. They are
+     * listed because nothing validates the string, and the empty key they produce is
+     * also the value an unset `sortBy`/`groupBy` demand carries - so it passes the
+     * `in_array()` allow list in `ProfileRepository` and orders by a property named ''.
+     *
+     * @return array<string, array{0: string, 1: array<string, string>}>
+     */
+    public static function configuredValueStrings(): array
+    {
+        return [
+            'the shipped default shape - property name and LLL label' => [
+                'firstName=LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.first_name'
+                    . ',lastName=LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.last_name',
+                [
+                    'firstName' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.first_name',
+                    'lastName' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.last_name',
+                ],
+            ],
+            'an entry without a label is its own label' => [
+                'firstName,lastName',
+                ['firstName' => 'firstName', 'lastName' => 'lastName'],
+            ],
+            'labelled and unlabelled entries mix' => [
+                'firstName=First name,lastName',
+                ['firstName' => 'First name', 'lastName' => 'lastName'],
+            ],
+            'whitespace around both separators is dropped' => [
+                "  firstName = First name ,\n lastName = Last name  ",
+                ['firstName' => 'First name', 'lastName' => 'Last name'],
+            ],
+            'a label may contain an equals sign' => [
+                'firstName=a=b',
+                ['firstName' => 'a=b'],
+            ],
+            'a repeated value keeps the last label' => [
+                'firstName=First,firstName=Second',
+                ['firstName' => 'Second'],
+            ],
+            'an empty configuration produces one empty item' => [
+                '',
+                ['' => ''],
+            ],
+            'a trailing comma produces an empty item' => [
+                'firstName=First name,',
+                ['firstName' => 'First name', '' => ''],
+            ],
+            'a gap between two entries produces an empty item' => [
+                'firstName=First,,lastName=Last',
+                ['firstName' => 'First', '' => '', 'lastName' => 'Last'],
+            ],
+        ];
+    }
+
+    /**
+     * `ProfileRepository` builds a fresh instance per query through
+     * `GeneralUtility::makeInstance()`, so the extension configuration is read on every
+     * list rendering. Nothing caches the parsed list on the instance beyond the
+     * constructor either.
+     */
+    #[Test]
+    public function theExtensionConfigurationIsAskedOncePerInstance(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->expects($this->once())
+            ->method('get')
+            ->with('academic_persons', 'demand/allowedSortByValues')
+            ->willReturn('firstName=First name');
+
+        $subject = new SortByValues($extensionConfiguration);
+
+        $this->assertSame(['firstName' => 'First name'], $subject->getAll());
+        $this->assertSame(['firstName' => 'First name'], $subject->getAll());
+    }
+
+    /**
+     * `loadValuesByExtensionConfigurationProperty()` returns early once anything was
+     * loaded. Neither shipped subclass hits that - each one loads a single property -
+     * but a subclass merging two properties would silently get only the first one, with
+     * no error to point at it. Pinned here so the trap is visible if such a subclass is
+     * ever written.
+     */
+    #[Test]
+    public function aSecondPropertyIsSilentlyIgnored(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnMap([
+            ['academic_persons', 'demand/allowedSortByValues', 'firstName=First name'],
+            ['academic_persons', 'demand/allowedGroupByValues', 'lastNameAlpha=Last name'],
+        ]);
+
+        $subject = new class ($extensionConfiguration) extends AbstractDemandValues {
+            protected function initialize(): void
+            {
+                $this->loadValuesByExtensionConfigurationProperty('demand/allowedSortByValues');
+                $this->loadValuesByExtensionConfigurationProperty('demand/allowedGroupByValues');
+            }
+        };
+
+        $this->assertSame(['firstName' => 'First name'], $subject->getAll());
+    }
+
+    private function subject(string $configured): SortByValues
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($configured);
+
+        return new SortByValues($extensionConfiguration);
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/DemandValues/DemandValuesTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/DemandValues/DemandValuesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\DemandValues;
+
+use FGTCLB\AcademicPersons\DemandValues\DemandValuesInterface;
+use FGTCLB\AcademicPersons\DemandValues\GroupByValues;
+use FGTCLB\AcademicPersons\DemandValues\SortByValues;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The two implementations differ in exactly one string: the extension configuration
+ * path they read. They are used in pairs - `Tca\DemandValues` fills the `groupBy` and
+ * the `sortBy` FlexForm select from them, `ProfileRepository` validates against both -
+ * so swapping the two paths would not fail anywhere, it would offer the group-by
+ * values as sort-by values and accept them as orderings.
+ *
+ * The parser they share is covered by `AbstractDemandValuesTest`.
+ */
+final class DemandValuesTest extends UnitTestCase
+{
+    #[Test]
+    public function groupByValuesReadTheAllowedGroupByConfiguration(): void
+    {
+        $subject = new GroupByValues($this->extensionConfigurationExpecting('demand/allowedGroupByValues'));
+
+        $this->assertInstanceOf(DemandValuesInterface::class, $subject);
+        $this->assertSame(['own' => 'Own'], $subject->getAll());
+    }
+
+    #[Test]
+    public function sortByValuesReadTheAllowedSortByConfiguration(): void
+    {
+        $subject = new SortByValues($this->extensionConfigurationExpecting('demand/allowedSortByValues'));
+
+        $this->assertInstanceOf(DemandValuesInterface::class, $subject);
+        $this->assertSame(['own' => 'Own'], $subject->getAll());
+    }
+
+    /**
+     * `ExtensionConfiguration::get()` throws `ExtensionConfigurationPathDoesNotExistException`
+     * for a path that `ext_conf_template.txt` never declared, and nothing here catches
+     * it - both the FlexForm `itemsProcFunc` and every profile list query go through
+     * these classes. The template writes the path with dots and the classes ask for it
+     * with slashes, which is why a plain string comparison would not do.
+     */
+    #[Test]
+    #[DataProvider('configurationPaths')]
+    public function eachConfigurationPathIsDeclaredInTheExtensionConfigurationTemplate(string $path): void
+    {
+        $template = (string)file_get_contents(__DIR__ . '/../../../ext_conf_template.txt');
+
+        $this->assertMatchesRegularExpression(
+            '/^' . preg_quote(str_replace('/', '.', $path), '/') . '\s*=/m',
+            $template,
+            sprintf('ext_conf_template.txt does not declare "%s"', $path),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function configurationPaths(): array
+    {
+        return [
+            'group by' => ['demand/allowedGroupByValues'],
+            'sort by' => ['demand/allowedSortByValues'],
+        ];
+    }
+
+    private function extensionConfigurationExpecting(string $path): ExtensionConfiguration
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->expects($this->once())
+            ->method('get')
+            ->with('academic_persons', $path)
+            ->willReturn('own=Own');
+
+        return $extensionConfiguration;
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Settings/AcademicPersonsSettingsTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Settings/AcademicPersonsSettingsTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Settings;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersons\Settings\ProfileInformationType;
+use FGTCLB\AcademicPersons\Settings\Validation;
+use FGTCLB\AcademicPersons\Settings\ValidationSet;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The settings object is what `AcademicPersonsSettingsFactory` hands to TCA overrides
+ * and to the Extbase validation, and it is what the factory writes into the core cache
+ * as `return <var_export>;`. Two things therefore have to hold: the lookups must fail
+ * softly, because TCA files ask for identifiers that need not be configured, and the
+ * object must survive `var_export()`/`require`, because that is how it is restored on
+ * every request after the first.
+ */
+final class AcademicPersonsSettingsTest extends UnitTestCase
+{
+    #[Test]
+    public function aRegisteredProfileInformationTypeIsReturned(): void
+    {
+        $profileInformationType = $this->profileInformationType('email');
+
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: ['email' => $profileInformationType],
+            validations: [],
+            raw: [],
+        );
+
+        $this->assertSame($profileInformationType, $subject->getProfileInformationType('email'));
+    }
+
+    /**
+     * TCA files ask by identifier for types an integrator may never have configured.
+     * Returning null rather than raising is what lets them skip the column instead of
+     * taking the TCA build down.
+     */
+    #[Test]
+    public function anUnknownProfileInformationTypeIsNull(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: ['email' => $this->profileInformationType('email')],
+            validations: [],
+            raw: [],
+        );
+
+        $this->assertNull($subject->getProfileInformationType('phone'));
+    }
+
+    #[Test]
+    public function aRegisteredValidationSetIsReturned(): void
+    {
+        $validationSet = new ValidationSet(identifier: 'profile', validations: []);
+
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: ['profile' => $validationSet],
+            raw: [],
+        );
+
+        $this->assertSame($validationSet, $subject->getValidationSet('profile'));
+    }
+
+    #[Test]
+    public function anUnknownValidationSetIsNull(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [],
+            raw: [],
+        );
+
+        $this->assertNull($subject->getValidationSet('profile'));
+    }
+
+    /**
+     * The fallback is the variant callers use when they need to ask a set for a field
+     * unconditionally. It has to carry the *requested* identifier, not an empty one -
+     * anything logging or comparing the returned set would otherwise attribute it to
+     * the wrong table.
+     */
+    #[Test]
+    public function anUnknownValidationSetFallsBackToAnEmptySetOfTheSameIdentifier(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [],
+            raw: [],
+        );
+
+        $fallback = $subject->getValidationSetWithFallback('profile');
+
+        $this->assertSame('profile', $fallback->identifier);
+        $this->assertSame([], $fallback->validations);
+        $this->assertNull($fallback->get('first_name'));
+    }
+
+    #[Test]
+    public function aRegisteredValidationSetIsNotReplacedByTheFallback(): void
+    {
+        $validationSet = new ValidationSet(identifier: 'profile', validations: []);
+
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: ['profile' => $validationSet],
+            raw: [],
+        );
+
+        $this->assertSame($validationSet, $subject->getValidationSetWithFallback('profile'));
+    }
+
+    /**
+     * The result is merged into `$GLOBALS['TCA']`, so the array key is the column name
+     * - the `fieldName` of the validation, not the key it is registered under. Those
+     * two are deliberately different here, because a set is keyed by validation
+     * identifier and nothing enforces that it equals the column.
+     */
+    #[Test]
+    public function theTcaConfigIsKeyedByTheFieldNameOfEachValidation(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [
+                'profile' => new ValidationSet(
+                    identifier: 'profile',
+                    validations: [
+                        'firstName' => $this->validation('first_name', ['type' => 'input', 'required' => true]),
+                        'lastName' => $this->validation('last_name', ['type' => 'input', 'max' => 60]),
+                    ],
+                ),
+            ],
+            raw: [],
+        );
+
+        $this->assertSame(
+            [
+                'columns' => [
+                    'first_name' => ['config' => ['type' => 'input', 'required' => true]],
+                    'last_name' => ['config' => ['type' => 'input', 'max' => 60]],
+                ],
+            ],
+            $subject->getValidationTcaTableConfig('profile'),
+        );
+    }
+
+    /**
+     * A validation may only exist to attach an Extbase validator, in which case it has
+     * nothing to say about TCA. Skipping it matters beyond tidiness: writing an empty
+     * `config` into `$GLOBALS['TCA']` would drop the column's own configuration.
+     */
+    #[Test]
+    public function aValidationWithoutTcaConfigContributesNothing(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [
+                'profile' => new ValidationSet(
+                    identifier: 'profile',
+                    validations: [
+                        'firstName' => $this->validation('first_name', []),
+                        'lastName' => $this->validation('last_name', ['type' => 'input']),
+                    ],
+                ),
+            ],
+            raw: [],
+        );
+
+        $this->assertSame(
+            ['columns' => ['last_name' => ['config' => ['type' => 'input']]]],
+            $subject->getValidationTcaTableConfig('profile'),
+        );
+    }
+
+    /**
+     * Not even an empty `columns` key: the caller merges the result into the table TCA,
+     * and `['columns' => []]` is not the same neutral element as `[]` for every merge
+     * strategy.
+     */
+    #[Test]
+    public function aSetWithoutAnyTcaConfigProducesAnEmptyArray(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [
+                'profile' => new ValidationSet(
+                    identifier: 'profile',
+                    validations: ['firstName' => $this->validation('first_name', [])],
+                ),
+            ],
+            raw: [],
+        );
+
+        $this->assertSame([], $subject->getValidationTcaTableConfig('profile'));
+    }
+
+    /**
+     * TCA override files call this for every table the extension knows, whether or not
+     * an integrator configured a validation set for it.
+     */
+    #[Test]
+    public function anUnknownIdentifierProducesAnEmptyArray(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [],
+            raw: [],
+        );
+
+        $this->assertSame([], $subject->getValidationTcaTableConfig('profile'));
+    }
+
+    /**
+     * Two validations of one set naming the same column silently collapse into the last
+     * one - the earlier `config` is replaced, not merged. Pinned because the set is
+     * keyed by validation identifier, so nothing stops a configuration from doing it.
+     */
+    #[Test]
+    public function twoValidationsOnOneColumnKeepTheLastTcaConfig(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [
+                'profile' => new ValidationSet(
+                    identifier: 'profile',
+                    validations: [
+                        'firstName' => $this->validation('first_name', ['type' => 'input']),
+                        'firstNameAgain' => $this->validation('first_name', ['type' => 'text']),
+                    ],
+                ),
+            ],
+            raw: [],
+        );
+
+        $this->assertSame(
+            ['columns' => ['first_name' => ['config' => ['type' => 'text']]]],
+            $subject->getValidationTcaTableConfig('profile'),
+        );
+    }
+
+    /**
+     * `AcademicPersonsSettingsFactory` caches the settings as `return <var_export>;` in
+     * a `PhpFrontend` and restores them with `require`, which is the only reason the
+     * four `__set_state()` implementations exist. This exercises the whole nesting in
+     * one go - a property added to any of them without being added to its
+     * `__set_state()` breaks the cached request but not the uncached one, so it is a
+     * defect that only shows on the second hit.
+     */
+    #[Test]
+    public function theWholeObjectGraphSurvivesTheVarExportRoundTrip(): void
+    {
+        $subject = new AcademicPersonsSettings(
+            profileInformationTypes: ['email' => $this->profileInformationType('email')],
+            validations: [
+                'profile' => new ValidationSet(
+                    identifier: 'profile',
+                    validations: ['firstName' => $this->validation('first_name', ['type' => 'input'])],
+                ),
+            ],
+            raw: ['profileInformationTypes' => ['email' => ['fieldName' => 'email']]],
+        );
+
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(AcademicPersonsSettings::class, $restored);
+        $this->assertEquals($subject, $restored);
+        $this->assertNotSame($subject, $restored);
+    }
+
+    /**
+     * @param array<string, mixed> $tcaConfig
+     */
+    private function validation(string $fieldName, array $tcaConfig): Validation
+    {
+        return new Validation(
+            identifier: 'validation of ' . $fieldName,
+            fieldName: $fieldName,
+            required: false,
+            disabled: false,
+            readOnly: false,
+            validatorClassNames: [],
+            tcaConfig: $tcaConfig,
+        );
+    }
+
+    private function profileInformationType(string $identifier): ProfileInformationType
+    {
+        return new ProfileInformationType(
+            identifier: $identifier,
+            fieldName: $identifier,
+            type: 'string',
+            label: 'Label of ' . $identifier,
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Settings/ProfileInformationTypeTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Settings/ProfileInformationTypeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Settings;
+
+use FGTCLB\AcademicPersons\Settings\ProfileInformationType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `isValid()` is the gate a configured profile information type has to pass before the
+ * factory keeps it, so what it accepts is what ends up in the cached settings - and
+ * what it rejects is dropped silently, without a log line.
+ */
+final class ProfileInformationTypeTest extends UnitTestCase
+{
+    #[Test]
+    #[DataProvider('profileInformationTypes')]
+    public function onlyAFullyNamedTypeIsValid(
+        string $identifier,
+        string $fieldName,
+        string $type,
+        string $label,
+        bool $expected,
+    ): void {
+        $subject = new ProfileInformationType(
+            identifier: $identifier,
+            fieldName: $fieldName,
+            type: $type,
+            label: $label,
+        );
+
+        $this->assertSame($expected, $subject->isValid());
+    }
+
+    /**
+     * Three of the four properties are checked. `fieldName` is not - an entry without
+     * one passes, which is the case worth pinning: it is the property that names the
+     * database column, so an incomplete configuration is kept rather than dropped.
+     *
+     * Emptiness is also literal, not semantic: a blank is a value.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string, 4: bool}>
+     */
+    public static function profileInformationTypes(): array
+    {
+        return [
+            'fully configured' => ['email', 'email', 'string', 'E-Mail', true],
+            'without an identifier' => ['', 'email', 'string', 'E-Mail', false],
+            'without a type' => ['email', 'email', '', 'E-Mail', false],
+            'without a label' => ['email', 'email', 'string', '', false],
+            'without anything' => ['', '', '', '', false],
+            'without a field name' => ['email', '', 'string', 'E-Mail', true],
+            'whitespace counts as configured' => ['email', 'email', ' ', ' ', true],
+        ];
+    }
+
+    /**
+     * Restored from the core cache the factory writes as `return <var_export>;`, so
+     * every property has to make the round trip - a value lost here is a type that
+     * silently differs between the first request and every later one.
+     */
+    #[Test]
+    public function everyPropertySurvivesTheVarExportRoundTrip(): void
+    {
+        $subject = new ProfileInformationType(
+            identifier: 'email',
+            fieldName: 'email',
+            type: 'string',
+            label: 'E-Mail',
+        );
+
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(ProfileInformationType::class, $restored);
+        $this->assertEquals($subject, $restored);
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Settings/ValidationSetTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Settings/ValidationSetTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Settings;
+
+use FGTCLB\AcademicPersons\Settings\Validation;
+use FGTCLB\AcademicPersons\Settings\ValidationSet;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * A validation set is the per-table bundle the Extbase validation and the TCA overrides
+ * ask a single field of. `get()` has to answer for a field nobody configured, because
+ * the caller iterates over the model's fields, not over the configured ones.
+ */
+final class ValidationSetTest extends UnitTestCase
+{
+    #[Test]
+    public function aRegisteredValidationIsReturned(): void
+    {
+        $validation = $this->validation('first_name');
+
+        $subject = new ValidationSet(identifier: 'profile', validations: ['firstName' => $validation]);
+
+        $this->assertSame($validation, $subject->get('firstName'));
+    }
+
+    /**
+     * The lookup key is the key the validation is registered under, not its `fieldName`
+     * or its own `identifier`. Those need not be equal, and this is the one place where
+     * mixing them up produces a silent null instead of an error.
+     */
+    #[Test]
+    public function theLookupUsesTheRegistrationKeyRatherThanTheFieldName(): void
+    {
+        $subject = new ValidationSet(
+            identifier: 'profile',
+            validations: ['firstName' => $this->validation('first_name')],
+        );
+
+        $this->assertNull($subject->get('first_name'));
+    }
+
+    #[Test]
+    public function anUnknownValidationIsNull(): void
+    {
+        $subject = new ValidationSet(identifier: 'profile', validations: []);
+
+        $this->assertNull($subject->get('firstName'));
+    }
+
+    /**
+     * Restored from the core cache the factory writes as `return <var_export>;`, which
+     * means the nested `Validation` objects have to make the round trip together with
+     * the keys they are registered under - a re-indexed array would make every `get()`
+     * miss.
+     */
+    #[Test]
+    public function theRegistrationKeysSurviveTheVarExportRoundTrip(): void
+    {
+        $subject = new ValidationSet(
+            identifier: 'profile',
+            validations: [
+                'firstName' => $this->validation('first_name'),
+                'lastName' => $this->validation('last_name'),
+            ],
+        );
+
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(ValidationSet::class, $restored);
+        $this->assertEquals($subject, $restored);
+        $this->assertSame(['firstName', 'lastName'], array_keys($restored->validations));
+    }
+
+    private function validation(string $fieldName): Validation
+    {
+        return new Validation(
+            identifier: 'validation of ' . $fieldName,
+            fieldName: $fieldName,
+            required: true,
+            disabled: false,
+            readOnly: false,
+            validatorClassNames: [],
+            tcaConfig: [],
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Settings/ValidationTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Settings/ValidationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Settings;
+
+use FGTCLB\AcademicPersons\Settings\Validation;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Validation\Validator\NotEmptyValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\StringLengthValidator;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Validation` carries no behaviour beyond `__set_state()` - it is a readonly data
+ * object whose properties are read directly. That one method is not decoration though:
+ * `AcademicPersonsSettingsFactory` caches the settings as `return <var_export>;` and
+ * restores them with `require`, so a constructor property that `__set_state()` does not
+ * pass on is lost on every request but the first, where nothing points at it.
+ */
+final class ValidationTest extends UnitTestCase
+{
+    #[Test]
+    public function everyPropertySurvivesTheVarExportRoundTrip(): void
+    {
+        $subject = new Validation(
+            identifier: 'firstName',
+            fieldName: 'first_name',
+            required: true,
+            disabled: false,
+            readOnly: true,
+            validatorClassNames: [NotEmptyValidator::class, StringLengthValidator::class],
+            tcaConfig: ['type' => 'input', 'max' => 60, 'eval' => 'trim'],
+            inputType: 'text',
+        );
+
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(Validation::class, $restored);
+        $this->assertEquals($subject, $restored);
+        $this->assertSame('firstName', $restored->identifier);
+        $this->assertSame('first_name', $restored->fieldName);
+        $this->assertTrue($restored->required);
+        $this->assertFalse($restored->disabled);
+        $this->assertTrue($restored->readOnly);
+        $this->assertSame(
+            [NotEmptyValidator::class, StringLengthValidator::class],
+            $restored->validatorClassNames,
+        );
+        $this->assertSame(['type' => 'input', 'max' => 60, 'eval' => 'trim'], $restored->tcaConfig);
+        $this->assertSame('text', $restored->inputType);
+    }
+
+    /**
+     * `inputType` is the only constructor argument with a default, and `__set_state()`
+     * reads it as a required array key. That holds as long as the array comes from
+     * `var_export()` of a real instance - this pins that it does, because a validation
+     * built without an `inputType` is the common case.
+     */
+    #[Test]
+    public function aDefaultedInputTypeIsStillExportedAndRestored(): void
+    {
+        $subject = new Validation(
+            identifier: 'firstName',
+            fieldName: 'first_name',
+            required: false,
+            disabled: false,
+            readOnly: false,
+            validatorClassNames: [],
+            tcaConfig: [],
+        );
+
+        $restored = eval('return ' . var_export($subject, true) . ';');
+
+        $this->assertInstanceOf(Validation::class, $restored);
+        $this->assertSame('', $restored->inputType);
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Types/AbstractTypesTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Types/AbstractTypesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Types;
+
+use FGTCLB\AcademicPersons\Types\AbstractTypes;
+use FGTCLB\AcademicPersons\Types\EmailAddressTypes;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `AbstractTypes` turns one extension configuration string into the item list a TCA
+ * `select` offers for `type` columns of `tx_academicpersons_domain_model_profile_*`
+ * records. The parser is the whole class - the three subclasses only name a
+ * configuration path - so it is covered here through `EmailAddressTypes`, and the
+ * paths are covered in `TypesTest`.
+ *
+ * What is stored in a record is the array *key*, so a change in how a configured
+ * entry is split into key and label silently repoints existing records.
+ */
+final class AbstractTypesTest extends UnitTestCase
+{
+    /**
+     * @param array<string, string> $expected
+     */
+    #[Test]
+    #[DataProvider('configuredTypeStrings')]
+    public function aConfigurationStringBecomesAnItemList(string $configured, array $expected): void
+    {
+        $this->assertSame($expected, $this->subject($configured)->getAll());
+    }
+
+    /**
+     * The last four cases are not what an integrator means to configure, but the parser
+     * has no validation in front of it, so they document what reaches the item list.
+     *
+     * @return array<string, array{0: string, 1: array<string, string>}>
+     */
+    public static function configuredTypeStrings(): array
+    {
+        return [
+            'the shipped default' => [
+                'private=Private,business=Business',
+                ['private' => 'Private', 'business' => 'Business'],
+            ],
+            'an entry without a label is its own label' => [
+                'private,business',
+                ['private' => 'private', 'business' => 'business'],
+            ],
+            'labelled and unlabelled entries mix' => [
+                'private=Private,business',
+                ['private' => 'Private', 'business' => 'business'],
+            ],
+            'whitespace around both separators is dropped' => [
+                "  private = Private ,\n business = Business  ",
+                ['private' => 'Private', 'business' => 'Business'],
+            ],
+            'a label may contain an equals sign' => [
+                'private=Private=ish',
+                ['private' => 'Private=ish'],
+            ],
+            'an LLL reference is a label like any other' => [
+                'private=LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:type.private',
+                ['private' => 'LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:type.private'],
+            ],
+            'a repeated value keeps the last label' => [
+                'private=First,private=Second',
+                ['private' => 'Second'],
+            ],
+            'an empty configuration produces one empty item' => [
+                '',
+                ['' => ''],
+            ],
+            'a trailing comma produces an empty item' => [
+                'private=Private,',
+                ['private' => 'Private', '' => ''],
+            ],
+            'a gap between two entries produces an empty item' => [
+                'private=Private,,business=Business',
+                ['private' => 'Private', '' => '', 'business' => 'Business'],
+            ],
+        ];
+    }
+
+    /**
+     * The item list is read straight from the extension configuration on every
+     * instantiation - there is no runtime cache and no `$GLOBALS` fallback - so an
+     * integrator's change takes effect without a cache flush.
+     */
+    #[Test]
+    public function theExtensionConfigurationIsAskedOncePerInstance(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->expects($this->once())
+            ->method('get')
+            ->with('academic_persons', 'types/emailAddressTypes')
+            ->willReturn('private=Private');
+
+        $subject = new EmailAddressTypes($extensionConfiguration);
+
+        $this->assertSame(['private' => 'Private'], $subject->getAll());
+        $this->assertSame(['private' => 'Private'], $subject->getAll());
+    }
+
+    /**
+     * `loadTypesByExtensionConfigurationProperty()` returns early once anything was
+     * loaded. None of the three shipped subclasses hits that - each one loads a single
+     * property - but a subclass merging two properties would silently get only the
+     * first one, with no error to point at it. Pinned here so the trap is visible if
+     * such a subclass is ever written.
+     */
+    #[Test]
+    public function aSecondPropertyIsSilentlyIgnored(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnMap([
+            ['academic_persons', 'types/emailAddressTypes', 'private=Private'],
+            ['academic_persons', 'types/phoneNumberTypes', 'mobile=Mobile'],
+        ]);
+
+        $subject = new class ($extensionConfiguration) extends AbstractTypes {
+            protected function initialize(): void
+            {
+                $this->loadTypesByExtensionConfigurationProperty('types/emailAddressTypes');
+                $this->loadTypesByExtensionConfigurationProperty('types/phoneNumberTypes');
+            }
+        };
+
+        $this->assertSame(['private' => 'Private'], $subject->getAll());
+    }
+
+    private function subject(string $configured): EmailAddressTypes
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($configured);
+
+        return new EmailAddressTypes($extensionConfiguration);
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Unit/Types/TypesTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Unit/Types/TypesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Unit\Types;
+
+use FGTCLB\AcademicPersons\Types\EmailAddressTypes;
+use FGTCLB\AcademicPersons\Types\PhoneNumberTypes;
+use FGTCLB\AcademicPersons\Types\PhysicalAddressTypes;
+use FGTCLB\AcademicPersons\Types\TypesInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The three concrete implementations differ in exactly one string: the extension
+ * configuration path they read. `Tca\RecordTypes` picks the class per column, so a
+ * swapped or mistyped path is not a fatal - it fills the `type` select of one table
+ * with the item list of another, or lets `ExtensionConfiguration::get()` throw while
+ * a backend form is being rendered. Neither is visible without asserting the paths.
+ *
+ * The parser they share is covered by `AbstractTypesTest`.
+ */
+final class TypesTest extends UnitTestCase
+{
+    #[Test]
+    public function emailAddressTypesReadTheEmailAddressConfiguration(): void
+    {
+        $subject = new EmailAddressTypes($this->extensionConfigurationExpecting('types/emailAddressTypes'));
+
+        $this->assertInstanceOf(TypesInterface::class, $subject);
+        $this->assertSame(['own' => 'Own'], $subject->getAll());
+    }
+
+    #[Test]
+    public function phoneNumberTypesReadThePhoneNumberConfiguration(): void
+    {
+        $subject = new PhoneNumberTypes($this->extensionConfigurationExpecting('types/phoneNumberTypes'));
+
+        $this->assertInstanceOf(TypesInterface::class, $subject);
+        $this->assertSame(['own' => 'Own'], $subject->getAll());
+    }
+
+    #[Test]
+    public function physicalAddressTypesReadThePhysicalAddressConfiguration(): void
+    {
+        $subject = new PhysicalAddressTypes($this->extensionConfigurationExpecting('types/physicalAddressTypes'));
+
+        $this->assertInstanceOf(TypesInterface::class, $subject);
+        $this->assertSame(['own' => 'Own'], $subject->getAll());
+    }
+
+    /**
+     * `ExtensionConfiguration::get()` throws `ExtensionConfigurationPathDoesNotExistException`
+     * for a path that `ext_conf_template.txt` never declared, and nothing here catches
+     * it - the TCA `itemsProcFunc` would take the whole backend form down. The template
+     * writes the path with dots and the classes ask for it with slashes, which is why a
+     * plain string comparison would not do.
+     */
+    #[Test]
+    #[DataProvider('configurationPaths')]
+    public function eachConfigurationPathIsDeclaredInTheExtensionConfigurationTemplate(string $path): void
+    {
+        $template = (string)file_get_contents(__DIR__ . '/../../../ext_conf_template.txt');
+
+        $this->assertMatchesRegularExpression(
+            '/^' . preg_quote(str_replace('/', '.', $path), '/') . '\s*=/m',
+            $template,
+            sprintf('ext_conf_template.txt does not declare "%s"', $path),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function configurationPaths(): array
+    {
+        return [
+            'email addresses' => ['types/emailAddressTypes'],
+            'phone numbers' => ['types/phoneNumberTypes'],
+            'physical addresses' => ['types/physicalAddressTypes'],
+        ];
+    }
+
+    private function extensionConfigurationExpecting(string $path): ExtensionConfiguration
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->expects($this->once())
+            ->method('get')
+            ->with('academic_persons', $path)
+            ->willReturn('own=Own');
+
+        return $extensionConfiguration;
+    }
+}


### PR DESCRIPTION
Resolves ACE-408 on `main`. Part of the test coverage round tracked under ACE-10.

`Classes/Types/`, `Classes/DemandValues/` and `Classes/Settings/` had no unit tests. They are the value sets the TCA item procFuncs and the profile settings are built from, so what they parse out of the extension configuration decides what an editor can select.

## Two defects, pinned as current behaviour

**1. An empty or gappy configuration produces the item `'' => ''`**, because `trimExplode(',', '')` returns an array holding one empty string. Same for a trailing comma and for `a,,b`.

For the demand values that is **not cosmetic**: `ProfileRepository::getOrderingsFromDemand()` checks the allowed list with `in_array($demand->getSortBy(), $allowed, true)`, and an unset `sortBy` **is** the empty string — so it passes the allow list and produces an Extbase ordering on a property named `''`.

**2. A malformed entry writes `null` into an `array<string, string>`** — `'private='` or `'=Private'` makes the inner `trimExplode('=', …, true, 2)` filter the empty half away and re-index, so the list destructuring reads an undefined key. **Deliberately not pinned:** the suite fails on warnings, so the test would be permanently red on a defect this change does not fix.

## What else is now guarded

**Every extension configuration path these classes read is asserted to exist in `ext_conf_template.txt`.** `ExtensionConfiguration::get()` is never guarded anywhere in this code, so a path missing from the template — or an extension configuration not yet synchronised — throws straight out of a TCA `itemsProcFunc` and out of `ProfileRepository`. Nothing else catches that today.

Plus the dead early-return guard in both abstract classes, which never fires as shipped (the constructor calls `initialize()` exactly once) but would silently drop the second source for any subclass merging two configuration properties.

## Worth naming

**`AbstractTypes` and `AbstractDemandValues` are the same class twice** — identical parser, identical guard, identical defects, differing only in a property name and a method name. Both defects above therefore have to be fixed in two places.

Smaller: `ProfileInformationType::isValid()` does not check `fieldName`, although that is the property naming the database column, and its `__set_state()` is typed `: object` where the three siblings are typed `: self`; `getValidationTcaTableConfig()` silently collapses two validations on one column (the second `config` replaces the first); `Classes/Settings/Validation.php` is the only one of the four Settings classes **without `declare(strict_types=1);`**; and `initialize()` is `abstract protected` on `AbstractTypes` while all three `Types` subclasses widen it to `public` and both `DemandValues` subclasses do not.

Outside this unit but noticed: `Classes/Tca/DemandValues.php` still builds TCA items in the legacy numeric `[$label, $value]` form while `Classes/Tca/RecordTypes.php` uses the associative form — worth checking whether the numeric form still works on v14, since both consume exactly the classes covered here.

## Proof the tests can fail

25 mutations, every test method shown red by at least one: the `str_contains($type, '=')` check retargeted (13 failures), the `trimExplode` limit changed (1), the early-return guard removed (1), `removeEmptyValues` flipped (3), the label emptied (2), the three configuration paths crossed over (2 each), a configuration path dropped from `ext_conf_template.txt` (1–2 each), and fifteen more across the Settings classes.

**One mutation stayed green and was replaced rather than kept**: `getValidationSet` → `array_values(...)[0] ?? null` cannot fail a test whose fixture set is empty. The stronger variant, returning a fabricated `ValidationSet`, produced the two failures.

## Scope

No production code is changed. `TypesInterface` and `DemandValuesInterface` are covered transitively through the concrete classes; `AcademicPersonsSettingsFactory` needs a container and belongs in a functional test.
