### PR TITLE
[TASK] ACE-415: Cover the profile and contract findAll

### DIFF
--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ContractRepositoryFindAllTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ContractRepositoryFindAllTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Domain\Repository;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Repository\ContractRepository;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Coverage for `ContractRepository::findAll()`.
+ *
+ * `findByUids()` is pinned down for hidden records by `ContractRepositoryShowHiddenRecordsTest`,
+ * and `getContractItemsForTcaItemsProcFunc()` - which does nothing but delegate here - is
+ * exercised through FormEngine by `Tests/Functional/Backend/FormEngine/ContractItemsTest`. That
+ * makes this method the one every contract select item in the backend is built from, so what it
+ * leaves out is what an editor cannot pick.
+ *
+ * The override exists for one line, `setRespectStoragePage(false)`. Without a request the
+ * Extbase `QueryFactory` falls back to `storagePid = 0`; the inherited implementation would
+ * therefore offer the contracts stored on page `0`, which in a real installation is none of
+ * them.
+ *
+ * No orderings are set and `ContractRepository` declares no `$defaultOrderings`. The table's TCA
+ * `sortby`/`default_sortby` is a backend concept Extbase does not read, so the statement carries
+ * no `ORDER BY` and the result order belongs to the DBMS - the assertions compare sorted uid
+ * sets rather than an order.
+ */
+final class ContractRepositoryFindAllTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function contractsAreReturnedFromEveryStoragePage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $result = $this->subject()->findAll();
+
+        $this->assertSame([1, 2, 5], $this->resultUids($result));
+        $this->assertSame([20, 30], $this->resultPids($result));
+    }
+
+    #[Test]
+    public function hiddenContractsAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $this->assertNotContains(3, $this->resultUids($this->subject()->findAll()));
+    }
+
+    #[Test]
+    public function deletedContractsAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $this->assertNotContains(4, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * The language restriction is left in place, so the default language selects
+     * `sys_language_uid IN (0, -1)`.
+     */
+    #[Test]
+    public function contractForAllLanguagesIsReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $this->assertContains(5, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * A translated contract is an overlay of its default language record. Returning it as a
+     * record of its own would put the same contract into the backend select twice, once per
+     * language.
+     *
+     * The assertion counts occurrences rather than looking for the translation's own uid `6`:
+     * Extbase maps a translated row onto the uid of its default language record, so a leaking
+     * translation shows up as contract `1` a second time, never under its own uid.
+     */
+    #[Test]
+    public function translationDoesNotAppearBesideItsDefaultLanguageRecord(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $uids = $this->resultUids($this->subject()->findAll());
+
+        $this->assertContains(1, $uids);
+        $this->assertCount(1, array_keys($uids, 1, true));
+    }
+
+    /**
+     * The contracts come back mapped, not as raw rows - `ContractItemsTest` builds its select
+     * labels from the model, so an empty `position` there would be a broken select item here.
+     */
+    #[Test]
+    public function returnedContractsAreMappedModels(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractRepositoryFindAll/contracts.csv');
+
+        $positions = [];
+        foreach ($this->subject()->findAll() as $contract) {
+            $this->assertInstanceOf(Contract::class, $contract);
+            $positions[] = $contract->getPosition();
+        }
+        sort($positions);
+
+        $this->assertSame(['Dean', 'Professor', 'Research Assistant'], $positions);
+    }
+
+    #[Test]
+    public function emptyTableYieldsAnEmptyResult(): void
+    {
+        $result = $this->subject()->findAll();
+
+        $this->assertCount(0, $result);
+        $this->assertSame([], $this->resultUids($result));
+    }
+
+    private function subject(): ContractRepository
+    {
+        return $this->get(ContractRepository::class);
+    }
+
+    /**
+     * @param QueryResultInterface<int, Contract> $result
+     * @return int[]
+     */
+    private function resultUids(QueryResultInterface $result): array
+    {
+        $uids = [];
+        foreach ($result as $contract) {
+            $uids[] = (int)$contract->getUid();
+        }
+        sort($uids);
+        return $uids;
+    }
+
+    /**
+     * @param QueryResultInterface<int, Contract> $result
+     * @return int[]
+     */
+    private function resultPids(QueryResultInterface $result): array
+    {
+        $pids = [];
+        foreach ($result as $contract) {
+            $pids[] = (int)$contract->getPid();
+        }
+        $pids = array_values(array_unique($pids));
+        sort($pids);
+        return $pids;
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ContractRepositoryFindAll/contracts.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ContractRepositoryFindAll/contracts.csv
@@ -1,0 +1,23 @@
+"pages",
+,"uid","pid","sorting","doktype","title","slug","is_siteroot","sys_language_uid","hidden","deleted",
+,1,0,2,1,"Site Root (EN)","/",1,0,0,0,
+,20,1,2,254,"Profile Storage One","/profile-storage-one",0,0,0,0,
+,30,1,4,254,"Profile Storage Two","/profile-storage-two",0,0,0,0,
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","sys_language_uid","l10n_parent","hidden","deleted","first_name","last_name",
+,1,20,0,0,0,0,"Anna","Abel",
+,2,30,0,0,0,0,"Bruno","Brecht",
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","sorting","sys_language_uid","l10n_parent","hidden","deleted","profile","position",
+# Visible contract on the first storage page.
+,1,20,1,0,0,0,0,1,"Professor",
+# Visible contract on a second storage page - only found when the storage page restriction is off.
+,2,30,1,0,0,0,0,2,"Research Assistant",
+# Hidden contract: excluded, findAll() has no "show hidden" switch.
+,3,20,2,0,0,1,0,1,"Hidden Lecturer",
+# Deleted contract: excluded.
+,4,20,3,0,0,0,1,1,"Deleted Lecturer",
+# Contract in "all languages" (-1): part of every language's result.
+,5,20,4,-1,0,0,0,1,"Dean",
+# Translation of contract 1 into language 1: not a record of its own for the default language.
+,6,20,1,1,1,0,0,1,"Professorin",

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv
@@ -1,0 +1,23 @@
+"pages",
+,"uid","pid","sorting","doktype","title","slug","is_siteroot","sys_language_uid","hidden","deleted",
+,1,0,2,1,"Site Root (EN)","/",1,0,0,0,
+,20,1,2,254,"Profile Storage One","/profile-storage-one",0,0,0,0,
+,30,1,4,254,"Profile Storage Two","/profile-storage-two",0,0,0,0,
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","sys_language_uid","l10n_parent","hidden","deleted","first_name","last_name",
+,1,20,0,0,0,0,"Anna","Abel",
+,2,30,0,0,0,0,"Bruno","Brecht",
+"tx_academicpersons_domain_model_profile_information",
+,"uid","pid","sorting","sys_language_uid","l10n_parent","hidden","deleted","profile","type","title","year","year_start","year_end",
+# Visible entry on the first storage page.
+,1,20,1,0,0,0,0,1,"type_1","Storage One - Publication",2020,\NULL,\NULL,
+# Visible entry on a second storage page - only found when the storage page restriction is off.
+,2,30,1,0,0,0,0,2,"type_1","Storage Two - Publication",2021,\NULL,\NULL,
+# Hidden entry: excluded, findAll() has no "show hidden" switch.
+,3,20,2,0,0,1,0,1,"type_1","Storage One - Hidden",2020,\NULL,\NULL,
+# Deleted entry: excluded.
+,4,20,3,0,0,0,1,1,"type_1","Storage One - Deleted",2020,\NULL,\NULL,
+# Entry in "all languages" (-1): part of every language's result.
+,5,20,4,-1,0,0,0,1,"type_2","Storage One - All Languages",2020,\NULL,\NULL,
+# Translation of entry 1 into language 1: not a record of its own for the default language.
+,6,20,1,1,1,0,0,1,"type_1","Storage One - Publication (DE)",2020,\NULL,\NULL,

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileRepositoryFindAll/profiles.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileRepositoryFindAll/profiles.csv
@@ -1,0 +1,25 @@
+"pages",
+,"uid","pid","sorting","doktype","title","slug","is_siteroot","sys_language_uid","hidden","deleted",
+,1,0,2,1,"Site Root (EN)","/",1,0,0,0,
+,20,1,2,254,"Profile Storage One","/profile-storage-one",0,0,0,0,
+,30,1,4,254,"Profile Storage Two","/profile-storage-two",0,0,0,0,
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","sys_language_uid","l10n_parent","hidden","deleted","starttime","endtime","first_name","last_name",
+# Plain, visible profile on the first storage page.
+,1,20,0,0,0,0,0,0,"Anna","Abel",
+# Plain, visible profile on a second storage page - only found when the storage page restriction is off.
+,2,30,0,0,0,0,0,0,"Bruno","Brecht",
+# Hidden profile: excluded, findAll() has no "show hidden" switch.
+,3,20,0,0,1,0,0,0,"Clara","Curie",
+# Deleted profile: excluded.
+,4,30,0,0,0,1,0,0,"Dora","Dahl",
+# Profile in "all languages" (-1): part of every language's result.
+,5,20,-1,0,0,0,0,0,"Ellen","Engel",
+# Translation of profile 1 into language 1: not a record of its own for the default language.
+,6,20,1,1,0,0,0,0,"Anna (DE)","Abel",
+# Publication starts in 2038 - deliberately below 2147483647, because `starttime` is a
+# 32 bit signed integer column and PostgreSQL rejects anything above it while SQLite
+# accepts it silently.
+,7,20,0,0,0,0,2145916800,0,"Frida","Fontane",
+# Publication ended in the year 2000.
+,8,20,0,0,0,0,0,946684800,"Gustav","Grass",

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileRepositoryFrontendUser/profilesOfFrontendUsers.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/Fixtures/ProfileRepositoryFrontendUser/profilesOfFrontendUsers.csv
@@ -1,0 +1,44 @@
+"pages",
+,"uid","pid","sorting","doktype","title","slug","is_siteroot","sys_language_uid","hidden","deleted",
+,1,0,2,1,"Site Root (EN)","/",1,0,0,0,
+,20,1,2,254,"Profile Storage One","/profile-storage-one",0,0,0,0,
+,30,1,4,254,"Profile Storage Two","/profile-storage-two",0,0,0,0,
+"fe_users",
+,"uid","pid","username","deleted","disable","tx_extbase_type",
+# The user under test.
+,10,20,"owner",0,0,"Tx_Academicpersonsedit_Domain_Model_FrontendUser",
+# A second user - none of the profiles below may cross over to the user above.
+,11,20,"other",0,0,"Tx_Academicpersonsedit_Domain_Model_FrontendUser",
+# A user without any profile at all.
+,12,20,"stranger",0,0,"Tx_Academicpersonsedit_Domain_Model_FrontendUser",
+# A disabled user that still owns a visible profile.
+,13,20,"disabled",0,1,"Tx_Academicpersonsedit_Domain_Model_FrontendUser",
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","sys_language_uid","l10n_parent","hidden","deleted","first_name","last_name",
+# Owner, visible.
+,1,20,0,0,0,0,"Anna","Abel",
+# Belongs to the other user only.
+,2,20,0,0,0,0,"Bruno","Brecht",
+# Owner, hidden.
+,3,20,0,0,1,0,"Clara","Curie",
+# Owner, deleted.
+,4,20,0,0,0,1,"Dora","Dahl",
+# Shared between the owner and the other user.
+,5,20,0,0,0,0,"Ellen","Engel",
+# Owner, on a second storage page.
+,6,30,0,0,0,0,"Frida","Fontane",
+# Translation of profile 1, carrying the same relation.
+,7,20,1,1,0,0,"Anna (DE)","Abel",
+# Belongs to the disabled user.
+,8,20,0,0,0,0,"Gustav","Grass",
+"tx_academicpersons_feuser_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign",
+,1,10,1,0,
+,2,11,1,0,
+,3,10,2,0,
+,4,10,3,0,
+,5,10,4,0,
+,5,11,2,0,
+,6,10,5,0,
+,7,10,1,0,
+,8,13,1,0,

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileInformationRepositoryFindAllTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileInformationRepositoryFindAllTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Domain\Repository;
+
+use FGTCLB\AcademicPersons\Domain\Model\ProfileInformation;
+use FGTCLB\AcademicPersons\Domain\Repository\ProfileInformationRepository;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Coverage for `ProfileInformationRepository::findAll()`, the untested half of the repository -
+ * `findByProfileAndType()` is pinned down by `ProfileInformationRepositoryTest`.
+ *
+ * The override exists for one line, `setRespectStoragePage(false)`. Without a request the
+ * Extbase `QueryFactory` falls back to `storagePid = 0`, so the inherited implementation would
+ * answer with the records on page `0` - with nothing, in an installation that stores its
+ * profiles anywhere else.
+ *
+ * The contrast with `findByProfileAndType()` is what makes the rest of this class worth writing:
+ * that method sorts explicitly by `sorting, uid`, this one sets no orderings at all and
+ * `ProfileInformationRepository` declares no `$defaultOrderings`. The TCA `sortby`/`default_sortby`
+ * of the table is a backend concept Extbase does not read, so the statement carries no `ORDER BY`
+ * and the result order belongs to the DBMS. The assertions below therefore compare sorted uid
+ * sets rather than an order.
+ */
+final class ProfileInformationRepositoryFindAllTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function profileInformationIsReturnedFromEveryStoragePage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $result = $this->subject()->findAll();
+
+        $this->assertSame([1, 2, 5], $this->resultUids($result));
+        $this->assertSame([20, 30], $this->resultPids($result));
+    }
+
+    /**
+     * The entries of a profile are rendered on its detail page, so a hidden one leaking through
+     * here would publish a publication an editor took offline.
+     */
+    #[Test]
+    public function hiddenProfileInformationIsNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $this->assertNotContains(3, $this->resultUids($this->subject()->findAll()));
+    }
+
+    #[Test]
+    public function deletedProfileInformationIsNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $this->assertNotContains(4, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * The language restriction is left in place, so the default language selects
+     * `sys_language_uid IN (0, -1)`. An entry marked "all languages" - a publication title that
+     * is not translated on purpose - belongs to every language's result.
+     */
+    #[Test]
+    public function profileInformationForAllLanguagesIsReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $this->assertContains(5, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * The assertion counts occurrences rather than looking for the translation's own uid `6`:
+     * Extbase maps a translated row onto the uid of its default language record, so a leaking
+     * translation shows up as entry `1` a second time, never under its own uid.
+     */
+    #[Test]
+    public function translationDoesNotAppearBesideItsDefaultLanguageRecord(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $uids = $this->resultUids($this->subject()->findAll());
+
+        $this->assertContains(1, $uids);
+        $this->assertCount(1, array_keys($uids, 1, true));
+    }
+
+    /**
+     * The type is the record type of the table. `findAll()` passes no type, so entries of every
+     * configured type come back together - which is exactly what `findByProfileAndType()` is
+     * there to narrow down again.
+     */
+    #[Test]
+    public function entriesOfEveryTypeAreReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationRepositoryFindAll/profileInformation.csv');
+
+        $types = [];
+        foreach ($this->subject()->findAll() as $profileInformation) {
+            $types[] = $profileInformation->getType();
+        }
+        sort($types);
+
+        $this->assertSame(['type_1', 'type_1', 'type_2'], $types);
+    }
+
+    #[Test]
+    public function emptyTableYieldsAnEmptyResult(): void
+    {
+        $result = $this->subject()->findAll();
+
+        $this->assertCount(0, $result);
+        $this->assertSame([], $this->resultUids($result));
+    }
+
+    private function subject(): ProfileInformationRepository
+    {
+        return $this->get(ProfileInformationRepository::class);
+    }
+
+    /**
+     * @param QueryResultInterface<int, ProfileInformation> $result
+     * @return int[]
+     */
+    private function resultUids(QueryResultInterface $result): array
+    {
+        $uids = [];
+        foreach ($result as $profileInformation) {
+            $uids[] = (int)$profileInformation->getUid();
+        }
+        sort($uids);
+        return $uids;
+    }
+
+    /**
+     * @param QueryResultInterface<int, ProfileInformation> $result
+     * @return int[]
+     */
+    private function resultPids(QueryResultInterface $result): array
+    {
+        $pids = [];
+        foreach ($result as $profileInformation) {
+            $pids[] = (int)$profileInformation->getPid();
+        }
+        $pids = array_values(array_unique($pids));
+        sort($pids);
+        return $pids;
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileRepositoryFindAllTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileRepositoryFindAllTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Domain\Repository;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Coverage for `ProfileRepository::findAll()`, which overrides the Extbase one for a single
+ * reason: it switches the storage page restriction off. Without a request the Extbase
+ * `QueryFactory` falls back to `storagePid = 0`, so the inherited implementation would answer
+ * with the records on page `0` - in practice with nothing at all. That makes the storage page
+ * cases below the ones that actually pin the override down; everything else pins the settings
+ * the method deliberately leaves alone.
+ *
+ * `findAll()` sets no orderings and `ProfileRepository` declares no `$defaultOrderings`, so the
+ * statement carries no `ORDER BY` and the result order is whatever the DBMS returns. The
+ * assertions therefore compare sorted uid sets - asserting an order here would pin SQLite
+ * behaviour that MySQL, MariaDB and PostgreSQL are free to differ on.
+ *
+ * The hidden and deleted expectations look like the ones in
+ * `ProfileRepositoryShowHiddenRecordsTest`, but they are about a different method: there is no
+ * `$showHidden` argument on `findAll()`, and there is no way to reach hidden profiles through it.
+ */
+final class ProfileRepositoryFindAllTest extends AbstractAcademicPersonsTestCase
+{
+    #[Test]
+    public function profilesAreReturnedFromEveryStoragePage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $result = $this->subject()->findAll();
+
+        $this->assertSame([1, 2, 5], $this->resultUids($result));
+        $this->assertSame([20, 30], $this->resultPids($result));
+    }
+
+    /**
+     * `findAll()` is the list view's entry point, so a hidden profile leaking through it would
+     * publish a record an editor took offline.
+     */
+    #[Test]
+    public function hiddenProfilesAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $this->assertNotContains(3, $this->resultUids($this->subject()->findAll()));
+    }
+
+    #[Test]
+    public function deletedProfilesAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $this->assertNotContains(4, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * `tx_academicpersons_domain_model_profile` carries `starttime` and `endtime` enable
+     * columns. `findAll()` touches neither, so a profile that is not published yet stays out -
+     * which is the reason the enable fields are not switched off wholesale together with the
+     * storage page restriction.
+     */
+    #[Test]
+    public function profilesOutsideTheirPublicationPeriodAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $uids = $this->resultUids($this->subject()->findAll());
+
+        $this->assertNotContains(7, $uids);
+        $this->assertNotContains(8, $uids);
+    }
+
+    /**
+     * The language restriction is left in place, so the default language selects
+     * `sys_language_uid IN (0, -1)`: a profile marked "all languages" belongs to every
+     * language's result.
+     */
+    #[Test]
+    public function profileForAllLanguagesIsReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $this->assertContains(5, $this->resultUids($this->subject()->findAll()));
+    }
+
+    /**
+     * A translation is an overlay of its default language record, not a second profile. Were it
+     * returned as one, the list view would show the same person twice.
+     *
+     * The assertion counts occurrences rather than looking for the translation's own uid `6`,
+     * because that uid never reaches the caller: Extbase maps a translated row onto the uid of
+     * its default language record, so a leaking translation shows up as profile `1` a second
+     * time. Dropping the language restriction produces exactly that - `[1, 1, 2, 5]`.
+     */
+    #[Test]
+    public function translationDoesNotAppearBesideItsDefaultLanguageRecord(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFindAll/profiles.csv');
+
+        $uids = $this->resultUids($this->subject()->findAll());
+
+        $this->assertContains(1, $uids);
+        $this->assertCount(1, array_keys($uids, 1, true));
+    }
+
+    /**
+     * No fixture at all - an installation without a single profile must answer with an empty
+     * result rather than with an exception. This is the case the storage page fallback would
+     * turn into `InconsistentQuerySettingsException` were the table configured `rootLevel = 1`.
+     */
+    #[Test]
+    public function emptyTableYieldsAnEmptyResult(): void
+    {
+        $result = $this->subject()->findAll();
+
+        $this->assertCount(0, $result);
+        $this->assertSame([], $this->resultUids($result));
+    }
+
+    private function subject(): ProfileRepository
+    {
+        return $this->get(ProfileRepository::class);
+    }
+
+    /**
+     * @param QueryResultInterface<int, Profile> $result
+     * @return int[]
+     */
+    private function resultUids(QueryResultInterface $result): array
+    {
+        $uids = [];
+        foreach ($result as $profile) {
+            $uids[] = (int)$profile->getUid();
+        }
+        sort($uids);
+        return $uids;
+    }
+
+    /**
+     * @param QueryResultInterface<int, Profile> $result
+     * @return int[]
+     */
+    private function resultPids(QueryResultInterface $result): array
+    {
+        $pids = [];
+        foreach ($result as $profile) {
+            $pids[] = (int)$profile->getPid();
+        }
+        $pids = array_values(array_unique($pids));
+        sort($pids);
+        return $pids;
+    }
+}

--- a/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileRepositoryFrontendUserTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Domain/Repository/ProfileRepositoryFrontendUserTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Domain\Repository;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\Domain\Repository\ProfileRepository;
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Coverage for `ProfileRepository::findByFrontendUser()`.
+ *
+ * This is the access-control shaped method of the repository: `EXT:academic_persons_edit` asks
+ * it which profile the logged-in frontend user may edit, and the profile update command asks it
+ * which profile a user's data has to be written into. Everything it returns is therefore
+ * something the caller is about to hand out or overwrite, which makes the negative cases -
+ * another user's profile, a user without a profile, an unknown uid - the ones worth having.
+ *
+ * The constraint is an `IN` sub-select over the M:N table `tx_academicpersons_feuser_mm`
+ * (`uid_local` = profile, `uid_foreign` = frontend user). It looks at the relation only: the
+ * frontend user's own enable fields are not part of it, see
+ * `profileOfADisabledFrontendUserIsStillReturned()`.
+ *
+ * `$showHidden` exists for the synchronization, which must keep a hidden profile up to date
+ * without publishing it. The frontend keeps the default.
+ */
+final class ProfileRepositoryFrontendUserTest extends AbstractAcademicPersonsTestCase
+{
+    private const FRONTEND_USER_OWNER = 10;
+    private const FRONTEND_USER_OTHER = 11;
+    private const FRONTEND_USER_WITHOUT_PROFILE = 12;
+    private const FRONTEND_USER_DISABLED = 13;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRepositoryFrontendUser/profilesOfFrontendUsers.csv');
+    }
+
+    #[Test]
+    public function profilesAssignedToTheFrontendUserAreReturned(): void
+    {
+        $result = $this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER);
+
+        $this->assertSame([1, 5, 6], $this->resultUids($result));
+    }
+
+    /**
+     * The case this whole test class exists for. Profile 2 belongs to another frontend user and
+     * nothing else distinguishes it from profile 1 - same page, same visibility, same language.
+     * If it ever shows up here, a logged-in user can read and edit a stranger's record.
+     */
+    #[Test]
+    public function profileOfAnotherFrontendUserIsNotReturned(): void
+    {
+        $uids = $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER));
+
+        $this->assertNotContains(2, $uids);
+    }
+
+    /**
+     * ... and not through the `$showHidden` switch either, which lifts a visibility restriction
+     * and must not widen the ownership one.
+     */
+    #[Test]
+    public function profileOfAnotherFrontendUserIsNotReturnedWithHiddenRecordsIncluded(): void
+    {
+        $uids = $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER, true));
+
+        $this->assertNotContains(2, $uids);
+    }
+
+    /**
+     * A profile may be assigned to more than one frontend user, so each of them sees it. That is
+     * the one shape in which two users legitimately share a record.
+     */
+    #[Test]
+    public function sharedProfileIsReturnedForEveryAssignedFrontendUser(): void
+    {
+        $this->assertContains(5, $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER)));
+        $this->assertSame([2, 5], $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OTHER)));
+    }
+
+    /**
+     * The frontend controller uses an empty result to decide that there is nothing to edit, so
+     * "no profile" has to be an empty result rather than a fallback to anything.
+     */
+    #[Test]
+    public function frontendUserWithoutAProfileGetsAnEmptyResult(): void
+    {
+        $result = $this->subject()->findByFrontendUser(self::FRONTEND_USER_WITHOUT_PROFILE);
+
+        $this->assertCount(0, $result);
+        $this->assertSame([], $this->resultUids($result));
+    }
+
+    #[Test]
+    public function unknownFrontendUserGetsAnEmptyResult(): void
+    {
+        $this->assertSame([], $this->resultUids($this->subject()->findByFrontendUser(999)));
+    }
+
+    /**
+     * `0` is what an unauthenticated request carries. It must not match the relation rows whose
+     * `uid_foreign` happens to be missing or `0`.
+     */
+    #[Test]
+    public function frontendUserUidZeroGetsAnEmptyResult(): void
+    {
+        $this->assertSame([], $this->resultUids($this->subject()->findByFrontendUser(0)));
+    }
+
+    #[Test]
+    public function hiddenProfileIsNotReturnedByDefault(): void
+    {
+        $this->assertNotContains(3, $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER)));
+    }
+
+    /**
+     * The synchronization has to keep writing into a hidden profile, so it asks for it
+     * explicitly - and must still only get the profiles of that one user.
+     */
+    #[Test]
+    public function hiddenProfileIsReturnedWhenRequested(): void
+    {
+        $result = $this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER, true);
+
+        $this->assertSame([1, 3, 5, 6], $this->resultUids($result));
+    }
+
+    /**
+     * `$showHidden` lifts the `disabled` restriction, never the deleted one - a deleted profile
+     * is gone for the synchronization as much as for the frontend.
+     */
+    #[Test]
+    public function deletedProfileIsNeverReturned(): void
+    {
+        $this->assertNotContains(4, $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER)));
+        $this->assertNotContains(4, $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER, true)));
+    }
+
+    /**
+     * The storage page restriction is off, and it has to be: the profile of a frontend user is
+     * wherever an editor put it, not on the page the plugin happens to be configured with.
+     */
+    #[Test]
+    public function profileOnAnotherStoragePageIsReturned(): void
+    {
+        $result = $this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER);
+
+        $this->assertContains(6, $this->resultUids($result));
+        $this->assertSame([20, 30], $this->resultPids($result));
+    }
+
+    /**
+     * The relation is the only thing the query looks at, so whether the frontend user is
+     * disabled is none of this method's business - the caller has already authenticated. Pinned
+     * because it reads like an omission and is not one.
+     */
+    #[Test]
+    public function profileOfADisabledFrontendUserIsStillReturned(): void
+    {
+        $this->assertSame([8], $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_DISABLED)));
+    }
+
+    /**
+     * Profile 7 is the translation of profile 1 and carries a relation row of its own. In the
+     * default language it is an overlay of profile 1, not a second profile the user owns -
+     * otherwise the edit plugin would offer the same person twice.
+     *
+     * The assertion counts occurrences rather than looking for uid `7`: Extbase maps a
+     * translated row onto the uid of its default language record, so a leaking translation
+     * shows up as profile `1` a second time, never under its own uid.
+     */
+    #[Test]
+    public function translationDoesNotAppearBesideItsDefaultLanguageRecord(): void
+    {
+        $uids = $this->resultUids($this->subject()->findByFrontendUser(self::FRONTEND_USER_OWNER));
+
+        $this->assertContains(1, $uids);
+        $this->assertCount(1, array_keys($uids, 1, true));
+    }
+
+    private function subject(): ProfileRepository
+    {
+        return $this->get(ProfileRepository::class);
+    }
+
+    /**
+     * @param QueryResultInterface<int, Profile> $result
+     * @return int[]
+     */
+    private function resultUids(QueryResultInterface $result): array
+    {
+        $uids = [];
+        foreach ($result as $profile) {
+            $uids[] = (int)$profile->getUid();
+        }
+        sort($uids);
+        return $uids;
+    }
+
+    /**
+     * @param QueryResultInterface<int, Profile> $result
+     * @return int[]
+     */
+    private function resultPids(QueryResultInterface $result): array
+    {
+        $pids = [];
+        foreach ($result as $profile) {
+            $pids[] = (int)$profile->getPid();
+        }
+        $pids = array_values(array_unique($pids));
+        sort($pids);
+        return $pids;
+    }
+}


### PR DESCRIPTION
Resolves ACE-415 on `main`. Part of the test coverage round tracked under ACE-10.

`ProfileRepository` is 315 lines and was covered **only** for the hidden-record flag — `findAll()` and `findByFrontendUser()` were untested, as were `ProfileInformationRepository::findAll()` and `ContractRepository::findAll()`.

## `findByFrontendUser()` is the access-control-shaped one

So it gets the attention: a user with no profile, a hidden profile, a deleted profile, a foreign storage page, a translation, `uid 0`, and unknown uids.

**The result is worth stating plainly: no fixture could be constructed in which another user's profile comes back.** The constraint is an `IN` sub-select on `tx_academicpersons_feuser_mm` keyed on `uid_foreign`, and neither `$showHidden`, nor a shared profile, nor a foreign storage page, nor a translation widens it. Two tests pin that explicitly, so a future change that does widen it fails here.

## Three things documented rather than fixed

1. **None of the three `findAll()` methods defines an ordering** — no `setOrderings()`, no `$defaultOrderings`, and Extbase does not read the tables' TCA `sortby`/`default_sortby`. The statement carries no `ORDER BY`, so the order is DBMS-dependent. That is user-visible for `getContractItemsForTcaItemsProcFunc()`, whose result becomes the backend select item list. All assertions compare sorted uid sets for that reason.
2. **`getContractItemsForTcaItemsProcFunc()` ignores its `$parameters` entirely** and delegates to a `findAll()` that disables the storage-page restriction — so a multi-site backend offers every contract of every site in that select. Matches the `@todo` already in `findAll()`; named here because the `itemsProcFunc` is where it is felt.
3. **`includeHiddenRecords()`'s docblock is only true in frontend context.** It claims "other enable fields (deleted, start-/endtime, fe_group) stay in effect", but `Typo3DbQueryParser` honours `enableFieldsToBeIgnored` only on the **frontend** branch; the backend/CLI branch drops `BEenableFields()` wholesale, so `starttime`/`endtime` are lifted too. That matters for the profile sync command, which runs in CLI and calls `findByFrontendUser($uid, true)`. **Deliberately not pinned** — asserting it would freeze core behaviour that legitimately differs between FE and CLI.

## Worth knowing for further language tests here

**A translated record never reaches a caller under its own uid** — Extbase maps a translated row onto the uid of its default-language record, so `assertNotContains(<translation uid>, …)` is a tautology. Found while proving the tests can fail (a dropped language restriction produced `[1, 1, 2, 5]`); all four translation tests now assert the default record appears **exactly once** instead.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| `findAll()`: `setRespectStoragePage(false)` removed | 3 (result goes empty — `storagePid` falls back to `0`) |
| `findAll()`: `setIgnoreEnableFields(true)` added | 3 |
| `findAll()`: deleted + language lifted | 2 + 2 |
| `findByFrontendUser()`: the mm constraint replaced by `uid >= 0` | 9 |
| `findByFrontendUser()`: hidden + deleted + language always lifted | 5 |
| `findByFrontendUser()`: storage page restored | 6 |
| the same two mutations on `ProfileInformationRepository` / `ContractRepository` | 4 and 5 each |

**Stated rather than hidden:** the three `emptyTableYieldsAnEmptyResult` tests could **not** be shown to fail under any mutation — an empty table cannot yield rows. They guard against an exception, not against a wrong result set. Keeping them is cheap; calling them proven would be false.

## Scope

No production code is changed. `fe_group` is inert in a non-frontend context (`BEenableFields()` does not evaluate it) and belongs to a plugin-rendering test; `getContractItemsForTcaItemsProcFunc()` is pure delegation already exercised through FormEngine by `ContractItemsTest`.
