### PR TITLE
[TASK] ACE-405: Cover the partner demand and models

### DIFF
--- a/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/Dto/PartnerDemandTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/Dto/PartnerDemandTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPartners\Domain\Model\Dto\PartnerDemand;
+use FGTCLB\AcademicPartners\Enumeration\SortingOptions;
+use FGTCLB\CategoryTypes\Collection\FilterCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `PartnerDemand` is assembled from FlexForm settings and request arguments by
+ * `Factory\DemandFactory` and then handed to `PartnerRepository::findByDemand()`, where
+ * the sorting reaches Extbase as an ordering. What it rejects therefore matters as much
+ * as what it stores.
+ */
+final class PartnerDemandTest extends UnitTestCase
+{
+    #[Test]
+    public function aFreshDemandSortsByTheDefaultOption(): void
+    {
+        $subject = new PartnerDemand();
+
+        $this->assertSame(SortingOptions::__default, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame('asc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function aFreshDemandSelectsNoPageAndNoFilter(): void
+    {
+        $subject = new PartnerDemand();
+
+        $this->assertSame([], $subject->getPages());
+        $this->assertNull($subject->getFilterCollection());
+        $this->assertFalse($subject->getShowHiddenRecords());
+    }
+
+    #[Test]
+    #[DataProvider('knownSortingOptions')]
+    public function aKnownOptionIsSplitIntoFieldAndDirection(string $option, string $field, string $direction): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setSorting($option);
+
+        $this->assertSame($option, $subject->getSorting());
+        $this->assertSame($field, $subject->getSortingField());
+        $this->assertSame($direction, $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function knownSortingOptions(): \Generator
+    {
+        yield 'title ascending' => [SortingOptions::SORT_BY_TITLE_ASC, 'title', 'asc'];
+        yield 'title descending' => [SortingOptions::SORT_BY_TITLE_DESC, 'title', 'desc'];
+        yield 'last updated ascending' => [SortingOptions::SORT_BY_LASTUPDATED_ASC, 'lastUpdated', 'asc'];
+        yield 'last updated descending' => [SortingOptions::SORT_BY_LASTUPDATED_DESC, 'lastUpdated', 'desc'];
+        yield 'backend sorting ascending' => [SortingOptions::SORT_BY_SORTING_ASC, 'sorting', 'asc'];
+        yield 'backend sorting descending' => [SortingOptions::SORT_BY_SORTING_DESC, 'sorting', 'desc'];
+    }
+
+    /**
+     * An unknown option leaves the demand as it was rather than clearing the ordering. A
+     * stored FlexForm value that refers to a since-renamed option therefore falls back to
+     * the previous sorting instead of reaching Extbase as an empty `ORDER BY`.
+     *
+     * The last case is the one that matters for safety: the value is used verbatim as an
+     * Extbase ordering, so anything not on the allow list must never be stored.
+     *
+     * @param string $value the rejected value
+     */
+    #[Test]
+    #[DataProvider('unusableSortingValues')]
+    public function anUnknownOptionIsIgnored(string $value): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_LASTUPDATED_DESC);
+
+        $subject->setSorting($value);
+
+        $this->assertSame(SortingOptions::SORT_BY_LASTUPDATED_DESC, $subject->getSorting());
+        $this->assertSame('lastUpdated', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function unusableSortingValues(): \Generator
+    {
+        yield 'empty' => [''];
+        yield 'field without direction' => ['title'];
+        yield 'direction without field' => [' asc'];
+        yield 'unknown field' => ['uid asc'];
+        yield 'unknown direction' => ['title sideways'];
+        yield 'wrong case' => ['TITLE ASC'];
+        yield 'constant name instead of value' => ['SORT_BY_TITLE_ASC'];
+        yield 'padded with whitespace' => [' title asc'];
+        yield 'sql injected into the ordering' => ['title asc; DROP TABLE pages'];
+    }
+
+    /**
+     * The direction is kept, so switching the column in a list view does not silently flip
+     * the order back to ascending.
+     */
+    #[Test]
+    public function changingTheFieldKeepsTheDirection(): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_DESC);
+
+        $subject->setSortingField('lastUpdated');
+
+        $this->assertSame(SortingOptions::SORT_BY_LASTUPDATED_DESC, $subject->getSorting());
+        $this->assertSame('lastUpdated', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    #[Test]
+    public function changingTheDirectionKeepsTheField(): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setSorting(SortingOptions::SORT_BY_TITLE_ASC);
+
+        $subject->setSortingDirection('desc');
+
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_DESC, $subject->getSorting());
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame('desc', $subject->getSortingDirection());
+    }
+
+    /**
+     * Unlike the sibling demand of `EXT:academic_programs`, every field here has both
+     * directions in `SortingOptions`, so reversing the order works for each of them.
+     * A dropped counterpart would turn "reverse" into a silent no-op for one column only,
+     * which is the kind of thing that is never noticed in a review.
+     */
+    #[Test]
+    #[DataProvider('sortingFields')]
+    public function anyFieldCanBeReversed(string $ascending, string $descending, string $field): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setSorting($ascending);
+
+        $subject->setSortingDirection('desc');
+        $this->assertSame($descending, $subject->getSorting());
+        $this->assertSame($field, $subject->getSortingField());
+
+        $subject->setSortingDirection('asc');
+        $this->assertSame($ascending, $subject->getSorting());
+        $this->assertSame($field, $subject->getSortingField());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function sortingFields(): \Generator
+    {
+        yield 'title' => [SortingOptions::SORT_BY_TITLE_ASC, SortingOptions::SORT_BY_TITLE_DESC, 'title'];
+        yield 'last updated' => [
+            SortingOptions::SORT_BY_LASTUPDATED_ASC,
+            SortingOptions::SORT_BY_LASTUPDATED_DESC,
+            'lastUpdated',
+        ];
+        yield 'backend sorting' => [
+            SortingOptions::SORT_BY_SORTING_ASC,
+            SortingOptions::SORT_BY_SORTING_DESC,
+            'sorting',
+        ];
+    }
+
+    /**
+     * There is no option without a direction, so the direction cannot be cleared. Worth
+     * pinning: it means `getSortingDirection()` never returns an empty string once the
+     * constructor has run, which is what lets the repository use it unchecked.
+     */
+    #[Test]
+    public function theDirectionCannotBeCleared(): void
+    {
+        $subject = new PartnerDemand();
+
+        $subject->setSortingDirection('');
+
+        $this->assertSame('asc', $subject->getSortingDirection());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, $subject->getSorting());
+    }
+
+    /**
+     * Same for the field: an unknown column never reaches the ordering, not even by way of
+     * `setSortingField()` reassembling it with a valid direction.
+     */
+    #[Test]
+    public function anUnknownFieldIsRejected(): void
+    {
+        $subject = new PartnerDemand();
+
+        $subject->setSortingField('uid');
+
+        $this->assertSame('title', $subject->getSortingField());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, $subject->getSorting());
+    }
+
+    /**
+     * The pages list reaches `findByDemand()` as an uid list for an `IN` constraint, and an
+     * empty one is valid there since ACE-349 - so the demand must not invent a value.
+     */
+    #[Test]
+    public function thePageListIsStoredAsGiven(): void
+    {
+        $subject = new PartnerDemand();
+        $subject->setPages([12, 34]);
+
+        $this->assertSame([12, 34], $subject->getPages());
+
+        $subject->setPages([]);
+
+        $this->assertSame([], $subject->getPages());
+    }
+
+    /**
+     * The category filter is optional, and clearing it has to be possible - the repository
+     * branches on `null` to skip the category constraint entirely.
+     */
+    #[Test]
+    public function theFilterCollectionCanBeSetAndClearedAgain(): void
+    {
+        $subject = new PartnerDemand();
+        $filterCollection = new FilterCollection();
+
+        $subject->setFilterCollection($filterCollection);
+        $this->assertSame($filterCollection, $subject->getFilterCollection());
+
+        $subject->setFilterCollection(null);
+        $this->assertNull($subject->getFilterCollection());
+    }
+}

--- a/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/PartnerTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/PartnerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPartners\Domain\Model\Partner;
+use FGTCLB\CategoryTypes\Collection\CategoryCollection;
+use FGTCLB\CategoryTypes\Collection\GetCategoryCollectionInterface;
+use FGTCLB\CategoryTypes\Domain\Repository\CategoryRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Country\CountryProvider;
+use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Three parts of `Partner` do more than hold a value: the country lookup, the lazily
+ * fetched category collection and the object storage set up in `initializeObject()`.
+ * The plain accessors are deliberately not covered - they would assert that PHP works.
+ *
+ * Both non-accessor methods reach for a collaborator through `GeneralUtility::makeInstance()`,
+ * which is why they are pinned here: the instance stack of the testing framework fails the
+ * test when a lookup happens that should not have happened, and PHP fails it with an
+ * `ArgumentCountError` when one happens that the test did not prepare for.
+ */
+final class PartnerTest extends UnitTestCase
+{
+    /**
+     * The label is a `LLL:` reference, not a translated string - the Fluid template runs it
+     * through `f:translate`. Asserting the reference is what keeps the two ends in sync.
+     */
+    #[Test]
+    public function anIsoCodeIsResolvedToTheLocalizedCountryLabel(): void
+    {
+        $subject = new Partner();
+        $subject->_setProperty('addressCountry', 'DE');
+        GeneralUtility::addInstance(CountryProvider::class, $this->countryProvider());
+
+        $this->assertSame(
+            'LLL:EXT:core/Resources/Private/Language/Iso/countries.xlf:DE.name',
+            $subject->getAddressCountryLocalizedNameLabel(),
+        );
+    }
+
+    /**
+     * `CountryProvider::getByIsoCode()` accepts the alpha-3 code as well, and the TCA field
+     * is a free text field on older records - so both spellings have to arrive at the same
+     * label rather than one of them falling through to the empty string.
+     */
+    #[Test]
+    public function theAlphaThreeCodeResolvesToTheSameLabel(): void
+    {
+        $subject = new Partner();
+        $subject->_setProperty('addressCountry', 'DEU');
+        GeneralUtility::addInstance(CountryProvider::class, $this->countryProvider());
+
+        $this->assertSame(
+            'LLL:EXT:core/Resources/Private/Language/Iso/countries.xlf:DE.name',
+            $subject->getAddressCountryLocalizedNameLabel(),
+        );
+    }
+
+    /**
+     * A code that no longer exists must not take the detail view down with a call on
+     * `null`. It renders without a country instead.
+     */
+    #[Test]
+    #[DataProvider('unresolvableCountryCodes')]
+    public function anUnresolvableCodeYieldsAnEmptyLabel(string $code): void
+    {
+        $subject = new Partner();
+        $subject->_setProperty('addressCountry', $code);
+        GeneralUtility::addInstance(CountryProvider::class, $this->countryProvider());
+
+        $this->assertSame('', $subject->getAddressCountryLocalizedNameLabel());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function unresolvableCountryCodes(): \Generator
+    {
+        yield 'a withdrawn iso code' => ['XX'];
+        yield 'a country name instead of a code' => ['Germany'];
+        yield 'a numeric code' => ['276'];
+    }
+
+    /**
+     * The empty default of the TCA field is the common case - every partner record without
+     * an address goes through here - so it must not cost a `CountryProvider` instantiation.
+     *
+     * The prepared instance is still on the stack afterwards, which is what proves the
+     * lookup was skipped; it is consumed explicitly so the tearDown integrity check of the
+     * testing framework stays satisfied.
+     */
+    #[Test]
+    public function noCountryIsNotLookedUpAtAll(): void
+    {
+        $subject = new Partner();
+        $countryProvider = $this->countryProvider();
+        GeneralUtility::addInstance(CountryProvider::class, $countryProvider);
+
+        $this->assertSame('', $subject->getAddressCountryLocalizedNameLabel());
+        $this->assertSame($countryProvider, GeneralUtility::makeInstance(CountryProvider::class));
+    }
+
+    /**
+     * The categories of a partner are fetched by page uid, from the `partners` category
+     * group. They are rendered repeatedly in a list view, once per partner, so the query
+     * must happen once per object and not once per template access.
+     */
+    #[Test]
+    public function theCategoriesAreFetchedOnceAndThenReused(): void
+    {
+        $subject = new Partner();
+        $subject->_setProperty('uid', 42);
+        $categoryCollection = new CategoryCollection();
+
+        $categoryRepository = $this->createMock(CategoryRepository::class);
+        $categoryRepository->expects($this->once())
+            ->method('findByGroupAndPageId')
+            ->with('partners', 42)
+            ->willReturn($categoryCollection);
+        GeneralUtility::addInstance(CategoryRepository::class, $categoryRepository);
+
+        $this->assertSame($categoryCollection, $subject->getAttributes());
+        $this->assertSame($categoryCollection, $subject->getAttributes());
+    }
+
+    /**
+     * An already resolved collection is handed out untouched. Only one repository instance
+     * is prepared above, so a second fetch would fail loudly rather than quietly costing a
+     * query - and here none is prepared at all.
+     */
+    #[Test]
+    public function anAlreadyResolvedCollectionIsNotFetchedAgain(): void
+    {
+        $subject = new Partner();
+        $categoryCollection = new CategoryCollection();
+        $subject->_setProperty('attributes', $categoryCollection);
+
+        $this->assertSame($categoryCollection, $subject->getAttributes());
+    }
+
+    /**
+     * `getCategoryCollection()` is the `GetCategoryCollectionInterface` end of the same
+     * data - `EXT:category_types` calls it, the Fluid templates call `getAttributes()`.
+     * The two must not drift apart into two separate lookups.
+     */
+    #[Test]
+    public function theInterfaceMethodReturnsTheSameCollection(): void
+    {
+        $subject = new Partner();
+        $categoryCollection = new CategoryCollection();
+        $subject->_setProperty('attributes', $categoryCollection);
+
+        $this->assertInstanceOf(GetCategoryCollectionInterface::class, $subject);
+        $this->assertSame($categoryCollection, $subject->getCategoryCollection());
+    }
+
+    /**
+     * `$media` is a typed property without a default, so reading it before
+     * `initializeObject()` has run is an `Error`, not a `null`. Extbase calls the method
+     * itself when it reconstitutes an object; the constructor is what covers every other
+     * caller, including `new Partner()` in a test or a command.
+     */
+    #[Test]
+    public function theMediaStorageExistsWithoutExtbaseHavingInitializedIt(): void
+    {
+        $subject = new Partner();
+
+        $this->assertInstanceOf(ObjectStorage::class, $subject->getMedia());
+        $this->assertCount(0, $subject->getMedia());
+    }
+
+    private function countryProvider(): CountryProvider
+    {
+        return new CountryProvider(new NoopEventDispatcher());
+    }
+}

--- a/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/PartnershipTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Unit/Domain/Model/PartnershipTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Unit\Domain\Model;
+
+use FGTCLB\AcademicPartners\Domain\Model\Partner;
+use FGTCLB\AcademicPartners\Domain\Model\Partnership;
+use FGTCLB\AcademicPartners\Domain\Model\Role;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `getLabel()` is the only method of `Partnership` that decides anything. It is what
+ * `Backend\FormEngine\PartnershipLabels::getTitle()` writes into the record title of an
+ * inline element, so an editor picks a partnership out of a list by exactly this string.
+ * Both relations are nullable in TCA, so all four combinations occur in a real record set.
+ */
+final class PartnershipTest extends UnitTestCase
+{
+    #[Test]
+    public function theLabelJoinsTheRoleAndThePartner(): void
+    {
+        $subject = new Partnership();
+        $subject->_setProperty('role', $this->role('Sponsor'));
+        $subject->_setProperty('partner', $this->partner('Example University'));
+
+        $this->assertSame('Sponsor - Example University', $subject->getLabel());
+    }
+
+    /**
+     * The role comes first. Reversing the two would silently re-sort every inline label in
+     * the backend, which is a visible regression and nothing a type check catches.
+     */
+    #[Test]
+    public function theRoleIsNamedBeforeThePartner(): void
+    {
+        $subject = new Partnership();
+        $subject->_setProperty('role', $this->role('First'));
+        $subject->_setProperty('partner', $this->partner('Second'));
+
+        $this->assertStringStartsWith('First', $subject->getLabel());
+    }
+
+    /**
+     * A partnership without a role is a legal record. The separator has to disappear with
+     * the missing part rather than leaving a dangling " - " in the record title.
+     */
+    #[Test]
+    public function aMissingRoleLeavesNoSeparator(): void
+    {
+        $subject = new Partnership();
+        $subject->_setProperty('partner', $this->partner('Example University'));
+
+        $this->assertNull($subject->getRole());
+        $this->assertSame('Example University', $subject->getLabel());
+    }
+
+    /**
+     * The mirrored case: a role that has not been pointed at a partner yet, which is what
+     * a freshly created inline record looks like before it is saved.
+     */
+    #[Test]
+    public function aMissingPartnerLeavesNoSeparator(): void
+    {
+        $subject = new Partnership();
+        $subject->_setProperty('role', $this->role('Sponsor'));
+
+        $this->assertNull($subject->getPartner());
+        $this->assertSame('Sponsor', $subject->getLabel());
+    }
+
+    /**
+     * An empty label is what `PartnershipLabels` hands FormEngine for an untouched new
+     * record, and FormEngine falls back to its own "[No title]" for that. Returning
+     * something like " - " instead would suppress that fallback.
+     */
+    #[Test]
+    public function anUnrelatedPartnershipHasNoLabel(): void
+    {
+        $subject = new Partnership();
+
+        $this->assertSame('', $subject->getLabel());
+    }
+
+    /**
+     * Both relations set but unnamed. The parts are joined without being checked for
+     * content, so the label is the bare separator - the one case where the record title
+     * ends up as visual noise instead of an empty string. Pinned deliberately: it is
+     * current behaviour, and a change to it should be a decision, not a side effect.
+     */
+    #[Test]
+    public function relationsWithoutATitleStillProduceTheSeparator(): void
+    {
+        $subject = new Partnership();
+        $subject->_setProperty('role', new Role());
+        $subject->_setProperty('partner', new Partner());
+
+        $this->assertSame(' - ', $subject->getLabel());
+    }
+
+    private function role(string $name): Role
+    {
+        $role = new Role();
+        $role->_setProperty('name', $name);
+        return $role;
+    }
+
+    private function partner(string $title): Partner
+    {
+        $partner = new Partner();
+        $partner->_setProperty('title', $title);
+        return $partner;
+    }
+}

--- a/packages/fgtclb/academic-partners/Tests/Unit/Enumeration/SortingOptionsTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Unit/Enumeration/SortingOptionsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Unit\Enumeration;
+
+use FGTCLB\AcademicPartners\Enumeration\SortingOptions;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The values are used verbatim as Extbase ordering strings, and `getConstants()` is what
+ * `PartnerDemand::setSorting()` validates against - so a value that drops out of this
+ * list stops being selectable without anything failing loudly.
+ */
+final class SortingOptionsTest extends UnitTestCase
+{
+    /**
+     * The full set, asserted as a whole rather than by counting: a renamed constant or a
+     * changed ordering string has to show up here, since both are part of what a stored
+     * FlexForm value refers to.
+     *
+     * Unlike `EXT:academic_programs`, which offers `sorting` ascending only, every field
+     * here is offered in both directions. `PartnerDemandTest` pins what that means for
+     * `setSortingDirection()`.
+     */
+    #[Test]
+    public function everySortingOptionIsOffered(): void
+    {
+        $this->assertSame(
+            [
+                'SORT_BY_TITLE_ASC' => 'title asc',
+                'SORT_BY_TITLE_DESC' => 'title desc',
+                'SORT_BY_LASTUPDATED_ASC' => 'lastUpdated asc',
+                'SORT_BY_LASTUPDATED_DESC' => 'lastUpdated desc',
+                'SORT_BY_SORTING_ASC' => 'sorting asc',
+                'SORT_BY_SORTING_DESC' => 'sorting desc',
+            ],
+            SortingOptions::getConstants(),
+        );
+    }
+
+    /**
+     * `__default` is an alias of an option that is already in the list, so offering it
+     * would present the same ordering twice in the sorting select.
+     */
+    #[Test]
+    public function theDefaultAliasIsNotAnOptionOfItsOwn(): void
+    {
+        $this->assertArrayNotHasKey('__default', SortingOptions::getConstants());
+        $this->assertSame(SortingOptions::SORT_BY_TITLE_ASC, SortingOptions::__default);
+    }
+
+    /**
+     * `PartnerDemand::setSorting()` splits an accepted option with a plain
+     * `explode(' ', $sorting)` into exactly two variables, so an option carrying no space
+     * - or more than one - would raise "Undefined array key 1" instead of sorting. The
+     * suite runs with `failOnNotice`, so that would be a failure rather than a line of
+     * output, but only once such an option reached the list. This asserts it cannot.
+     */
+    #[Test]
+    public function everyOptionIsExactlyAFieldAndADirection(): void
+    {
+        foreach (SortingOptions::getConstants() as $name => $value) {
+            $this->assertMatchesRegularExpression(
+                '/^[a-zA-Z0-9_]+ (asc|desc)$/',
+                $value,
+                sprintf('%s is not a "<field> <asc|desc>" pair', $name),
+            );
+        }
+    }
+
+    /**
+     * Two constants sharing a value would make the option list ambiguous - the FlexForm
+     * stores the value, not the constant name, so the second one could never be selected.
+     */
+    #[Test]
+    public function noOrderingIsOfferedTwice(): void
+    {
+        $values = array_values(SortingOptions::getConstants());
+        $this->assertSame($values, array_values(array_unique($values)));
+    }
+
+    /**
+     * Every field is offered ascending *and* descending here. `setSortingDirection()`
+     * reassembles field and direction and drops the result when it is not a known option,
+     * so a missing counterpart would make "reverse the order" a silent no-op for that one
+     * column only.
+     */
+    #[Test]
+    public function everyFieldIsOfferedInBothDirections(): void
+    {
+        $directionsPerField = [];
+        foreach (SortingOptions::getConstants() as $value) {
+            [$field, $direction] = explode(' ', $value);
+            $directionsPerField[$field][] = $direction;
+        }
+
+        foreach ($directionsPerField as $field => $directions) {
+            sort($directions);
+            $this->assertSame(['asc', 'desc'], $directions, sprintf('%s is not offered in both directions', $field));
+        }
+    }
+}


### PR DESCRIPTION
Resolves ACE-405 on `main`. Part of the test coverage round tracked under ACE-10.

`EXT:academic_partners` had **one** unit test, `VersionCompatTest`. The sorting options, the demand object and the logic-carrying parts of `Partner` and `Partnership` had none.

## What is covered

`PartnerDemand` is assembled from FlexForm settings and request arguments and handed to `PartnerRepository::findByDemand()`, so **its allow list is the only thing between a request and an Extbase ordering** — the injection case is covered explicitly. Both partial sorting setters reassemble a full option and go back through that list.

Unlike the `EXT:academic_programs` twin (#483), **every field here is offered in both directions**, so the tests assert that *symmetry* rather than that extension's asymmetry — `anyFieldCanBeReversed` and `everyFieldIsOfferedInBothDirections` fail if it is ever broken.

`Partner` gets its lazy category-collection contract pinned — one fetch per object, the right group and uid, and no fetch at all once the collection is present. `Partnership` gets its label assembly.

## Three findings, reported not fixed

**1. `PartnershipLabels::getTitle()` has `&&` where `||` is meant.**

```php
if (!isset($parameters['row']) && !isset($parameters['row']['uid'])) { return; }
```

When `row` *is* set but carries no `uid`, the guard does not fire, the next line reads `$parameters['row']['uid']` — an undefined-key notice — and `findByUid(null)` is called. The second `isset()` already implies the first, so the whole guard is equivalent to its first condition alone.

**2. `Partner::getUid(): int` returns `null` on a non-persisted entity.** `AbstractDomainObject::$uid` is `?int` defaulting to `null`, so `(new Partner())->getUid()` is a `TypeError` — and the docblock says `@return int<0, max>|null`, contradicting the declared type. Reachable through `getAttributes()`, which hands the value straight into `findByGroupAndPageId(string, int)`. `getPid()` carries the same contradictory docblock but is correctly typed `?int`.

**3. `Partnership::getLabel()` produces the bare string `' - '`** when both relations exist but carry no title. `PartnershipLabels::getTitle()` writes that into the FormEngine record title, which suppresses FormEngine's own "[No title]" fallback with visual noise. Pinned as current behaviour, with the reason in its docblock.

Smaller: `Partner::getAddressCountryLocalizedNameLabel()` uses a truthiness check rather than `!== ''` — the pattern that makes `'0'` silently skip the lookup.

## Proof the tests can fail

| Mutation | Result |
|---|---|
| `getConstants()` stops excluding `__default` | 4 failures |
| `SORT_BY_SORTING_DESC` given a duplicate value | 4 failures |
| `setSorting()`'s allow-list guard removed | 11 failures |
| `setSortingField()` hardcodes `' asc'`; direction setter swaps operands | 5 failures |
| `initializeObject()` emptied | 3 failures |
| `Partner`: country guard removed, `??=` → `=` in `getAttributes()` | 4 errors |
| `Partner`: label falls back to `getName()`, fallback `''` → `'unknown'` | 5 failures + 1 error |
| `Partnership::getLabel()` parts reordered, separator changed, null guards replaced by `?->` | 6 failures |

Every new test method is covered by at least one.

## Scope

`Domain\Model\Role` is **deliberately left uncovered** — three getters and an empty `initializeObject()`. It is exercised indirectly as a collaborator in the partnership tests.

`Partner::getAttributes()` against a real `CategoryRepository` needs a `ConnectionPool`, so the query itself belongs in a functional test; the unit tests pin the lazy-init contract only.

No production code is changed.
