### PR TITLE
[TASK] ACE-421: Cover the project factory and demand

### DIFF
--- a/packages/fgtclb/academic-projects/Tests/Functional/Domain/Repository/Fixtures/ProjectRepository/projectsWithEndDates.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Domain/Repository/Fixtures/ProjectRepository/projectsWithEndDates.csv
@@ -1,0 +1,9 @@
+"pages",
+,"uid","pid","doktype","sys_language_uid","hidden","deleted","starttime","endtime","title","slug","tx_academicprojects_end_date"
+,1,0,1,0,0,0,0,0,"Site Root","/",\NULL
+,100,1,1,0,0,0,0,0,"Storage A","/storage-a",\NULL
+,101,1,1,0,0,0,0,0,"Storage B","/storage-b",\NULL
+,10,100,30,0,0,0,0,0,"Open ended project","/open-ended",0
+,11,100,30,0,0,0,0,0,"Running project","/running",2145916800
+,12,100,30,0,0,0,0,0,"Finished project","/finished",946684800
+,13,101,30,0,0,0,0,0,"Project without an end date column value","/no-end-date",\NULL

--- a/packages/fgtclb/academic-projects/Tests/Functional/Domain/Repository/ProjectRepositoryTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Domain/Repository/ProjectRepositoryTest.php
@@ -54,4 +54,94 @@ final class ProjectRepositoryTest extends AbstractAcademicProjectsTestCase
         $result = $this->getProjectRepository()->findByDemand($this->createDemand(true));
         $this->assertSame([1, 2, 3, 4], $this->resultUids($result));
     }
+
+    /**
+     * The default state. Nothing is added to the query, so every project page is returned
+     * whatever its end date - the baseline the two filtered states below are read against.
+     */
+    #[Test]
+    public function findByDemandReturnsEveryProjectRegardlessOfItsEndDateByDefault(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectRepository/projectsWithEndDates.csv');
+        $result = $this->getProjectRepository()->findByDemand(new ProjectDemand());
+        $this->assertSame([10, 11, 12, 13], $this->resultUids($result));
+    }
+
+    /**
+     * "Active" is two conditions, not one: an end date of `0` means the project has no
+     * planned end and stays in the list forever, and anything still in the future is
+     * running. Dropping the `equals(…, 0)` half is the plausible simplification, and it
+     * would silently hide every open ended project.
+     */
+    #[Test]
+    public function theActiveStateSelectsOpenEndedAndStillRunningProjects(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectRepository/projectsWithEndDates.csv');
+        $result = $this->getProjectRepository()->findByDemand($this->createDemandForActiveState('active'));
+        $this->assertSame([10, 11], $this->resultUids($result));
+    }
+
+    /**
+     * The counterpart is deliberately not the complement: it requires an end date that is
+     * both set and passed, so an open ended project is in neither list.
+     */
+    #[Test]
+    public function theCompletedStateSelectsProjectsWhoseEndDateHasPassed(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectRepository/projectsWithEndDates.csv');
+        $result = $this->getProjectRepository()->findByDemand($this->createDemandForActiveState('completed'));
+        $this->assertSame([12], $this->resultUids($result));
+    }
+
+    /**
+     * `tx_academicprojects_end_date` is `DEFAULT NULL` in `ext_tables.sql` while the TCA
+     * field is not `nullable`, so FormEngine writes `0` and a row that never went through
+     * it keeps `NULL` - a page created before the extension was installed, or by an import.
+     * Such a project is in neither state: `NULL = 0` and `NULL > <now>` are both unknown in
+     * SQL, so it disappears from a list that filters at all while being visible in the
+     * unfiltered one. Uid 13 of the fixture is that row.
+     */
+    #[Test]
+    public function aProjectWithoutAnyEndDateValueIsNeitherActiveNorCompleted(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectRepository/projectsWithEndDates.csv');
+
+        $active = $this->getProjectRepository()->findByDemand($this->createDemandForActiveState('active'));
+        $completed = $this->getProjectRepository()->findByDemand($this->createDemandForActiveState('completed'));
+
+        $this->assertNotContains(13, $this->resultUids($active));
+        $this->assertNotContains(13, $this->resultUids($completed));
+    }
+
+    /**
+     * With `showSelected` - which `DemandFactory` derives from the single view CType - the
+     * plugin's `pages` field names the project records themselves, matched on `uid`
+     * instead of `pid`.
+     *
+     * Its counterpart, the storage page branch, is deliberately not asserted here: it
+     * switches `setRespectStoragePage(true)` back on, and that restriction is fed from the
+     * Extbase framework configuration rather than from the demand. In a frontend request
+     * `FrontendConfigurationManager::overrideStoragePidIfStartingPointIsSet()` fills it
+     * from the same `pages` field (which is what adds `recursive` support), while a
+     * repository called outside a request gets the default `storagePid = 0` and the two
+     * restrictions intersect to nothing. That branch is therefore only meaningful in a
+     * plugin rendering test.
+     */
+    #[Test]
+    public function showSelectedTurnsThePageSelectionIntoARecordSelection(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectRepository/projectsWithEndDates.csv');
+        $demand = new ProjectDemand();
+        $demand->setPages([11, 13]);
+        $demand->setShowSelected(true);
+        $result = $this->getProjectRepository()->findByDemand($demand);
+        $this->assertSame([11, 13], $this->resultUids($result));
+    }
+
+    private function createDemandForActiveState(string $activeState): ProjectDemand
+    {
+        $demand = new ProjectDemand();
+        $demand->setActiveState($activeState);
+        return $demand;
+    }
 }

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/DemandFactorySettingsTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/DemandFactorySettingsTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Factory;
+
+use FGTCLB\AcademicProjects\Domain\Model\Dto\ProjectDemand;
+use FGTCLB\AcademicProjects\Factory\DemandFactory;
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `DemandFactoryCategoryFilterTest` covers the category filter submitted by the list form.
+ * This one covers the rest of `createDemandObject()`: the branch taken when there is no
+ * form data and the plugin settings decide, and the tail that applies to both branches.
+ *
+ * The three arguments come from `ProjectController::listAction()` and are of very
+ * different trustworthiness - `$demandFromForm` is the unvalidated request array,
+ * `$settings` is the plugin FlexForm and `$contentElementData` is the `tt_content` row of
+ * the plugin. The factory is the only place where that is sorted out, so what is asserted
+ * here is which input is allowed to reach which property, and what happens to a value that
+ * makes no sense.
+ */
+final class DemandFactorySettingsTest extends AbstractAcademicProjectsTestCase
+{
+    /**
+     * The plugin FlexForm offers a fixed select, so an unknown state can only arrive from a
+     * hand-edited record or a TypoScript override. `ProjectDemand::setActiveState()` throws
+     * on one (code 1743627158); the factory normalizes through `tryFromDefault()` first, so
+     * the plugin degrades to "all" instead of taking the page down.
+     */
+    #[Test]
+    public function anUnknownActiveStateInThePluginSettingsFallsBackToAll(): void
+    {
+        $demand = $this->createDemandFromSettings(['activeState' => 'nonsense']);
+
+        $this->assertSame('all', $demand->getActiveState());
+    }
+
+    #[Test]
+    public function thePluginSettingsProvideTheActiveState(): void
+    {
+        $demand = $this->createDemandFromSettings(['activeState' => 'completed']);
+
+        $this->assertSame('completed', $demand->getActiveState());
+    }
+
+    #[Test]
+    public function thePluginSettingsProvideTheSorting(): void
+    {
+        $demand = $this->createDemandFromSettings(['sorting' => 'title desc']);
+
+        $this->assertSame('title desc', $demand->getSorting());
+        $this->assertSame('title', $demand->getSortingField());
+        $this->assertSame('desc', $demand->getSortingDirection());
+    }
+
+    /**
+     * A sorting outside `SortingOptions` is dropped by the setter rather than reported, so
+     * the demand keeps the default. That is what stops an arbitrary string from reaching
+     * `ProjectRepository::findByDemand()`, which puts the value into `setOrderings()`
+     * unquoted.
+     */
+    #[Test]
+    public function anUnknownSortingInThePluginSettingsIsIgnored(): void
+    {
+        $demand = $this->createDemandFromSettings(['sorting' => 'nonsense desc']);
+
+        $this->assertSame('title asc', $demand->getSorting());
+    }
+
+    /**
+     * The `categories` setting is a checkbox: it does not carry the category uids, it only
+     * says that the ones related to the plugin record itself are to be used. They are read
+     * from the `sys_category_record_mm` rows of that `tt_content` uid - which is why this
+     * needs a database and the form branch does not.
+     */
+    #[Test]
+    public function theCategoriesRelatedToTheContentElementBecomeTheFilter(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactorySettings/pluginCategories.csv');
+
+        $demand = $this->createDemandFromSettings(['categories' => '1'], ['uid' => 1]);
+
+        $this->assertSame([1, 2], $this->filteredUids($demand));
+    }
+
+    /**
+     * Category uid 3 in the fixture is of type `program_type`, which belongs to
+     * `EXT:academic_programs`. The group `projects` is passed explicitly, so a relation on
+     * the same content element to a category of a foreign group is not part of the filter -
+     * asserted by the test above returning two of three relations, and here by the demand
+     * of a content element without relations carrying no filter at all.
+     */
+    #[Test]
+    public function aContentElementWithoutRelatedCategoriesGetsAnEmptyFilter(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactorySettings/pluginCategories.csv');
+
+        $demand = $this->createDemandFromSettings(['categories' => '1'], ['uid' => 2]);
+
+        $this->assertSame([], $this->filteredUids($demand));
+    }
+
+    /**
+     * Without the setting the relations are not even looked at, and no `FilterCollection`
+     * is built - `null` rather than an empty one, which is what
+     * `ProjectRepository::findByDemand()` checks for before adding a `contains` constraint
+     * per category.
+     */
+    #[Test]
+    public function noFilterIsBuiltWhenTheContentElementSelectsNoCategories(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DemandFactorySettings/pluginCategories.csv');
+
+        $demand = $this->createDemandFromSettings(['categories' => '0'], ['uid' => 1]);
+
+        $this->assertNull($demand->getFilterCollection());
+    }
+
+    /**
+     * The branch is chosen on `=== null`, not on emptiness. An empty array is form data,
+     * so the plugin's own active state and sorting are discarded rather than used as the
+     * starting point the form overrides - which is what the comment in the factory
+     * describes.
+     */
+    #[Test]
+    public function anEmptyFormArrayDiscardsThePluginSettings(): void
+    {
+        $demand = $this->createDemand([], ['activeState' => 'completed', 'sorting' => 'title desc']);
+
+        $this->assertSame('all', $demand->getActiveState());
+        $this->assertSame('title asc', $demand->getSorting());
+    }
+
+    /**
+     * The form submits field and direction separately, while the demand stores one string
+     * and validates it as a whole. Each of the two setters therefore rebuilds that string
+     * from the other half, and only the combination has to be a known `SortingOptions`
+     * value - so the two halves have to arrive together for either to take effect.
+     */
+    #[Test]
+    public function theFormSetsSortingFieldAndDirectionSeparately(): void
+    {
+        $demand = $this->createDemand(['sortingField' => 'title', 'sortingDirection' => 'desc']);
+
+        $this->assertSame('title desc', $demand->getSorting());
+    }
+
+    /**
+     * The page restriction is never taken from the request: it is the plugin's `pages`
+     * field, a comma separated list of uids as FormEngine stores a group field.
+     */
+    #[Test]
+    public function theSelectedPagesComeFromTheContentElementRecord(): void
+    {
+        $demand = $this->createDemand(null, [], ['pages' => '10,11,12']);
+
+        $this->assertSame([10, 11, 12], $demand->getPages());
+    }
+
+    /**
+     * A plugin without a page selection restricts nothing, and the guard is on the type as
+     * well as on the value - `pages` is `null` on a record read with a schema that has the
+     * column, and absent on the `[]` that `listAction()` falls back to when there is no
+     * content object.
+     */
+    #[Test]
+    public function anEmptyOrAbsentPageSelectionRestrictsNothing(): void
+    {
+        $this->assertSame([], $this->createDemand(null, [], ['pages' => ''])->getPages());
+        $this->assertSame([], $this->createDemand(null, [], ['pages' => null])->getPages());
+        $this->assertSame([], $this->createDemand(null, [], [])->getPages());
+    }
+
+    /**
+     * `showSelected` flips the page restriction of the repository from "these are the
+     * storage pages" to "these are the records", so it decides what the `pages` field
+     * means. It is derived from the CType alone, not from a setting.
+     */
+    #[Test]
+    public function onlyTheSingleViewPluginTreatsTheSelectedPagesAsRecords(): void
+    {
+        $single = $this->createDemand(null, [], ['CType' => 'academicprojects_projectlistsingle']);
+        $list = $this->createDemand(null, [], ['CType' => 'academicprojects_projectlist']);
+        $none = $this->createDemand(null, [], []);
+
+        $this->assertTrue($single->getShowSelected());
+        $this->assertFalse($list->getShowSelected());
+        $this->assertFalse($none->getShowSelected());
+    }
+
+    /**
+     * Unlike active state and sorting, `showHiddenRecords` is applied outside the branch,
+     * so it comes from the plugin settings even when the form was submitted. A visitor
+     * cannot switch it on through the request.
+     */
+    #[Test]
+    public function hiddenRecordsAreShownOnPluginSettingsEvenWithFormData(): void
+    {
+        $withForm = $this->createDemand(['activeState' => 'active'], ['showHiddenRecords' => '1']);
+        $withoutForm = $this->createDemand(null, ['showHiddenRecords' => '1']);
+        $unset = $this->createDemand(null, []);
+
+        $this->assertTrue($withForm->getShowHiddenRecords());
+        $this->assertTrue($withoutForm->getShowHiddenRecords());
+        $this->assertFalse($unset->getShowHiddenRecords());
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $contentElementData
+     */
+    private function createDemandFromSettings(array $settings, array $contentElementData = []): ProjectDemand
+    {
+        return $this->createDemand(null, $settings, $contentElementData);
+    }
+
+    /**
+     * @param ?array<string, mixed> $demandFromForm
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $contentElementData
+     */
+    private function createDemand(
+        ?array $demandFromForm,
+        array $settings = [],
+        array $contentElementData = [],
+    ): ProjectDemand {
+        return $this->get(DemandFactory::class)->createDemandObject(
+            $demandFromForm,
+            $settings,
+            $contentElementData,
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function filteredUids(ProjectDemand $demand): array
+    {
+        $uids = [];
+        foreach ($demand->getFilterCollection()?->getFilterCategories() ?? [] as $category) {
+            $uids[] = $category->getUid();
+        }
+        sort($uids);
+
+        return $uids;
+    }
+}

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/DemandFactorySettings/pluginCategories.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/DemandFactorySettings/pluginCategories.csv
@@ -1,0 +1,14 @@
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","pages","categories"
+,1,1,0,0,0,0,"academicprojects_projectlist","Projects with a category selection","",3
+,2,1,0,0,0,0,"academicprojects_projectlist","Projects without a category selection","",0
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,1,0,0,0,"competence_field","Quantum Physics",0,0
+,2,1,0,0,0,"cooperation","Industry Partner",0,0
+,3,1,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,1,"tt_content","pi_flexform",0,1
+,2,1,"tt_content","pi_flexform",0,2
+,3,1,"tt_content","pi_flexform",0,3

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/ProjectFactory/projects.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/Fixtures/ProjectFactory/projects.csv
@@ -1,0 +1,20 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title","categories","tx_academicprojects_project_title","tx_academicprojects_short_description","tx_academicprojects_start_date","tx_academicprojects_end_date","tx_academicprojects_budget","tx_academicprojects_funders"
+,1,0,1,0,0,0,0,"/","Site Root",0,"","",\NULL,\NULL,\NULL,""
+,10,1,30,0,0,0,0,"/quantum-research","Quantum Research",2,"Quantum research beyond the lab","Investigating quantum effects.",1704067200,1735689600,123456.78,"Deutsche Forschungsgemeinschaft"
+,11,1,30,0,0,0,0,"/solar-fields","Solar Fields",0,"","",0,0,\NULL,""
+,12,1,30,0,0,0,0,"/category-edge-cases","Category Edge Cases",2,"","",\NULL,\NULL,\NULL,""
+,13,1,30,0,1,0,0,"/hidden-lab","Hidden Lab",0,"Hidden laboratory","Not published yet.",\NULL,\NULL,\NULL,""
+,14,1,1,0,0,0,0,"/regular-page","Regular Page",0,"","",\NULL,\NULL,\NULL,""
+"sys_category",
+,"uid","pid","deleted","hidden","parent","type","title","sys_language_uid","l10n_parent"
+,1,1,0,0,0,"competence_field","Quantum Physics",0,0
+,2,1,0,0,0,"cooperation","Industry Partner",0,0
+,3,1,0,1,0,"competence_field","Hidden Competence Field",0,0
+,4,1,0,0,0,"program_type","Full-time",0,0
+"sys_category_record_mm",
+,"uid_local","uid_foreign","tablenames","fieldname","sorting","sorting_foreign"
+,1,10,"pages","categories",0,1
+,2,10,"pages","categories",0,2
+,3,12,"pages","categories",0,1
+,4,12,"pages","categories",0,2

--- a/packages/fgtclb/academic-projects/Tests/Functional/Factory/ProjectFactoryTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Factory/ProjectFactoryTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Factory;
+
+use FGTCLB\AcademicProjects\Domain\Model\Project;
+use FGTCLB\AcademicProjects\Factory\ProjectFactory;
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * `ProjectFactory::get()` is three lines around `DataMapper::map()`, which is exactly why
+ * it needs a functional test rather than a unit one: what it actually does is bind
+ * `Configuration/Extbase/Persistence/Classes.php`, the `pages` TCA of this extension and
+ * the `Project` model together. Every one of those three can be changed without touching
+ * a line of the factory, and nothing else asserts the result.
+ *
+ * Its only caller is `DataProcessing\ProjectProcessor`, which hands over the raw page
+ * record of the page being rendered - `$processedData['data']`, or the `PAGEVIEW` page
+ * record. The tests therefore read the row from the database the way the frontend does
+ * instead of hand-building it, except where a deliberately incomplete row is the point.
+ *
+ * Two properties of the factory follow from that caller and are asserted here because
+ * they are easy to assume the other way round:
+ *
+ * - it validates nothing. Doktype and the enable fields are the caller's business, and
+ *   `ProjectProcessor` is bound to the page type through TypoScript, not through a check
+ *   in PHP;
+ * - the categories are not part of the mapping at all. `Project::getAttributes()` resolves
+ *   them lazily through `GeneralUtility::makeInstance(CategoryRepository::class)` against
+ *   the hardcoded group `projects`, so they are reached only once a template asks for
+ *   them - and with the `pages` restrictions of an ordinary frontend query.
+ */
+final class ProjectFactoryTest extends AbstractAcademicProjectsTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProjectFactory/projects.csv');
+    }
+
+    #[Test]
+    public function aPageRecordIsMappedToAProjectModel(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(10));
+
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertSame(10, $project->getUid());
+        $this->assertSame(1, $project->getPid());
+        $this->assertSame(30, $project->getDoktype());
+        $this->assertSame('Quantum Research', $project->getTitle());
+    }
+
+    /**
+     * The four scalar project columns carry the `tx_academicprojects_` prefix in the
+     * database and none of it in the model, so this pins the property map rather than the
+     * mapper: a renamed column or a dropped entry in `Classes.php` silently leaves the
+     * property at its default instead of failing.
+     */
+    #[Test]
+    public function theProjectColumnsAreMappedToTheirModelProperties(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(10));
+
+        $this->assertSame('Quantum research beyond the lab', $project->getProjectTitle());
+        $this->assertSame('Investigating quantum effects.', $project->getShortDescription());
+        $this->assertSame('Deutsche Forschungsgemeinschaft', $project->getFunders());
+        $this->assertSame(123456.78, $project->getBudget());
+    }
+
+    /**
+     * Both date columns are integer timestamps, and the assertion is on the timestamp
+     * rather than on a formatted date on purpose - the `DateTime` the mapper builds
+     * carries the PHP local timezone, so a formatted comparison would assert the test
+     * container's timezone rather than the mapping.
+     */
+    #[Test]
+    public function theDateColumnsAreMappedToDateTimeObjects(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(10));
+
+        $this->assertInstanceOf(\DateTime::class, $project->getStartDate());
+        $this->assertInstanceOf(\DateTime::class, $project->getEndDate());
+        $this->assertSame(1704067200, $project->getStartDate()->getTimestamp());
+        $this->assertSame(1735689600, $project->getEndDate()->getTimestamp());
+    }
+
+    /**
+     * A record that never had a date set stores `0`, not `NULL`, because neither column is
+     * declared `nullable` in TCA. The mapper maps that empty value back to `null`, which is
+     * what the model's `?\DateTime` promises and what a Fluid `f:if` on the property
+     * expects. Without it every project would render as having started on 1970-01-01.
+     */
+    #[Test]
+    public function aZeroDateColumnIsMappedToNull(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(11));
+
+        $this->assertNull($project->getStartDate());
+        $this->assertNull($project->getEndDate());
+    }
+
+    /**
+     * The same result through a different route: the columns are `DEFAULT NULL` in
+     * `ext_tables.sql`, so a page created before the extension was installed carries
+     * `NULL`, and the mapper skips a column that is not `isset()` instead of mapping it.
+     */
+    #[Test]
+    public function aNullDateColumnIsMappedToNull(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(14));
+
+        $this->assertNull($project->getStartDate());
+        $this->assertNull($project->getEndDate());
+    }
+
+    /**
+     * `tx_academicprojects_budget` is nullable in the database while `Project::$budget` is
+     * a non-nullable `float`, so "no budget recorded" and "a budget of zero" are the same
+     * value once the record is mapped. A template cannot tell them apart.
+     */
+    #[Test]
+    public function aBudgetThatWasNeverEnteredIsMappedToZero(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(11));
+
+        $this->assertSame(0.0, $project->getBudget());
+    }
+
+    /**
+     * The factory takes whatever array it is handed - `ProjectProcessor` passes
+     * `$processedData['data']`, and a `FLUIDTEMPLATE` can be configured to fill that with
+     * something other than a full page row. A missing column must leave the model default
+     * in place rather than raise anything, the more so because the suite fails on notices.
+     */
+    #[Test]
+    public function aRecordWithoutTheProjectColumnsKeepsTheModelDefaults(): void
+    {
+        $project = $this->subject()->get(['uid' => 4711, 'pid' => 1]);
+
+        $this->assertSame(4711, $project->getUid());
+        $this->assertSame(0, $project->getDoktype());
+        $this->assertSame('', $project->getTitle());
+        $this->assertSame('', $project->getProjectTitle());
+        $this->assertSame('', $project->getShortDescription());
+        $this->assertSame('', $project->getFunders());
+        $this->assertSame(0.0, $project->getBudget());
+        $this->assertNull($project->getStartDate());
+        $this->assertNull($project->getEndDate());
+        $this->assertCount(0, $project->getMedia());
+    }
+
+    /**
+     * The factory has no notion of the project page type. Handing it an ordinary page
+     * yields a `Project` carrying that doktype - which is correct, because the guard is the
+     * TypoScript that binds `ProjectProcessor` to page type 30, but it means the factory
+     * cannot be used as a filter.
+     */
+    #[Test]
+    public function aPageOfAnotherDoktypeIsMappedNonetheless(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(14));
+
+        $this->assertSame(14, $project->getUid());
+        $this->assertSame(1, $project->getDoktype());
+        $this->assertSame('Regular Page', $project->getTitle());
+    }
+
+    /**
+     * The same for the enable fields: a hidden page reaching the processor is already a
+     * decision the frontend made, so the factory maps it like any other row.
+     */
+    #[Test]
+    public function aHiddenPageIsMappedNonetheless(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(13));
+
+        $this->assertSame(13, $project->getUid());
+        $this->assertSame('Hidden laboratory', $project->getProjectTitle());
+    }
+
+    /**
+     * The categories are not in the mapped row - `pages.categories` holds a relation count,
+     * nothing else - so this is the one part of the result that costs a second query, fired
+     * by the model rather than by the factory, and keyed by the uid the factory mapped.
+     */
+    #[Test]
+    public function theCategoriesOfTheMappedPageAreResolvedAsAttributes(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(10));
+
+        $this->assertSame(
+            [1 => 'Quantum Physics', 2 => 'Industry Partner'],
+            $this->attributeTitles($project),
+        );
+    }
+
+    /**
+     * `getCategoryCollection()` is what `GetCategoryCollectionInterface` requires and what
+     * `CategoryRepository::findAllApplicable()` calls; it must not resolve a second,
+     * independent collection.
+     */
+    #[Test]
+    public function theCategoryCollectionIsTheAttributeCollection(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(10));
+
+        $this->assertSame($project->getAttributes(), $project->getCategoryCollection());
+    }
+
+    #[Test]
+    public function aPageWithoutCategoriesHasAnEmptyAttributeCollection(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(11));
+
+        $this->assertCount(0, $project->getAttributes());
+    }
+
+    /**
+     * Page 12 is linked to a hidden category and to one whose type belongs to no group of
+     * this extension. Both are dropped, for different reasons - the first by the default
+     * restrictions of the query, the second because the group `projects` resolves to the
+     * four types of `Configuration/CategoryTypes.yaml` - and the collection ends up empty
+     * although `pages.categories` counts two relations.
+     */
+    #[Test]
+    public function hiddenCategoriesAndCategoriesOutsideTheProjectsGroupAreNotAttributes(): void
+    {
+        $project = $this->subject()->get($this->pageRecord(12));
+
+        $this->assertCount(0, $project->getAttributes());
+    }
+
+    /**
+     * Not an optimisation but a property worth knowing: `DataMapper` registers every mapped
+     * row in the Extbase persistence session, so a second `get()` for the same uid returns
+     * the object built the first time and the values of the second row are discarded. Two
+     * `ProjectProcessor` runs in one request - a page rendering a detail view of itself, or
+     * a `PAGEVIEW` after a `FLUIDTEMPLATE` - therefore share one model.
+     */
+    #[Test]
+    public function theSameRecordIsMappedToTheSameObjectInstance(): void
+    {
+        $record = $this->pageRecord(10);
+        $first = $this->subject()->get($record);
+
+        $record['title'] = 'Renamed in the meantime';
+        $second = $this->subject()->get($record);
+
+        $this->assertSame($first, $second);
+        $this->assertSame('Quantum Research', $second->getTitle());
+    }
+
+    /**
+     * `ProjectFactory` is a private service, so it is not retrievable from the container -
+     * and `ProjectProcessor` does not retrieve it either, it uses `makeInstance()`.
+     */
+    private function subject(): ProjectFactory
+    {
+        return GeneralUtility::makeInstance(ProjectFactory::class);
+    }
+
+    /**
+     * The full page row, as the frontend hands it to `ProjectProcessor`. Only the deleted
+     * restriction is kept so that the hidden page of the fixture can be read too.
+     *
+     * @return array<string, mixed>
+     */
+    private function pageRecord(int $uid): array
+    {
+        $queryBuilder = $this->get(ConnectionPool::class)->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
+        $record = $queryBuilder
+            ->select('*')
+            ->from('pages')
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchAssociative();
+
+        $this->assertIsArray($record, sprintf('Page %d is missing from the fixture.', $uid));
+
+        return $record;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function attributeTitles(Project $project): array
+    {
+        $titles = [];
+        foreach ($project->getAttributes() as $category) {
+            $titles[$category->getUid()] = $category->getTitle();
+        }
+        ksort($titles);
+
+        return $titles;
+    }
+}


### PR DESCRIPTION
Resolves ACE-421 on `main`. Part of the test coverage round tracked under ACE-10.

`ProjectFactory` had no test, `DemandFactory` was covered only for the category-filter path, and `ProjectRepository` only for the hidden-record flag. This closes the disjoint halves — a new `DemandFactorySettingsTest` for the no-form-data branch and the always-applied tail, plus five tests on the repository for the `activeState` branches and `showSelected`. The existing category-filter test is left untouched.

**Both new classes are green on SQLite *and* PostgreSQL.**

## Three findings, reported not fixed

**1. A project whose `tx_academicprojects_end_date` is `NULL` is neither "active" nor "completed".** The column is `DEFAULT NULL` in `ext_tables.sql` while the TCA field is not `nullable`, so FormEngine writes `0` — but any row that did not go through FormEngine (import, pre-install page) keeps `NULL`, and `NULL = 0` / `NULL > now` are both *unknown*. Such a project shows in the unfiltered list and **vanishes from either filtered one**. Pinned by `aProjectWithoutAnyEndDateValueIsNeitherActiveNorCompleted`.

**2. `$demandFromForm === []` is treated as "form submitted"**, so an empty demand array discards the plugin's configured `activeState`, `sorting` and `categories` entirely rather than using them as defaults. Pinned by `anEmptyFormArrayDiscardsThePluginSettings`.

**3. The storage-page branch of `findByDemand()` cannot be exercised as plain repository API at all.** For `pages` set with `showSelected` false it calls `setRespectStoragePage(true)`, and that restriction comes from Extbase's `persistence.storagePid`, not from the demand. In a frontend request `FrontendConfigurationManager::overrideStoragePidIfStartingPointIsSet()` fills it from the same `tt_content.pages` field — which is what adds `recursive` support — but called directly the default `storagePid = 0` intersects with `pid IN (…)` and the result is **always empty**. Verified with a throwaway probe. The test written for that branch was **dropped and the reason recorded in the class**; it belongs in a plugin-rendering test. `EXT:academic_programs`' `ProgramRepository` does not do this.

Also noted, not covered: `DemandFactory` reads `$contentElementData['uid']` unguarded while guarding the two neighbouring keys — an undefined-key warning under the `[]` fallback of `listAction()`, which `failOnWarning` would turn into a red test on a defect this change does not fix. And `ProjectFactory` validates nothing: doktype and enable fields pass straight through, and `DataMapper`'s identity map means a second `get()` for the same uid returns the first object with the first row's values. Both are now pinned rather than assumed.

## A surprise worth recording

`Configuration/Extbase/Persistence/Classes.php` maps a `lastUpdated` property that **does not exist** on `Project` — and it is still load-bearing. `DataMapFactory` builds column maps from the table's TCA columns through the `fieldName → property` map, which is what makes `SortingOptions::SORT_BY_LASTUPDATED_*` resolve to the `lastUpdated` column instead of falling back to `last_updated`. Verified by probe.

## Proof the tests can fail

Three mutation rounds; every one of the 31 new tests failed in at least one. Round 1: 14 + 5 failures (factory row stripped, settings branches removed, `intExplode` separator changed, CType comparison flipped, `in('uid')` → `in('pid')`). Round 2: 12 + 3 (model defaults, `getAttributes()` page id, `tryFromDefault` dropped, `logicalAnd` → `logicalOr`). Round 3: 4 (category group renamed).

## Scope

No production code is changed. `Project::getMedia()` with real file relations is not covered (needs `sys_file`/`sys_file_storage` fixtures); language/overlay behaviour is already covered by `AcademicProjectsProjectListLocalizationTest`.
