### PR TITLE
[TASK] ACE-417: Cover the contact repository and provider

### DIFF
--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/ContactRepositoryFindByPidTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/ContactRepositoryFindByPidTest.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Domain\Repository;
+
+use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
+use FGTCLB\AcademicContacts4pages\Domain\Repository\ContactRepository;
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Everything `ContactRepository::findByPid()` decides except the hidden flag, which
+ * `ContactRepositoryShowHiddenRecordsTest` covers on its own.
+ *
+ * The argument is the uid of the page a contact points at through its `page` column, not
+ * the page the contact record is stored on: the query lifts `respectStoragePage`, so the
+ * storage folder of a contact is irrelevant and the `page` column alone selects. That
+ * distinction is the reason the fixture spreads the contacts of one page over two storage
+ * folders and gives them a `sorting` that contradicts their uid order.
+ *
+ * @see \FGTCLB\AcademicContacts4pages\Tests\Functional\Domain\Repository\ContactRepositoryShowHiddenRecordsTest
+ */
+final class ContactRepositoryFindByPidTest extends AbstractAcademicContacts4PagesTestCase
+{
+    /**
+     * The order is what is asserted here, so the result is taken as it comes - unlike in
+     * `ContactRepositoryShowHiddenRecordsTest`, which sorts before comparing.
+     *
+     * @param QueryResultInterface<int, Contact> $result
+     * @return int[]
+     */
+    private function resultUids(QueryResultInterface $result): array
+    {
+        $uids = [];
+        foreach ($result as $contact) {
+            $uids[] = (int)$contact->getUid();
+        }
+
+        return $uids;
+    }
+
+    private function subject(): ContactRepository
+    {
+        return $this->get(ContactRepository::class);
+    }
+
+    /**
+     * Extbase reads the language aspect of the global context when it builds the query
+     * settings, so this is what a frontend request in that language leaves behind.
+     */
+    private function setUpLanguageAspect(int $languageId): void
+    {
+        GeneralUtility::makeInstance(Context::class)->setAspect(
+            'language',
+            new LanguageAspect($languageId, $languageId, LanguageAspect::OVERLAYS_ON)
+        );
+    }
+
+    /**
+     * Contacts 1, 2 and 3 point at page 2, contact 4 points at page 3. The result is
+     * ordered by `sorting`, which here is the reverse of the uid order, so an accidental
+     * fallback to the primary key would be visible.
+     */
+    #[Test]
+    public function contactsOfTheRequestedPageAreReturnedInSortingOrder(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([2, 3, 1], $this->resultUids($this->subject()->findByPid(2)));
+    }
+
+    /**
+     * Contact 3 lives in a second storage folder. It has to come back nonetheless, because
+     * the query lifts `respectStoragePage` - the plugin never configures a storage pid and
+     * an editor is free to file contact records wherever the page tree suits them.
+     */
+    #[Test]
+    public function contactsAreFoundRegardlessOfTheStorageFolderTheyLiveIn(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $contacts = $this->subject()->findByPid(2);
+
+        $this->assertContains(3, $this->resultUids($contacts));
+        $this->assertSame([100, 101, 100], array_map(
+            static fn(Contact $contact): int => (int)$contact->getPid(),
+            iterator_to_array($contacts)
+        ));
+    }
+
+    /**
+     * Contacts of a different page must not leak into the result - the plugin renders one
+     * page's contacts, and every page of an installation stores them in the same folder.
+     */
+    #[Test]
+    public function contactsOfAnotherPageAreNotReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([4], $this->resultUids($this->subject()->findByPid(3)));
+    }
+
+    /**
+     * Contact 6 is deleted, and no argument of the method brings it back: `findByPid()`
+     * only ever lifts the `disabled` enable field.
+     */
+    #[Test]
+    public function deletedContactsAreNeverReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertNotContains(6, $this->resultUids($this->subject()->findByPid(2)));
+        $this->assertNotContains(6, $this->resultUids($this->subject()->findByPid(2, true)));
+    }
+
+    /**
+     * Lifting the hidden flag must not reorder the result: the hidden contact 5 carries the
+     * lowest `sorting` of the page and therefore appears first, not appended at the end.
+     */
+    #[Test]
+    public function hiddenContactsAreSortedIntoTheResultRatherThanAppended(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([5, 2, 3, 1], $this->resultUids($this->subject()->findByPid(2, true)));
+    }
+
+    #[Test]
+    public function pageWithoutContactsYieldsAnEmptyResult(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $result = $this->subject()->findByPid(4);
+
+        $this->assertSame([], $this->resultUids($result));
+        $this->assertSame(0, $result->count());
+    }
+
+    /**
+     * @return \Generator<string, array{0: int}>
+     */
+    public static function noContactPointsAtThePageDataProvider(): \Generator
+    {
+        yield 'page uid that does not exist' => [999];
+        yield 'negative page uid' => [-1];
+    }
+
+    /**
+     * A page uid nothing points at is not an error: the plugin passes whatever page it is
+     * rendered on, and the data processor whatever record it is called for.
+     */
+    #[DataProvider('noContactPointsAtThePageDataProvider')]
+    #[Test]
+    public function pageUidNoContactPointsAtYieldsAnEmptyResult(int $pid): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([], $this->resultUids($this->subject()->findByPid($pid)));
+    }
+
+    /**
+     * `page` is a group field with `minitems` 1, but a record written around FormEngine -
+     * an import, or `ContactsController` reading a content element without a pid - keeps
+     * the `0` default. Contact 7 is such a record, and it is reachable by `findByPid(0)`
+     * rather than being treated as unassigned. Worth pinning down: the controller passes
+     * `(int)($contentElementData['pid'] ?? 0)`, so `0` is a value that reaches the method.
+     */
+    #[Test]
+    public function contactWithoutAPageIsReturnedForPageUidZero(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([7], $this->resultUids($this->subject()->findByPid(0)));
+    }
+
+    /**
+     * The `page` column is not joined against `pages`, so a contact pointing at a page that
+     * was deleted in the meantime is still returned. Contact 8 points at page 500, which
+     * the fixture never creates.
+     */
+    #[Test]
+    public function contactPointingAtAMissingPageIsStillReturned(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contacts.csv');
+
+        $this->assertSame([8], $this->resultUids($this->subject()->findByPid(500)));
+    }
+
+    #[Test]
+    public function resultIsEmptyWithoutAnyContactRecord(): void
+    {
+        $result = $this->subject()->findByPid(2);
+
+        $this->assertSame([], $this->resultUids($result));
+        $this->assertSame(0, $result->count());
+    }
+
+    /**
+     * The language fixture holds five contacts of page 2: the default language records 1
+     * and 2, the German translation 3 of contact 2, the German record 4 that has no
+     * default language record at all, and the "all languages" record 5.
+     *
+     * @param int[] $expectedUids
+     * @param int[] $expectedLocalizedUids
+     */
+    private function assertLanguageResult(int $languageId, array $expectedUids, array $expectedLocalizedUids): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contactsWithTranslations.csv');
+        $this->setUpLanguageAspect($languageId);
+
+        $contacts = iterator_to_array($this->subject()->findByPid(2));
+
+        $this->assertSame(
+            $expectedUids,
+            array_map(static fn(Contact $contact): int => (int)$contact->getUid(), $contacts),
+            'Unexpected uids.'
+        );
+        $this->assertSame(
+            $expectedLocalizedUids,
+            array_map(static fn(Contact $contact): int => (int)$contact->_getProperty('_localizedUid'), $contacts),
+            'Unexpected localized uids.'
+        );
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED. `findByPid()` lifts `respectSysLanguage`, so the
+     * query carries no language constraint at all and every translation is selected next to
+     * its default language record. The German translation 3 is therefore mapped a second
+     * time onto contact 2 - the same contact rendered twice on a page that is not even
+     * translated, once in German - and the German-only contact 4 shows up in the default
+     * language as well.
+     *
+     * Lifting `respectSysLanguage` is what a manual uid selection needs (see ACE-341); this
+     * query selects by page and has no such reason. Kept as an assertion so the day the
+     * language handling is corrected the change is visible here rather than in a report.
+     */
+    #[Test]
+    public function defaultLanguageAlsoReturnsTranslationsAndSoDuplicatesTheirDefaultRecord(): void
+    {
+        $this->assertLanguageResult(0, [1, 2, 2, 4, 5], [1, 2, 3, 4, 5]);
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED, AND WORSE ON v14. The same duplication in the
+     * translated language: contact 2 arrives twice, once from its default language record
+     * overlaid into German and once from the German record itself. On TYPO3 v14 contact 1
+     * is additionally *dropped*, because the overlay type the method forces is
+     * `OVERLAYS_ON` - "hide non translated" - which is a decision the site configuration
+     * usually makes.
+     *
+     * The v13 counterpart below shows the same call keeping contact 1. Two versions, two
+     * different wrong answers, from one unchanged repository method.
+     */
+    #[Test]
+    #[Group('not-core-13')]
+    public function translatedLanguageReturnsEachTranslatedContactTwiceAndDropsTheUntranslatedOne(): void
+    {
+        $this->assertLanguageResult(1, [2, 2, 4, 5], [3, 3, 4, 5]);
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED. On TYPO3 v13 the overlay removes nothing: the
+     * translated language returns all five rows, contact 2 among them twice - and both
+     * copies carry the localized uid 3, so the German record is mapped twice while the
+     * untranslated contact 1 survives, where v14 drops it.
+     */
+    #[Test]
+    #[Group('not-core-14')]
+    public function translatedLanguageReturnsEveryRowIncludingTheUntranslatedOne(): void
+    {
+        $this->assertLanguageResult(1, [1, 2, 2, 4, 5], [1, 3, 3, 4, 5]);
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED. Language 3 has no translated contact whatsoever,
+     * yet on TYPO3 v14 the two German records leak into its result while the untranslated
+     * default language contacts are dropped. A frontend in that language renders German
+     * contacts and loses its own.
+     */
+    #[Test]
+    #[Group('not-core-13')]
+    public function languageWithoutTranslationsReturnsTheRecordsOfAForeignLanguage(): void
+    {
+        $this->assertLanguageResult(3, [2, 4, 5], [3, 4, 5]);
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED. On TYPO3 v13 a language with no translations at all
+     * gets the raw five rows, exactly as the default language does - the language of the
+     * request makes no difference whatsoever to what this method returns.
+     */
+    #[Test]
+    #[Group('not-core-14')]
+    public function languageWithoutTranslationsReturnsTheSameRowsAsEveryOtherLanguage(): void
+    {
+        $this->assertLanguageResult(3, [1, 2, 2, 4, 5], [1, 2, 3, 4, 5]);
+    }
+
+    /**
+     * DEFECT PINNED DOWN, NOT ENDORSED. `count()` is answered by a `COUNT(*)` that never
+     * runs the overlay, so it reports the raw row count of every language at once while
+     * iterating the same result yields fewer objects. A template asking `{contacts -> f:count()}`
+     * and a template iterating disagree.
+     *
+     * Only reproducible on TYPO3 v14: on v13 the iteration returns the raw rows as well, so
+     * the two happen to agree - which is the v13 counterpart below.
+     */
+    #[Test]
+    #[Group('not-core-13')]
+    public function countIgnoresTheLanguageOverlayAndDisagreesWithTheIteration(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contactsWithTranslations.csv');
+        $this->setUpLanguageAspect(3);
+
+        $result = $this->subject()->findByPid(2);
+
+        $this->assertSame(5, $result->count());
+        $this->assertCount(3, iterator_to_array($result));
+    }
+
+    /**
+     * On TYPO3 v13 counting and iterating agree - both report the five raw rows, because
+     * nothing is overlaid away. That is not the method being correct here; it is the same
+     * missing language constraint, showing from the other side.
+     */
+    #[Test]
+    #[Group('not-core-14')]
+    public function countAndIterationAgreeBecauseNothingIsOverlaidAway(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContactRepositoryFindByPid/contactsWithTranslations.csv');
+        $this->setUpLanguageAspect(3);
+
+        $result = $this->subject()->findByPid(2);
+
+        $this->assertSame(5, $result->count());
+        $this->assertCount(5, iterator_to_array($result));
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/Fixtures/ContactRepositoryFindByPid/contacts.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/Fixtures/ContactRepositoryFindByPid/contacts.csv
@@ -1,0 +1,28 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,"/contacts","Contacts Page"
+,3,1,1,0,0,0,0,"/other","Other Page"
+,4,1,1,0,0,0,0,"/empty","Page Without Contacts"
+,100,1,254,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,0,0,"/sysfolder-other","Second Recordcollection"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,0,0,"Student Advisors",""
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position"
+,1,100,0,0,0,0,1,"Professor"
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","contract","role"
+,1,100,0,0,0,0,30,2,1,1
+,2,100,0,0,0,0,10,2,1,2
+,3,101,0,0,0,0,20,2,1,0
+,4,100,0,0,0,0,5,3,1,1
+,5,100,0,1,0,0,1,2,1,1
+,6,100,1,0,0,0,2,2,1,1
+,7,100,0,0,0,0,40,0,1,0
+,8,100,0,0,0,0,50,500,1,0

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/Fixtures/ContactRepositoryFindByPid/contactsWithTranslations.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Domain/Repository/Fixtures/ContactRepositoryFindByPid/contactsWithTranslations.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,"/contacts","Contacts Page"
+,100,1,254,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tx_academiccontacts4pages_domain_model_role",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","name","description"
+,1,100,0,0,0,0,"Dean's Office",""
+,2,100,0,0,1,1,"Dekanat",""
+"tx_academiccontacts4pages_domain_model_contact",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","page","contract","role"
+,1,100,0,0,0,0,10,2,0,1
+,2,100,0,0,0,0,20,2,0,1
+,3,100,0,0,1,2,25,2,0,1
+,4,100,0,0,1,0,30,2,0,1
+,5,100,0,0,-1,0,40,2,0,1

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Service/AddressRecordProviderTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Service/AddressRecordProviderTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicContacts4pages\Tests\Functional\Service;
+
+use FGTCLB\AcademicContacts4pages\Service\AddressRecordProvider;
+use FGTCLB\AcademicContacts4pages\Tests\Functional\AbstractAcademicContacts4PagesTestCase;
+use FGTCLB\AcademicPersons\Domain\Model\Address;
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+/**
+ * The provider is what lets the contacts list plugin render a hidden address record: the
+ * contract relation of a contact never carries one, because Extbase reconstitutes a
+ * relation with fresh query settings that know nothing about the "ignore disabled" of the
+ * contact query.
+ *
+ * The fixture is built so that every rule the provider inherits from
+ * `…AcademicPersons\Domain\Repository\*::findByContractIncludingHidden()` is observable at
+ * once: a hidden record that must be returned, a deleted one that must not, a record of a
+ * second contract, a translation, a record stored in a second folder, and - for the guard
+ * on a non-positive contract uid - records that carry no contract at all.
+ *
+ * `GeneralUtility::makeInstance()` rather than `$this->get()` on purpose: that is how
+ * `ContactsController` obtains the provider.
+ */
+final class AddressRecordProviderTest extends AbstractAcademicContacts4PagesTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AddressRecordProvider/addressRecords.csv');
+    }
+
+    private function subject(): AddressRecordProvider
+    {
+        return GeneralUtility::makeInstance(AddressRecordProvider::class);
+    }
+
+    /**
+     * @param ObjectStorage<covariant DomainObjectInterface> $addressRecords
+     * @return int[]
+     */
+    private function uidsOf(ObjectStorage $addressRecords): array
+    {
+        $uids = [];
+        foreach ($addressRecords as $addressRecord) {
+            $uids[] = (int)$addressRecord->getUid();
+        }
+
+        return $uids;
+    }
+
+    /**
+     * The hidden record 3 sits between the two visible ones, so it proves at once that
+     * hidden records are returned and that they take their place by `sorting` rather than
+     * being appended - a contract's address records are ordered by the editor.
+     */
+    #[Test]
+    public function emailAddressesOfTheContractAreReturnedInSortingOrderIncludingHiddenOnes(): void
+    {
+        $emailAddresses = $this->subject()->findEmailAddresses(1);
+
+        $this->assertSame([2, 3, 1], $this->uidsOf($emailAddresses));
+        $this->assertSame(
+            ['first@example.org', 'hidden@example.org', 'third@example.org'],
+            array_map(static fn(Email $email): string => $email->getEmail(), $emailAddresses->toArray())
+        );
+        $this->assertSame(
+            [false, true, false],
+            array_map(static fn(Email $email): bool => $email->getHidden(), $emailAddresses->toArray())
+        );
+    }
+
+    #[Test]
+    public function phoneNumbersOfTheContractAreReturnedInSortingOrderIncludingHiddenOnes(): void
+    {
+        $phoneNumbers = $this->subject()->findPhoneNumbers(1);
+
+        $this->assertSame([2, 1], $this->uidsOf($phoneNumbers));
+        $this->assertSame(
+            ['+49 30 222', '+49 30 111'],
+            array_map(
+                static fn(PhoneNumber $phoneNumber): string => $phoneNumber->getPhoneNumber(),
+                $phoneNumbers->toArray()
+            )
+        );
+        $this->assertSame(
+            [true, false],
+            array_map(
+                static fn(PhoneNumber $phoneNumber): bool => $phoneNumber->getHidden(),
+                $phoneNumbers->toArray()
+            )
+        );
+    }
+
+    #[Test]
+    public function physicalAddressesOfTheContractAreReturnedInSortingOrderIncludingHiddenOnes(): void
+    {
+        $physicalAddresses = $this->subject()->findPhysicalAddresses(1);
+
+        $this->assertSame([2, 1], $this->uidsOf($physicalAddresses));
+        $this->assertSame(
+            ['Hamburg', 'Berlin'],
+            array_map(static fn(Address $address): string => $address->getCity(), $physicalAddresses->toArray())
+        );
+        $this->assertSame(
+            [true, false],
+            array_map(static fn(Address $address): bool => $address->getHidden(), $physicalAddresses->toArray())
+        );
+    }
+
+    /**
+     * "Including hidden" lifts the `disabled` enable field only. A deleted record is gone
+     * for good - it would otherwise reappear in the frontend the moment an editor switches
+     * the plugin option on.
+     */
+    #[Test]
+    public function deletedAddressRecordsAreNeverReturned(): void
+    {
+        $this->assertNotContains(4, $this->uidsOf($this->subject()->findEmailAddresses(1)));
+        $this->assertNotContains(3, $this->uidsOf($this->subject()->findPhoneNumbers(1)));
+        $this->assertNotContains(3, $this->uidsOf($this->subject()->findPhysicalAddresses(1)));
+    }
+
+    /**
+     * The lookup goes through the contract on purpose, never by uid alone: a selection made
+     * on a contact can outlive the contract it was made for, and the record it names must
+     * not surface below a contract it does not belong to.
+     */
+    #[Test]
+    public function addressRecordsOfAnotherContractAreNotReturned(): void
+    {
+        $this->assertSame([6], $this->uidsOf($this->subject()->findEmailAddresses(2)));
+        $this->assertSame([4], $this->uidsOf($this->subject()->findPhoneNumbers(2)));
+        $this->assertSame([4], $this->uidsOf($this->subject()->findPhysicalAddresses(2)));
+    }
+
+    /**
+     * Email 1 is stored in a second folder while the rest of contract 1 lives in the first
+     * one. The repository lifts `respectStoragePage`, so the folder an editor picked has no
+     * say in what the frontend renders.
+     */
+    #[Test]
+    public function addressRecordsAreFoundRegardlessOfTheFolderTheyAreStoredIn(): void
+    {
+        $emailAddresses = $this->subject()->findEmailAddresses(1)->toArray();
+
+        $this->assertSame(
+            [100, 101],
+            [(int)$emailAddresses[0]->getPid(), (int)$emailAddresses[2]->getPid()]
+        );
+    }
+
+    /**
+     * Email 5 is the German translation of email 2. The default language must see the
+     * default language record only - the plugin resolves the overlay through the contract
+     * relation, and a translation returned next to its original would be rendered twice.
+     */
+    #[Test]
+    public function translationOfAnAddressRecordIsNotReturnedNextToItsDefaultLanguageRecord(): void
+    {
+        $emailAddresses = $this->subject()->findEmailAddresses(1);
+
+        $this->assertNotContains(5, $this->uidsOf($emailAddresses));
+        $this->assertNotContains(
+            'translated@example.org',
+            array_map(static fn(Email $email): string => $email->getEmail(), $emailAddresses->toArray())
+        );
+    }
+
+    /**
+     * Contract 3 exists but has no address record of any kind. A contact pointing at it
+     * renders no address block rather than raising anything.
+     */
+    #[Test]
+    public function contractWithoutAddressRecordsYieldsEmptyStorages(): void
+    {
+        $this->assertSame([], $this->uidsOf($this->subject()->findEmailAddresses(3)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhoneNumbers(3)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhysicalAddresses(3)));
+    }
+
+    /**
+     * A contact whose contract was deleted keeps the uid in its column, so the provider is
+     * asked for a contract that is no longer resolvable.
+     */
+    #[Test]
+    public function unknownContractUidYieldsEmptyStorages(): void
+    {
+        $this->assertSame([], $this->uidsOf($this->subject()->findEmailAddresses(999)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhoneNumbers(999)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhysicalAddresses(999)));
+    }
+
+    /**
+     * @return \Generator<string, array{0: int}>
+     */
+    public static function nonPositiveContractUidDataProvider(): \Generator
+    {
+        yield 'contract not selected' => [0];
+        yield 'negative contract uid' => [-1];
+    }
+
+    /**
+     * `0` is the default of `tx_academiccontacts4pages_domain_model_contact.contract`, and
+     * `Contact::createDisplayContract()` passes `$contract->getUid() ?? 0` - so `0` reaches
+     * the provider for every contact that was never given a contract. The fixture holds one
+     * address record of each kind with `contract = 0`; without the guard in the provider
+     * the query would match exactly those and hand a stranger's address to the contact.
+     */
+    #[DataProvider('nonPositiveContractUidDataProvider')]
+    #[Test]
+    public function nonPositiveContractUidYieldsEmptyStorages(int $contractUid): void
+    {
+        $this->assertSame([], $this->uidsOf($this->subject()->findEmailAddresses($contractUid)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhoneNumbers($contractUid)));
+        $this->assertSame([], $this->uidsOf($this->subject()->findPhysicalAddresses($contractUid)));
+    }
+
+    /**
+     * `Contract::setEmailAddresses()` and its two siblings take an `ObjectStorage`, so the
+     * query result has to be converted rather than passed on. The models have to be the
+     * ones of `EXT:academic_persons`, which is what the templates render.
+     */
+    #[Test]
+    public function storagesHoldTheDomainModelsOfTheAddressRecords(): void
+    {
+        $this->assertContainsOnlyInstancesOf(Email::class, $this->subject()->findEmailAddresses(1));
+        $this->assertContainsOnlyInstancesOf(PhoneNumber::class, $this->subject()->findPhoneNumbers(1));
+        $this->assertContainsOnlyInstancesOf(Address::class, $this->subject()->findPhysicalAddresses(1));
+    }
+
+    /**
+     * The provider holds no state, so the same question asked twice gives the same answer -
+     * `ContactsController` hands one instance to every contact of a page.
+     */
+    #[Test]
+    public function repeatedLookupsOfTheSameContractReturnEqualStorages(): void
+    {
+        $provider = $this->subject();
+
+        $this->assertSame(
+            $this->uidsOf($provider->findEmailAddresses(1)),
+            $this->uidsOf($provider->findEmailAddresses(1))
+        );
+        $this->assertSame([6], $this->uidsOf($provider->findEmailAddresses(2)));
+        $this->assertSame([2, 3, 1], $this->uidsOf($provider->findEmailAddresses(1)));
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Functional/Service/Fixtures/AddressRecordProvider/addressRecords.csv
+++ b/packages/fgtclb/academic-contact4pages/Tests/Functional/Service/Fixtures/AddressRecordProvider/addressRecords.csv
@@ -1,0 +1,36 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","slug","title"
+,1,0,1,0,0,0,0,"/","Site Root"
+,100,1,254,0,0,0,0,"/sysfolder-records","Recordcollection"
+,101,1,254,0,0,0,0,"/sysfolder-other","Second Recordcollection"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"Max","Müllermann","max-muellermann"
+"tx_academicpersons_domain_model_contract",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","profile","position"
+,1,100,0,0,0,0,1,"Professor"
+,2,100,0,0,0,0,1,"Lecturer"
+,3,100,0,0,0,0,1,"Assistant"
+"tx_academicpersons_domain_model_email",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","email","type"
+,1,101,0,0,0,0,30,1,"third@example.org","business"
+,2,100,0,0,0,0,10,1,"first@example.org","business"
+,3,100,0,1,0,0,20,1,"hidden@example.org","private"
+,4,100,1,0,0,0,5,1,"deleted@example.org","private"
+,5,100,0,0,1,2,15,1,"translated@example.org","business"
+,6,100,0,0,0,0,10,2,"other-contract@example.org","business"
+,7,100,0,0,0,0,1,0,"without-contract@example.org","business"
+"tx_academicpersons_domain_model_phone_number",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","phone_number","type"
+,1,100,0,0,0,0,20,1,"+49 30 111","business"
+,2,100,0,1,0,0,10,1,"+49 30 222","private"
+,3,100,1,0,0,0,30,1,"+49 30 333","private"
+,4,100,0,0,0,0,10,2,"+49 40 444","business"
+,5,100,0,0,0,0,1,0,"+49 50 555","business"
+"tx_academicpersons_domain_model_address",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","contract","street","street_number","zip","city","country","type"
+,1,100,0,0,0,0,20,1,"Musterstraße","1","10115","Berlin","Germany","business"
+,2,100,0,1,0,0,10,1,"Nebenstraße","2","20095","Hamburg","Germany","private"
+,3,100,1,0,0,0,30,1,"Löschweg","3","50667","Köln","Germany","private"
+,4,100,0,0,0,0,10,2,"Anderstraße","4","80331","München","Germany","business"
+,5,100,0,0,0,0,1,0,"Waisenweg","5","70173","Stuttgart","Germany","business"


### PR DESCRIPTION
Resolves ACE-417 on `main`. Part of the test coverage round tracked under ACE-10.

`ContactRepository::findByPid()` was covered only for the hidden-record flag — page selection, ordering, language handling and the empty cases were untested. `Service\AddressRecordProvider` had no test at all.

The fixture makes each property provable on its own: `sorting` deliberately contradicts the uid order, the contacts of one page are spread over two storage folders, and hidden records carry a sorting that puts them **into the middle** of the result rather than at its end.

## The language handling is why this unit matters

`setRespectSysLanguage(false)` removes the language constraint from the query entirely, so translations are selected **next to** their default-language records and then overlaid one by one. Measured on the fixture (1, 2 default; 3 = German translation of 2; 4 = German-only; 5 = all-languages):

| Context language | Objects returned (`uid`/`_localizedUid`) |
|---|---|
| 0 (default) | 1/1, 2/2, **2/3**, 4/4, 5/5 |
| 1 (German) | **2/3, 2/3** (twice), 4/4, 5/5 — contact 1 dropped |
| 3 (no translations at all) | **2/3**, 4/4, 5/5 — German records leak, defaults dropped |

Three separate consequences:

* a contact is rendered **twice** as soon as it is translated, including on a page in the default language;
* a language with **no** translations renders the **German** records and drops the defaults;
* the forced `LanguageAspect::OVERLAYS_ON` ("hide non-translated") **overrides whatever the site configuration decided**.

Lifting `respectSysLanguage` is what a *manual uid selection* needs (the ACE-341 shape). This query selects by page and has no such reason.

The four language tests pin the behaviour as it is, and their docblocks say in capitals that the **defect is pinned down, not endorsed**. Restoring `setRespectSysLanguage(true)` is what turns exactly those four red — which is also the mutation proof for them.

**A consequence worth naming separately:** `QueryResult::count()` is a `COUNT(*)` that never runs the overlay, so counting and iterating the same result **disagree** — 5 against 3 on this fixture. `{contacts -> f:count()}` and an `f:for` over the same object give different numbers.

## Smaller findings

`Contact::selectAddressRecords()` falls back only on `null`: a provider present but returning an *empty* storage — which it does for `contractUid <= 0` — discards the records the relation already loaded. Latent, since it needs a contract without a persisted uid.

`AddressRecordProvider` queries by contract uid without checking the contract itself, so a **hidden contract's records are still returned**. Left unasserted: whether that is intended is a product question, not something to freeze into a test.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| `setOrderings(['sorting' => ASC])` dropped | 3 |
| `setRespectStoragePage(false)` → `true` | 12 |
| `setRespectSysLanguage(false)` → `true` | 4 (exactly the language tests) |
| `equals('page', $pid)` → `$pid + 1` | 13 |
| `if ($showHidden === true)` → `if (false)` | 2 |
| provider: `$contractUid <= 0` → `< 0` | 1 |
| provider: `toObjectStorage()` attaches only the first record | 5 |
| provider: `findEmailAddresses()` uses the phone repository | 6 |
| fixture: deleted rows un-deleted, translation un-translated | 7 |

## Trap for the next test author here

`Extbase\Persistence\ObjectStorage::key()` returns the **object hash**, so `iterator_to_array()` on one yields string keys and `$storage[0]` is `null`. Use `->toArray()`. Worth a line in `docs/testing/`.

## Scope

No production code is changed. Workspaces are not covered — `versioningWS` is on for the contact table and Extbase runs `versionOL()`, but no test in this package touches workspaces and it is a topic of its own size. The `fe_group` / start- and endtime claim in the `findByPid()` comment is untestable as the table stands: it declares no such enable columns.

---

## Added after the v13 gate run: the defect is *worse* on v14

The three language tests were written and proven against v14. Running the full suite on **TYPO3 v13** turned all three red — not because the tests are wrong, but because **the same unchanged repository method returns different wrong answers on the two core versions**:

| | v13 | v14 |
|---|---|---|
| translated language (1) | `[1, 2, 2, 4, 5]` — all five rows, contact 2 twice | `[2, 2, 4, 5]` — **contact 1 dropped** |
| language with no translations (3) | `[1, 2, 2, 4, 5]` — identical to every other language | `[2, 4, 5]` — **defaults dropped, German leaks** |
| `count()` vs iteration | 5 and 5 — they agree | 5 and 3 — **they disagree** |

On v13 the overlay removes nothing, so the language of the request makes no difference whatsoever to what the method returns. On v14 the overlay *is* applied on top of the missing language constraint, and **records start vanishing**.

Each of the three is therefore split into a `not-core-13` and a `not-core-14` variant carrying its own expectation, per the repository's grouping convention. That is more valuable than one version-agnostic assertion would have been: it makes the version-dependence itself part of what regresses visibly.
