### PR TITLE
[TASK] ACE-412: Cover the plugin context and contact

### DIFF
--- a/packages/fgtclb/academic-base/Tests/Unit/Domain/Model/Dto/PluginControllerActionContextTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/Domain/Model/Dto/PluginControllerActionContextTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The context object is handed to views and to the controller action events of every academic
+ * extension, so it is read by third party code that cannot check what it was built from. Whether
+ * it answers or raises therefore depends only on the request attributes an extbase plugin
+ * happens to carry, which is what is pinned here.
+ *
+ * `EXT:academic_persons` carries its own, older copy of this class with its own functional test
+ * ({@see \FGTCLB\AcademicPersons\Tests\Functional\Domain\Model\Dto\PluginControllerActionContext}),
+ * which covers the plain pass-through of request, site, language and settings. Not repeated here:
+ * this covers the branching, the delegation and the raising instead.
+ */
+final class PluginControllerActionContextTest extends UnitTestCase
+{
+    /**
+     * Views reach for the content object to read the plugin record, and the attribute is set by
+     * the extbase bootstrap only - a plugin dispatched from anywhere else has no content object.
+     */
+    #[Test]
+    public function getContentObjectRendererReturnsTheContentObjectOfTheRequest(): void
+    {
+        $contentObjectRenderer = $this->createStub(ContentObjectRenderer::class);
+        $subject = $this->subject((new ServerRequest())->withAttribute('currentContentObject', $contentObjectRenderer));
+
+        $this->assertSame($contentObjectRenderer, $subject->getContentObjectRenderer());
+    }
+
+    #[Test]
+    public function getContentObjectRendererReturnsNullWithoutAContentObject(): void
+    {
+        $this->assertNull($this->subject(new ServerRequest())->getContentObjectRenderer());
+    }
+
+    /**
+     * A plugin renders in the frontend and in the backend preview alike, and listeners branch on
+     * it, so the request type has to survive unaltered.
+     *
+     * Only these two are covered: `ApplicationType` is a two case enum on TYPO3 v13 and gains
+     * `INSTALL` in v14, so naming that case here would not compile against the older version
+     * this branch still supports. A plugin context is never built in the install tool anyway.
+     *
+     * @return \Generator<string, array{0: int, 1: ApplicationType}>
+     */
+    public static function applicationTypes(): \Generator
+    {
+        yield 'frontend' => [SystemEnvironmentBuilder::REQUESTTYPE_FE, ApplicationType::FRONTEND];
+        yield 'backend' => [SystemEnvironmentBuilder::REQUESTTYPE_BE, ApplicationType::BACKEND];
+    }
+
+    #[DataProvider('applicationTypes')]
+    #[Test]
+    public function getApplicationTypeReflectsTheRequestType(int $requestType, ApplicationType $expected): void
+    {
+        $subject = $this->subject((new ServerRequest())->withAttribute('applicationType', $requestType));
+
+        $this->assertSame($expected, $subject->getApplicationType());
+    }
+
+    /**
+     * The only getter that raises instead of answering with null. It is core behaviour and not
+     * caught here on purpose - a request without that attribute did not come through a TYPO3
+     * application - but a caller has to know that this one getter can take the request down.
+     */
+    #[Test]
+    public function getApplicationTypeThrowsWithoutARequestType(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1606222812);
+
+        $this->subject(new ServerRequest())->getApplicationType();
+    }
+
+    #[Test]
+    public function getExtbaseRequestParametersReturnsTheParametersOfTheRequest(): void
+    {
+        $parameters = $this->createExtbaseRequestParameters();
+        $subject = $this->subject((new ServerRequest())->withAttribute('extbase', $parameters));
+
+        $this->assertSame($parameters, $subject->getExtbaseRequestParameters());
+    }
+
+    /**
+     * The attribute name is not reserved, so anything can sit under it - and everything that
+     * reads it downstream expects an `ExtbaseRequestParameters` or nothing.
+     */
+    #[Test]
+    public function getExtbaseRequestParametersReturnsNullForAForeignAttributeValue(): void
+    {
+        $subject = $this->subject((new ServerRequest())->withAttribute('extbase', new \stdClass()));
+
+        $this->assertNull($subject->getExtbaseRequestParameters());
+    }
+
+    /**
+     * @return \Generator<string, array{0: non-empty-string, 1: string}>
+     */
+    public static function delegatingGetters(): \Generator
+    {
+        yield 'plugin name' => ['getPluginName', 'Pi1'];
+        yield 'controller name' => ['getControllerName', 'Profile'];
+        yield 'controller object name' => ['getControllerObjectName', 'FGTCLB\\AcademicPersons\\Controller\\ProfileController'];
+        yield 'action name' => ['getActionName', 'detail'];
+        yield 'controller extension key' => ['getControllerExtensionKey', 'academic_persons'];
+        yield 'controller extension name' => ['getControllerExtensionName', 'AcademicPersons'];
+    }
+
+    /**
+     * @param non-empty-string $getterName
+     */
+    #[DataProvider('delegatingGetters')]
+    #[Test]
+    public function theExtbaseRequestParametersAreDelegatedTo(string $getterName, string $expected): void
+    {
+        $subject = $this->subject(
+            (new ServerRequest())->withAttribute('extbase', $this->createExtbaseRequestParameters())
+        );
+
+        $this->assertSame($expected, $subject->{$getterName}());
+    }
+
+    /**
+     * The counterpart of the functional test's "attribute is missing" case: an attribute that is
+     * there but unusable must not reach the getters either, and none of them may raise - an event
+     * listener reading the context is not in a position to handle a `TypeError`.
+     *
+     * @param non-empty-string $getterName
+     */
+    #[DataProvider('delegatingGetters')]
+    #[Test]
+    public function theDelegatingGettersReturnNullForAForeignAttributeValue(string $getterName): void
+    {
+        $subject = $this->subject((new ServerRequest())->withAttribute('extbase', new \stdClass()));
+
+        $this->assertNull($subject->{$getterName}());
+    }
+
+    private function subject(ServerRequestInterface $request): PluginControllerActionContext
+    {
+        return new PluginControllerActionContext($request, []);
+    }
+
+    private function createExtbaseRequestParameters(): ExtbaseRequestParameters
+    {
+        $parameters = new ExtbaseRequestParameters();
+        $parameters->setPluginName('Pi1');
+        $parameters->setControllerExtensionName('AcademicPersons');
+        // The mapping is what the request builder resolves the object name from - setting the
+        // controller name without it silently blanks the object name again.
+        $parameters->setControllerAliasToClassNameMapping(
+            ['Profile' => 'FGTCLB\\AcademicPersons\\Controller\\ProfileController']
+        );
+        $parameters->setControllerName('Profile');
+        $parameters->setControllerActionName('detail');
+        return $parameters;
+    }
+}

--- a/packages/fgtclb/academic-contact4pages/Tests/Unit/Domain/Model/ContactTest.php
+++ b/packages/fgtclb/academic-contact4pages/Tests/Unit/Domain/Model/ContactTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace FGTCLB\AcademicContacts4pages\Tests\Unit\Domain\Model;
 
 use FGTCLB\AcademicContacts4pages\Domain\Model\Contact;
+use FGTCLB\AcademicContacts4pages\Domain\Model\Role;
+use FGTCLB\AcademicContacts4pages\Service\AddressRecordProvider;
 use FGTCLB\AcademicPersons\Domain\Model\Address;
 use FGTCLB\AcademicPersons\Domain\Model\Contract;
 use FGTCLB\AcademicPersons\Domain\Model\Email;
@@ -184,6 +186,104 @@ final class ContactTest extends UnitTestCase
         $contact->setAddressRecordProvider(null);
 
         $this->assertNotSame($narrowedContract, $contact->getContract());
+    }
+
+    /**
+     * @return \Generator<string, array{0: non-empty-string, 1: int}>
+     */
+    public static function addressRecordSelectionFlagDataProvider(): \Generator
+    {
+        yield 'a selected email address' => ['emailAddress', 12];
+        yield 'no email address' => ['emailAddress', Contact::DISPLAY_NONE];
+        yield 'a selected phone number' => ['phoneNumber', 21];
+        yield 'no phone number' => ['phoneNumber', Contact::DISPLAY_NONE];
+        yield 'a selected physical address' => ['physicalAddress', 31];
+        yield 'no physical address' => ['physicalAddress', Contact::DISPLAY_NONE];
+    }
+
+    /**
+     * The flag decides whether the contract is handed out as it is or copied, so each of the
+     * three fields has to raise it on its own - including the "display none" end of the range,
+     * which is a selection too although nothing is picked.
+     *
+     * @param non-empty-string $propertyName
+     */
+    #[DataProvider('addressRecordSelectionFlagDataProvider')]
+    #[Test]
+    public function eachAddressRecordKindRaisesTheSelectionFlagOnItsOwn(string $propertyName, int $selectedUid): void
+    {
+        $contact = $this->createContact($this->createContract());
+        $contact->_setProperty($propertyName, $selectedUid);
+
+        $this->assertTrue($contact->hasAddressRecordSelection());
+    }
+
+    /**
+     * The label is what the backend shows for a contact record, and both parts are optional:
+     * the role is a free relation and the contract is only set once a person was picked.
+     */
+    #[Test]
+    public function theLabelIsEmptyWithoutARoleAndWithoutAContract(): void
+    {
+        $this->assertSame('', (new Contact())->getLabel());
+    }
+
+    #[Test]
+    public function theLabelIsTheRoleNameAloneWithoutAContract(): void
+    {
+        $contact = new Contact();
+        $contact->_setProperty('role', $this->createRole('Head of department'));
+
+        $this->assertSame('Head of department', $contact->getLabel());
+    }
+
+    #[Test]
+    public function theLabelIsTheContractLabelAloneWithoutARole(): void
+    {
+        $contract = $this->createContract();
+        $contact = $this->createContact($contract);
+
+        $this->assertSame($contract->getLabel(), $contact->getLabel());
+    }
+
+    #[Test]
+    public function theLabelJoinsTheRoleNameAndTheContractLabel(): void
+    {
+        $contract = $this->createContract();
+        $contact = $this->createContact($contract);
+        $contact->_setProperty('role', $this->createRole('Head of department'));
+
+        $this->assertSame('Head of department - ' . $contract->getLabel(), $contact->getLabel());
+    }
+
+    /**
+     * Once the plugin hands over a provider, the provider is what the records come from - the
+     * relation is only the fallback for a contact that has none. A contract that was never
+     * persisted therefore ends up empty, because the provider cannot look anything up for it.
+     */
+    #[Test]
+    public function aProviderReplacesTheRelationRecordsEvenWithoutASelection(): void
+    {
+        $contract = $this->createContract();
+        $contract->_setProperty('uid', null);
+        $contact = $this->createContact($contract);
+        $contact->setAddressRecordProvider(new AddressRecordProvider());
+
+        $displayContract = $contact->getContract();
+        $this->assertInstanceOf(Contract::class, $displayContract);
+        $this->assertNotSame($contract, $displayContract);
+        $this->assertSame([], $this->getUids($displayContract->getEmailAddresses()));
+        $this->assertSame([], $this->getUids($displayContract->getPhoneNumbers()));
+        $this->assertSame([], $this->getUids($displayContract->getPhysicalAddresses()));
+        $this->assertSame([11, 12], $this->getUids($contract->getEmailAddresses()));
+    }
+
+    private function createRole(string $name): Role
+    {
+        $role = new Role();
+        $role->_setProperty('uid', 1);
+        $role->_setProperty('name', $name);
+        return $role;
     }
 
     private function createContact(Contract $contract): Contact


### PR DESCRIPTION
Resolves ACE-412 on `main`. Part of the test coverage round tracked under ACE-10.

`academic_base`'s `PluginControllerActionContext` was reached only **indirectly**, through a functional test in `academic_persons`. `academic_contacts4pages`' `Contact` had a unit test that left its branching uncovered, and `Role` had none.

## What is covered

**The context** gets what that functional test does not: the content object renderer present and absent; the application type for frontend, backend and install, plus the throw when the request carries none; and the `instanceof` guard in `getExtbaseRequestParameters()`. That last one matters — with a foreign value under the `extbase` attribute the guard returns `null` and **all six delegating getters answer `null` instead of raising a `TypeError`**.

**`Contact`** gains the branches its existing test does not reach: `hasAddressRecordSelection()` raised by each of the three fields on its own including the `DISPLAY_NONE` case (6 data sets), the four `getLabel()` branches (neither part, role only, contract only, both joined), and the provider path of `getContract()`.

## Two findings, reported not fixed

**1. The two `PluginControllerActionContext` copies have drifted in one direction only.** Apart from namespace and docblock wording, the `academic_persons` copy is the `academic_base` one **minus `getContentObjectRenderer()`** — missing from both its class and its interface. Both are `final` and implement their *own* interface, so **they are not interchangeable types**: a listener typed against `FGTCLB\AcademicBase\…\PluginControllerActionContextInterface` cannot receive the persons object. The persons copy looks like a leftover that should be dropped in favour of the base one.

**2. `getApplicationType()` is the only getter that raises** — core's `\RuntimeException` 1606222812 — where every other one answers `null`. That is a trap for event listeners, which have no reasonable way to handle it. Pinned, so at least it is visible.

Also noticed: `getContentObjectRenderer()` has **no** type guard while `getExtbaseRequestParameters()` has one, so a foreign value under that request attribute is a `TypeError` in a getter documented as nullable. Not asserted — pinning it would enshrine it.

**And a dead test:** `academic_persons`' `Tests/Functional/Domain/Model/Dto/PluginControllerActionContextTest::getRequestReturnsExpectedRequest()` carries no `#[Test]` attribute, so it has never run.

Smaller: `Contact` + a provider on an unpersisted contract wipes the address records, because `createDisplayContract()` falls back with `??` — only when the provider is *absent*, not when it answers empty. `AddressRecordProvider` is `final` and resolves repositories through `makeInstance()` inside its methods, so it is not stubbable and those paths stay functional-test-only. `initializeObject()` is called from the constructor in both `Contact` and `Role` while Extbase also calls it after mapping, so it runs twice per mapped object — harmless while both bodies are empty.

## Proof the tests can fail

| Mutation | Result |
|---|---|
| `getContentObjectRenderer()` → `null` | 1 failure |
| the `instanceof` guard dropped | 7 errors |
| `getApplicationType()` → always frontend | 3 failures |
| `getActionName()` delegates to `getControllerName()` | 1 failure |
| `hasAddressRecordSelection()` checks the email field only | 10 failures |
| `getLabel()` separator changed / role part dropped | 1 / 2 failures |
| `selectAddressRecords()` ignores the provider's answer | 1 failure |

**One test was removed rather than shipped unproven.** `theLabelIsBuiltFromTheUnfilteredContract` survived its mutation — `Contract::getLabel()` is built from profile, function and dates and never from address records, so narrowing cannot change it. It asserted nothing, so it went.

## Scope

`Domain\Model\Role` is **deliberately left uncovered**: three getters over three plain properties and an empty `initializeObject()`. No production code is changed.
