### PR TITLE
[TASK] ACE-410: Cover the persons edit form data DTOs

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AbstractFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AbstractFormDataTest.php
@@ -159,4 +159,51 @@ final class AbstractFormDataTest extends UnitTestCase
 
         $this->assertFalse($form->shouldApplyProperty('lastName'));
     }
+
+    /**
+     * `_getProperty()`/`_hasProperty()` mirror the `AbstractDomainObject` API without this
+     * class extending it, so a caller written against an Extbase entity keeps working when
+     * it is handed a form data object instead.
+     */
+    #[Test]
+    public function getPropertyReadsAPropertyDeclaredBySubclass(): void
+    {
+        $form = new ProfileFormData(firstName: 'Jane', skipSync: true);
+
+        $this->assertTrue($form->_hasProperty('firstName'));
+        $this->assertSame('Jane', $form->_getProperty('firstName'));
+        $this->assertTrue($form->_getProperty('skipSync'));
+    }
+
+    /**
+     * An unknown property may not raise: the counterpart on an Extbase entity returns
+     * `null` as well, and callers branch on `_hasProperty()` rather than on an exception.
+     */
+    #[Test]
+    public function getPropertyReturnsNullForAnUndeclaredProperty(): void
+    {
+        $form = new ProfileFormData();
+
+        $this->assertFalse($form->_hasProperty('thisDoesNotExist'));
+        $this->assertNull($form->_getProperty('thisDoesNotExist'));
+    }
+
+    /**
+     * `property_exists()` ignores visibility and the `isset()` check runs in the scope of
+     * the declaring class, so the bookkeeping of this base class is readable through the
+     * same accessor as the form fields. Pinned down because it is surprising, not because
+     * it is desirable - a caller iterating over `_getProperty()` gets the request object
+     * and the override registry handed out along with the form values.
+     */
+    #[Test]
+    public function getPropertyAlsoExposesThePrivateStateOfTheBaseClass(): void
+    {
+        $form = new ProfileFormData();
+        $form->setArgumentName('profileFormData');
+        $form->setPropertyOverride('firstName', 'override');
+
+        $this->assertTrue($form->_hasProperty('propertyOverrides'));
+        $this->assertSame(['firstName' => 'override'], $form->_getProperty('propertyOverrides'));
+        $this->assertSame('profileFormData', $form->_getProperty('argumentName'));
+    }
 }

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AddressFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/AddressFormDataTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\Address;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AddressFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Controller\PhysicalAddressController::editAction()` hands the result of
+ * {@see AddressFormData::createFromAddress()} to the edit template. Everything the
+ * template does not receive here renders as an empty input, and a save then writes
+ * that empty value back through `Domain\Factory\AddressFactory`.
+ */
+final class AddressFormDataTest extends UnitTestCase
+{
+    private function createPersistedAddress(): Address
+    {
+        $address = new Address();
+        $address->setStreet('Marktplatz');
+        $address->setStreetNumber('7a');
+        $address->setAdditional('Building B, 3rd floor');
+        $address->setZip('72070');
+        $address->setCity('Tübingen');
+        $address->setState('Baden-Württemberg');
+        $address->setCountry('DE');
+        $address->setType('work');
+        return $address;
+    }
+
+    /**
+     * Eight same-typed string properties next to each other: a swapped assignment in the
+     * factory is invisible unless every value differs and all of them are asserted at
+     * once. Street and street number are the pair that would hurt most.
+     */
+    #[Test]
+    public function everyPersistedPropertyOfAnAddressReachesTheFormData(): void
+    {
+        $formData = AddressFormData::createFromAddress($this->createPersistedAddress());
+
+        $this->assertSame(
+            [
+                'street' => 'Marktplatz',
+                'streetNumber' => '7a',
+                'additional' => 'Building B, 3rd floor',
+                'zip' => '72070',
+                'city' => 'Tübingen',
+                'state' => 'Baden-Württemberg',
+                'country' => 'DE',
+                'type' => 'work',
+            ],
+            [
+                'street' => $formData->getStreet(),
+                'streetNumber' => $formData->getStreetNumber(),
+                'additional' => $formData->getAdditional(),
+                'zip' => $formData->getZip(),
+                'city' => $formData->getCity(),
+                'state' => $formData->getState(),
+                'country' => $formData->getCountry(),
+                'type' => $formData->getType(),
+            ],
+        );
+    }
+
+    /**
+     * An address the editor never filled in must arrive as empty strings rather than as
+     * uninitialized typed properties - the template reads all of them unconditionally.
+     */
+    #[Test]
+    public function anEmptyAddressProducesEmptyStringsRatherThanUninitializedProperties(): void
+    {
+        $formData = AddressFormData::createFromAddress(new Address());
+
+        $this->assertSame(
+            ['', '', '', '', '', '', '', ''],
+            [
+                $formData->getStreet(),
+                $formData->getStreetNumber(),
+                $formData->getAdditional(),
+                $formData->getZip(),
+                $formData->getCity(),
+                $formData->getState(),
+                $formData->getCountry(),
+                $formData->getType(),
+            ],
+        );
+    }
+
+    /**
+     * The factory produces a display object: no request is bound and no override is
+     * registered, so `AddressFactory` may not write a single one of these values back.
+     * Were that not the case, merely opening the edit form and posting an unrelated
+     * argument would re-persist the whole record.
+     */
+    #[Test]
+    public function aFormDataCreatedFromAnAddressAppliesNoPropertyToADomainModel(): void
+    {
+        $formData = AddressFormData::createFromAddress($this->createPersistedAddress());
+
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('street'));
+        $this->assertFalse($formData->shouldApplyProperty('city'));
+        $this->assertFalse($formData->shouldApplyProperty('type'));
+    }
+
+    /**
+     * The property override registry is per instance state. Two form data objects of the
+     * same request - the profile and one of its addresses - must not see each other's
+     * overrides, which is what a `static` registry would produce.
+     */
+    #[Test]
+    public function propertyOverridesAreNotSharedBetweenFormDataObjects(): void
+    {
+        $addressFormData = AddressFormData::createFromAddress($this->createPersistedAddress());
+        $addressFormData->setPropertyOverride('type', 'private');
+
+        $this->assertFalse((new AddressFormData())->hasPropertyOverride('type'));
+        $this->assertFalse((new ProfileFormData())->hasPropertyOverride('type'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ContractFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ContractFormDataTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\FunctionType;
+use FGTCLB\AcademicPersons\Domain\Model\Location;
+use FGTCLB\AcademicPersons\Domain\Model\OrganisationalUnit;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Controller\ContractController::editAction()` prefills its form with
+ * {@see ContractFormData::createFromContract()}. This is the only form data object
+ * carrying relations and dates rather than plain strings, so it is the one where the
+ * mapping can lose more than a text value.
+ */
+final class ContractFormDataTest extends UnitTestCase
+{
+    /**
+     * The select fields of the edit form need the persisted relation itself, not a copy:
+     * Fluid compares the option value against the identity of the assigned object.
+     */
+    #[Test]
+    public function theRelationsOfAContractAreHandedOverAsTheSameObjects(): void
+    {
+        $organisationalUnit = new OrganisationalUnit();
+        $functionType = new FunctionType();
+        $location = new Location();
+        $contract = new Contract();
+        $contract->setOrganisationalUnit($organisationalUnit);
+        $contract->setFunctionType($functionType);
+        $contract->setLocation($location);
+
+        $formData = ContractFormData::createFromContract($contract);
+
+        $this->assertSame($organisationalUnit, $formData->getOrganisationalUnit());
+        $this->assertSame($functionType, $formData->getFunctionType());
+        $this->assertSame($location, $formData->getLocation());
+    }
+
+    /**
+     * An open-ended contract has no relations and no end date. Those must stay `null`
+     * instead of becoming an empty object or the epoch, because `ContractFactory` writes
+     * `null` through to the database as "not set".
+     */
+    #[Test]
+    public function anEmptyContractKeepsItsNullRelationsAndDates(): void
+    {
+        $formData = ContractFormData::createFromContract(new Contract());
+
+        $this->assertNull($formData->getOrganisationalUnit());
+        $this->assertNull($formData->getFunctionType());
+        $this->assertNull($formData->getLocation());
+        $this->assertNull($formData->getValidFrom());
+        $this->assertNull($formData->getValidTo());
+    }
+
+    /**
+     * `validFrom`/`validTo` are mutable `\DateTime` instances that are shared with the
+     * persisted model rather than cloned. Pinning that down documents the trap: whoever
+     * modifies the date on the form data modifies the entity Extbase will persist.
+     */
+    #[Test]
+    public function theDatesOfAContractAreSharedWithThePersistedModel(): void
+    {
+        $validFrom = new \DateTime('2024-04-01 00:00:00');
+        $validTo = new \DateTime('2027-03-31 00:00:00');
+        $contract = new Contract();
+        $contract->setValidFrom($validFrom);
+        $contract->setValidTo($validTo);
+
+        $formData = ContractFormData::createFromContract($contract);
+
+        $this->assertSame($validFrom, $formData->getValidFrom());
+        $this->assertSame($validTo, $formData->getValidTo());
+    }
+
+    /**
+     * The three text properties are same-typed neighbours, so a swapped assignment is
+     * only caught when all of them are asserted at once against distinct values.
+     */
+    #[Test]
+    public function theTextPropertiesOfAContractReachTheFormData(): void
+    {
+        $contract = new Contract();
+        $contract->setPosition('Research Assistant');
+        $contract->setRoom('B 3.14');
+        $contract->setOfficeHours('Tue 10-12');
+
+        $formData = ContractFormData::createFromContract($contract);
+
+        $this->assertSame(
+            ['position' => 'Research Assistant', 'room' => 'B 3.14', 'officeHours' => 'Tue 10-12'],
+            [
+                'position' => $formData->getPosition(),
+                'room' => $formData->getRoom(),
+                'officeHours' => $formData->getOfficeHours(),
+            ],
+        );
+    }
+
+    /**
+     * `publish` decides whether the contract shows up in the frontend at all, and the form
+     * data defaults it to `false`. A mapping that never assigns it would pass every test
+     * built on an unpublished contract, so the published case is the one that matters.
+     */
+    #[Test]
+    public function thePublishFlagOfAContractIsTakenOver(): void
+    {
+        $published = new Contract();
+        $published->setPublish(true);
+
+        $this->assertTrue(ContractFormData::createFromContract($published)->isPublish());
+        $this->assertFalse(ContractFormData::createFromContract(new Contract())->isPublish());
+    }
+
+    /**
+     * The factory produces a display object: nothing is bound to a request and nothing is
+     * overridden, so `ContractFactory` may not write any of it back.
+     */
+    #[Test]
+    public function aFormDataCreatedFromAContractAppliesNoPropertyToADomainModel(): void
+    {
+        $formData = ContractFormData::createFromContract(new Contract());
+
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('organisationalUnit'));
+        $this->assertFalse($formData->shouldApplyProperty('validFrom'));
+        $this->assertFalse($formData->shouldApplyProperty('publish'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/EmailFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/EmailFormDataTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\EmailFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Controller\EmailAddressController::editAction()` prefills its form with
+ * {@see EmailFormData::createFromEmail()}.
+ */
+final class EmailFormDataTest extends UnitTestCase
+{
+    /**
+     * Both properties are strings, so a swapped assignment in the factory would only show
+     * up when address and type are asserted together.
+     */
+    #[Test]
+    public function bothPersistedPropertiesOfAnEmailReachTheFormData(): void
+    {
+        $email = new Email();
+        $email->setEmail('jane.doe@example.org');
+        $email->setType('work');
+
+        $formData = EmailFormData::createFromEmail($email);
+
+        $this->assertSame(
+            ['email' => 'jane.doe@example.org', 'type' => 'work'],
+            ['email' => $formData->getEmail(), 'type' => $formData->getType()],
+        );
+    }
+
+    /**
+     * The factory produces a display object: nothing is bound to a request and nothing is
+     * overridden, so `EmailFactory` may not write any of it back to the domain model.
+     */
+    #[Test]
+    public function aFormDataCreatedFromAnEmailAppliesNoPropertyToADomainModel(): void
+    {
+        $formData = EmailFormData::createFromEmail(new Email());
+
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('email'));
+        $this->assertFalse($formData->shouldApplyProperty('type'));
+    }
+
+    /**
+     * `setEmail()` exists so a PSR-14 listener can correct the submitted address before
+     * the transformation runs. It changes the form data only - the value the factory
+     * writes is still governed by the request/override machinery, and this object is
+     * bound to neither.
+     */
+    #[Test]
+    public function changingTheEmailOnTheFormDataDoesNotMakeItApplicable(): void
+    {
+        $formData = EmailFormData::createFromEmail(new Email());
+        $formData->setEmail('jane.doe@example.org');
+
+        $this->assertSame('jane.doe@example.org', $formData->getEmail());
+        $this->assertFalse($formData->shouldApplyProperty('email'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/PhoneNumberFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/PhoneNumberFormDataTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Controller\PhoneNumberController::editAction()` prefills its form with
+ * {@see PhoneNumberFormData::createFromPhoneNumber()}.
+ */
+final class PhoneNumberFormDataTest extends UnitTestCase
+{
+    /**
+     * Both properties are strings, so a swapped assignment in the factory would only show
+     * up when number and type are asserted together.
+     */
+    #[Test]
+    public function bothPersistedPropertiesOfAPhoneNumberReachTheFormData(): void
+    {
+        $phoneNumber = new PhoneNumber();
+        $phoneNumber->setPhoneNumber('+49 7071 29-0');
+        $phoneNumber->setType('office');
+
+        $formData = PhoneNumberFormData::createFromPhoneNumber($phoneNumber);
+
+        $this->assertSame(
+            ['phoneNumber' => '+49 7071 29-0', 'type' => 'office'],
+            ['phoneNumber' => $formData->getPhoneNumber(), 'type' => $formData->getType()],
+        );
+    }
+
+    /**
+     * A phone number is stored as an unnormalized string. Nothing in the mapping may
+     * touch it, because leading plus signs and spacing are what the editor typed.
+     */
+    #[Test]
+    public function thePhoneNumberIsTakenOverVerbatim(): void
+    {
+        $phoneNumber = new PhoneNumber();
+        $phoneNumber->setPhoneNumber(' 0049 (0)7071 / 29-0 ');
+
+        $this->assertSame(
+            ' 0049 (0)7071 / 29-0 ',
+            PhoneNumberFormData::createFromPhoneNumber($phoneNumber)->getPhoneNumber(),
+        );
+    }
+
+    /**
+     * The factory produces a display object: nothing is bound to a request and nothing is
+     * overridden, so `PhoneNumberFactory` may not write any of it back.
+     */
+    #[Test]
+    public function aFormDataCreatedFromAPhoneNumberAppliesNoPropertyToADomainModel(): void
+    {
+        $formData = PhoneNumberFormData::createFromPhoneNumber(new PhoneNumber());
+
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('phoneNumber'));
+        $this->assertFalse($formData->shouldApplyProperty('type'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ProfileFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ProfileFormDataTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFormDataFactoryInterface;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * {@see ProfileFormData::createFromProfile()} is the deprecated predecessor of
+ * {@see ProfileFormDataFactoryInterface::createFromProfile()}; `ProfileController` uses
+ * the interface, no caller in this repository uses the static method any more. It is
+ * still public API for projects, so both its mapping and its deprecation notice are
+ * pinned down here until it is actually removed.
+ *
+ * The suite runs with `failOnDeprecation`, which PHPUnit only lifts through
+ * `#[IgnoreDeprecations]`; `expectUserDeprecationMessage()` alone does not. The pair is
+ * what makes the notice an asserted outcome rather than a silenced one - drop the
+ * expectation and the attribute would turn into exactly the suppression this suite
+ * forbids.
+ */
+final class ProfileFormDataTest extends UnitTestCase
+{
+    private const DEPRECATION_MESSAGE = 'ProfileFormData::createFromProfile() is deprecated since 2.3 and will be '
+        . 'removed in 3.0. Use ProfileFormDataFactoryInterface->createFromProfile() instead.';
+
+    private function createPersistedProfile(): Profile
+    {
+        $profile = new Profile();
+        $profile->setTitle('Prof. Dr.');
+        $profile->setFirstName('Jane');
+        $profile->setMiddleName('Q.');
+        $profile->setLastName('Doe');
+        $profile->setGender('female');
+        $profile->setPublicationsLink('https://example.org/publications');
+        $profile->setPublicationsLinkTitle('All publications');
+        $profile->setWebsite('https://example.org/jane');
+        $profile->setWebsiteTitle('Personal website');
+        $profile->setCoreCompetences('Machine learning');
+        $profile->setMiscellaneous('Speaks four languages');
+        $profile->setSupervisedDoctoralThesis('Doctoral thesis on graph theory');
+        $profile->setSupervisedThesis('Master thesis on clustering');
+        $profile->setTeachingArea('Algorithms');
+        $profile->setSkipSync(true);
+        return $profile;
+    }
+
+    /**
+     * Fifteen properties, fourteen of them same-typed strings, and several of them
+     * confusable pairs (`website`/`websiteTitle`, `supervisedThesis`/
+     * `supervisedDoctoralThesis`). Only asserting all of them at once against distinct
+     * values catches a swapped or forgotten assignment.
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function everyPersistedPropertyOfAProfileReachesTheFormData(): void
+    {
+        $this->expectUserDeprecationMessage(self::DEPRECATION_MESSAGE);
+
+        $formData = ProfileFormData::createFromProfile($this->createPersistedProfile());
+
+        $this->assertSame(
+            [
+                'title' => 'Prof. Dr.',
+                'firstName' => 'Jane',
+                'middleName' => 'Q.',
+                'lastName' => 'Doe',
+                'gender' => 'female',
+                'publicationsLink' => 'https://example.org/publications',
+                'publicationsLinkTitle' => 'All publications',
+                'website' => 'https://example.org/jane',
+                'websiteTitle' => 'Personal website',
+                'coreCompetences' => 'Machine learning',
+                'miscellaneous' => 'Speaks four languages',
+                'supervisedDoctoralThesis' => 'Doctoral thesis on graph theory',
+                'supervisedThesis' => 'Master thesis on clustering',
+                'teachingArea' => 'Algorithms',
+                'skipSync' => true,
+            ],
+            [
+                'title' => $formData->getTitle(),
+                'firstName' => $formData->getFirstName(),
+                'middleName' => $formData->getMiddleName(),
+                'lastName' => $formData->getLastName(),
+                'gender' => $formData->getGender(),
+                'publicationsLink' => $formData->getPublicationsLink(),
+                'publicationsLinkTitle' => $formData->getPublicationsLinkTitle(),
+                'website' => $formData->getWebsite(),
+                'websiteTitle' => $formData->getWebsiteTitle(),
+                'coreCompetences' => $formData->getCoreCompetences(),
+                'miscellaneous' => $formData->getMiscellaneous(),
+                'supervisedDoctoralThesis' => $formData->getSupervisedDoctoralThesis(),
+                'supervisedThesis' => $formData->getSupervisedThesis(),
+                'teachingArea' => $formData->getTeachingArea(),
+                'skipSync' => $formData->getSkipSync(),
+            ],
+        );
+    }
+
+    /**
+     * The whole point of the deprecation is that projects find out they should switch to
+     * the factory service. A silent removal of the notice would take that away, and the
+     * unit suite runs with `failOnDeprecation`, so an unexpected notice fails loudly too.
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function theDeprecatedStaticFactoryAnnouncesItsReplacement(): void
+    {
+        $this->expectUserDeprecationMessage(self::DEPRECATION_MESSAGE);
+
+        ProfileFormData::createFromProfile(new Profile());
+    }
+
+    /**
+     * The factory produces a display object: nothing is bound to a request and nothing is
+     * overridden, so `ProfileFactory` may not write any of it back to the domain model.
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function aFormDataCreatedFromAProfileAppliesNoPropertyToADomainModel(): void
+    {
+        $this->expectUserDeprecationMessage(self::DEPRECATION_MESSAGE);
+
+        $formData = ProfileFormData::createFromProfile($this->createPersistedProfile());
+
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('firstName'));
+        $this->assertFalse($formData->shouldApplyProperty('lastName'));
+        $this->assertFalse($formData->shouldApplyProperty('skipSync'));
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ProfileInformationFormDataTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Model/Dto/ProfileInformationFormDataTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Model\Dto;
+
+use FGTCLB\AcademicPersons\Domain\Model\ProfileInformation;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `Controller\ProfileInformationController` instantiates this class through the
+ * configurable `$profileInformationFormDataClassName`, not through a hard coded name, so
+ * both static factories have to honour late static binding. It is the only form data
+ * object with a second factory for the "new record" case and with nullable properties.
+ */
+final class ProfileInformationFormDataTest extends UnitTestCase
+{
+    /**
+     * The `newAction()` case. The type is what decides which fields the template renders
+     * and under which type the record is stored, so it is the one value that must survive;
+     * everything else has to arrive as its default so the form comes up empty.
+     */
+    #[Test]
+    public function anEmptyFormDataCarriesOnlyTheRequestedType(): void
+    {
+        $formData = ProfileInformationFormData::createEmptyForType('publications');
+
+        $this->assertSame('publications', $formData->getType());
+        $this->assertSame(['', '', ''], [$formData->getTitle(), $formData->getBodytext(), $formData->getLink()]);
+        $this->assertNull($formData->getYear());
+        $this->assertNull($formData->getYearStart());
+        $this->assertNull($formData->getYearEnd());
+    }
+
+    /**
+     * `ProfileInformationController::newAction()` resolves an unknown type to an empty
+     * string rather than raising. The factory must not turn that into something else -
+     * the validator downstream is what rejects it.
+     */
+    #[Test]
+    public function anUnresolvedTypeIsKeptAsAnEmptyString(): void
+    {
+        $this->assertSame('', ProfileInformationFormData::createEmptyForType('')->getType());
+    }
+
+    /**
+     * Four strings and three nullable integers, with `year`, `yearStart` and `yearEnd`
+     * being interchangeable at the type level: a swapped assignment is only visible when
+     * all seven are asserted at once against distinct values.
+     */
+    #[Test]
+    public function everyPersistedPropertyOfAProfileInformationReachesTheFormData(): void
+    {
+        $profileInformation = new ProfileInformation();
+        $profileInformation->setType('vita');
+        $profileInformation->setTitle('Research assistant');
+        $profileInformation->setBodytext('Worked on distributed systems.');
+        $profileInformation->setLink('https://example.org/vita');
+        $profileInformation->setYear(2021);
+        $profileInformation->setYearStart(2018);
+        $profileInformation->setYearEnd(2024);
+
+        $formData = ProfileInformationFormData::createFromProfileInformation($profileInformation);
+
+        $this->assertSame(
+            [
+                'type' => 'vita',
+                'title' => 'Research assistant',
+                'bodytext' => 'Worked on distributed systems.',
+                'link' => 'https://example.org/vita',
+                'year' => 2021,
+                'yearStart' => 2018,
+                'yearEnd' => 2024,
+            ],
+            [
+                'type' => $formData->getType(),
+                'title' => $formData->getTitle(),
+                'bodytext' => $formData->getBodytext(),
+                'link' => $formData->getLink(),
+                'year' => $formData->getYear(),
+                'yearStart' => $formData->getYearStart(),
+                'yearEnd' => $formData->getYearEnd(),
+            ],
+        );
+    }
+
+    /**
+     * A vita entry without an end year is an ongoing one. `null` and `0` mean different
+     * things to the template and to the database, so the mapping may not cast.
+     */
+    #[Test]
+    public function unsetYearsStayNullInsteadOfBecomingZero(): void
+    {
+        $profileInformation = new ProfileInformation();
+        $profileInformation->setYearStart(2018);
+
+        $formData = ProfileInformationFormData::createFromProfileInformation($profileInformation);
+
+        $this->assertSame(2018, $formData->getYearStart());
+        $this->assertNull($formData->getYear());
+        $this->assertNull($formData->getYearEnd());
+    }
+
+    /**
+     * Both factories use `new static()`. A project replacing
+     * `$profileInformationFormDataClassName` with its own subclass would otherwise get the
+     * base class back and lose every property its own validator relies on.
+     */
+    #[Test]
+    public function bothFactoriesRespectTheLateStaticBoundClass(): void
+    {
+        $subclass = new class () extends ProfileInformationFormData {};
+
+        $this->assertInstanceOf($subclass::class, $subclass::createEmptyForType('vita'));
+        $this->assertInstanceOf($subclass::class, $subclass::createFromProfileInformation(new ProfileInformation()));
+    }
+
+    /**
+     * Both factories produce display objects: nothing is bound to a request and nothing is
+     * overridden, so `ProfileInformationFactory` may not write any of it back.
+     */
+    #[Test]
+    public function neitherFactoryProducesAnApplicableProperty(): void
+    {
+        foreach ([
+            ProfileInformationFormData::createEmptyForType('vita'),
+            ProfileInformationFormData::createFromProfileInformation(new ProfileInformation()),
+        ] as $formData) {
+            $this->assertNull($formData->getArgumentName());
+            $this->assertFalse($formData->shouldApplyProperty('type'));
+            $this->assertFalse($formData->shouldApplyProperty('title'));
+            $this->assertFalse($formData->shouldApplyProperty('year'));
+        }
+    }
+}


### PR DESCRIPTION
Resolves ACE-410 on `main`. Part of the test coverage round tracked under ACE-10.

The six `*FormData` DTOs had no test of their own — only the shared `AbstractFormData` had one. What matters about them is not the accessors but the `createFrom*()` mappings and the machinery deciding whether a submitted field reaches the database at all: **a regression there silently loses user edits rather than failing.**

The base class gains the one behaviour its existing test does not reach — `_getProperty()`/`_hasProperty()` — as a **characterization** test, clearly labelled as surprising rather than desirable (see below).

## Three findings, reported not fixed

**1. An override with the value `null` is silently discarded by every `Domain/Factory/*`.**

`AbstractFormData` explicitly supports registering `null` — `hasPropertyOverride()` returns `true` for it, and the existing base test asserts exactly that. But each factory setter reads:

```php
is_string($override) ? $override : $form->getX()
```

So registering `null` makes the property **applicable** and then writes the **form** value instead of clearing it. Worst on `ProfileInformationFactory::setYear()/setYearStart()/setYearEnd()`, where the model properties are `?int` — **a PSR-14 listener cannot null a year at all.**

This is the highest-value defect this unit found. It lives in `Classes/Domain/Factory/`, which is outside this unit's write path and is untested; #499 covers those factories functionally.

**2. `ContractFormData::createFromContract()` shares the mutable `\DateTime` instances** with the persisted `Contract` rather than cloning them — mutating `$formData->getValidFrom()` mutates the entity Extbase will persist. Pinned so the current contract is at least visible; `DateTimeImmutable` or a clone would be safer.

**3. `ProfileFormData::createFromProfile()` is past its own removal date.** The docblock says "removed in 3.0", `main` is `3.0.0-dev`, and nothing in the repository calls it any more — `ProfileController` goes through `ProfileFormDataFactoryInterface`. Its mapping and its deprecation notice are pinned until it goes.

Smaller: `AbstractFormData::_getProperty()`/`_hasProperty()` **leak the base class's private state** — `property_exists()` ignores visibility and the `isset()` runs in the declaring scope, so `_getProperty('request')`, `'argumentName'` and `'propertyOverrides'` all hand out internal bookkeeping, and nothing in the repository calls either method. `ProfileInformationFormData` uses `new static()` while the other five use `new self()`, with every return type declared `self` — late static binding hidden from static analysis. `EmailFormData` is the only DTO with a setter.

## Proof the tests can fail

14 mutations, one per behaviour: `street`/`streetNumber` swapped (1 failure), `publish` hardcoded (1), `validFrom` cloned (1), `location` dropped (1), `type` filled from the address (1), the number trimmed (1), the deprecation notice removed (3), `website`/`websiteTitle` swapped (1), `new static()` → `new self()` (1), `year` cast to `int` (1), `createEmptyForType()` ignoring its type (1), `shouldApplyProperty()` always true (8), `_getProperty()` always null (2), `_hasProperty()` always false (2).

## A harness detail worth recording

**`expectUserDeprecationMessage()` does not satisfy `failOnDeprecation` on its own** — PHPUnit 11 sets `ignoredByTest` only from `#[IgnoreDeprecations]`. The three affected tests therefore carry **both**: the attribute so they pass, the expectation so the message stays asserted rather than merely suppressed. Explained in the class docblock.

## Scope

No production code is changed. Per-subclass request binding is not duplicated six times — `AbstractFormDataTest` already covers the bound-request paths generically; each subclass instead asserts the case that actually loses data, namely that a `createFrom*()` result is unbound so `shouldApplyProperty()` is `false` for everything.
