### PR TITLE
[TASK] ACE-411: Cover the persons edit form validators

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/AbstractFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/AbstractFormDataValidatorTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersonsEdit\Exception\UnknownValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\NotAValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\SilentValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\TestFormData;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\TestFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * `AbstractFormDataValidator::processValidations()` is the only piece of validation
+ * logic in this extension - the six concrete validators do nothing but a type guard
+ * and a call into it with their validation set identifier. Everything a profile
+ * editor is allowed to save therefore goes through this one method, driven by
+ * `Configuration/AcademicPersons/Settings.yaml`, which an integrator overrides.
+ */
+final class AbstractFormDataValidatorTest extends UnitTestCase
+{
+    /**
+     * The value a validator sees is what ends up deciding acceptance, so an error
+     * message carrying it (see `RecordingValidator`) is the assertion subject here.
+     */
+    #[Test]
+    public function anErrorIsAttachedToThePropertyItsValidatorWasConfiguredFor(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $this->assertSame(
+            ['readable' => ['string(submitted)']],
+            $this->messagesByProperty($subject->validate(new TestFormData('submitted')))
+        );
+    }
+
+    /**
+     * The error code is what a template or a listener can branch on; it is the code
+     * of the failing validator, not one of this extension's own.
+     */
+    #[Test]
+    public function theErrorCodeOfTheFailingValidatorIsKept(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $errors = $subject->validate(new TestFormData())->forProperty('readable')->getErrors();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(RecordingValidator::ERROR_CODE, $errors[0]->getCode());
+    }
+
+    /**
+     * An identifier that no `Settings.yaml` registers must not raise - it means
+     * "nothing configured for this form", which is a valid state for a project that
+     * only overrides one of the six sets.
+     */
+    #[Test]
+    public function anUnregisteredValidationSetValidatesNothing(): void
+    {
+        $subject = new TestFormDataValidator('setThatNobodyRegistered');
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $this->assertFalse($subject->validate(new TestFormData())->hasErrors());
+    }
+
+    /**
+     * `Settings.yaml` maps a property to a list, and a required email field maps to
+     * both `NotEmptyValidator` and `EmailAddressValidator` - dropping the second one
+     * silently would let any string through.
+     */
+    #[Test]
+    public function everyValidatorConfiguredForAPropertyRuns(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', [
+                'readable' => [SilentValidator::class, RecordingValidator::class, RecordingValidator::class],
+            ])
+        );
+
+        $this->assertSame(
+            ['readable' => ['string()', 'string()']],
+            $this->messagesByProperty($subject->validate(new TestFormData()))
+        );
+    }
+
+    /**
+     * Every configured property is validated, and each keeps its own error bucket -
+     * the profile edit templates render the errors per field.
+     */
+    #[Test]
+    public function everyConfiguredPropertyIsValidatedSeparately(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', [
+                'readable' => [RecordingValidator::class],
+                'nullableYear' => [RecordingValidator::class],
+                'flag' => [SilentValidator::class],
+            ])
+        );
+
+        $this->assertSame(
+            ['readable' => ['string(a)'], 'nullableYear' => ['int(1999)']],
+            $this->messagesByProperty($subject->validate(new TestFormData('a', 1999)))
+        );
+    }
+
+    /**
+     * The DTO properties are `protected`, so the value has to be reached through the
+     * public getter - including the `is*()` form a boolean uses. A property that has
+     * no getter, or no declaration at all, is silently handed over as `null` instead
+     * of raising: a typo in an integrator's `Settings.yaml` therefore turns into a
+     * "must not be empty" error on a field the form never rendered.
+     *
+     * @param 'readable'|'nullableYear'|'flag'|'withoutGetter'|'notDeclaredAtAll' $property
+     */
+    #[Test]
+    #[DataProvider('propertyValues')]
+    public function aPropertyValueIsResolvedThroughItsPublicGetter(string $property, string $expectedDescription): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', [$property => [RecordingValidator::class]])
+        );
+
+        $this->assertSame(
+            [$property => [$expectedDescription]],
+            $this->messagesByProperty($subject->validate(new TestFormData('text', 2024, true)))
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function propertyValues(): array
+    {
+        return [
+            'string behind a get*() getter' => ['readable', 'string(text)'],
+            'nullable int behind a get*() getter' => ['nullableYear', 'int(2024)'],
+            'boolean behind an is*() getter' => ['flag', 'bool(true)'],
+            'declared property without a getter' => ['withoutGetter', 'null'],
+            'property that does not exist' => ['notDeclaredAtAll', 'null'],
+        ];
+    }
+
+    /**
+     * `Settings.yaml` is normalized into class names without any check, so an
+     * integrator override reaches `GeneralUtility::makeInstance()` unverified. The
+     * guard has to be loud, because a silently skipped entry would mean a field that
+     * is no longer validated at all.
+     */
+    #[Test]
+    public function aConfiguredClassThatIsNoValidatorRaises(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [NotAValidator::class]])
+        );
+
+        $this->expectException(UnknownValidatorException::class);
+        $this->expectExceptionCode(1702379249);
+        $this->expectExceptionMessage('Unknown validator');
+
+        $subject->validate(new TestFormData());
+    }
+
+    /**
+     * The counterpart of `Domain/Factory/*`: those ask `shouldApplyProperty()` before
+     * they write a value onto the domain model, so a property that was not submitted
+     * is not applied. `processValidations()` does not ask - it reads every configured
+     * property off the DTO, where an unsubmitted one still carries its declared
+     * default. A partial form submit is therefore validated as if the missing fields
+     * had been sent empty, and a required field that a template does not render at
+     * all can never be saved.
+     */
+    #[Test]
+    public function aPropertyThatWasNotSubmittedIsValidatedNevertheless(): void
+    {
+        $formData = new TestFormData();
+        $parameters = new ExtbaseRequestParameters();
+        $parameters->setArguments(['testFormData' => ['flag' => '1']]);
+        $formData->setRequest((new ServerRequest())->withAttribute('extbase', $parameters));
+        $formData->setArgumentName('testFormData');
+
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $this->assertFalse($formData->shouldApplyProperty('readable'));
+        $this->assertSame(
+            ['readable' => ['string()']],
+            $this->messagesByProperty($subject->validate($formData))
+        );
+    }
+
+    /**
+     * `AbstractValidator::validate()` skips `isValid()` for `null` and `''` because
+     * `$acceptsEmptyValues` is left at its default. Neither the type guard of the
+     * concrete validators nor any configured validation therefore runs for them: an
+     * argument that failed property mapping arrives as `null` and passes validation
+     * unnoticed, and the guard that would have rejected it is never reached.
+     */
+    #[Test]
+    #[DataProvider('emptyValues')]
+    public function anEmptyArgumentIsNotValidatedAtAll(mixed $value): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $this->assertFalse($subject->validate($value)->hasErrors());
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function emptyValues(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+        ];
+    }
+
+    /**
+     * A validator instance is reused for both the create and the update action of a
+     * controller, so a result left over from a previous run would report an error on
+     * a submit that is fine.
+     */
+    #[Test]
+    public function aResultIsNotCarriedOverIntoTheNextRun(): void
+    {
+        $subject = new TestFormDataValidator();
+        $subject->injectAcademicPersonsSettings(
+            ValidationSettings::forIdentifier('testSet', ['readable' => [RecordingValidator::class]])
+        );
+
+        $subject->validate(new TestFormData('first'));
+
+        $this->assertSame(
+            ['readable' => ['string(second)']],
+            $this->messagesByProperty($subject->validate(new TestFormData('second')))
+        );
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private function messagesByProperty(Result $result): array
+    {
+        $messages = [];
+        foreach ($result->getFlattenedErrors() as $propertyPath => $errors) {
+            foreach ($errors as $error) {
+                $messages[$propertyPath][] = $error->getMessage();
+            }
+        }
+        return $messages;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/AddressFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/AddressFormDataValidatorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AddressFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\EmailFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\AddressFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `PhysicalAddressController::createAction()` and
+ * `updateAction()` against the validation set `physicalAddress`.
+ */
+final class AddressFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'physicalAddress';
+
+    /**
+     * The set identifier is the contract with `Settings.yaml`. Changing it - or
+     * changing the key in the yaml file - disables address validation completely
+     * rather than raising, because an unregistered set validates nothing.
+     */
+    #[Test]
+    public function theValidationSetPhysicalAddressIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['city' => [RecordingValidator::class]]),
+            new AddressFormData(city: 'Munich')
+        );
+
+        $this->assertSame(['string(Munich)'], $this->messagesFor($result, 'city'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('address', ['city' => [RecordingValidator::class]]),
+            new AddressFormData(city: 'Munich')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * The property names in `Settings.yaml` are resolved off the DTO through
+     * `ObjectAccess`, which yields `null` for anything it cannot read instead of
+     * raising. Renaming a DTO property without touching the yaml file would
+     * therefore keep validating - against `null` - and a required address field
+     * would become unsaveable. Every property the shipped configuration names is
+     * pinned here to prove it still resolves to the submitted value.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new AddressFormData(
+                street: 'Bahnhofstrasse',
+                streetNumber: '12a',
+                additional: 'c/o Faculty',
+                zip: '80331',
+                city: 'Munich',
+                state: 'Bavaria',
+                country: 'DE',
+                type: 'work'
+            )
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Required in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'street' => ['street', 'string(Bahnhofstrasse)'],
+            'streetNumber' => ['streetNumber', 'string(12a)'],
+            'zip' => ['zip', 'string(80331)'],
+            'city' => ['city', 'string(Munich)'],
+            'country' => ['country', 'string(DE)'],
+            // Not configured by default, but readable, so a project may require them.
+            'additional' => ['additional', 'string(c/o Faculty)'],
+            'state' => ['state', 'string(Bavaria)'],
+            'type' => ['type', 'string(work)'],
+        ];
+    }
+
+    /**
+     * The counter example to the test above: this is what a stale property name in
+     * `Settings.yaml` looks like from the inside.
+     */
+    #[Test]
+    public function aPropertyTheFormDataDoesNotHaveIsValidatedAsNull(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['houseNumber' => [RecordingValidator::class]]),
+            new AddressFormData(streetNumber: '12a')
+        );
+
+        $this->assertSame(['null'], $this->messagesFor($result, 'houseNumber'));
+    }
+
+    /**
+     * The validator is wired per controller argument, so a mismatch is a programming
+     * error and has to surface instead of passing an unvalidated object on.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButAddressFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new AddressFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid address object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new EmailFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['not an object'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new AddressFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ContractFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ContractFormDataValidatorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ContractFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `ContractController::createAction()` and
+ * `updateAction()` against the validation set `contract`. `position` is the only
+ * property the shipped `Settings.yaml` requires.
+ */
+final class ContractFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'contract';
+
+    /**
+     * The set identifier is the contract with `Settings.yaml`; an identifier that
+     * does not match a registered set disables contract validation silently.
+     */
+    #[Test]
+    public function theValidationSetContractIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['position' => [RecordingValidator::class]]),
+            new ContractFormData(position: 'Professor')
+        );
+
+        $this->assertSame(['string(Professor)'], $this->messagesFor($result, 'position'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('contracts', ['position' => [RecordingValidator::class]]),
+            new ContractFormData(position: 'Professor')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * Unlike the other form data objects, this one carries relations and dates. A
+     * validator configured for one of them is handed the object itself, and the
+     * unset ones arrive as `null` - which is what `NotEmptyValidator` reports as
+     * "must not be empty" once a project requires them.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new ContractFormData(
+                validFrom: new \DateTime('2024-01-01'),
+                position: 'Professor',
+                room: 'B 2.14',
+                officeHours: 'Tue 10-12',
+                publish: true
+            )
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Required in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'position' => ['position', 'string(Professor)'],
+            // Readable, but not configured by default.
+            'room' => ['room', 'string(B 2.14)'],
+            'officeHours' => ['officeHours', 'string(Tue 10-12)'],
+            'publish behind an is*() getter' => ['publish', 'bool(true)'],
+            'validFrom as an object' => ['validFrom', 'DateTime'],
+            'unset date' => ['validTo', 'null'],
+            'unset relation' => ['organisationalUnit', 'null'],
+            'unset function type' => ['functionType', 'null'],
+            'unset location' => ['location', 'null'],
+        ];
+    }
+
+    /**
+     * A wrong argument type is a wiring mistake and must surface instead of letting
+     * an unvalidated object through.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButContractFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new ContractFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid contract object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new ProfileFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['not an object'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new ContractFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/EmailFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/EmailFormDataValidatorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AddressFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\EmailFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\EmailFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\SilentValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `EmailAddressController::createAction()` and
+ * `updateAction()` against the validation set `emailAddress`. It is the only
+ * shipped set that stacks two validators on one property: `email` is both required
+ * and syntax checked.
+ */
+final class EmailFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'emailAddress';
+
+    #[Test]
+    public function theValidationSetEmailAddressIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['email' => [RecordingValidator::class]]),
+            new EmailFormData(email: 'jane.doe@example.org')
+        );
+
+        $this->assertSame(['string(jane.doe@example.org)'], $this->messagesFor($result, 'email'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('email', ['email' => [RecordingValidator::class]]),
+            new EmailFormData(email: 'jane.doe@example.org')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * Both properties the shipped configuration names have to resolve off the DTO;
+     * a rename would degrade them to `null` instead of raising.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new EmailFormData(email: 'jane.doe@example.org', type: 'work')
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Both required in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'email' => ['email', 'string(jane.doe@example.org)'],
+            'type' => ['type', 'string(work)'],
+        ];
+    }
+
+    /**
+     * `email` is configured as `required` plus `email`, which normalizes to
+     * `NotEmptyValidator` and `EmailAddressValidator`. Both run and both may
+     * contribute, so an empty submit produces two errors on one field - dropping the
+     * second entry would leave any string acceptable.
+     */
+    #[Test]
+    public function bothValidatorsOfTheEmailPropertyContributeSeparateErrors(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [
+                'email' => [RecordingValidator::class, SilentValidator::class, RecordingValidator::class],
+            ]),
+            new EmailFormData()
+        );
+
+        $this->assertSame(['string()', 'string()'], $this->messagesFor($result, 'email'));
+    }
+
+    /**
+     * A wrong argument type is a wiring mistake and must surface instead of letting
+     * an unvalidated object through.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButEmailFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new EmailFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid email object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new AddressFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['jane.doe@example.org'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new EmailFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/NotAValidator.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/NotAValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+/**
+ * A class that is not a `ValidatorInterface`. `Settings.yaml` is normalized into
+ * class names without ever checking them, so an integrator override can put
+ * anything in there - this is what the runtime guard has to catch.
+ */
+final class NotAValidator {}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/RecordingValidator.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/RecordingValidator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
+
+/**
+ * A validator that always fails and reports the value it was handed as the error
+ * message. The real validators configured through `Settings.yaml` are
+ * `NotEmptyValidator` and `EmailAddressValidator`, and both translate their message
+ * through `LocalizationUtility`, which needs a container. Recording the received
+ * value here is what makes the property resolution of
+ * `AbstractFormDataValidator::processValidations()` observable in a unit test.
+ */
+final class RecordingValidator extends AbstractValidator
+{
+    public const ERROR_CODE = 1755350001;
+
+    /**
+     * The value must be inspected even when it is null or an empty string, which is
+     * exactly the case a required property produces.
+     *
+     * @var bool
+     */
+    protected $acceptsEmptyValues = false;
+
+    public function isValid(mixed $value): void
+    {
+        $this->addError(self::describe($value), self::ERROR_CODE);
+    }
+
+    /**
+     * A short, stable rendering of a value, so that a test can assert on both the
+     * type and the content of what a validator was given.
+     */
+    public static function describe(mixed $value): string
+    {
+        return match (true) {
+            $value === null => 'null',
+            is_bool($value) => 'bool(' . ($value ? 'true' : 'false') . ')',
+            is_int($value) => 'int(' . $value . ')',
+            is_string($value) => 'string(' . $value . ')',
+            default => get_debug_type($value),
+        };
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/SilentValidator.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/SilentValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
+
+/**
+ * A validator that accepts everything, used to prove that a configured property
+ * only contributes errors when one of its validators produces one.
+ */
+final class SilentValidator extends AbstractValidator
+{
+    /**
+     * @var bool
+     */
+    protected $acceptsEmptyValues = false;
+
+    public function isValid(mixed $value): void {}
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/TestFormData.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/TestFormData.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData;
+
+/**
+ * A form data object carrying one property of every shape the real DTOs use, so
+ * that the property resolution of `AbstractFormDataValidator` can be pinned once
+ * instead of per concrete validator: a string with a getter, a nullable int, a
+ * boolean behind an `is*()` getter, and a property with no getter at all.
+ */
+final class TestFormData extends AbstractFormData
+{
+    protected string $readable = '';
+    protected ?int $nullableYear = null;
+    protected bool $flag = false;
+    protected string $withoutGetter = 'never reachable';
+
+    public function __construct(
+        string $readable = '',
+        ?int $nullableYear = null,
+        bool $flag = false
+    ) {
+        $this->readable = $readable;
+        $this->nullableYear = $nullableYear;
+        $this->flag = $flag;
+    }
+
+    public function getReadable(): string
+    {
+        return $this->readable;
+    }
+
+    public function getNullableYear(): ?int
+    {
+        return $this->nullableYear;
+    }
+
+    public function isFlag(): bool
+    {
+        return $this->flag;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/TestFormDataValidator.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/TestFormDataValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\AbstractFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+
+/**
+ * The minimal concrete validator, shaped exactly like the six shipped ones: a type
+ * guard, then `processValidations()` with a validation set identifier.
+ * `processValidations()` is public but writes into `$this->result`,
+ * which only `AbstractValidator::validate()` initializes, so the shared machinery
+ * can only be exercised through a subclass.
+ */
+final class TestFormDataValidator extends AbstractFormDataValidator
+{
+    public function __construct(
+        private readonly string $validationsIdentifier = 'testSet'
+    ) {}
+
+    protected function isValid(mixed $value): void
+    {
+        if (!$value instanceof TestFormData) {
+            throw new UnsuitableValidatorException('Not a valid test form data object.', 1755350003);
+        }
+        $this->processValidations($value, $this->validationsIdentifier);
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/ValidationSettings.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/Fixtures/ValidationSettings.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersons\Settings\Validation;
+use FGTCLB\AcademicPersons\Settings\ValidationSet;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
+
+/**
+ * Builds the settings object the validators are normally injected with.
+ *
+ * The production instance comes from `AcademicPersonsSettingsFactory`, which reads
+ * every active package's `Configuration/AcademicPersons/Settings.yaml` and needs a
+ * `PackageManager` and the core cache. Assembling the result by hand keeps the
+ * validator under test isolated from that, and lets a test put a known validator
+ * behind a known property.
+ */
+final class ValidationSettings
+{
+    /**
+     * @param array<string, array<int, class-string>> $propertyValidators
+     */
+    public static function forIdentifier(string $identifier, array $propertyValidators): AcademicPersonsSettings
+    {
+        $validations = [];
+        foreach ($propertyValidators as $property => $validatorClassNames) {
+            /** @var array<int, class-string<ValidatorInterface>> $validatorClassNames */
+            $validations[$property] = new Validation(
+                identifier: $property,
+                fieldName: GeneralUtility::camelCaseToLowerCaseUnderscored($property),
+                required: true,
+                disabled: false,
+                readOnly: false,
+                validatorClassNames: $validatorClassNames,
+                tcaConfig: [],
+            );
+        }
+
+        return new AcademicPersonsSettings(
+            profileInformationTypes: [],
+            validations: [
+                $identifier => new ValidationSet(identifier: $identifier, validations: $validations),
+            ],
+            raw: [],
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/PhoneNumberFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/PhoneNumberFormDataValidatorTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\PhoneNumberFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `PhoneNumberController::createAction()` and
+ * `updateAction()` against the validation set `phoneNumber`. Set identifier and
+ * property name are spelled the same here, which makes a mix-up of the two easy
+ * and invisible - both are pinned separately below.
+ */
+final class PhoneNumberFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'phoneNumber';
+
+    #[Test]
+    public function theValidationSetPhoneNumberIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['phoneNumber' => [RecordingValidator::class]]),
+            new PhoneNumberFormData(phoneNumber: '+49 89 123456')
+        );
+
+        $this->assertSame(['string(+49 89 123456)'], $this->messagesFor($result, 'phoneNumber'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('phoneNumbers', ['phoneNumber' => [RecordingValidator::class]]),
+            new PhoneNumberFormData(phoneNumber: '+49 89 123456')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * Both properties the shipped configuration requires have to resolve off the
+     * DTO; a rename would degrade them to `null` instead of raising.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new PhoneNumberFormData(phoneNumber: '+49 89 123456', type: 'mobile')
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Both required in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'phoneNumber' => ['phoneNumber', 'string(+49 89 123456)'],
+            'type' => ['type', 'string(mobile)'],
+        ];
+    }
+
+    /**
+     * A wrong argument type is a wiring mistake and must surface instead of letting
+     * an unvalidated object through.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButPhoneNumberFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new PhoneNumberFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid phone number object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new ContractFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['+49 89 123456'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new PhoneNumberFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ProfileFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ProfileFormDataValidatorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `ProfileController::updateAction()` against the
+ * validation set `profile`. The profile form is the largest of the six and the one
+ * an integrator is most likely to extend, so the resolvability of every property is
+ * what matters here rather than a single required field.
+ */
+final class ProfileFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'profile';
+
+    #[Test]
+    public function theValidationSetProfileIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['lastName' => [RecordingValidator::class]]),
+            new ProfileFormData(lastName: 'Doe')
+        );
+
+        $this->assertSame(['string(Doe)'], $this->messagesFor($result, 'lastName'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('profiles', ['lastName' => [RecordingValidator::class]]),
+            new ProfileFormData(lastName: 'Doe')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * The shipped configuration names `firstName`, `middleName` and `lastName`; the
+     * remaining ones are what a project adds. All of them have to resolve off the
+     * DTO, because an unreadable property silently becomes `null` and would then be
+     * reported as empty on every submit.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new ProfileFormData(
+                title: 'Dr.',
+                firstName: 'Jane',
+                middleName: 'M.',
+                lastName: 'Doe',
+                gender: 'female',
+                publicationsLink: 'https://example.org/pub',
+                publicationsLinkTitle: 'Publications',
+                website: 'https://example.org',
+                websiteTitle: 'Homepage',
+                coreCompetences: 'Physics',
+                miscellaneous: 'Misc',
+                supervisedDoctoralThesis: 'Doctoral',
+                supervisedThesis: 'Thesis',
+                teachingArea: 'Optics',
+                skipSync: true
+            )
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Named in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'firstName' => ['firstName', 'string(Jane)'],
+            'middleName' => ['middleName', 'string(M.)'],
+            'lastName' => ['lastName', 'string(Doe)'],
+            // Readable, but not configured by default.
+            'title' => ['title', 'string(Dr.)'],
+            'gender' => ['gender', 'string(female)'],
+            'publicationsLink' => ['publicationsLink', 'string(https://example.org/pub)'],
+            'publicationsLinkTitle' => ['publicationsLinkTitle', 'string(Publications)'],
+            'website' => ['website', 'string(https://example.org)'],
+            'websiteTitle' => ['websiteTitle', 'string(Homepage)'],
+            'coreCompetences' => ['coreCompetences', 'string(Physics)'],
+            'miscellaneous' => ['miscellaneous', 'string(Misc)'],
+            'supervisedDoctoralThesis' => ['supervisedDoctoralThesis', 'string(Doctoral)'],
+            'supervisedThesis' => ['supervisedThesis', 'string(Thesis)'],
+            'teachingArea' => ['teachingArea', 'string(Optics)'],
+            'skipSync' => ['skipSync', 'bool(true)'],
+        ];
+    }
+
+    /**
+     * A wrong argument type is a wiring mistake and must surface instead of letting
+     * an unvalidated object through.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButProfileFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new ProfileFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid profile object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new PhoneNumberFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['not an object'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new ProfileFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ProfileInformationFormDataValidatorTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Unit/Domain/Validator/ProfileInformationFormDataValidatorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "academic_persons_edit" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator;
+
+use FGTCLB\AcademicPersons\Settings\AcademicPersonsSettings;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\EmailFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
+use FGTCLB\AcademicPersonsEdit\Domain\Validator\ProfileInformationFormDataValidator;
+use FGTCLB\AcademicPersonsEdit\Exception\UnsuitableValidatorException;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\RecordingValidator;
+use FGTCLB\AcademicPersonsEdit\Tests\Unit\Domain\Validator\Fixtures\ValidationSettings;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\Error\Result;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Validates the argument of `ProfileInformationController::createAction()` and
+ * `updateAction()` against the validation set `profileInformation`. This is the one
+ * form data object whose required properties are not strings: `year` is `?int`, so
+ * "not submitted" and "submitted empty" both arrive as `null` rather than as `''`.
+ */
+final class ProfileInformationFormDataValidatorTest extends UnitTestCase
+{
+    private const VALIDATION_SET = 'profileInformation';
+
+    #[Test]
+    public function theValidationSetProfileInformationIsProcessed(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['title' => [RecordingValidator::class]]),
+            new ProfileInformationFormData(title: 'A publication')
+        );
+
+        $this->assertSame(['string(A publication)'], $this->messagesFor($result, 'title'));
+    }
+
+    #[Test]
+    public function aValidationSetRegisteredUnderAnotherIdentifierIsIgnored(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier('profileInformations', ['title' => [RecordingValidator::class]]),
+            new ProfileInformationFormData(title: 'A publication')
+        );
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    /**
+     * `title` and `year` are the two the shipped configuration requires; the others
+     * are what a project adds. All of them have to resolve off the DTO, because an
+     * unreadable property silently becomes `null`.
+     */
+    #[Test]
+    #[DataProvider('configuredProperties')]
+    public function aConfiguredPropertyResolvesToTheSubmittedValue(string $property, string $expectedDescription): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, [$property => [RecordingValidator::class]]),
+            new ProfileInformationFormData(
+                type: 'publication',
+                title: 'A publication',
+                bodytext: 'Some text',
+                link: 'https://example.org',
+                year: 2024,
+                yearStart: 2020,
+                yearEnd: 2023
+            )
+        );
+
+        $this->assertSame([$expectedDescription], $this->messagesFor($result, $property));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function configuredProperties(): array
+    {
+        return [
+            // Both required in the shipped Configuration/AcademicPersons/Settings.yaml.
+            'title' => ['title', 'string(A publication)'],
+            'year' => ['year', 'int(2024)'],
+            // Readable, but not configured by default.
+            'type' => ['type', 'string(publication)'],
+            'bodytext' => ['bodytext', 'string(Some text)'],
+            'link' => ['link', 'string(https://example.org)'],
+            'yearStart' => ['yearStart', 'int(2020)'],
+            'yearEnd' => ['yearEnd', 'int(2023)'],
+        ];
+    }
+
+    /**
+     * A `?int` property has no empty-string state: an omitted or non numeric `year`
+     * arrives as `null`, which `NotEmptyValidator` reports with its *null* message
+     * and code 1221560910 rather than the empty one. That distinction is what a
+     * template branching on the error code sees.
+     */
+    #[Test]
+    public function anOmittedNullableIntIsHandedOverAsNull(): void
+    {
+        $result = $this->validate(
+            ValidationSettings::forIdentifier(self::VALIDATION_SET, ['year' => [RecordingValidator::class]]),
+            new ProfileInformationFormData(title: 'A publication')
+        );
+
+        $this->assertSame(['null'], $this->messagesFor($result, 'year'));
+    }
+
+    /**
+     * A wrong argument type is a wiring mistake and must surface instead of letting
+     * an unvalidated object through.
+     */
+    #[Test]
+    #[DataProvider('unsuitableSubjects')]
+    public function anythingButProfileInformationFormDataIsRejected(mixed $subject): void
+    {
+        $validator = new ProfileInformationFormDataValidator();
+        $validator->injectAcademicPersonsSettings(ValidationSettings::forIdentifier(self::VALIDATION_SET, []));
+
+        $this->expectException(UnsuitableValidatorException::class);
+        $this->expectExceptionCode(1297418975);
+        $this->expectExceptionMessage('Not a valid profile information object.');
+
+        $validator->validate($subject);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unsuitableSubjects(): array
+    {
+        return [
+            'a sibling form data object' => [new EmailFormData()],
+            'an arbitrary object' => [new \stdClass()],
+            'a non empty string' => ['not an object'],
+        ];
+    }
+
+    private function validate(AcademicPersonsSettings $settings, mixed $subject): Result
+    {
+        $validator = new ProfileInformationFormDataValidator();
+        $validator->injectAcademicPersonsSettings($settings);
+        return $validator->validate($subject);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messagesFor(Result $result, string $property): array
+    {
+        return array_map(
+            static fn($error): string => $error->getMessage(),
+            $result->forProperty($property)->getErrors()
+        );
+    }
+}


### PR DESCRIPTION
Resolves ACE-411 on `main`. Part of the test coverage round tracked under ACE-10.

The seven form-data validators had no test. They decide which submitted data is rejected, so a gap there **fails silently towards the user** — a field that stops being validated looks like nothing at all until somebody saves something they should not have been able to.

## What the tests pin

The two contracts that break silently rather than loudly:

* **the validation-set identifier** each validator uses, and
* that **every property name the shipped `Settings.yaml` refers to still resolves off its DTO**.

A recording-validator fixture makes property resolution observable, which is what the second one needs.

## Four findings, reported not fixed

**1. The shipped `profile` validation set produces zero validators.** In `academic-persons/Configuration/AcademicPersons/Settings.yaml`, `profile.firstName` is `[disabled, required]`, and `AcademicPersonsSettingsFactory::normalizeValidations()` computes

```php
$required = !$disabled && !$readOnly && in_array('required', …)
```

so `required` is `false` and `validatorClassNames` stays `[]`. `middleName`/`lastName` are `disabled` only. **`ProfileFormDataValidator` therefore validates nothing at all with the shipped configuration** — the `profile` set is currently decorative. Either `disabled` should stop cancelling `required`, or the `required` entry should be dropped from the YAML. That is a decision, not a fix I would make in a test-only change.

**2. `processValidations()` ignores `shouldApplyProperty()` entirely.** Every `Domain/Factory/*` asks it before writing a value onto the domain model; the validator reads **every** configured property straight off the DTO through `ObjectAccess`. An unsubmitted property still carries its declared default (`''`, `null`), so **a partial submit is validated as if the missing fields had been sent empty**: a required field a template does not render cannot be saved at all, and the error appears on a field the user never saw.

**3. A property name that does not resolve is silently validated as `null`.** `ObjectAccess::getPropertyPath()` swallows `PropertyNotAccessibleException`/`TypeError`. A typo in an integrator's `Settings.yaml` — or a renamed DTO property — is therefore reported as "must not be empty" **forever**, with no diagnostic anywhere.

**4. `null` and `''` bypass the validators completely.** `AbstractValidator::validate()` only calls `isValid()` when `$acceptsEmptyValues === false || !isEmpty($value)`, and none of the seven classes sets `$acceptsEmptyValues`. An argument that failed property mapping and arrives as `null` reaches neither the `instanceof` guard nor any configured validation — **the guard is dead for exactly the input most likely to be broken.**

Smaller: all six concrete validators share exception code `1297418975` for six different messages, and it is copied from core's `AbstractValidator` rather than being a fresh timestamp, so a caller cannot tell which validator rejected. The TYPO3 v12 fallback in `getAcademicPersonsSettings()` is obsolete on a branch that dropped v12.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| all six validation-set identifiers suffixed | 52 |
| `forProperty($property)->addError()` → `addError()` | 63 |
| the `UnknownValidatorException` throw → `continue` | 1 |
| `continue` after a successful validator → `break` | 2 |
| `UnsuitableValidatorException` code changed in all six | 18 |
| `processValidations()` made to honour `shouldApplyProperty()` | 64 |
| `$acceptsEmptyValues = false` on the abstract | 2 errors |

## Scope

No production code is changed.

**Deliberately left to a functional test:** which properties the shipped configuration really requires, and the behaviour of the core validators it names. Both need the container — the settings factory reads every package's `Settings.yaml` through `PackageManager` and the core cache, and `NotEmptyValidator`/`EmailAddressValidator` translate their messages through `LocalizationUtility` — and faking either would have tested the fake. That functional test is also **the only level at which finding 1 above becomes a red test**.
