### PR TITLE
[TASK] ACE-422: Cover the persons edit domain factories

### DIFF
--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/AbstractFactoryTestCase.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/AbstractFactoryTestCase.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Settings\Validation;
+use FGTCLB\AcademicPersons\Settings\ValidationSet;
+use FGTCLB\AcademicPersonsEdit\Controller\AbstractActionController;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AbstractFormData;
+use FGTCLB\AcademicPersonsEdit\Property\TypeConverter\AbstractFormDataConverter;
+use FGTCLB\AcademicPersonsEdit\Tests\Functional\AbstractAcademicPersonsEditTestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Property\PropertyMapper;
+use TYPO3\CMS\Extbase\Property\PropertyMappingConfiguration;
+use TYPO3\CMS\Extbase\Property\TypeConverter\DateTimeConverter;
+
+/**
+ * Shared scaffolding for the factory tests.
+ *
+ * The factories decide per property whether a submitted value reaches the domain model, and
+ * that decision is read off the *request*: {@see AbstractFormData::wasPropertySentInRequest()}
+ * looks into `$request->getAttribute('extbase')`. Building that array by hand next to a form
+ * data object built by hand — as the unit test has to — allows the two to disagree, which is
+ * exactly the state that can never occur in production.
+ *
+ * {@see mapFormData()} closes that gap: the form data object and the "was sent" information
+ * come from one and the same raw argument array, mapped through the real Extbase
+ * {@see PropertyMapper} and the extension's own {@see AbstractFormDataConverter}, configured
+ * the way {@see AbstractActionController::initializeAction()} configures an action argument.
+ */
+abstract class AbstractFactoryTestCase extends AbstractAcademicPersonsEditTestCase
+{
+    /**
+     * Maps one action argument of a request to its form data object.
+     *
+     * @template T of AbstractFormData
+     * @param class-string<T> $formDataClassName
+     * @param array<string, mixed> $requestArguments complete raw arguments of the request, not only the mapped one
+     * @param array<non-empty-string, string> $dateFormats property name to date format, mirroring `AbstractActionController::DATETIME_ARGUMENTS`
+     * @param string|null $boundArgumentName the name handed to the converter; defaults to `$argumentName`,
+     *                                       and an empty string leaves the form data object without one
+     * @return T
+     */
+    protected function mapFormData(
+        string $formDataClassName,
+        string $argumentName,
+        array $requestArguments,
+        array $dateFormats = [],
+        ?string $boundArgumentName = null,
+    ): AbstractFormData {
+        $source = $requestArguments[$argumentName] ?? [];
+        $configuration = new PropertyMappingConfiguration();
+        $configuration->allowAllProperties();
+        $configuration->setTypeConverterOptions(
+            AbstractFormDataConverter::class,
+            [
+                'request' => $this->createExtbaseRequest($requestArguments),
+                'argumentName' => $boundArgumentName ?? $argumentName,
+            ],
+        );
+        foreach ($dateFormats as $propertyName => $format) {
+            $configuration
+                ->forProperty($propertyName)
+                ->setTypeConverterOption(
+                    DateTimeConverter::class,
+                    DateTimeConverter::CONFIGURATION_DATE_FORMAT,
+                    $format,
+                );
+        }
+        $formData = $this->get(PropertyMapper::class)->convert($source, $formDataClassName, $configuration);
+        $this->assertInstanceOf($formDataClassName, $formData);
+        return $formData;
+    }
+
+    /**
+     * @param array<string, mixed> $requestArguments
+     */
+    protected function createExtbaseRequest(array $requestArguments): ServerRequestInterface
+    {
+        return (new ServerRequest())->withAttribute(
+            'extbase',
+            (new ExtbaseRequestParameters())->setArguments($requestArguments),
+        );
+    }
+
+    /**
+     * A validation set marking a single property read only or disabled, which is how an
+     * integrator takes a field out of the editable set.
+     */
+    protected function createValidationSet(
+        string $identifier,
+        string $propertyName = '',
+        bool $disabled = false,
+        bool $readOnly = false,
+    ): ValidationSet {
+        if ($propertyName === '') {
+            return new ValidationSet($identifier, []);
+        }
+        return new ValidationSet($identifier, [
+            $propertyName => new Validation($propertyName, $propertyName, false, $disabled, $readOnly, [], []),
+        ]);
+    }
+
+    protected function persistenceManager(): PersistenceManager
+    {
+        $persistenceManager = $this->get(PersistenceManagerInterface::class);
+        $this->assertInstanceOf(PersistenceManager::class, $persistenceManager);
+        return $persistenceManager;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/AddressFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/AddressFactoryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Address;
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\AddressFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\AddressFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The address form carries eight properties, which makes it the one place where "a property
+ * that was not submitted keeps its stored value" can be asserted for seven properties in a
+ * single row comparison rather than one at a time. A regression in `mayApplyProperty()` does
+ * not lose one field here, it empties an address.
+ *
+ * `AddressFactory` is a verbatim copy of the same logic in five sibling factories, so it is
+ * covered per factory on purpose: changing one of them is not changing the others.
+ */
+final class AddressFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/contractWithAddress.csv');
+    }
+
+    #[Test]
+    public function createFromFormDataBuildsRecordFromSubmittedValuesAndParentContract(): void
+    {
+        $formData = $this->mapFormData(
+            AddressFormData::class,
+            'addressFormData',
+            [
+                'contract' => '1',
+                'addressFormData' => [
+                    'street' => 'New Street',
+                    'streetNumber' => '2b',
+                    'additional' => 'Backyard',
+                    'zip' => '54321',
+                    'city' => 'New City',
+                    'state' => 'New State',
+                    'country' => 'New Country',
+                    'type' => 'private',
+                ],
+            ],
+        );
+        $contract = $this->persistenceManager()->getObjectByIdentifier(1, Contract::class);
+        $this->assertInstanceOf(Contract::class, $contract);
+
+        $address = (new AddressFactory())->createFromFormData(
+            $this->createValidationSet('physicalAddress'),
+            $contract,
+            $formData,
+        );
+
+        $this->assertSame($contract, $address->getContract());
+        $this->persistNew($address, 2);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/createdAddress.csv');
+    }
+
+    /**
+     * A submission carrying no form values at all - which is what an integrator gets after
+     * disabling every field of the form - still produces a record, and an empty one. The
+     * contract is the only property `createFromFormData()` writes unconditionally, so nothing
+     * here is a defect, but it is worth pinning: the factory has no notion of "nothing to do".
+     */
+    #[Test]
+    public function createFromFormDataWritesAnEmptyRecordWhenNothingWasSubmitted(): void
+    {
+        $formData = $this->mapFormData(
+            AddressFormData::class,
+            'addressFormData',
+            [
+                'contract' => '1',
+                'addressFormData' => [],
+            ],
+        );
+        $contract = $this->persistenceManager()->getObjectByIdentifier(1, Contract::class);
+        $this->assertInstanceOf(Contract::class, $contract);
+
+        $this->persistNew(
+            (new AddressFactory())->createFromFormData(
+                $this->createValidationSet('physicalAddress'),
+                $contract,
+                $formData,
+            ),
+            2,
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/createdEmptyAddress.csv');
+    }
+
+    /**
+     * Seven of the eight properties were not part of the request. Every one of them has the
+     * empty string as its form data default, so a factory writing unconditionally would empty
+     * the whole address record and leave the city behind.
+     */
+    #[Test]
+    public function updateKeepsStoredValuesOfEveryPropertyThatWasNotSubmitted(): void
+    {
+        $address = $this->updateAddressWith(['city' => 'New City']);
+
+        $this->assertSame('Stored Street', $address->getStreet());
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/updatedCityOnly.csv');
+    }
+
+    /**
+     * The near miss: an empty string that was submitted is an editor clearing the field, and it
+     * has to be written - while the six properties still absent stay untouched in the same run.
+     */
+    #[Test]
+    public function updateAppliesSubmittedEmptyValueWhileKeepingUnsubmittedOnes(): void
+    {
+        $this->updateAddressWith(['city' => 'New City', 'street' => '']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/updatedCityAndClearedStreet.csv');
+    }
+
+    #[Test]
+    public function updateAppliesRegisteredOverrideForPropertyThatWasNotSubmitted(): void
+    {
+        $this->updateAddressWith(['city' => 'New City'], ['country' => 'Overridden Country']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/updatedCityAndOverriddenCountry.csv');
+    }
+
+    /**
+     * A field the integrator marked read only is ignored even though the request carries a value
+     * for it - the check runs before the "was it sent" question.
+     */
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksReadOnly(): void
+    {
+        $this->updateAddressWith(
+            ['city' => 'New City', 'country' => 'Submitted Country'],
+            [],
+            'country',
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/updatedCityOnly.csv');
+    }
+
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksDisabled(): void
+    {
+        $this->updateAddressWith(
+            ['city' => 'New City', 'country' => 'Submitted Country'],
+            [],
+            '',
+            'country',
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/AddressFactoryTest/updatedCityOnly.csv');
+    }
+
+    /**
+     * @param array<string, string> $submitted
+     * @param array<string, mixed> $overrides
+     */
+    private function updateAddressWith(
+        array $submitted,
+        array $overrides = [],
+        string $readOnlyProperty = '',
+        string $disabledProperty = '',
+    ): Address {
+        $formData = $this->mapFormData(
+            AddressFormData::class,
+            'addressFormData',
+            [
+                'physicalAddress' => '1',
+                'addressFormData' => $submitted,
+            ],
+        );
+        foreach ($overrides as $propertyName => $value) {
+            $formData->setPropertyOverride($propertyName, $value);
+        }
+        $address = $this->persistenceManager()->getObjectByIdentifier(1, Address::class);
+        $this->assertInstanceOf(Address::class, $address);
+
+        $validationSet = $readOnlyProperty !== ''
+            ? $this->createValidationSet('physicalAddress', $readOnlyProperty, readOnly: true)
+            : ($disabledProperty !== ''
+                ? $this->createValidationSet('physicalAddress', $disabledProperty, disabled: true)
+                : $this->createValidationSet('physicalAddress'));
+
+        $address = (new AddressFactory())->updateFromFormData($validationSet, $address, $formData);
+        $this->persistenceManager()->update($address);
+        $this->persistenceManager()->persistAll();
+        return $address;
+    }
+
+    private function persistNew(Address $address, int $sorting): void
+    {
+        // The factory assigns no storage page - the controller leaves that to the Extbase
+        // `persistence.storagePid` setting - and no sorting value either.
+        $address->setPid(2);
+        $address->setSorting($sorting);
+        $this->persistenceManager()->add($address);
+        $this->persistenceManager()->persistAll();
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ContractFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ContractFactoryTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\FunctionType;
+use FGTCLB\AcademicPersons\Domain\Model\Location;
+use FGTCLB\AcademicPersons\Domain\Model\OrganisationalUnit;
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ContractFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ContractFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The contract form is the only one of the package whose form data carries anything but strings:
+ * three relations to persisted records, two `\DateTime` values and a boolean. Each of them has
+ * its own type check in `ContractFactory`, and each of those checks decides what happens when a
+ * property was not submitted or was overridden with a value of another type.
+ *
+ * The stakes are higher here than on a text field: a relation that is written as `null` does not
+ * lose a word of text, it detaches the contract from its organisational unit.
+ *
+ * The date properties are deliberately absent from the CSV of the *created* record. The
+ * production date format `d.m.Y` carries no time, and `\DateTime::createFromFormat()` fills the
+ * missing time from the current clock, so the stored timestamp of a freshly mapped date is not
+ * reproducible. Where a date matters it is asserted on the model, and the stored timestamps of
+ * the *existing* record are asserted in every update case.
+ */
+final class ContractFactoryTest extends AbstractFactoryTestCase
+{
+    private const DATE_FORMATS = [
+        'validFrom' => 'd.m.Y',
+        'validTo' => 'd.m.Y',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/profileWithContract.csv');
+    }
+
+    #[Test]
+    public function createFromFormDataResolvesRelationsAndDatesOfSubmittedValues(): void
+    {
+        $formData = $this->mapFormData(
+            ContractFormData::class,
+            'contractFormData',
+            [
+                'profile' => '1',
+                'contractFormData' => [
+                    'organisationalUnit' => '2',
+                    'functionType' => '2',
+                    'location' => '2',
+                    'validFrom' => '01.02.2021',
+                    'validTo' => '31.12.2021',
+                    'position' => 'New Position',
+                    'room' => 'New Room',
+                    'officeHours' => 'New office hours',
+                    'publish' => '1',
+                ],
+            ],
+            self::DATE_FORMATS,
+        );
+        $profile = $this->persistenceManager()->getObjectByIdentifier(1, Profile::class);
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $contract = (new ContractFactory())->createFromFormData(
+            $this->createValidationSet('contract'),
+            $profile,
+            $formData,
+        );
+
+        $this->assertSame($profile, $contract->getProfile());
+        $this->assertSame(2, $contract->getOrganisationalUnit()?->getUid());
+        $this->assertSame(2, $contract->getFunctionType()?->getUid());
+        $this->assertSame(2, $contract->getLocation()?->getUid());
+        $this->assertSame('01.02.2021', $contract->getValidFrom()?->format('d.m.Y'));
+        $this->assertSame('31.12.2021', $contract->getValidTo()?->format('d.m.Y'));
+        $this->assertTrue($contract->isPublish());
+
+        $contract->setPid(2);
+        $contract->setSorting(2);
+        $this->persistenceManager()->add($contract);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/createdContract.csv');
+    }
+
+    /**
+     * The most expensive of the "not submitted" cases: the form data defaults of the three
+     * relations are `null` and those of the two dates are `null` as well, so a factory writing
+     * unconditionally detaches the contract from its organisational unit, its function type and
+     * its location and forgets its runtime - from a request that only changed the position.
+     */
+    #[Test]
+    public function updateKeepsStoredRelationsDatesAndPublishFlagThatWereNotSubmitted(): void
+    {
+        $contract = $this->updateContractWith(['position' => 'New Position']);
+
+        $this->assertSame(1, $contract->getOrganisationalUnit()?->getUid());
+        $this->assertSame(1, $contract->getLocation()?->getUid());
+        $this->assertNotNull($contract->getValidFrom());
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/updatedPositionOnly.csv');
+    }
+
+    /**
+     * The near miss of the case above, and the reason it cannot be solved by looking at the
+     * value: an unpublish is submitted as the value `0`, which is indistinguishable from the
+     * boolean default of a checkbox that was never rendered.
+     */
+    #[Test]
+    public function updateAppliesSubmittedUnpublish(): void
+    {
+        $this->updateContractWith(['position' => 'New Position', 'publish' => '0']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/updatedPositionAndUnpublished.csv');
+    }
+
+    /**
+     * An override carrying a domain object is applied for a relation that was not submitted -
+     * the PSR-14 case for a unit resolved from another source than the form.
+     */
+    #[Test]
+    public function updateAppliesObjectOverrideForRelationThatWasNotSubmitted(): void
+    {
+        $organisationalUnit = $this->persistenceManager()->getObjectByIdentifier(2, OrganisationalUnit::class);
+        $this->assertInstanceOf(OrganisationalUnit::class, $organisationalUnit);
+
+        $this->updateContractWith(
+            ['position' => 'New Position'],
+            ['organisationalUnit' => $organisationalUnit],
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/updatedPositionAndOverriddenOrganisationalUnit.csv');
+    }
+
+    /**
+     * Documents current behaviour, and this is the most damaging shape of the override type
+     * check: registering the *uid* of a location rather than the location object - the obvious
+     * mistake, and what every raw request value looks like - passes `hasPropertyOverride()`,
+     * fails `instanceof Location`, and therefore writes the form data default `null`. The
+     * contract loses its stored location although nothing in the request mentioned it.
+     *
+     * @see ContractFactory::setLocation()
+     */
+    #[Test]
+    public function overrideCarryingAUidInsteadOfTheObjectDetachesTheStoredRelation(): void
+    {
+        $contract = $this->updateContractWith(['position' => 'New Position'], ['location' => 2]);
+
+        $this->assertNull($contract->getLocation());
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/updatedPositionAndClearedLocation.csv');
+    }
+
+    /**
+     * A date the integrator locked is not moved by a submitted one - the stored timestamp has to
+     * survive byte for byte, which is what the CSV of the unchanged record asserts.
+     */
+    #[Test]
+    public function updateSkipsDateTheValidationSetMarksReadOnly(): void
+    {
+        $this->updateContractWith(
+            ['position' => 'New Position', 'validFrom' => '05.06.2022'],
+            [],
+            'validFrom',
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ContractFactoryTest/updatedPositionOnly.csv');
+    }
+
+    /**
+     * The counterpart: without the read only marking the very same request moves the date. The
+     * assertion is on the model because the stored timestamp of a `d.m.Y` date depends on the
+     * time of day the test runs at.
+     */
+    #[Test]
+    public function updateAppliesSubmittedDate(): void
+    {
+        $contract = $this->updateContractWith(['position' => 'New Position', 'validFrom' => '05.06.2022']);
+
+        $this->assertSame('05.06.2022', $contract->getValidFrom()?->format('d.m.Y'));
+        // The second date was not part of the request and keeps the stored value.
+        $this->assertSame('01.01.2030', $contract->getValidTo()?->format('d.m.Y'));
+    }
+
+    /**
+     * A relation the integrator disabled is not written even though the request carries a valid
+     * uid for it, and the function type of the same request still is.
+     */
+    #[Test]
+    public function updateSkipsRelationTheValidationSetMarksDisabled(): void
+    {
+        $contract = $this->updateContractWith(
+            ['position' => 'New Position', 'organisationalUnit' => '2', 'functionType' => '2'],
+            [],
+            '',
+            'organisationalUnit',
+        );
+
+        $this->assertInstanceOf(OrganisationalUnit::class, $contract->getOrganisationalUnit());
+        $this->assertSame(1, $contract->getOrganisationalUnit()->getUid());
+        $this->assertInstanceOf(FunctionType::class, $contract->getFunctionType());
+        $this->assertSame(2, $contract->getFunctionType()->getUid());
+    }
+
+    /**
+     * @param array<string, string|object> $submitted
+     * @param array<string, mixed> $overrides
+     */
+    private function updateContractWith(
+        array $submitted,
+        array $overrides = [],
+        string $readOnlyProperty = '',
+        string $disabledProperty = '',
+    ): Contract {
+        $formData = $this->mapFormData(
+            ContractFormData::class,
+            'contractFormData',
+            [
+                'contract' => '1',
+                'contractFormData' => $submitted,
+            ],
+            self::DATE_FORMATS,
+        );
+        foreach ($overrides as $propertyName => $value) {
+            $formData->setPropertyOverride($propertyName, $value);
+        }
+        $contract = $this->persistenceManager()->getObjectByIdentifier(1, Contract::class);
+        $this->assertInstanceOf(Contract::class, $contract);
+
+        $validationSet = $readOnlyProperty !== ''
+            ? $this->createValidationSet('contract', $readOnlyProperty, readOnly: true)
+            : ($disabledProperty !== ''
+                ? $this->createValidationSet('contract', $disabledProperty, disabled: true)
+                : $this->createValidationSet('contract'));
+
+        $contract = (new ContractFactory())->updateFromFormData($validationSet, $contract, $formData);
+        $this->persistenceManager()->update($contract);
+        $this->persistenceManager()->persistAll();
+        return $contract;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/EmailFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/EmailFactoryTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\Email;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\EmailFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\EmailFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The email address form is the smallest of the edit plugin's forms - two properties - which
+ * makes it the place to pin down the rules every factory of this package repeats verbatim in
+ * its own `mayApplyProperty()`:
+ *
+ * - a property that was not part of the submitted form keeps its persisted value,
+ * - a property that was submitted empty is written as empty, and
+ * - a property registered as override is written although it was not submitted.
+ *
+ * The assertions go to the database rather than to the model, because losing a stored value is
+ * only harmless as long as it is not persisted, and `updateFromFormData()` feeds straight into
+ * `EmailRepository::update()` in `EmailAddressController::updateAction()`.
+ */
+final class EmailFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/contractWithEmail.csv');
+    }
+
+    /**
+     * The `contract` is not taken from the form data but handed to the factory as the parent
+     * record, and it is the one property `createFromFormData()` writes without asking the
+     * validation set - a new email address without a contract would be unreachable.
+     */
+    #[Test]
+    public function createFromFormDataBuildsRecordFromSubmittedValuesAndParentContract(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'contract' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'new@example.com',
+                    'type' => 'private',
+                ],
+            ],
+        );
+        $contract = $this->persistenceManager()->getObjectByIdentifier(1, Contract::class);
+        $this->assertInstanceOf(Contract::class, $contract);
+
+        $email = (new EmailFactory())->createFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $contract,
+            $formData,
+        );
+
+        $this->assertSame('new@example.com', $email->getEmail());
+        $this->assertSame('private', $email->getType());
+        $this->assertSame($contract, $email->getContract());
+
+        // The factory does not assign a storage page - the controller leaves that to the
+        // Extbase `persistence.storagePid` setting - so the test has to.
+        $email->setPid(2);
+        $email->setSorting(2);
+        $this->persistenceManager()->add($email);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/createdEmail.csv');
+    }
+
+    /**
+     * The case the whole mechanism exists for: the form rendered only the email input, so `type`
+     * never reached the request. Its default on the form data object is the empty string, and
+     * writing that would silently drop the stored type.
+     */
+    #[Test]
+    public function updateKeepsStoredValueOfPropertyThatWasNotSubmitted(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                ],
+            ],
+        );
+        $this->assertSame('', $formData->getType());
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailOnly.csv');
+    }
+
+    /**
+     * The near miss of the case above: an empty value that *was* submitted is a deletion the
+     * editor asked for, and must be written. Deciding on the value instead of on the request
+     * would make emptying a field impossible.
+     */
+    #[Test]
+    public function updateAppliesSubmittedEmptyValue(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                    'type' => '',
+                ],
+            ],
+        );
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailAndClearedType.csv');
+    }
+
+    /**
+     * The documented extension point: a PSR-14 listener fills a value from another source
+     * before the transformation runs. It has to win over "was not submitted".
+     */
+    #[Test]
+    public function updateAppliesRegisteredOverrideForPropertyThatWasNotSubmitted(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                ],
+            ],
+        );
+        $formData->setPropertyOverride('type', 'overridden');
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailAndOverriddenType.csv');
+    }
+
+    /**
+     * An override also wins over a value that *was* submitted, which is what makes it usable to
+     * correct rather than only to complete a submission.
+     */
+    #[Test]
+    public function overrideWinsOverSubmittedValue(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                    'type' => 'private',
+                ],
+            ],
+        );
+        $formData->setPropertyOverride('type', 'overridden');
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailAndOverriddenType.csv');
+    }
+
+    /**
+     * Documents current behaviour, and it is a trap: the override decides *whether* a property
+     * is written, the type check only decides *what* is written. An override whose value does
+     * not match the expected type therefore turns a property that was not submitted into a
+     * write of the form data default - the empty string - and the stored value is gone.
+     *
+     * @see EmailFactory::setType()
+     */
+    #[Test]
+    public function overrideOfMismatchingTypeClearsStoredValueOfPropertyThatWasNotSubmitted(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                ],
+            ],
+        );
+        // A listener that means "clear the type" - or simply passes the wrong type.
+        $formData->setPropertyOverride('type', null);
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailAndClearedType.csv');
+    }
+
+    /**
+     * `readOnly` and `disabled` come from the integrator's validation configuration and take a
+     * field out of the editable set. A value submitted for it anyway - a crafted request, or a
+     * form rendered before the configuration changed - must not reach the record.
+     */
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksReadOnly(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                    'type' => 'private',
+                ],
+            ],
+        );
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress', 'type', readOnly: true),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailOnly.csv');
+    }
+
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksDisabled(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                    'type' => 'private',
+                ],
+            ],
+        );
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress', 'type', disabled: true),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailOnly.csv');
+    }
+
+    /**
+     * A `readOnly` marking beats an override as well: the check runs before
+     * `shouldApplyProperty()`, so a listener cannot write a field the integrator locked.
+     */
+    #[Test]
+    public function readOnlyPropertyIsNotWrittenByAnOverrideEither(): void
+    {
+        $formData = $this->mapFormData(
+            EmailFormData::class,
+            'emailAddressFormData',
+            [
+                'emailAddress' => '1',
+                'emailAddressFormData' => [
+                    'email' => 'changed@example.com',
+                ],
+            ],
+        );
+        $formData->setPropertyOverride('type', 'overridden');
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress', 'type', readOnly: true),
+            $email,
+            $formData,
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/updatedEmailOnly.csv');
+    }
+
+    /**
+     * A form data object that never went through the property mapper - constructed in code, as
+     * `newAction()` does - carries no request, so nothing may be applied at all. Without that
+     * guard the constructor defaults would wipe the record.
+     */
+    #[Test]
+    public function updateWithFormDataNotBoundToARequestKeepsEverything(): void
+    {
+        $email = $this->persistenceManager()->getObjectByIdentifier(1, Email::class);
+        $this->assertInstanceOf(Email::class, $email);
+
+        $this->persistUpdate((new EmailFactory())->updateFromFormData(
+            $this->createValidationSet('emailAddress'),
+            $email,
+            new EmailFormData('unbound@example.com', 'unbound'),
+        ));
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/EmailFactoryTest/contractWithEmail.csv');
+    }
+
+    private function persistUpdate(Email $email): void
+    {
+        $this->persistenceManager()->update($email);
+        $this->persistenceManager()->persistAll();
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/contractWithAddress.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/contractWithAddress.csv
@@ -1,0 +1,13 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,first_name,last_name
+,1,2,"James","Kirk"
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,position
+,1,2,1,"Captain"
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","Stored Street","1a","Building A","12345","Stored City","Stored State","Stored Country",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/createdAddress.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/createdAddress.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","Stored Street","1a","Building A","12345","Stored City","Stored State","Stored Country",1
+,2,2,1,"private","New Street","2b","Backyard","54321","New City","New State","New Country",2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/createdEmptyAddress.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/createdEmptyAddress.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","Stored Street","1a","Building A","12345","Stored City","Stored State","Stored Country",1
+,2,2,1,"","","","","","","","",2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityAndClearedStreet.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityAndClearedStreet.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","","1a","Building A","12345","New City","Stored State","Stored Country",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityAndOverriddenCountry.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityAndOverriddenCountry.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","Stored Street","1a","Building A","12345","New City","Stored State","Overridden Country",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/AddressFactoryTest/updatedCityOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_address,
+,uid,pid,contract,type,street,street_number,additional,zip,city,state,country,sorting
+,1,2,1,"office","Stored Street","1a","Building A","12345","New City","Stored State","Stored Country",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/createdContract.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/createdContract.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,position,location,room,office_hours,publish,sorting
+,1,2,1,1,1,"Stored Position",1,"Stored Room","Stored office hours",1,1
+,2,2,1,2,2,"New Position",2,"New Room","New office hours",1,2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/profileWithContract.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/profileWithContract.csv
@@ -1,0 +1,22 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,first_name,last_name
+,1,2,"James","Kirk"
+tx_academicpersons_domain_model_organisational_unit,
+,uid,pid,unit_name
+,1,2,"Command"
+,2,2,"Science"
+tx_academicpersons_domain_model_function_type,
+,uid,pid,function_name
+,1,2,"Captain"
+,2,2,"Science Officer"
+tx_academicpersons_domain_model_location,
+,uid,pid,title
+,1,2,"Bridge"
+,2,2,"Sickbay"
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,valid_from,valid_to,position,location,room,office_hours,publish,sorting
+,1,2,1,1,1,1580515200,1893456000,"Stored Position",1,"Stored Room","Stored office hours",1,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndClearedLocation.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndClearedLocation.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,valid_from,valid_to,position,location,room,office_hours,publish,sorting
+,1,2,1,1,1,1580515200,1893456000,"New Position",0,"Stored Room","Stored office hours",1,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndOverriddenOrganisationalUnit.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndOverriddenOrganisationalUnit.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,valid_from,valid_to,position,location,room,office_hours,publish,sorting
+,1,2,1,2,1,1580515200,1893456000,"New Position",1,"Stored Room","Stored office hours",1,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndUnpublished.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionAndUnpublished.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,valid_from,valid_to,position,location,room,office_hours,publish,sorting
+,1,2,1,1,1,1580515200,1893456000,"New Position",1,"Stored Room","Stored office hours",0,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ContractFactoryTest/updatedPositionOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,organisational_unit,function_type,valid_from,valid_to,position,location,room,office_hours,publish,sorting
+,1,2,1,1,1,1580515200,1893456000,"New Position",1,"Stored Room","Stored office hours",1,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/contractWithEmail.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/contractWithEmail.csv
@@ -1,0 +1,13 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,first_name,last_name
+,1,2,"James","Kirk"
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,position
+,1,2,1,"Captain"
+tx_academicpersons_domain_model_email,
+,uid,pid,contract,email,type,sorting
+,1,2,1,"stored@example.com","office",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/createdEmail.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/createdEmail.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_email,
+,uid,pid,contract,email,type,sorting
+,1,2,1,"stored@example.com","office",1
+,2,2,1,"new@example.com","private",2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailAndClearedType.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailAndClearedType.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_email,
+,uid,pid,contract,email,type,sorting
+,1,2,1,"changed@example.com","",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailAndOverriddenType.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailAndOverriddenType.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_email,
+,uid,pid,contract,email,type,sorting
+,1,2,1,"changed@example.com","overridden",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/EmailFactoryTest/updatedEmailOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_email,
+,uid,pid,contract,email,type,sorting
+,1,2,1,"changed@example.com","office",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/contractWithPhoneNumber.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/contractWithPhoneNumber.csv
@@ -1,0 +1,13 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,first_name,last_name
+,1,2,"James","Kirk"
+tx_academicpersons_domain_model_contract,
+,uid,pid,profile,position
+,1,2,1,"Captain"
+tx_academicpersons_domain_model_phone_number,
+,uid,pid,contract,phone_number,type,sorting
+,1,2,1,"+49 123 456","office",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/createdPhoneNumber.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/createdPhoneNumber.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_phone_number,
+,uid,pid,contract,phone_number,type,sorting
+,1,2,1,"+49 123 456","office",1
+,2,2,1,"+49 987 654","mobile",2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/updatedNumberAndOverriddenType.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/updatedNumberAndOverriddenType.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_phone_number,
+,uid,pid,contract,phone_number,type,sorting
+,1,2,1,"+49 000 111","overridden",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/updatedNumberOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/PhoneNumberFactoryTest/updatedNumberOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_phone_number,
+,uid,pid,contract,phone_number,type,sorting
+,1,2,1,"+49 000 111","office",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/createdProfile.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/createdProfile.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_profile,
+,uid,pid,gender,title,first_name,middle_name,last_name,website,website_title,publications_link,publications_link_title,teaching_area,core_competences,supervised_thesis,supervised_doctoral_thesis,miscellaneous,skip_sync
+,1,2,"mr","Cpt.","James","Tiberius","Kirk","https://stored.example.com","Stored Website","https://stored.example.com/publications","Stored Publications","Stored teaching area","Stored core competences","Stored supervised thesis","Stored supervised doctoral thesis","Stored miscellaneous",1
+,2,2,"mrs","Dr.","Beverly","Cheryl","Crusher","https://new.example.com","New Website","https://new.example.com/publications","New Publications","New teaching area","New core competences","New supervised thesis","New supervised doctoral thesis","New miscellaneous",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/storedProfile.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/storedProfile.csv
@@ -1,0 +1,7 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,gender,title,first_name,middle_name,last_name,website,website_title,publications_link,publications_link_title,teaching_area,core_competences,supervised_thesis,supervised_doctoral_thesis,miscellaneous,skip_sync
+,1,2,"mr","Cpt.","James","Tiberius","Kirk","https://stored.example.com","Stored Website","https://stored.example.com/publications","Stored Publications","Stored teaching area","Stored core competences","Stored supervised thesis","Stored supervised doctoral thesis","Stored miscellaneous",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/updatedNamesAndSkipSyncOff.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/updatedNamesAndSkipSyncOff.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile,
+,uid,pid,gender,title,first_name,middle_name,last_name,website,website_title,publications_link,publications_link_title,teaching_area,core_competences,supervised_thesis,supervised_doctoral_thesis,miscellaneous,skip_sync
+,1,2,"mr","Cpt.","Jean-Luc","Tiberius","Picard","https://stored.example.com","Stored Website","https://stored.example.com/publications","Stored Publications","Stored teaching area","Stored core competences","Stored supervised thesis","Stored supervised doctoral thesis","Stored miscellaneous",0

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/updatedNamesOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFactoryTest/updatedNamesOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile,
+,uid,pid,gender,title,first_name,middle_name,last_name,website,website_title,publications_link,publications_link_title,teaching_area,core_competences,supervised_thesis,supervised_doctoral_thesis,miscellaneous,skip_sync
+,1,2,"mr","Cpt.","Jean-Luc","Tiberius","Picard","https://stored.example.com","Stored Website","https://stored.example.com/publications","Stored Publications","Stored teaching area","Stored core competences","Stored supervised thesis","Stored supervised doctoral thesis","Stored miscellaneous",1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFormDataFactoryTest/storedProfile.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileFormDataFactoryTest/storedProfile.csv
@@ -1,0 +1,8 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,gender,title,first_name,middle_name,last_name,website,website_title,publications_link,publications_link_title,teaching_area,core_competences,supervised_thesis,supervised_doctoral_thesis,miscellaneous,skip_sync
+,1,2,"mr","Cpt.","James","Tiberius","Kirk","https://stored.example.com","Stored Website","https://stored.example.com/publications","Stored Publications","Stored teaching area","Stored core competences","Stored supervised thesis","Stored supervised doctoral thesis","Stored miscellaneous",1
+,2,2,"mrs","Dr.","Beverly","Cheryl","Crusher","https://other.example.com","Other Website","https://other.example.com/publications","Other Publications","Other teaching area","Other core competences","Other supervised thesis","Other supervised doctoral thesis","Other miscellaneous",0

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/createdProfileInformation.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/createdProfileInformation.csv
@@ -1,0 +1,4 @@
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","Stored Title","Stored bodytext","https://stored.example.com",1999,1990,1995,1
+,2,2,1,"vita","New Title","New bodytext","https://new.example.com",2020,\NULL,\NULL,2

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/profileWithInformation.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/profileWithInformation.csv
@@ -1,0 +1,10 @@
+pages,
+,uid,pid,title,slug,doktype
+,1,0,Root,/,1
+,2,1,Storage,/storage,254
+tx_academicpersons_domain_model_profile,
+,uid,pid,first_name,last_name
+,1,2,"James","Kirk"
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","Stored Title","Stored bodytext","https://stored.example.com",1999,1990,1995,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndClearedYear.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndClearedYear.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","New Title","Stored bodytext","https://stored.example.com",\NULL,1990,1995,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndOverriddenYear.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndOverriddenYear.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","New Title","Stored bodytext","https://stored.example.com",2021,1990,1995,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndSubmittedYear.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleAndSubmittedYear.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","New Title","Stored bodytext","https://stored.example.com",2022,1990,1995,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleOnly.csv
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/Fixtures/ProfileInformationFactoryTest/updatedTitleOnly.csv
@@ -1,0 +1,3 @@
+tx_academicpersons_domain_model_profile_information,
+,uid,pid,profile,type,title,bodytext,link,year,year_start,year_end,sorting
+,1,2,1,"publications","New Title","Stored bodytext","https://stored.example.com",1999,1990,1995,1

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/PhoneNumberFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/PhoneNumberFactoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Contract;
+use FGTCLB\AcademicPersons\Domain\Model\PhoneNumber;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\PhoneNumberFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\PhoneNumberFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `PhoneNumberFactory` is byte for byte the same logic as `EmailFactory` with two other property
+ * names, and that is precisely why it gets its own coverage: the six factories of this package
+ * duplicate `mayApplyProperty()` rather than share it, so a fix applied to one of them says
+ * nothing about the other five.
+ */
+final class PhoneNumberFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PhoneNumberFactoryTest/contractWithPhoneNumber.csv');
+    }
+
+    #[Test]
+    public function createFromFormDataBuildsRecordFromSubmittedValuesAndParentContract(): void
+    {
+        $formData = $this->mapFormData(
+            PhoneNumberFormData::class,
+            'phoneNumberFormData',
+            [
+                'contract' => '1',
+                'phoneNumberFormData' => [
+                    'phoneNumber' => '+49 987 654',
+                    'type' => 'mobile',
+                ],
+            ],
+        );
+        $contract = $this->persistenceManager()->getObjectByIdentifier(1, Contract::class);
+        $this->assertInstanceOf(Contract::class, $contract);
+
+        $phoneNumber = (new PhoneNumberFactory())->createFromFormData(
+            $this->createValidationSet('phoneNumber'),
+            $contract,
+            $formData,
+        );
+
+        $this->assertSame($contract, $phoneNumber->getContract());
+        // Neither storage page nor sorting come from the factory.
+        $phoneNumber->setPid(2);
+        $phoneNumber->setSorting(2);
+        $this->persistenceManager()->add($phoneNumber);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/PhoneNumberFactoryTest/createdPhoneNumber.csv');
+    }
+
+    #[Test]
+    public function updateKeepsStoredValueOfPropertyThatWasNotSubmitted(): void
+    {
+        $this->updatePhoneNumberWith(['phoneNumber' => '+49 000 111']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/PhoneNumberFactoryTest/updatedNumberOnly.csv');
+    }
+
+    #[Test]
+    public function updateAppliesRegisteredOverrideForPropertyThatWasNotSubmitted(): void
+    {
+        $this->updatePhoneNumberWith(['phoneNumber' => '+49 000 111'], ['type' => 'overridden']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/PhoneNumberFactoryTest/updatedNumberAndOverriddenType.csv');
+    }
+
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksReadOnly(): void
+    {
+        $this->updatePhoneNumberWith(
+            ['phoneNumber' => '+49 000 111', 'type' => 'mobile'],
+            [],
+            'type',
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/PhoneNumberFactoryTest/updatedNumberOnly.csv');
+    }
+
+    /**
+     * The phone number itself is the property an integrator is most likely to lock, and locking
+     * it must not turn the record into a partially written one - the type in the same request
+     * still has to be applied.
+     */
+    #[Test]
+    public function readOnlyPropertyDoesNotStopTheOtherPropertiesOfTheSameRequest(): void
+    {
+        $phoneNumber = $this->updatePhoneNumberWith(
+            ['phoneNumber' => '+49 000 111', 'type' => 'overridden'],
+            [],
+            'phoneNumber',
+        );
+
+        $this->assertSame('+49 123 456', $phoneNumber->getPhoneNumber());
+        $this->assertSame('overridden', $phoneNumber->getType());
+    }
+
+    /**
+     * @param array<string, string> $submitted
+     * @param array<string, mixed> $overrides
+     */
+    private function updatePhoneNumberWith(
+        array $submitted,
+        array $overrides = [],
+        string $readOnlyProperty = '',
+    ): PhoneNumber {
+        $formData = $this->mapFormData(
+            PhoneNumberFormData::class,
+            'phoneNumberFormData',
+            [
+                'phoneNumber' => '1',
+                'phoneNumberFormData' => $submitted,
+            ],
+        );
+        foreach ($overrides as $propertyName => $value) {
+            $formData->setPropertyOverride($propertyName, $value);
+        }
+        $phoneNumber = $this->persistenceManager()->getObjectByIdentifier(1, PhoneNumber::class);
+        $this->assertInstanceOf(PhoneNumber::class, $phoneNumber);
+
+        $phoneNumber = (new PhoneNumberFactory())->updateFromFormData(
+            $readOnlyProperty !== ''
+                ? $this->createValidationSet('phoneNumber', $readOnlyProperty, readOnly: true)
+                : $this->createValidationSet('phoneNumber'),
+            $phoneNumber,
+            $formData,
+        );
+        $this->persistenceManager()->update($phoneNumber);
+        $this->persistenceManager()->persistAll();
+        return $phoneNumber;
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFactoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `Tests/Unit/Domain/Factory/ProfileFactoryTest` already covers the decision table of
+ * `mayApplyProperty()` on the model, with a request assembled next to a form data object
+ * assembled by hand. Nothing of that is repeated here. What this test adds is the part a unit
+ * test cannot reach:
+ *
+ * - the form data object and the "was it submitted" information come from one raw argument
+ *   array, mapped by the real property mapper, so the two cannot drift apart;
+ * - the result is persisted, so "the value was preserved" means the stored column, not a getter;
+ * - the coupling between the *argument name* and the request is exercised, which is where the
+ *   mechanism fails silently rather than loudly.
+ *
+ * The profile form is also the widest of the package - fifteen properties - which makes one row
+ * comparison enough to show that a request changing two names leaves thirteen columns alone.
+ */
+final class ProfileFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/storedProfile.csv');
+    }
+
+    /**
+     * `ProfileController` has no create action - a profile is created by
+     * `ProfileCreateCommandService` - but `createFromFormData()` is public API of the factory and
+     * has to produce a complete record from a complete submission.
+     */
+    #[Test]
+    public function createFromFormDataPersistsEverySubmittedProperty(): void
+    {
+        $formData = $this->mapFormData(
+            ProfileFormData::class,
+            'profileFormData',
+            ['profileFormData' => $this->fullSubmission()],
+        );
+
+        $profile = (new ProfileFactory())->createFromFormData(
+            $this->createValidationSet('profile'),
+            $formData,
+        );
+
+        $profile->setPid(2);
+        $this->persistenceManager()->add($profile);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/createdProfile.csv');
+    }
+
+    /**
+     * Thirteen properties were not part of the request, and every one of them would be written as
+     * the empty string - or, for `skipSync`, as `false` - if the factory did not ask the request
+     * first. This is the single assertion that shows what the mechanism is worth.
+     */
+    #[Test]
+    public function updateKeepsStoredValuesOfEveryPropertyThatWasNotSubmitted(): void
+    {
+        $this->updateProfileWith(['firstName' => 'Jean-Luc', 'lastName' => 'Picard']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/updatedNamesOnly.csv');
+    }
+
+    /**
+     * The near miss for the boolean: an editor switching the sync flag off submits `0`, which is
+     * the same value the form data default carries. Only the request decides between the two, and
+     * getting it wrong either way is a silent behaviour change of the translation sync.
+     */
+    #[Test]
+    public function updateAppliesSubmittedSkipSyncOff(): void
+    {
+        $this->updateProfileWith([
+            'firstName' => 'Jean-Luc',
+            'lastName' => 'Picard',
+            'skipSync' => '0',
+        ]);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/updatedNamesAndSkipSyncOff.csv');
+    }
+
+    /**
+     * The argument name is what turns the request arguments into "this form's" arguments, and it
+     * is set by `AbstractFormDataConverter` only when the controller configured it - which
+     * `AbstractActionController::initializeAction()` does for every argument of type
+     * `AbstractFormData`. A controller that does not go through that base class gets a form data
+     * object with a request but without an argument name, and then *nothing* is applied: the
+     * submitted values are dropped without any error.
+     */
+    #[Test]
+    public function formDataWithoutAnArgumentNameAppliesNothingAlthoughValuesWereSubmitted(): void
+    {
+        $formData = $this->mapFormData(
+            ProfileFormData::class,
+            'profileFormData',
+            ['profileFormData' => ['firstName' => 'Jean-Luc', 'lastName' => 'Picard']],
+            [],
+            '',
+        );
+        $this->assertSame('Jean-Luc', $formData->_getProperty('firstName'));
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('firstName'));
+
+        $this->applyAndPersist($formData);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/storedProfile.csv');
+    }
+
+    /**
+     * The same failure from the other side: the argument was renamed in the controller but the
+     * form still posts under the old name, so the values arrive, are mapped, and are then not
+     * recognised as belonging to this argument.
+     */
+    #[Test]
+    public function formDataBoundToAnotherArgumentNameAppliesNothing(): void
+    {
+        $formData = $this->mapFormData(
+            ProfileFormData::class,
+            'profileFormData',
+            ['profileFormData' => ['firstName' => 'Jean-Luc', 'lastName' => 'Picard']],
+            [],
+            'renamedProfileFormData',
+        );
+        $this->assertSame('renamedProfileFormData', $formData->getArgumentName());
+
+        $this->applyAndPersist($formData);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/storedProfile.csv');
+    }
+
+    /**
+     * An override is registered on the form data object, not in the request, so it survives both
+     * failures above - which is what makes it usable as a repair from a PSR-14 listener.
+     */
+    #[Test]
+    public function registeredOverrideIsAppliedEvenWithoutAnArgumentName(): void
+    {
+        $formData = $this->mapFormData(
+            ProfileFormData::class,
+            'profileFormData',
+            // Submitted values differ from the overridden ones, so applying the wrong source is
+            // visible in the record rather than accidentally correct.
+            ['profileFormData' => ['firstName' => 'Submitted', 'lastName' => 'Submitted']],
+            [],
+            '',
+        );
+        $formData->setPropertyOverride('firstName', 'Jean-Luc');
+        $formData->setPropertyOverride('lastName', 'Picard');
+
+        $this->applyAndPersist($formData);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFactoryTest/updatedNamesOnly.csv');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fullSubmission(): array
+    {
+        return [
+            'gender' => 'mrs',
+            'title' => 'Dr.',
+            'firstName' => 'Beverly',
+            'middleName' => 'Cheryl',
+            'lastName' => 'Crusher',
+            'website' => 'https://new.example.com',
+            'websiteTitle' => 'New Website',
+            'publicationsLink' => 'https://new.example.com/publications',
+            'publicationsLinkTitle' => 'New Publications',
+            'teachingArea' => 'New teaching area',
+            'coreCompetences' => 'New core competences',
+            'supervisedThesis' => 'New supervised thesis',
+            'supervisedDoctoralThesis' => 'New supervised doctoral thesis',
+            'miscellaneous' => 'New miscellaneous',
+            'skipSync' => '1',
+        ];
+    }
+
+    /**
+     * @param array<string, string> $submitted
+     */
+    private function updateProfileWith(array $submitted): void
+    {
+        $this->applyAndPersist($this->mapFormData(
+            ProfileFormData::class,
+            'profileFormData',
+            [
+                'profile' => '1',
+                'profileFormData' => $submitted,
+            ],
+        ));
+    }
+
+    private function applyAndPersist(ProfileFormData $formData): void
+    {
+        $profile = $this->persistenceManager()->getObjectByIdentifier(1, Profile::class);
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $profile = (new ProfileFactory())->updateFromFormData(
+            $this->createValidationSet('profile'),
+            $profile,
+            $formData,
+        );
+        $this->persistenceManager()->update($profile);
+        $this->persistenceManager()->persistAll();
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFormDataFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFormDataFactoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicBase\Domain\Model\Dto\PluginControllerActionContext;
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFormDataFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileFormDataFactoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `ProfileFormDataFactory` runs in the opposite direction of the five other factories: it fills
+ * the form data object `editAction()` renders from the persisted profile. Two things about it are
+ * only observable with a container and a database, which is what puts this test here:
+ *
+ * - it is published under its interface through `#[AsAlias(public: true)]`, and a project
+ *   replacing it does so by decorating that alias, so the alias itself is the contract, and
+ * - the object it returns carries no request, which decides what happens when it is handed back
+ *   into `ProfileFactory` instead of being rendered.
+ */
+final class ProfileFormDataFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileFormDataFactoryTest/storedProfile.csv');
+    }
+
+    /**
+     * The interface, not the class, is what `ProfileController` asks for and what a project
+     * decorates. A missing or private alias makes the controller unresolvable at runtime only.
+     */
+    #[Test]
+    public function factoryIsPublishedUnderItsInterface(): void
+    {
+        $factory = $this->get(ProfileFormDataFactoryInterface::class);
+
+        $this->assertInstanceOf(ProfileFormDataFactory::class, $factory);
+    }
+
+    /**
+     * Every property of `ProfileFormData` has to be filled, because the edit form renders the
+     * object rather than the profile: a property the factory forgets is an input rendered empty,
+     * and submitting that form then writes the empty value back over the stored one.
+     */
+    #[Test]
+    public function formDataCarriesEveryProfilePropertyOfTheEditForm(): void
+    {
+        $profile = $this->persistenceManager()->getObjectByIdentifier(1, Profile::class);
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $formData = $this->get(ProfileFormDataFactoryInterface::class)->createFromProfile(
+            new PluginControllerActionContext($this->createExtbaseRequest([]), []),
+            $profile,
+        );
+
+        $this->assertSame('mr', $formData->getGender());
+        $this->assertSame('Cpt.', $formData->getTitle());
+        $this->assertSame('James', $formData->getFirstName());
+        $this->assertSame('Tiberius', $formData->getMiddleName());
+        $this->assertSame('Kirk', $formData->getLastName());
+        $this->assertSame('https://stored.example.com', $formData->getWebsite());
+        $this->assertSame('Stored Website', $formData->getWebsiteTitle());
+        $this->assertSame('https://stored.example.com/publications', $formData->getPublicationsLink());
+        $this->assertSame('Stored Publications', $formData->getPublicationsLinkTitle());
+        $this->assertSame('Stored teaching area', $formData->getTeachingArea());
+        $this->assertSame('Stored core competences', $formData->getCoreCompetences());
+        $this->assertSame('Stored supervised thesis', $formData->getSupervisedThesis());
+        $this->assertSame('Stored supervised doctoral thesis', $formData->getSupervisedDoctoralThesis());
+        $this->assertSame('Stored miscellaneous', $formData->getMiscellaneous());
+        $this->assertTrue($formData->getSkipSync());
+    }
+
+    /**
+     * The object is built for rendering, not for writing: it never went through the property
+     * mapper, so it carries neither request nor argument name and `shouldApplyProperty()` is
+     * `false` for everything. Feeding it into `ProfileFactory` - the shortcut of "I already have
+     * a form data object" - therefore writes nothing at all, silently. Asserted with the data of
+     * a *different* profile so that a factory ignoring the guard would be visible in the record.
+     */
+    #[Test]
+    public function producedFormDataCarriesNoRequestAndThereforeWritesNothing(): void
+    {
+        $otherProfile = $this->persistenceManager()->getObjectByIdentifier(2, Profile::class);
+        $this->assertInstanceOf(Profile::class, $otherProfile);
+        $formData = $this->get(ProfileFormDataFactoryInterface::class)->createFromProfile(
+            new PluginControllerActionContext($this->createExtbaseRequest([]), []),
+            $otherProfile,
+        );
+        $this->assertNull($formData->getArgumentName());
+        $this->assertFalse($formData->shouldApplyProperty('firstName'));
+
+        $profile = $this->persistenceManager()->getObjectByIdentifier(1, Profile::class);
+        $this->assertInstanceOf(Profile::class, $profile);
+        $profile = (new ProfileFactory())->updateFromFormData(
+            $this->createValidationSet('profile'),
+            $profile,
+            $formData,
+        );
+        $this->persistenceManager()->update($profile);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertSame('James', $profile->getFirstName());
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileFormDataFactoryTest/storedProfile.csv');
+    }
+}

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileInformationFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileInformationFactoryTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Domain\Factory;
+
+use FGTCLB\AcademicPersons\Domain\Model\Profile;
+use FGTCLB\AcademicPersons\Domain\Model\ProfileInformation;
+use FGTCLB\AcademicPersonsEdit\Domain\Factory\ProfileInformationFactory;
+use FGTCLB\AcademicPersonsEdit\Domain\Model\Dto\ProfileInformationFormData;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Profile information is the only form of the package with nullable integer properties
+ * (`year`, `yearStart`, `yearEnd`), and `null` there is a meaningful stored value rather than
+ * an "empty" one. That makes it the place to pin two things the string based forms cannot show:
+ *
+ * - an empty year field that *was* submitted has to reach the record as `NULL`, and
+ * - the override type check is `is_int()`, so `null` - the only value that could express
+ *   "clear this year" - is the one value an override cannot carry.
+ */
+final class ProfileInformationFactoryTest extends AbstractFactoryTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/profileWithInformation.csv');
+    }
+
+    /**
+     * The two year properties that were not submitted stay `NULL` on a new record rather than
+     * being written as `0`, which is what the nullable column and the nullable property are for.
+     */
+    #[Test]
+    public function createFromFormDataBuildsRecordFromSubmittedValuesAndParentProfile(): void
+    {
+        $formData = $this->mapFormData(
+            ProfileInformationFormData::class,
+            'profileInformationFormData',
+            [
+                'profile' => '1',
+                'profileInformationFormData' => [
+                    'type' => 'vita',
+                    'title' => 'New Title',
+                    'bodytext' => 'New bodytext',
+                    'link' => 'https://new.example.com',
+                    'year' => '2020',
+                ],
+            ],
+        );
+        $this->assertSame(2020, $formData->getYear());
+        $this->assertNull($formData->getYearStart());
+        $profile = $this->persistenceManager()->getObjectByIdentifier(1, Profile::class);
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $profileInformation = (new ProfileInformationFactory())->createFromFormData(
+            $this->createValidationSet('profileInformation'),
+            $profile,
+            $formData,
+        );
+
+        $this->assertSame($profile, $profileInformation->getProfile());
+        $profileInformation->setPid(2);
+        $profileInformation->setSorting(2);
+        $this->persistenceManager()->add($profileInformation);
+        $this->persistenceManager()->persistAll();
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/createdProfileInformation.csv');
+    }
+
+    /**
+     * All three year properties are absent from the request. Their form data default is `null`,
+     * so writing them unconditionally would silently drop three stored years at once.
+     */
+    #[Test]
+    public function updateKeepsStoredYearsThatWereNotSubmitted(): void
+    {
+        $this->updateProfileInformationWith(['title' => 'New Title']);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleOnly.csv');
+    }
+
+    /**
+     * An emptied year input is submitted as an empty string, which the property mapper turns
+     * into `null` - and that `null` must be written, because clearing a year is a thing an
+     * editor is allowed to do.
+     */
+    #[Test]
+    public function updateAppliesSubmittedEmptyYearAsNull(): void
+    {
+        $formData = $this->mapFormDataForUpdate(['title' => 'New Title', 'year' => '']);
+        $this->assertNull($formData->getYear());
+        $this->assertTrue($formData->wasPropertySentInRequest('year'));
+
+        $this->applyAndPersist($formData);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleAndClearedYear.csv');
+    }
+
+    #[Test]
+    public function updateAppliesIntegerOverrideForYearThatWasNotSubmitted(): void
+    {
+        $this->updateProfileInformationWith(['title' => 'New Title'], ['year' => 2021]);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleAndOverriddenYear.csv');
+    }
+
+    /**
+     * Documents current behaviour, and it is the shape of a defect: `setYear()` applies the
+     * override only when it `is_int()`, so an override of `null` - the only way to say "clear
+     * the year" - falls through to the submitted value instead. A listener meaning to clear the
+     * year silently keeps whatever the editor sent.
+     *
+     * @see ProfileInformationFactory::setYear()
+     */
+    #[Test]
+    public function nullOverrideCannotClearAYearAndFallsBackToTheSubmittedValue(): void
+    {
+        $this->updateProfileInformationWith(
+            ['title' => 'New Title', 'year' => '2022'],
+            ['year' => null],
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleAndSubmittedYear.csv');
+    }
+
+    /**
+     * The same trap with the stakes raised: the year was not submitted, so the fallback is the
+     * form data default `null`, and a `null` override wipes the stored year although the type
+     * check was supposed to reject the value.
+     *
+     * @see ProfileInformationFactory::setYear()
+     */
+    #[Test]
+    public function nullOverrideWipesAStoredYearThatWasNotSubmitted(): void
+    {
+        $this->updateProfileInformationWith(['title' => 'New Title'], ['year' => null]);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleAndClearedYear.csv');
+    }
+
+    #[Test]
+    public function updateSkipsPropertyTheValidationSetMarksReadOnly(): void
+    {
+        $this->updateProfileInformationWith(
+            ['title' => 'New Title', 'bodytext' => 'Submitted bodytext'],
+            [],
+            'bodytext',
+        );
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ProfileInformationFactoryTest/updatedTitleOnly.csv');
+    }
+
+    /**
+     * @param array<string, string> $submitted
+     * @param array<string, mixed> $overrides
+     */
+    private function updateProfileInformationWith(
+        array $submitted,
+        array $overrides = [],
+        string $readOnlyProperty = '',
+    ): void {
+        $formData = $this->mapFormDataForUpdate($submitted);
+        foreach ($overrides as $propertyName => $value) {
+            $formData->setPropertyOverride($propertyName, $value);
+        }
+        $this->applyAndPersist($formData, $readOnlyProperty);
+    }
+
+    /**
+     * @param array<string, string> $submitted
+     */
+    private function mapFormDataForUpdate(array $submitted): ProfileInformationFormData
+    {
+        return $this->mapFormData(
+            ProfileInformationFormData::class,
+            'profileInformationFormData',
+            [
+                'profileInformation' => '1',
+                'profileInformationFormData' => $submitted,
+            ],
+        );
+    }
+
+    private function applyAndPersist(ProfileInformationFormData $formData, string $readOnlyProperty = ''): void
+    {
+        $profileInformation = $this->persistenceManager()->getObjectByIdentifier(1, ProfileInformation::class);
+        $this->assertInstanceOf(ProfileInformation::class, $profileInformation);
+
+        $profileInformation = (new ProfileInformationFactory())->updateFromFormData(
+            $readOnlyProperty !== ''
+                ? $this->createValidationSet('profileInformation', $readOnlyProperty, readOnly: true)
+                : $this->createValidationSet('profileInformation'),
+            $profileInformation,
+            $formData,
+        );
+        $this->persistenceManager()->update($profileInformation);
+        $this->persistenceManager()->persistAll();
+    }
+}


### PR DESCRIPTION
Resolves ACE-422 on `main`. Part of the test coverage round tracked under ACE-10.

The six factories in `Classes/Domain/Factory/` turn submitted form data into persisted records — where the edit plugin either works or **quietly loses data**. Only `ProfileFactory` had any test at all, a unit one.

## Technique, and why it is a functional test

`AbstractFactoryTestCase::mapFormData()` maps **one raw argument array** through the real Extbase `PropertyMapper` and the extension's own `AbstractFormDataConverter`, configured exactly as `AbstractActionController::initializeAction()` configures an action argument.

That is the point: the DTO *and* the `wasPropertySentInRequest()` information then come from a single array and **cannot drift apart** — which is the gap a unit test has to leave open, since it has to set both by hand. Results are persisted through `PersistenceManager` and asserted with `assertCSVDataSet`, so "the value was preserved" means the stored column, not an in-memory getter.

## Three findings, all data-loss shaped

**1. An override of the wrong type writes the form default — it does not fall back to the stored value.** All six factories do `is_string($override) ? $override : $form->getX()`, and `hasPropertyOverride()` has already flipped the property into "apply" mode. So a mistyped override on a property that was **not submitted** writes the DTO default (`''`, `null`, or a detached relation) over the stored value.

Worst shape: `setPropertyOverride('location', 2)` — the uid instead of the `Location` object, which is the obvious mistake and what every raw request value looks like — **detaches the contract from its stored location.**

**2. An override can never carry `null`**, so a listener cannot clear a nullable property: the three year fields, the three contract relations, both dates. The submitted value silently wins. Root cause shared with the first: `getPropertyOverride()` returns `null` both for "not registered" and "registered as null", so the factories cannot tell them apart and the type checks are a workaround for that. **A typed read gated on `hasPropertyOverride()` would fix 1 and 2 together.**

**3. A missing or mismatched argument name drops the whole submission silently.** `wasPropertySentInRequest()` returns `false` for every property when `getArgumentName()` is `null` or does not match the request key — so a controller not extending `AbstractActionController`, or an argument renamed without renaming the form field, **persists nothing and reports nothing**. Both directions covered.

This confirms from the persistence side what #499 found from the DTO side.

Also noted: `ProfileFactory::createFromFormData()` **has no caller** (profiles are created by `ProfileCreateCommandService`) — dead public API on an `@internal` class, covered anyway. `createFromFormData()` assigns neither `pid` nor `sorting`, so a factory result is not persistable on its own; the tests set both explicitly and say so. A detached relation is stored as `0`, not `NULL`, although the column is `DEFAULT NULL`.

## Proof the tests can fail

| Mutation | Failures |
|---|---|
| `shouldApplyProperty()` → `true` | 26 |
| `wasPropertySentInRequest()` final return → `false` | 38 |
| `hasPropertyOverride()` → `false` | 9 |
| `getPropertyOverride()` → `null` | 6 (+1 after strengthening one test) |
| readOnly/disabled guard neutralised in all six | 10 |
| `teachingArea` dropped; `setYear()` accepts `null` overrides | 3 |

46 tests, 335 assertions.

## Scope

No production code is changed. `ProfileFormData::createFromProfile()` is not exercised — it raises `E_USER_DEPRECATED` and the suite has `failOnDeprecation` (its removal is overdue: the notice says "removed in 3.0" and this branch **is** `3.0.0-dev`). Trusted properties are not derived from a `__trustedProperties` token; that belongs to the plugin-level form tests, which already exercise it.
