### PR TITLE
[TASK] ACE-447: Fix the validation settings comments

### DIFF
--- a/packages/fgtclb/academic-jobs/Configuration/AcademicJobs/Settings.yaml
+++ b/packages/fgtclb/academic-jobs/Configuration/AcademicJobs/Settings.yaml
@@ -1,12 +1,33 @@
+#-----------------------------------------------------------------------------------------------------------------------
+# EXT:academic_jobs - Field validation configuration for the frontend "new job" form.
+#
+# This is a separate mechanism from the one shipped by EXT:academic_persons and does not share its
+# behaviour. It is read by AcademicJobsSettingsRegistry and reaches the frontend form and the Extbase
+# validator only - it is NOT applied to the TYPO3 backend.
+#
+# Documented at:
+# https://docs.typo3.org/p/fgtclb/academic-jobs/main/en-us/Configuration/Validations/Index.html
+#-----------------------------------------------------------------------------------------------------------------------
+# @internal The syntax of this configuration file is considered experimental and may still change.
+#-----------------------------------------------------------------------------------------------------------------------
 validations:
   # @todo We either need a translation map (to TCA) or simply matching convention which resolves needs to be added.
   # @todo Syntax and build-up is more than sub-optimal and needs a complete redesign and implementation.
+  # @todo The three readers understand three different keyword sets, see ACE-429. "url" produces a
+  #       validator but no TCA configuration, "number" produces TCA configuration but no validator.
+  #
   # <identifier>:
   #   <propertyName>:
-  #      - required
-  #      - email
-  #      - disabled
-  #      - readonly
+  #      - required   # must not be empty; also marks the field in the form
+  #      - email      # must be an email address; renders an email input
+  #      - url        # must be a URL; renders a url input
+  #      - number     # renders a number input; NOT validated server side
+  #
+  # Keywords are matched case sensitively here - always write them in lower case.
+  #
+  # "disabled" and "readonly" are NOT supported by this extension. No reader understands them, and
+  # the form emits the first keyword that is not "required" verbatim as the HTML input type, so they
+  # would render as <input type="disabled">. Use them only in EXT:academic_persons.
   job:
     title:
       - required

--- a/packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml
+++ b/packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml
@@ -1,7 +1,15 @@
 #-----------------------------------------------------------------------------------------------------------------------
-# EXT:academic_persons - Validation configuration for EXT:academic_persons_edit or custom implementation.
+# EXT:academic_persons - Profile information types and field validation configuration.
+#
+# The "validations" section below is the single source of truth for both editing contexts: the TYPO3
+# backend FormEngine, through TCA merged by the table files of this extension, and the frontend
+# editing forms of EXT:academic_persons_edit. It applies to the backend whether or not that extension
+# is installed.
+#
+# Documented at:
+# https://docs.typo3.org/p/fgtclb/academic-persons/main/en-us/Configuration/Validations/Index.html
 #-----------------------------------------------------------------------------------------------------------------------
-# @internal Syntax if this configuration file is considered experimental and will change until 2.1.0 release.
+# @internal The syntax of this configuration file is considered experimental and may still change.
 #-----------------------------------------------------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -44,12 +52,18 @@ profileInformationsTypes:
 validations:
   # @todo We either need a translation map (to TCA) or simply matching convention which resolves needs to be added.
   # @todo Syntax and build-up is more than sub-optimal and needs a complete redesign and implementation.
+  #
   # <identifier>:
   #   <propertyName>:
-  #      - required
-  #      - email
-  #      - disabled
-  #      - readonly
+  #      - required   # must not be empty; adds the "required" flag to the TCA column
+  #      - email      # must be an email address; renders an email input
+  #      - number     # renders a number input; adds no further validation
+  #      - disabled   # must not be edited; implies "readonly" and cancels "required"
+  #      - readonly   # shown but not writable; cancels "required"
+  #
+  # Flag names are matched case insensitively, anything not listed above is ignored. A "disabled" or
+  # "readonly" property is never written by the frontend transformation, which is what protects
+  # already stored data from being emptied by a submitted form.
   contract:
     position:
       - required


### PR DESCRIPTION
Comment-only correction of the two `Settings.yaml` files that carry validation
configuration. ACE-447.

## Why

Both files describe themselves in comments, and both descriptions were wrong.
Until the manuals landed (ACE-446, #503) those comments were the only
description of the mechanism that existed, so they were what anyone looking it
up actually found.

**`academic_persons`**

* The header called the file *"Validation configuration for
  EXT:academic_persons_edit or custom implementation"* and omitted the TYPO3
  backend — which is half of what it does. All six TCA files merge in
  `getValidationTcaTableConfig()`, so the settings drive the record editor
  whether or not the editing extension is installed.
* `@internal Syntax if this configuration file is considered experimental and
  will change until 2.1.0 release.` — the deadline is long past, and the
  sentence is malformed.
* The inline flag list documented `required`, `email`, `disabled` and
  `readonly` but **not `number`**, which the same file uses for `streetNumber`,
  `zip` and `year`.

**`academic_jobs`** opened with a copy of that block, wrong in both directions:
it advertised `disabled` and `readonly`, which **none** of its three readers
understand, and omitted `url` and `number`, which the shipped configuration
below it actually uses. The file had no header at all.

## What changed

Both files now name their consumers, link the rendered manual and annotate each
flag. The jobs file additionally states that it does **not** reach the backend,
that its keywords are matched case sensitively, and that `disabled`/`readonly`
must not be used there — its form ViewHelper emits the first keyword that is not
`required` verbatim as the HTML input type, so they would render as
`<input type="disabled">` rather than being ignored.

The keyword divergence itself is **not** touched here; that is ACE-429.

## Verification

Comments only. Both files parse to exactly the same structure as before —
checked by loading the old and new versions and comparing the parsed data, not
by reading the diff.

Green locally on both core versions, each after its own `composerUpdate`:
`lintPhp`, `cgl -n`, `phpstan`, `unit` (641), `functional` (1084 on v13, 1092 on
v14).

Depends on nothing, but reads better merged after #503, which adds the manuals
these comments link to. Backport to `2` follows.
