### PR TITLE
[TASK] ACE-446: Document the validation settings

### DIFF
--- a/docs/Index.md
+++ b/docs/Index.md
@@ -29,12 +29,14 @@ such manual per extension; this tree is the single, repository-wide counterpart.
 
 ## [Architecture](architecture/Index.md)
 
-| Page                                                               | Contents                                                                                             |
-|--------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| [Core version aware code](architecture/core-version-aware-code.md) | Version switches, and when to split classes and configuration per core version.                      |
-| [Dependency injection](architecture/dependency-injection.md)       | Service configuration, stateless services, the TYPO3 attributes that are safe on both core versions. |
-| [Class design](architecture/class-design.md)                       | What the code base actually does with `final`, `readonly`, injection and data objects.               |
-| [Database queries](architecture/database-queries.md)               | The two query builder rules that were learned from released defects.                                 |
+| Page                                                                 | Contents                                                                                                      |
+|----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| [Core version aware code](architecture/core-version-aware-code.md)   | Version switches, and when to split classes and configuration per core version.                               |
+| [Dependency injection](architecture/dependency-injection.md)         | Service configuration, stateless services, the TYPO3 attributes that are safe on both core versions.          |
+| [Class design](architecture/class-design.md)                         | What the code base actually does with `final`, `readonly`, injection and data objects.                        |
+| [Database queries](architecture/database-queries.md)                 | The two query builder rules that were learned from released defects.                                          |
+| [Validation settings](architecture/validation-settings.md)           | The one YAML driving both the backend FormEngine and the frontend edit form, and how it is overridden.        |
+| [Form data transformation](architecture/form-data-transformation.md) | When a submitted value reaches the domain model, and why the shipped `profile` defaults lock the name fields. |
 
 ## [Testing](testing/Index.md)
 

--- a/docs/architecture/Index.md
+++ b/docs/architecture/Index.md
@@ -16,15 +16,23 @@ This branch supports **TYPO3 v12 and v13**.
 - Never hand a raw array to `in()` or `notIn()`, and build a constraint on the
   query builder that executes it. Both rules come from defects that reached a
   release, and the first one bites hardest on v12, which has no guard at all.
+- One YAML in `academic_persons` drives field validation for **both** the backend
+  FormEngine and the frontend edit form. It ships there, not in
+  `academic_persons_edit`, because the TCA needs it.
+- In the frontend edit forms, a `disabled` or `readOnly` property is **never**
+  written, whatever the request carries. The shipped `profile` set locks the
+  three name fields that way, which is intended and regularly misread.
 
 ## Pages
 
-| Page                                                  | Contents                                                                                                                                         |
-|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Core version aware code](core-version-aware-code.md) | The four mechanisms in use, the `Core12/`/`Core13/` split in `academic-base`, and how version specific tests are grouped.                        |
-| [Dependency injection](dependency-injection.md)       | How services are configured across the extensions, why they must be stateless, and which Symfony and TYPO3 attributes exist on both v12 and v13. |
-| [Class design](class-design.md)                       | `final`, `readonly`, constructor versus method injection, data objects, and the traps in Extbase models.                                         |
-| [Database queries](database-queries.md)               | Quoting value lists, and keeping a constraint on the builder that executes it.                                                                   |
+| Page                                                    | Contents                                                                                                                                         |
+|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Core version aware code](core-version-aware-code.md)   | The four mechanisms in use, the `Core12/`/`Core13/` split in `academic-base`, and how version specific tests are grouped.                        |
+| [Dependency injection](dependency-injection.md)         | How services are configured across the extensions, why they must be stateless, and which Symfony and TYPO3 attributes exist on both v12 and v13. |
+| [Class design](class-design.md)                         | `final`, `readonly`, constructor versus method injection, data objects, and the traps in Extbase models.                                         |
+| [Database queries](database-queries.md)                 | Quoting value lists, and keeping a constraint on the builder that executes it.                                                                   |
+| [Validation settings](validation-settings.md)           | The one YAML that drives both the backend FormEngine and the frontend edit form, its flags, and how an installation overrides it.                |
+| [Form data transformation](form-data-transformation.md) | How a submitted value reaches the model, why `disabled` wins over everything, and the shipped defaults that surprise people.                     |
 
 ## See also
 

--- a/docs/architecture/form-data-transformation.md
+++ b/docs/architecture/form-data-transformation.md
@@ -1,0 +1,205 @@
+# Form data transformation
+
+How `EXT:academic_persons_edit` decides whether a submitted value reaches the
+domain model. The rules are small; the reason to write them down is that two of
+them look like defects when you meet them for the first time, and both have
+already been misread once.
+
+The code is `packages/fgtclb/academic-persons-edit/Classes/Domain/Factory/` —
+six factories, one private setter per property — plus
+`Classes/Domain/Model/Dto/AbstractFormData.php`.
+
+## The decision, in order
+
+Every factory setter is guarded by the same private helper, `mayApplyProperty()`,
+identical in all six (`ProfileFactory.php:63`, `ContractFactory.php:56`,
+`AddressFactory.php:58`, `ProfileInformationFactory.php:49`,
+`EmailFactory.php:39`, `PhoneNumberFactory.php:39`):
+
+```php
+private function mayApplyProperty(ValidationSet $validationSet, ProfileFormData $form, string $propertyName): bool
+{
+    $validation = $validationSet->get($propertyName);
+    if ($validation !== null && ($validation->readOnly || $validation->disabled)) {
+        // ReadOnly or disabled: keep existing persisted data and ignore the submitted value.
+        return false;
+    }
+    return $form->shouldApplyProperty($propertyName);
+}
+```
+
+So a value is written only when **both** hold:
+
+1. the property is not configured `readOnly` or `disabled`, and
+2. it was either sent in the request, or registered as an override —
+   `shouldApplyProperty()` is `wasPropertySentInRequest() || hasPropertyOverride()`.
+
+The order matters and is deliberate: the validation configuration wins over
+everything, including an override. A listener cannot write a property the
+configuration locks.
+
+## Rule 1 — `disabled` and `readOnly` protect persisted data
+
+This is not a validation rule that leaked into the wrong layer. It is the
+server-side half of a policy whose client-side half is the rendered form.
+
+The guard arrived with `dfabb2943` (`[TASK] ACE-33: Refactor configuration
+handling`), whose comment states the motive directly: *ignore value to prevent
+empty existing persisted data*. `63609482d` later hoisted it into
+`mayApplyProperty()` and added the request detection of rule 2, keeping the
+precedence explicit — *"readOnly/disabled validation configuration keeps
+precedence to protect persisted data"*.
+
+### What the browser does, and where the guard is actually load-bearing
+
+All five form partials under `Resources/Private/Partials/Profile/Forms/` render
+the flags onto the control, e.g. `Textfield.html:36-38`:
+
+```html
+disabled="{validation.disabled ? 'disabled' : ''}"
+required="{validation.required ? 'required' : ''}"
+readonly="{validation.readOnly ? 'readonly' : ''}"
+```
+
+The empty branch is safe: Fluid drops a registered tag attribute whose value is
+`''`, so `disabled=""` — which *would* disable the control — never reaches the
+HTML.
+
+What the server then receives differs per control type, and this is the part
+worth knowing:
+
+| Control                               | Marked `disabled`                        | Marked `readOnly`                              |
+|---------------------------------------|------------------------------------------|------------------------------------------------|
+| `f:form.textfield`, `f:form.textarea` | Not submitted at all — the key is absent | Submitted, with the value it was rendered with |
+| `f:form.select`, `f:form.checkbox`    | **Submitted as `''`** — see below        | Submitted, with the value it was rendered with |
+
+The select and checkbox case is the one that bites. Both view helpers emit a
+companion hidden field so that an empty selection still reaches the server, and
+that hidden field is **not** disabled — see
+`renderHiddenFieldForEmptyValue()` in
+`cms-fluid/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php`, whose last
+statement is:
+
+```php
+return '<input type="hidden" name="' . htmlspecialchars($fieldName) . '" value="" />';
+```
+
+So for a disabled select or checkbox the property *does* arrive, with an empty
+value, and `wasPropertySentInRequest()` returns `true`. Without rule 1 the stored
+value would be overwritten with `''` on every save. **That is the data loss the
+guard exists to prevent**, and no amount of request-level detection would catch
+it, because as far as the request is concerned the field was submitted.
+
+For a disabled text field the guard is belt-and-braces: a browser omits the key,
+so rule 2 would already skip it. It still matters, because a hand-built or
+forged POST can carry the key anyway.
+
+## Rule 2 — only what the request carried
+
+`AbstractFormData::wasPropertySentInRequest()` (`AbstractFormData.php:81-93`)
+reads exactly one source:
+
+```php
+$arguments = $this->getActionRequestArguments();   // $request->getAttribute('extbase')->getArguments()
+$argumentName = $this->getArgumentName();          // set by AbstractFormDataConverter
+...
+return array_key_exists($propertyName, $namespacedArguments);
+```
+
+Never `getParsedBody()`. The arguments come from `RequestBuilder`, already
+stripped of the plugin namespace and keyed by action argument name, and the
+argument name is `$argument->getName()`, configured onto the type converter by
+`AbstractActionController::initializeAction()`.
+
+This exists because before `63609482d` the factories wrote **every** property on
+every request, so a field that was not part of a form was overwritten with the
+empty DTO default. See
+`packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-FormDataTransformationOnlyMapsSubmittedFields.rst`.
+
+## The shipped defaults, and the trap they set
+
+`packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml:80-87`
+is the only place the `profile` set is defined:
+
+```yaml
+  profile:
+    firstName:
+      - disabled
+      - required
+    middleName:
+      - disabled
+    lastName:
+      - disabled
+```
+
+**The three name fields are locked on purpose.** The commit that did it,
+`7c9ae9a0c`, says so: *"the name fields of the profile were set not only to
+required, but also to disabled as the fields should not be overwritten in the
+frontend."* They are typically owned elsewhere — an Active Directory or LDAP
+backed `fe_user`, synchronised into the profile — which is also why
+`skipSync` exists.
+
+> **The trap.** A test, a script or a `curl` that posts `profileFormData[firstName]`
+> and then asserts the record changed will find it unchanged, and it is very easy
+> to read that as "the form is broken" or "the request detection does not work".
+> It is neither. No browser sends that key, because the input is rendered
+> `disabled`; the value only arrives because it was posted by hand, and rule 1
+> then discards it exactly as intended. This has already been misdiagnosed once,
+> while writing
+> `packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileFormSubmissionTest.php`
+> — whose first version asserted on the name fields for this reason. **When a
+> transformation test needs an editable property, use one that the shipped set
+> does not lock** — `website` and `websiteTitle` are the ones that test settled on.
+
+### `- required` on `firstName` is inert
+
+`AcademicPersonsSettingsFactory::normalizeValidations()` (`:99-109`) computes:
+
+```php
+$required = !$disabled && !$readOnly && in_array('required', $validators, true);
+...
+if ($disabled) {
+    // @todo Investigate how to handle that for the backend / TCA FormEngine, therefore switch to
+    //       readOnly for now
+    $readOnly = true;
+}
+```
+
+So `disabled` cancels `required` and additionally forces `readOnly`. For the
+shipped set that means no validator is produced for any of the three properties,
+which is correct — a field the user cannot edit cannot be required of them. The
+`- required` entry on `firstName` is a leftover with no effect.
+
+`disabled` therefore always implies `readOnly` for anything this factory
+produces, so the `||` in rule 1 only distinguishes the two for a `Validation`
+built by hand.
+
+**The same configuration also drives the TYPO3 backend**, deliberately: all six
+TCA tables merge in `getValidationTcaTableConfig()`, so a locked field is read
+only in the record editor as well. That coupling — and the reason the settings
+ship in `academic_persons` rather than in the edit extension — is documented in
+[Validation settings](validation-settings.md).
+
+## Overriding the set in an instance
+
+An installation that wants the names editable ships its own `Settings.yaml`. The
+mechanism has sharp edges — a shallow merge that replaces all six sets at once —
+and is described in
+[Validation settings](validation-settings.md#overriding-the-settings-in-an-installation).
+Note that it changes the backend record editor at the same time.
+
+## See also
+
+- [Validation settings](validation-settings.md) — the shared configuration behind
+  rule 1, why it lives in `academic_persons`, and how it drives the backend
+  FormEngine as well.
+- [Class design](class-design.md) — the DTO and data object conventions these
+  form data objects follow.
+- [Dependency injection](dependency-injection.md) — how the factories and the
+  settings service are wired.
+- [Functional tests](../testing/functional-tests.md) — running the plugin
+  rendering tests that exercise this path end to end.
+- `packages/fgtclb/academic-persons-edit/Documentation/Changelog/2.4/Important-FormDataTransformationOnlyMapsSubmittedFields.rst`
+  — the integrator-facing entry for rule 2.
+- `packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml`
+  — the shipped sets, and the only file that defines them.

--- a/docs/architecture/validation-settings.md
+++ b/docs/architecture/validation-settings.md
@@ -1,0 +1,245 @@
+# Validation settings
+
+One YAML file describes, per record type and per field, whether a field is
+required, read only or disabled. It is the **single source of truth for both
+editing contexts**: the TYPO3 backend FormEngine and the frontend edit form of
+`EXT:academic_persons_edit`.
+
+This page describes the `academic_persons` mechanism. **`academic_jobs` ships a
+second, unrelated implementation** of the same idea, with its own file, its own
+loader and a different keyword vocabulary — see
+[The second implementation](#the-second-implementation-in-academic_jobs) at the
+end. The two share no code.
+
+That is why the file ships in **`academic_persons`** and not in the edit
+extension. `academic_persons` owns the domain models and their TCA, so it must
+own the configuration that drives the backend forms; the frontend edit extension
+is the *second* consumer of the same data, not its owner. An installation that
+does not have `academic_persons_edit` installed still gets the backend half.
+
+## The file
+
+`packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml`
+is the only place the sets are defined. The dual purpose is stated in the file
+itself, above the `validations` key:
+
+```yaml
+# Validation configuration for frontend fluid forms and backend formengine configured using TCA adoption.
+```
+
+Until the integrator manual was written, that one comment was the only place in
+the repository stating the coupling at all — see
+[Documentation state](#documentation-state) below.
+
+A set maps a property name to a list of flags. The shipped `profile` set is the
+shortest example, and the one most often met:
+
+```yaml
+  profile:
+    firstName:
+      - disabled
+      - required
+    middleName:
+      - disabled
+    lastName:
+      - disabled
+```
+
+Six sets exist, one per editable record type: `profile`, `contract`,
+`emailAddress`, `phoneNumber`, `physicalAddress`, `profileInformation`.
+
+The recognised flags, all matched case-insensitively
+(`AcademicPersonsSettingsFactory::normalizeValidations()`):
+
+| Flag       | Effect                                                                  |
+|------------|-------------------------------------------------------------------------|
+| `required` | Adds `NotEmptyValidator`, and `required` + `minitems` to the TCA config |
+| `disabled` | Field must not be edited. Forces `readOnly`, and cancels `required`     |
+| `readonly` | Field is shown but not writable. Cancels `required`                     |
+| `email`    | Adds `EmailAddressValidator`, TCA `type` and input type `email`         |
+| `number`   | TCA `type` and input type `number` — no validator today                 |
+
+Anything else in the list is ignored. There is no `url` flag yet; the source
+carries a `@todo` for it.
+
+## Normalisation
+
+The factory turns each flag list into one `Validation` value object:
+
+```php
+$readOnly = in_array('readonly', $validators, true);
+$disabled = in_array('disabled', $validators, true);
+$required = !$disabled && !$readOnly && in_array('required', $validators, true);
+...
+if ($disabled) {
+    // @todo Investigate how to handle that for the backend / TCA FormEngine, therefore switch to
+    //       readOnly for now
+    $readOnly = true;
+}
+```
+
+Two consequences worth knowing:
+
+- **`disabled` implies `readOnly`.** FormEngine has no per-field notion matching
+  the HTML `disabled` attribute, so `disabled` is expressed to the backend as
+  `readOnly`. The `@todo` records that this mapping is provisional, not that the
+  backend coupling is unintended. For anything produced by this factory,
+  `disabled` therefore never occurs without `readOnly`.
+- **`disabled` and `readonly` cancel `required`.** A field the user cannot edit
+  cannot be demanded of them, so no validator is generated. This is why the
+  shipped `profile` set produces no validators at all — all three of its entries
+  are `disabled` — and why the `- required` on `firstName` has no effect.
+
+`Validation::$fieldName` is the property name converted with
+`GeneralUtility::camelCaseToLowerCaseUnderscored()`, i.e. the database column:
+`firstName` becomes `first_name`. That is what lets one entry address both the
+Extbase property and the TCA column.
+
+## Consumer 1 — the TYPO3 backend FormEngine
+
+`AcademicPersonsSettings::getValidationTcaTableConfig($identifier)` returns a
+`columns.<field>.config` fragment built from each `Validation::$tcaConfig`, and
+**every one of the six TCA files merges it in**:
+
+| Set                  | TCA file                                                  |
+|----------------------|-----------------------------------------------------------|
+| `profile`            | `tx_academicpersons_domain_model_profile.php`             |
+| `contract`           | `tx_academicpersons_domain_model_contract.php`            |
+| `emailAddress`       | `tx_academicpersons_domain_model_email.php`               |
+| `phoneNumber`        | `tx_academicpersons_domain_model_phone_number.php`        |
+| `physicalAddress`    | `tx_academicpersons_domain_model_address.php`             |
+| `profileInformation` | `tx_academicpersons_domain_model_profile_information.php` |
+
+So marking a field `disabled` or `readonly` in the YAML makes it read only in the
+backend record editor as well — by design, and for every backend user.
+
+The merge is not written the same way everywhere: the profile table uses
+`ArrayUtility::mergeRecursiveWithOverrule()`, the contract table uses
+`array_replace_recursive()`. Both achieve the merge; the inconsistency is
+cosmetic. All six call sites carry the same `@todo`:
+
+> MAIN TCA Files should be kept without dynamic calls, and following should be
+> done in override files.
+
+That is a structural note about *where* the call belongs — `Configuration/TCA/`
+versus `Configuration/TCA/Overrides/` — not a doubt about the coupling itself.
+
+## Consumer 2 — the frontend edit form
+
+`AcademicPersonsSettings::getValidationSetWithFallback($identifier)` returns the
+`ValidationSet`, and `EXT:academic_persons_edit` uses it in three places:
+
+1. **Rendering.** The form partials under
+   `Resources/Private/Partials/Profile/Forms/` map the flags straight onto the
+   control: `disabled`, `readonly` and `required` attributes.
+2. **Validation.** `required` contributes `NotEmptyValidator` to the
+   `*FormDataValidator` of the matching argument.
+3. **Transformation.** `disabled` and `readOnly` properties are never written to
+   the model, whatever the request contains — see
+   [Form data transformation](form-data-transformation.md), which is where that
+   rule and the traps around it are documented.
+
+An unknown identifier yields an empty `ValidationSet`, so every property falls
+through as unconfigured.
+
+## Overriding the settings in an installation
+
+`AcademicPersonsSettingsFactory::loadUncached()` walks every **active package**,
+reads `Configuration/AcademicPersons/Settings.yaml` if present, and folds them
+together with `array_merge()`. To change a set:
+
+- Ship the file in a site package that **depends on `academic_persons`**, so that
+  the package is ordered after it — the last one loaded wins.
+- Restate the **whole `validations` block**. `array_merge()` is shallow and
+  `validations` is a top-level key, so redefining it replaces all six sets at
+  once. There is no deep merge, and no syntax for removing a single flag from a
+  single field.
+- Flush the core cache afterwards; the normalised result is cached in
+  `cache.core`.
+
+There is no TypoScript and no site-set path — the site sets do not expose
+validations.
+
+Because both consumers read the same data, an override changes the backend and
+the frontend together. Re-enabling the profile name fields for the frontend edit
+form therefore also makes those columns writable again in the backend record
+editor. That is usually what is wanted, but it is worth being deliberate about.
+
+## The second implementation, in `academic_jobs`
+
+`academic_jobs` has its own `Configuration/AcademicJobs/Settings.yaml`, read by
+`AcademicJobsSettingsLoader` into `AcademicJobsSettingsRegistry`. The package
+walk and the shallow `array_merge()` are the same algorithm, so the override
+rules match — but nothing else does, and the two systems share no code.
+
+|                         | `academic_persons`                                | `academic_jobs`                                       |
+|-------------------------|---------------------------------------------------|-------------------------------------------------------|
+| Normalisation           | once, at load, into `Validation` objects          | none — three readers reinterpret the raw array        |
+| Keyword case            | lowercased before matching                        | case sensitive                                        |
+| Backend TCA             | merged by all six TCA files                       | `getValidationsForTca()` exists but **has no caller** |
+| Frontend rendering      | `disabled` / `readonly` / `required` / input type | required asterisk and input type only                 |
+| Transformation guard    | yes — locked properties are never written         | none                                                  |
+| `disabled` / `readonly` | supported                                         | **understood by none of the three readers**           |
+| `url`                   | not understood                                    | validator only, no TCA                                |
+| `number`                | TCA and input type, no validator                  | TCA and input type, no validator                      |
+
+Two of those deserve emphasis because they are traps rather than gaps:
+
+- `FieldTypeFromValidationViewHelper` returns **the first non-`required` list
+  entry verbatim as the HTML `type` attribute**. An unknown keyword is therefore
+  not ignored — `disabled` renders `<input type="disabled">`. It is the only
+  place in either system where a typo produces output instead of silence.
+- The jobs `Settings.yaml` carries a copy of the persons comment block, so it
+  documents `disabled` and `readonly`, which do nothing there, and omits `url`
+  and `number`, which it actually uses.
+
+The divergence between its three readers is tracked as ACE-429.
+
+## Documentation state
+
+Integrator-facing documentation was written on 2026-08-16 and now exists:
+
+- `academic-persons/Documentation/Configuration/Validations/Index.rst` — the
+  reference: sets, flags, the locked-by-default name fields, both consumers, and
+  the override procedure.
+- `academic-jobs/Documentation/Configuration/Validations/Index.rst` — the second
+  implementation, documenting only what actually takes effect, with the
+  `disabled`/`readonly` trap called out.
+- `academic-persons-edit/Documentation/Configuration/General/Index.rst` — a
+  *Which fields can be edited* section pointing at the persons manual, since that
+  is where integrators meet the locked name fields.
+
+Before that there was nothing: across the `Documentation/` trees of all twelve
+packages there was not one hit for `Settings.yaml`, for the `validations` key, or
+for `AcademicPersonsSettings`, and neither README mentioned it.
+
+Cross-extension links are plain external URLs to docs.typo3.org. That is
+deliberate — no FGTCLB extension registers an intersphinx inventory in its
+`guides.xml`, and adding one would make the render depend on a sibling's
+published inventory being reachable, which `--fail-on-log --fail-on-error` would
+turn red.
+
+Still open, in the YAML files themselves rather than in the manuals:
+
+- The persons header calls it "Validation configuration for
+  EXT:academic_persons_edit or custom implementation" — it omits the backend,
+  which is half the point.
+- Its inline flag list documents `required`, `email`, `disabled` and `readonly`
+  but **not** `number`, which the file itself uses for `streetNumber`, `zip` and
+  `year`.
+- `@internal … will change until 2.1.0 release` is stale; the branch is
+  `2.4.x-dev`.
+- The jobs file's copied comment block is wrong for that extension, as above.
+
+## See also
+
+- [Form data transformation](form-data-transformation.md) — how the frontend edit
+  form decides whether a submitted value reaches the model, and why a `disabled`
+  property is discarded even when it was submitted.
+- [Class design](class-design.md) — the value object conventions `Validation` and
+  `ValidationSet` follow.
+- `packages/fgtclb/academic-persons/Configuration/AcademicPersons/Settings.yaml`
+  — the shipped sets.
+- `packages/fgtclb/academic-persons/Classes/Settings/` —
+  `AcademicPersonsSettingsFactory`, `AcademicPersonsSettings`, `ValidationSet`
+  and `Validation`.

--- a/packages/fgtclb/academic-jobs/Documentation/Configuration/Index.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Configuration/Index.rst
@@ -9,3 +9,4 @@ Configuration
    :titlesonly:
 
    General/Index
+   Validations/Index

--- a/packages/fgtclb/academic-jobs/Documentation/Configuration/Validations/Index.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Configuration/Validations/Index.rst
@@ -1,0 +1,133 @@
+..  index:: Configuration; Validations
+..  _configuration-validations:
+
+===================
+Validation settings
+===================
+
+:file:`Configuration/AcademicJobs/Settings.yaml` describes which fields of a job
+record are required, and how they are rendered in the public *new job* form.
+
+..  attention::
+    The syntax of this file is still considered experimental and may change in a
+    future release. Read :ref:`configuration-validations-limits` before relying
+    on it — not every keyword takes effect in every place.
+
+The file
+========
+
+The shipped configuration defines a single set, :yaml:`job`. Its keys are
+**property names** in camel case, each carrying a list of flags:
+
+..  code-block:: yaml
+
+    validations:
+      job:
+        title:
+          - required
+        link:
+          - url
+        contactEmail:
+          - email
+        contactPhone:
+          - number
+
+A property that is not listed is neither required nor specially rendered.
+
+Where the settings take effect
+==============================
+
+The configuration is read in three independent places, and — this is the
+important part — **they do not all understand the same keywords**:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Keyword
+        -   New job form
+        -   Server side validation
+        -   Backend (TCA)
+    *   -   :yaml:`required`
+        -   Marks the field with an asterisk
+        -   Value must not be empty
+        -   Not applied
+    *   -   :yaml:`email`
+        -   Renders :html:`<input type="email">`
+        -   Value must be an email address
+        -   Not applied
+    *   -   :yaml:`url`
+        -   Renders :html:`<input type="url">`
+        -   Value must be a URL
+        -   Not applied
+    *   -   :yaml:`number`
+        -   Renders :html:`<input type="number">`
+        -   **No validation**
+        -   Not applied
+
+Server side validation runs when a job is **created** through the frontend form.
+It does not run for records edited in the TYPO3 backend.
+
+..  _configuration-validations-limits:
+
+Current limitations
+===================
+
+..  warning::
+    :yaml:`disabled` and :yaml:`readonly` are **not supported** by this
+    extension, even though older comments inside the shipped
+    :file:`Settings.yaml` mention them.
+
+    They do not lock a field anywhere. Worse, because the form takes the first
+    keyword that is not :yaml:`required` and uses it directly as the HTML input
+    type, writing :yaml:`disabled` produces :html:`<input type="disabled">`,
+    which browsers fall back to rendering as an ordinary text field. Do not use
+    these two keywords here.
+
+    They *are* supported by :guilabel:`academic_persons`, which is a separate
+    mechanism — see `its validation settings
+    <https://docs.typo3.org/p/fgtclb/academic-persons/main/en-us/Configuration/Validations/Index.html>`__.
+
+Further points to be aware of:
+
+*   **Keywords are case sensitive.** :yaml:`Required` or :yaml:`EMAIL` are
+    silently ignored. Always write them in lower case.
+*   **Any unknown keyword becomes an HTML input type** in the new job form, as
+    described in the warning above. A typo therefore produces an invalid input
+    type rather than being ignored.
+*   :yaml:`number` marks the field as numeric in the form but adds no server
+    side validation, so a non-numeric value submitted by other means is
+    accepted.
+*   :yaml:`required` cannot detect an unselected value for the job type and
+    employment type fields, because those are stored as numbers and an unset
+    selection is indistinguishable from a valid zero.
+*   The configuration is **not** applied to the TYPO3 backend. Required fields
+    in the backend record editor are configured separately in the extension's
+    TCA, and the two may differ.
+
+Overriding the settings
+=======================
+
+Settings are collected from **all installed extensions**. Every package that
+contains :file:`Configuration/AcademicJobs/Settings.yaml` contributes, and the
+package loaded last wins.
+
+To change them for an installation:
+
+#.  Add :file:`Configuration/AcademicJobs/Settings.yaml` to your site package.
+#.  Make the site package **depend on** :guilabel:`academic_jobs` in its
+    :file:`composer.json` or :file:`ext_emconf.php`, so that it is loaded after
+    it.
+#.  Repeat the **complete** :yaml:`validations` block, see the warning below.
+#.  Flush the TYPO3 caches — the parsed settings are cached, and a changed file
+    has no effect until the cache is cleared.
+
+..  warning::
+    The files are merged on the top level only. :yaml:`validations` is a
+    top-level key, so a site package that defines it replaces the whole block —
+    anything it does not repeat is lost, not inherited.
+
+    Copy the whole :yaml:`validations` block from
+    :file:`EXT:academic_jobs/Configuration/AcademicJobs/Settings.yaml` and edit
+    the copy. There is no syntax for removing a single flag from a single field.
+
+There is no TypoScript and no site set equivalent for these settings.

--- a/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
+++ b/packages/fgtclb/academic-persons-edit/Documentation/Configuration/General/Index.rst
@@ -32,6 +32,36 @@ assigned profile and that meets the criteria logs in.
     A comma-separated list of language IDs. These IDs configure in which languages a
     persons profile can be translated by a frontend user.
 
+..  _configuration-general-validations:
+
+Which fields can be edited
+==========================
+
+Which profile fields the editing forms offer, which are mandatory and which are
+locked is **not** configured in this extension. It comes from the validation
+settings shipped by :guilabel:`academic_persons`, in
+:file:`Configuration/AcademicPersons/Settings.yaml`, which the editing forms
+read directly.
+
+Consequences worth knowing before reporting a problem:
+
+*   A field configured :yaml:`disabled` or :yaml:`readonly` is rendered locked,
+    and a value submitted for it anyway is discarded rather than stored. This is
+    deliberate and protects already stored data.
+*   :guilabel:`First name`, :guilabel:`Middle name` and :guilabel:`Last name` are
+    **locked by default**, because profile names are usually owned by the
+    connected frontend user record and synchronised from elsewhere. They are
+    therefore not editable in the frontend form — and, since the same
+    configuration also drives the backend, not in the TYPO3 record editor
+    either.
+*   Because both editing contexts share one configuration, unlocking a field for
+    the frontend form also unlocks it in the backend.
+
+See `Validation settings
+<https://docs.typo3.org/p/fgtclb/academic-persons/main/en-us/Configuration/Validations/Index.html>`__
+in the :guilabel:`academic_persons` manual for the available flags, the shipped
+defaults and how to override them.
+
 ..  _configuration-general-webp:
 
 Image processing: WebP is required

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFactoryTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Domain/Factory/ProfileFactoryTest.php
@@ -92,9 +92,17 @@ final class ProfileFactoryTest extends AbstractFactoryTestCase
      * The argument name is what turns the request arguments into "this form's" arguments, and it
      * is set by `AbstractFormDataConverter` only when the controller configured it - which
      * `AbstractActionController::initializeAction()` does for every argument of type
-     * `AbstractFormData`. A controller that does not go through that base class gets a form data
-     * object with a request but without an argument name, and then *nothing* is applied: the
-     * submitted values are dropped without any error.
+     * `AbstractFormData`. Without it *nothing* is applied: the submitted values are dropped
+     * without any error.
+     *
+     * A guard rail, not a reachable defect (ACE-424). Every shipped controller is `final`,
+     * extends `AbstractActionController` and does not override `initializeAction()`, so only
+     * third party code could produce this state. What the test protects is the contract itself:
+     * should the base class ever stop configuring the converter, the silent-drop is caught here
+     * rather than in a support ticket.
+     *
+     * @see \FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins\AcademicPersonsEditProfileFormSubmissionTest
+     *      for the same code path exercised through a real frontend request
      */
     #[Test]
     public function formDataWithoutAnArgumentNameAppliesNothingAlthoughValuesWereSubmitted(): void
@@ -116,9 +124,19 @@ final class ProfileFactoryTest extends AbstractFactoryTestCase
     }
 
     /**
-     * The same failure from the other side: the argument was renamed in the controller but the
-     * form still posts under the old name, so the values arrive, are mapped, and are then not
-     * recognised as belonging to this argument.
+     * The same failure from the other side: the form data object is bound to an argument name
+     * the request does not carry, so the values arrive, are mapped, and are then not recognised
+     * as belonging to this argument.
+     *
+     * Extbase cannot produce this. `mapRequestArgumentsToControllerArguments()` hands the
+     * converter `$argument->getName()`, and only enters that branch when
+     * `$this->request->hasArgument($argument->getName())` is true - so the bound name is always
+     * a key the request carries. A form posting under a name the controller does not declare
+     * raises `RequiredArgumentMissingException` 1298012500 instead, because no `*FormData`
+     * action argument is optional. The state is reached here by handing `mapFormData()` an
+     * explicit `$boundArgumentName`, which is the converter option a controller supplies.
+     *
+     * Kept as a guard rail over that invariant - see ACE-424.
      */
     #[Test]
     public function formDataBoundToAnotherArgumentNameAppliesNothing(): void
@@ -139,7 +157,12 @@ final class ProfileFactoryTest extends AbstractFactoryTestCase
 
     /**
      * An override is registered on the form data object, not in the request, so it survives both
-     * failures above - which is what makes it usable as a repair from a PSR-14 listener.
+     * failures above - which is what would make it usable as a repair from a listener.
+     *
+     * Note that no such listener can exist yet: the extension dispatches no event carrying an
+     * `AbstractFormData`, so `setPropertyOverride()` has no production caller at all. The event
+     * is ACE-445, and the typed read the factories need before it can ship is part of that
+     * issue's scope.
      */
     #[Test]
     public function registeredOverrideIsAppliedEvenWithoutAnArgumentName(): void

--- a/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileFormSubmissionTest.php
+++ b/packages/fgtclb/academic-persons-edit/Tests/Functional/Plugins/AcademicPersonsEditProfileFormSubmissionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersonsEdit\Tests\Functional\Plugins;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+
+/**
+ * Submits the profile edit form of the `academicpersonsedit_profileediting` plugin through a
+ * real frontend request and pins the DTO to domain model transformation end to end.
+ *
+ * The factory tests in `Tests/Functional/Domain/Factory/` drive the property mapper directly,
+ * which lets them configure the type converter with an `argumentName` of their choosing. This
+ * test does not: it walks the plugin the way a visitor does, so the argument name is the one
+ * `AbstractActionController::initializeAction()` derives from the action signature, and the
+ * request arguments are the ones `RequestBuilder` assembles from the posted body.
+ *
+ * That closes the only gap the factory tests leave open — whether the "was this property sent"
+ * detection works when nothing about the request is arranged by hand.
+ */
+final class AcademicPersonsEditProfileFormSubmissionTest extends AbstractProfileEditingPluginTestCase
+{
+    /**
+     * Walks the plugin from the profile list to the profile edit form and returns its URI.
+     *
+     * The inherited `extractActionLink()` cannot be used: it matches an action name by prefix,
+     * so `edit` returns the `editImage` link that is rendered above it.
+     */
+    private function getProfileEditFormUrl(): string
+    {
+        preg_match_all('@href="([^"]+)"@', $this->getProfileShowPage(), $matches);
+        foreach ($matches[1] as $href) {
+            $href = html_entity_decode($href);
+            if (!str_contains($href, urlencode('[action]') . '=edit&')) {
+                continue;
+            }
+            return str_starts_with($href, '/') ? 'https://www.acme.com' . $href : $href;
+        }
+        $this->fail('No link to the "edit" action found on the profile show page.');
+    }
+
+    /**
+     * Renders the edit page and returns the update form's action URI together with its hidden
+     * fields. The action carries controller and action, the hidden fields carry `__referrer`
+     * and the `__trustedProperties` HMAC, so neither can be hardcoded.
+     *
+     * The page renders more than one form, therefore the update form is selected by its action.
+     *
+     * @return array{action: string, fields: array<string, string>}
+     */
+    private function renderEditFormAndExtractSubmitData(string $formUrl): array
+    {
+        $content = $this->getPageAsFrontendUser($formUrl);
+
+        // The action attribute is URL encoded, so the action name appears as `%5Baction%5D=update`.
+        $this->assertSame(
+            1,
+            preg_match(
+                '@<form [^>]*action="([^"]*' . urlencode('[action]') . '=update[^"]*)"(.*?)</form>@s',
+                $content,
+                $formMatch,
+            ),
+            'The profile edit page does not contain a form posting to the "update" action.',
+        );
+
+        $fields = [];
+        preg_match_all(
+            '@<input[^>]+type="hidden"[^>]+name="([^"]+)"[^>]+value="([^"]*)"@',
+            $formMatch[2],
+            $matches,
+            PREG_SET_ORDER,
+        );
+        foreach ($matches as $match) {
+            $fields[html_entity_decode($match[1])] = html_entity_decode($match[2]);
+        }
+        $this->assertNotEmpty($fields, 'The profile update form contains no hidden fields.');
+
+        return [
+            'action' => html_entity_decode($formMatch[1]),
+            'fields' => $fields,
+        ];
+    }
+
+    /**
+     * @param array<string, string> $submittedProperties property name to value, the only
+     *                                                   `profileFormData` keys that are posted
+     */
+    private function submitProfileForm(string $formUrl, array $submittedProperties): ResponseInterface
+    {
+        $submitData = $this->renderEditFormAndExtractSubmitData($formUrl);
+
+        $parsedBody = $this->pluginArgumentsOfFormAction($submitData['action']);
+        foreach ($submitData['fields'] as $name => $value) {
+            $this->addFormValue($parsedBody, $name, $value);
+        }
+        foreach ($submittedProperties as $propertyName => $value) {
+            $this->addFormValue(
+                $parsedBody,
+                sprintf('tx_academicpersonsedit_profileediting[profileFormData][%s]', $propertyName),
+                $value,
+            );
+        }
+
+        // The body is provided explicitly: the testing framework otherwise serialises the parsed
+        // body with `GuzzleHttp\Psr7\Query::build()`, which cannot handle the nested plugin
+        // arguments and emits an "Array to string conversion" warning.
+        $body = new Stream('php://temp', 'rw');
+        $body->write(http_build_query($parsedBody));
+        $body->rewind();
+
+        $request = (new InternalRequest('https://www.acme.com/home'))
+            ->withMethod('POST')
+            ->withAddedHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($body)
+            ->withParsedBody($parsedBody);
+
+        return $this->requestAsFrontendUser($request);
+    }
+
+    /**
+     * @return array{website: string, website_title: string}
+     */
+    private function getStoredWebsiteFields(): array
+    {
+        $row = $this->getConnectionPool()
+            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
+            ->executeQuery(
+                'SELECT website, website_title FROM tx_academicpersons_domain_model_profile WHERE uid = ?',
+                [self::PROFILE_ID],
+            )
+            ->fetchAssociative();
+        $this->assertIsArray($row, 'The profile record is missing.');
+
+        return [
+            'website' => (string)$row['website'],
+            'website_title' => (string)$row['website_title'],
+        ];
+    }
+
+    /**
+     * Seeds both website fields so that "kept its stored value" is distinguishable from
+     * "was empty all along".
+     */
+    private function seedWebsiteFields(): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable('tx_academicpersons_domain_model_profile')
+            ->update(
+                'tx_academicpersons_domain_model_profile',
+                ['website' => 'https://stored.example.org', 'website_title' => 'Stored title'],
+                ['uid' => self::PROFILE_ID],
+            );
+    }
+
+    /**
+     * Turns `a[b][c]` notation into the nested array the request expects.
+     *
+     * @param array<string, mixed> $target
+     */
+    private function addFormValue(array &$target, string $name, string $value): void
+    {
+        $position = strpos($name, '[');
+        if ($position === false) {
+            $target[$name] = $value;
+            return;
+        }
+        preg_match_all('@\[([^]]*)]@', $name, $matches);
+        $keys = array_merge([substr($name, 0, $position)], $matches[1]);
+        $current = &$target;
+        foreach ($keys as $key) {
+            if (!isset($current[$key]) || !is_array($current[$key])) {
+                $current[$key] = [];
+            }
+            $current = &$current[$key];
+        }
+        $current = $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pluginArgumentsOfFormAction(string $action): array
+    {
+        $query = parse_url($action, PHP_URL_QUERY);
+        if (!is_string($query) || $query === '') {
+            return [];
+        }
+        $parsed = [];
+        parse_str($query, $parsed);
+
+        $arguments = [];
+        foreach ($parsed as $name => $value) {
+            $arguments[(string)$name] = $value;
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * The baseline: a submitted property reaches the record. If the argument name were not set
+     * on the form data object, `shouldApplyProperty()` would be false for every property and
+     * both fields would keep their seeded values.
+     *
+     * `website` and `websiteTitle` are used rather than the name fields, because the shipped
+     * `profile` validation set marks `firstName`, `middleName` and `lastName` as `disabled`,
+     * so `mayApplyProperty()` rejects them before the request is consulted at all.
+     */
+    #[Test]
+    public function submittedPropertyIsPersisted(): void
+    {
+        $this->setUpTestCase();
+        $this->seedWebsiteFields();
+
+        $this->submitProfileForm($this->getProfileEditFormUrl(), [
+            'website' => 'https://submitted.example.org',
+            'websiteTitle' => 'Submitted title',
+        ]);
+
+        $this->assertSame(
+            ['website' => 'https://submitted.example.org', 'website_title' => 'Submitted title'],
+            $this->getStoredWebsiteFields(),
+        );
+    }
+
+    /**
+     * The other half, and the behaviour ACE-33 introduced: a property that is not part of the
+     * submitted body keeps its stored value instead of being overwritten with the empty form
+     * data default.
+     *
+     * Both halves together prove that `wasPropertySentInRequest()` discriminates correctly in a
+     * request nothing arranged by hand — the argument name resolves from the action signature,
+     * and the per-property decision follows the posted keys.
+     */
+    #[Test]
+    public function propertyMissingFromTheSubmissionKeepsItsStoredValue(): void
+    {
+        $this->setUpTestCase();
+        $this->seedWebsiteFields();
+
+        $this->submitProfileForm(
+            $this->getProfileEditFormUrl(),
+            ['website' => 'https://submitted.example.org'],
+        );
+
+        $this->assertSame(
+            ['website' => 'https://submitted.example.org', 'website_title' => 'Stored title'],
+            $this->getStoredWebsiteFields(),
+        );
+    }
+}

--- a/packages/fgtclb/academic-persons/Documentation/Configuration/Index.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Configuration/Index.rst
@@ -9,3 +9,4 @@ Configuration
    :titlesonly:
 
    General/Index
+   Validations/Index

--- a/packages/fgtclb/academic-persons/Documentation/Configuration/Validations/Index.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Configuration/Validations/Index.rst
@@ -1,0 +1,239 @@
+..  index:: Configuration; Validations
+..  _configuration-validations:
+
+===================
+Validation settings
+===================
+
+:file:`Configuration/AcademicPersons/Settings.yaml` describes, per record type
+and per field, whether a field is **required**, **read only** or **disabled**.
+
+One file drives **both editing contexts**:
+
+*   the TYPO3 backend record editor (FormEngine), through generated TCA, and
+*   the frontend editing forms of `EXT:academic_persons_edit
+    <https://extensions.typo3.org/extension/academic_persons_edit>`__.
+
+This is why the file ships with :guilabel:`academic_persons`, which owns the
+records and their TCA, and not with the editing extension. The backend half
+applies even when the editing extension is not installed.
+
+..  attention::
+    The syntax of this file is still considered experimental and may change in
+    a future release.
+
+Where the sets live
+===================
+
+Six sets exist, one per editable record type. The set name selects the record
+type, the keys below it are **property names** in camel case, and each property
+carries a list of flags:
+
+..  code-block:: yaml
+
+    validations:
+      profile:
+        firstName:
+          - disabled
+        website:
+          - required
+
+The six set names, and the records they configure:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Set
+        -   Record
+    *   -   :yaml:`profile`
+        -   Profile
+    *   -   :yaml:`contract`
+        -   Contract
+    *   -   :yaml:`emailAddress`
+        -   Email address
+    *   -   :yaml:`phoneNumber`
+        -   Phone number
+    *   -   :yaml:`physicalAddress`
+        -   Physical address
+    *   -   :yaml:`profileInformation`
+        -   Profile information
+
+A property that is not listed is unconfigured: it is editable, not required, and
+no validator runs for it.
+
+Available flags
+===============
+
+Flag names are matched case insensitively. Anything not listed here is ignored.
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Flag
+        -   Effect
+    *   -   :yaml:`required`
+        -   The field must not be empty. Adds a *not empty* validation in the
+            frontend and marks the field required in the backend.
+    *   -   :yaml:`disabled`
+        -   The field must not be edited at all. See the note below.
+    *   -   :yaml:`readonly`
+        -   The field is shown but cannot be written.
+    *   -   :yaml:`email`
+        -   The value must be a valid email address, and the field is rendered
+            as an email input.
+    *   -   :yaml:`number`
+        -   The field is rendered as a number input. No additional server side
+            validation is performed.
+
+..  note::
+    :yaml:`disabled` and :yaml:`readonly` both **cancel** :yaml:`required`. A
+    field that cannot be edited cannot be demanded from the editor, so combining
+    them has no effect — the field is simply locked.
+
+    :yaml:`disabled` additionally implies :yaml:`readonly`. FormEngine has no
+    equivalent of the HTML :html:`disabled` attribute, so a disabled field is
+    presented as read only in the backend.
+
+..  _configuration-validations-defaults:
+
+Fields that are locked by default
+=================================
+
+Three profile fields ship as :yaml:`disabled`:
+
+..  code-block:: yaml
+
+    validations:
+      profile:
+        firstName:
+          - disabled
+          - required
+        middleName:
+          - disabled
+        lastName:
+          - disabled
+
+This is intentional. Profile names are usually owned by the connected frontend
+user record — commonly fed from a directory service such as LDAP or Active
+Directory, and synchronised into the profile — so they must not be overwritten
+from an editing form.
+
+The consequences, which surprise people who did not expect them:
+
+*   :guilabel:`First name`, :guilabel:`Middle name` and :guilabel:`Last name`
+    are **read only in the backend** record editor, for every backend user.
+*   The same three fields are rendered disabled in the frontend editing form,
+    and a value submitted for them is discarded on the server.
+
+The :yaml:`required` entry on :yaml:`firstName` has no effect, because
+:yaml:`disabled` cancels it.
+
+If the profile names are maintained in TYPO3 rather than synchronised from
+elsewhere, remove those entries as described below.
+
+Effects in the TYPO3 backend
+============================
+
+The settings are merged into the TCA of the matching table, so a locked field is
+read only in the record editor and a required field is marked as such:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Set
+        -   Table
+    *   -   :yaml:`profile`
+        -   :sql:`tx_academicpersons_domain_model_profile`
+    *   -   :yaml:`contract`
+        -   :sql:`tx_academicpersons_domain_model_contract`
+    *   -   :yaml:`emailAddress`
+        -   :sql:`tx_academicpersons_domain_model_email`
+    *   -   :yaml:`phoneNumber`
+        -   :sql:`tx_academicpersons_domain_model_phone_number`
+    *   -   :yaml:`physicalAddress`
+        -   :sql:`tx_academicpersons_domain_model_address`
+    *   -   :yaml:`profileInformation`
+        -   :sql:`tx_academicpersons_domain_model_profile_information`
+
+The property name is translated to the database column automatically:
+:yaml:`firstName` addresses :sql:`first_name`.
+
+Effects in the frontend editing plugin
+======================================
+
+When `EXT:academic_persons_edit
+<https://extensions.typo3.org/extension/academic_persons_edit>`__ is installed,
+the same configuration is used three times:
+
+#.  The form field is rendered with the matching :html:`disabled`,
+    :html:`readonly` and :html:`required` attributes.
+#.  :yaml:`required` and :yaml:`email` add server side validation of the
+    submitted form.
+#.  A :yaml:`disabled` or :yaml:`readonly` property is **never written** to the
+    record, whatever the request contains. This is deliberate: it protects
+    already stored data, and it is what prevents a locked field from being
+    emptied when a form is submitted.
+
+..  _configuration-validations-override:
+
+Overriding the settings
+=======================
+
+Settings are collected from **all installed extensions**. Every package that
+contains :file:`Configuration/AcademicPersons/Settings.yaml` contributes, and
+the package loaded last wins.
+
+To change them for an installation:
+
+#.  Add :file:`Configuration/AcademicPersons/Settings.yaml` to your site
+    package.
+#.  Make the site package **depend on** :guilabel:`academic_persons` in its
+    :file:`composer.json` or :file:`ext_emconf.php`, so that it is loaded after
+    it.
+#.  Repeat the **complete** :yaml:`validations` block, see the warning below.
+#.  Flush the TYPO3 caches.
+
+..  warning::
+    The files are merged on the top level only. :yaml:`validations` is a
+    top-level key, so a site package that defines it replaces **all six sets**
+    at once — the sets it does not repeat are lost, not inherited.
+
+    Copy the whole :yaml:`validations` block from
+    :file:`EXT:academic_persons/Configuration/AcademicPersons/Settings.yaml`
+    and edit the copy. There is no syntax for removing a single flag from a
+    single field.
+
+Example — making the profile names editable again, in the backend and in the
+frontend editing form. The other five sets are repeated unchanged and are
+shortened here for readability:
+
+..  code-block:: yaml
+
+    validations:
+      profile:
+        # The three name fields are no longer listed and are therefore editable.
+        website:
+          - required
+      contract:
+        position:
+          - required
+      emailAddress:
+        email:
+          - required
+          - email
+      phoneNumber:
+        phoneNumber:
+          - required
+      physicalAddress:
+        street:
+          - required
+      profileInformation:
+        title:
+          - required
+
+..  note::
+    Because both editing contexts read the same configuration, an override
+    always changes them together. Unlocking the profile names for the frontend
+    editing form also makes those columns writable in the backend record editor.
+
+There is no TypoScript and no site set equivalent for these settings.


### PR DESCRIPTION
Backport of #503 to `2`. ACE-446.

Documents the validation settings for integrators and adds the end-to-end
coverage of the form data transformation. See #503 for the reasoning; this
description covers only what had to differ.

## What had to be adapted

The two commits cherry-pick cleanly except for the two developer documentation
index tables, which describe this branch's own reality and must keep doing so:

* `docs/architecture/Index.md` — kept this branch's rows (the four
  core-version mechanisms and the `Core12/`/`Core13/` split in `academic-base`,
  Symfony and TYPO3 attributes on v12 and v13, and the *"bites hardest on v12,
  which has no guard at all"* note). Only the two new rows and the two new
  summary bullets were added.
* `docs/Index.md` — same, the *Core version aware code* row keeps this branch's
  wording.
* `docs/architecture/validation-settings.md` — the stale `@internal` note is
  described against `2.4.x-dev` here rather than `3.0.0-dev`.

Everything else is identical, and deliberately so — all of it was verified
against this branch rather than assumed:

* The shipped `profile` set locks `firstName`, `middleName` and `lastName` by
  `disabled` here too, byte-identical.
* The `mayApplyProperty()` guard exists in all six factories at the **same line
  numbers** as on `main`, so the developer page's references are correct
  unchanged.
* `getValidationsForTca()` has no production caller here either, so the
  `academic_jobs` page's central statement holds.
* `Documentation/Changelog/2.4/Important-FormDataTransformationOnlyMapsSubmittedFields.rst`,
  which both pages reference, exists on this branch.
* The new functional test uses only helpers this branch's
  `AbstractProfileEditingPluginTestCase` already provides — it calls
  `executeFrontendSubRequest()` directly and does not need the
  `FrontendPluginRenderingTrait`, which does not exist here.

## Verification

Green locally on **both** core versions of this branch, each after its own
`composerUpdate`:

| Suite | v12 | v13 |
|---|---|---|
| `lintPhp` | pass | pass |
| `cgl -n` | pass | pass |
| `phpstan` | pass | pass |
| `unit` | 640 tests | 640 tests |
| `functional` | 926 tests | 926 tests |

`checkRstRenderingAll` passes for all twelve packages, `lintMarkdown -n` reports
no problems.

The new end-to-end test passes on v12 as well as v13, which was the one thing
that could have blocked this backport.
