### PR TITLE
[TASK] ACE-440: Isolate functional test instances

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -624,6 +624,10 @@ SUFFIX=$(echo $RANDOM)
 NETWORK="academic-extensions-${SUFFIX}"
 ${CONTAINER_BIN} network create ${NETWORK} >/dev/null
 
+# Suffix every bind mount needs, kept next to the mounts that use it. Empty except for
+# podman on Linux, which relabels the mount for SELinux - see the assignments below.
+CONTAINER_MOUNT_SUFFIX=""
+
 if [ "${CONTAINER_BIN}" == "docker" ]; then
     # docker needs the add-host for xdebug remote debugging. podman has host.container.internal built in
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host ${CONTAINER_HOST}:host-gateway ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
@@ -647,6 +651,7 @@ else
     # without an explicit owner. "mode=1777" is kept for the rootful case.
     TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,mode=1777"
     if [ $( uname ) = "Linux" ]; then
+        CONTAINER_MOUNT_SUFFIX=":Z"
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
     else
@@ -781,6 +786,25 @@ case ${TEST_SUITE} in
     functional)
         PHPUNIT_CONFIG_FILE="Build/phpunit/FunctionalTests.xml"
         COMMAND=(.Build/bin/phpunit -c ${PHPUNIT_CONFIG_FILE} --exclude-group not-${DBMS} --exclude-group not-core-${CORE_VERSION} "$@")
+        # Each functional test case gets its own TYPO3 instance below
+        # "typo3temp/var/tests/functional-<identifier>". The testing framework derives that
+        # identifier itself, as "substr(sha1(<test class>), 0, 7)", so it is the same in every
+        # run of the same test class - see FunctionalTestCase::getInstanceIdentifier().
+        #
+        # Two runs in one checkout therefore work in the *same* instance directories, and
+        # "removeOldInstanceIfExists()" of the one deletes the instance the other is currently
+        # using. It surfaces as "No such file or directory", "no such table" and "UNIQUE
+        # constraint failed" in tests that have nothing to do with each other, and it cost
+        # roughly one run in three during the ACE-403 .. ACE-422 round.
+        #
+        # Give every run its own directory on the host and mount it where the testing framework
+        # expects to find it, so concurrent runs cannot see each other's instances. A bind mount
+        # rather than a tmpfs on purpose: 150 test classes at some 5 MB each would put the better
+        # part of a gigabyte into RAM, and a failed run stays inspectable this way.
+        FUNCTIONAL_INSTANCE_DIR="${ROOT_DIR}/.Build/Web/typo3temp/var/tests-${SUFFIX}"
+        mkdir -p "${FUNCTIONAL_INSTANCE_DIR}"
+        SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
+        CONTAINER_COMMON_PARAMS="${CONTAINER_COMMON_PARAMS} -v ${FUNCTIONAL_INSTANCE_DIR}:${ROOT_DIR}/.Build/Web/typo3temp/var/tests${CONTAINER_MOUNT_SUFFIX}"
         case ${DBMS} in
             mariadb)
                 echo "Using driver: ${DATABASE_DRIVER}"
@@ -816,9 +840,11 @@ case ${TEST_SUITE} in
                 ;;
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
-                rm -rf "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
-                SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
-                mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
+                #
+                # The directory is created inside this run's own instance directory, which is
+                # mounted over "typo3temp/var/tests" above. It is therefore empty already and
+                # is not shared with any other run, so nothing has to be removed first.
+                mkdir -p "${FUNCTIONAL_INSTANCE_DIR}/functional-sqlite-dbs"
                 SUITE_EXIT_CODE=$? && [[ "${SUITE_EXIT_CODE}" -ne 0 ]] && printSummary
                 # "${TMPFS_MOUNT_OPTIONS}" carries the owner and mode the mount needs, which
                 # differ per container binary - see where it is assigned. Without them the
@@ -829,6 +855,14 @@ case ${TEST_SUITE} in
                 SUITE_EXIT_CODE=$?
                 ;;
         esac
+        # A green run has nothing left to look at, and the instances are some 5 MB each. A red
+        # one is kept, because the instance of a failing test - its configuration, its
+        # typo3temp, the files a test wrote - is usually where the answer is.
+        if [[ ${SUITE_EXIT_CODE} -eq 0 ]]; then
+            rm -rf "${FUNCTIONAL_INSTANCE_DIR}"
+        else
+            echo "Test instances of this run kept for inspection: ${FUNCTIONAL_INSTANCE_DIR}"
+        fi
         ;;
     lintPhp)
         # The DDEV instances install their own vendor tree next to the sources.

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -51,6 +51,31 @@ Each run creates its own container network — `NETWORK` is
 `academic-extensions-${SUFFIX}` — and `cleanUp()` removes it together with
 every attached container, so parallel runs on one machine do not collide.
 
+Functional runs need one thing more, because the collision there is not in the
+containers but in the files they share. The testing framework puts each test
+case's TYPO3 instance in `typo3temp/var/tests/functional-<identifier>`, and
+derives that identifier as `substr(sha1(<test class>), 0, 7)` — the same value in
+every run. Two runs in one checkout would therefore work in the same instance
+directories, and `removeOldInstanceIfExists()` of the one would delete the
+instance the other is using. It surfaced as `No such file or directory`, `no such
+table` and `UNIQUE constraint failed` in tests that had nothing to do with each
+other, and it cost roughly one functional run in three (ACE-440).
+
+`runTests.sh` therefore gives every functional run its own
+`typo3temp/var/tests-${SUFFIX}` on the host and bind mounts it where the testing
+framework looks. A bind mount rather than a tmpfs deliberately: 150 test classes
+at some 5 MB each would put the better part of a gigabyte into RAM.
+
+**A green run removes its directory; a red one keeps it and prints the path.**
+The instance of a failing test — its configuration, its `typo3temp`, the files
+the test wrote — is usually where the answer is, so it is worth looking at before
+running anything else. They are not cleaned up automatically, so delete them when
+you are done:
+
+```bash
+rm -rf .Build/Web/typo3temp/var/tests-*
+```
+
 ### A pseudo TTY only when there is a terminal
 
 `CONTAINER_INTERACTIVE` is `-it --init` by default, and drops to `--init` when


### PR DESCRIPTION
Two functional runs in one checkout destroyed each other. ACE-440.

## The issue's diagnosis was wrong

ACE-440 blames the SQLite database directory and proposes suffixing it. Both were
checked by experiment before anything was changed, and both are wrong.

**The SQLite directory is not shared.** It is mounted as a `--tmpfs`, and the
project is bind mounted at the same absolute path, so every container already has
a private filesystem there. Probing the host directory every ten seconds through a
whole functional run shows **0 files at every sample**. Interfering with it
mid-run — running exactly the `rm -rf` + `mkdir -p` a second run performs — left a
running suite completely unharmed: 344 tests, still green.

**Suffixing it is not possible from the script anyway.** The path is derived
inside the testing framework as
`dirname($instancePath) . '/functional-sqlite-dbs/'`, with
`$instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/functional-' . $identifier`.
The only lever is the whole web root.

## What actually collides

The **instance** directories. Each test case gets
`typo3temp/var/tests/functional-<identifier>`, and the identifier is
`substr(sha1(<test class>), 0, 7)` — deterministic, so identical in every run of
the same class. Two runs work in the same directories, and
`removeOldInstanceIfExists()` of the one deletes the instance the other is using.
They live on the bind mounted project tree, in no tmpfs. The same probe counts 35
of them on the host at every sample.

Reproduced deterministically, two concurrent runs of the same test path:

```
run A: Errors: 40   7x No such file or directory, 4x no such table, 57x UNIQUE constraint failed
run B: Errors: 53   6x No such file or directory,                  138x UNIQUE constraint failed
```

— the issue's symptom list exactly. It also corrects the `-d postgres`
observation: that path was stable because those runs were not concurrent, not
because it is immune. It shares the same instance directories.

## The change

Every functional run gets its own `typo3temp/var/tests-${SUFFIX}` on the host,
bind mounted where the testing framework looks. A bind mount rather than a tmpfs
deliberately: 150 test classes at some 5 MB each would put the better part of a
gigabyte into RAM.

A green run removes its directory; **a red one keeps it and prints the path**,
since the instance of a failing test is usually where the answer is.

The SQLite tmpfs stays, nested inside the per-run directory — it still serves the
permission handling its comment describes. Its `rm -rf` is dropped: the directory
is fresh per run now, and it only ever removed an empty directory.

`CONTAINER_MOUNT_SUFFIX` is introduced so the new mount carries the same `:Z`
SELinux relabel that podman on Linux already uses for the project mount.

## Verification

| Check | Before | After |
|---|---|---|
| Two concurrent runs, same path | 40 and 53 errors | **114 tests each, green** |
| Full functional suite, SQLite, v13 | — | 1086 tests green |
| `-d postgres` subset | — | 114 tests green |
| Failing run keeps its instance | — | verified, path printed |
| Green run cleans up | — | verified, no leftovers |

The postgres run matters: the mount now applies to the server DBMS branches too,
which previously had no protection at all.

Backport to `2` follows.
