### PR TITLE
[TASK] ACE-452: Authenticate the release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ concurrency:
 #
 # "runTests.sh" forwards the variable into the container with a bare
 # "-e COMPOSER_AUTH", so the token is never written onto a command line.
+#
+# "publish.yml", the twelve package publish workflows and the template in
+# "Build/templates/extensions/" set the same variable for tooling they install
+# on the runner host, where there is no container to forward it into.
 env:
   COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,16 @@ cold job from failing is the token — `ci.yml` sets `COMPOSER_AUTH` from
 unauthenticated dist downloads are limited to 60 requests per hour and per
 runner IP while a cold install pulls some 158 archives (ACE-452).
 
+The release workflows carry the same variable for a related reason: they install
+`typo3/tailor` on the runner host, outside any container, so `runTests.sh` has
+nothing to forward it into and each has to set it itself — `publish.yml` at the
+repository root, the twelve `packages/fgtclb/*/.github/workflows/publish.yml`
+that are split out with their package, and
+`Build/templates/extensions/.github/workflows/publish.yml`, the template a new
+extension is created from. All fourteen carry the same block; change them
+together. Do not add `github-token` to their `shivammathur/setup-php` step —
+that input already defaults to `github.token`.
+
 There are no `core-*.yml` workflows any more; `core-11.yml` … `core-14.yml` were
 consolidated into `ci.yml`. No badge in this repository referenced them.
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -557,8 +557,10 @@ CI_PARAMS="${CI_PARAMS:-}"
 # IP, and an install with a cold cache pulls some 158 archives - which is why
 # runs used to die in "composerUpdate" with "HTTP/2 429" from codeload or
 # "502"/"504" from the API, in the dependency step and never in a gate. A token
-# lifts the limit to 1000 requests per hour. The workflows set the variable from
-# their own token, see ".github/workflows/ci.yml" (ACE-452).
+# lifts the limit to 1000 requests per hour. "ci.yml" sets the variable from its
+# own token and this script forwards it, see ".github/workflows/ci.yml"
+# (ACE-452). The release workflows set it too, but for tooling they install on
+# the runner host - nothing there goes through this script.
 #
 # The value is deliberately *not* written into the "-e" argument. A bare
 # "-e COMPOSER_AUTH" tells the runtime to take the value from this process's

--- a/Build/templates/extensions/.github/workflows/publish.yml
+++ b/Build/templates/extensions/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -426,9 +426,16 @@ invocation in the workflow — every step is a `Build/Scripts/runTests.sh` call.
 A gate therefore cannot behave differently in CI than locally, and reproducing
 a red pipeline is a matter of copying the command from the log.
 
-The two deviations from a plain local run are both explained in the workflow
-itself: `-b docker` on every step, explained in its header comment, and the
-`composerUpdate` that precedes every job needing a vendor tree.
+The three deviations from a plain local run are all explained in the workflow
+itself: `-b docker` on every step, explained in its header comment, the
+`composerUpdate` that precedes every job needing a vendor tree, and a workflow
+level `COMPOSER_AUTH` built from `github.token`, which `runTests.sh` forwards
+into the container with a bare `-e COMPOSER_AUTH` so that a job with a cold
+composer cache is not throttled to 60 dist downloads per hour (ACE-452).
+
+The release workflows set the same variable for the same reason, but for tooling
+they install on the runner host rather than in a container — see
+[Releasing](../workflow/releasing.md).
 
 ### Why the pull-request comment is a separate workflow
 
@@ -482,6 +489,8 @@ Two consequences follow, and both have cost time before:
 - [Core version aware code](../architecture/core-version-aware-code.md)
 - [Pull requests](../workflow/pull-requests.md) — what has to be green before
   pushing, and how to read a red pipeline.
+- [Releasing](../workflow/releasing.md) — the publish workflows, and the token
+  they share with continuous integration.
 - [`AGENTS.md`](../../AGENTS.md) — the short form, including the definition of
   done.
 - [`CONTRIBUTING.md`](../../CONTRIBUTING.md)

--- a/docs/workflow/releasing.md
+++ b/docs/workflow/releasing.md
@@ -196,9 +196,9 @@ tag X.Y.Z pushed to fgtclb/academic-extensions
 ```
 
 **Step 1 — here.** `.github/workflows/publish.yml` triggers on any pushed tag,
-verifies its shape, installs `typo3/tailor`, then loops over
-`packages/fgtclb/*`, reads each extension key from that package's
-`composer.json` at runtime, and builds one artifact per extension. The keys are
+verifies its shape, installs `typo3/tailor` with an authenticated composer (see
+below), then loops over `packages/fgtclb/*`, reads each extension key from that
+package's `composer.json` at runtime, and builds one artifact per extension. The keys are
 read rather than derived from the directory name because they differ:
 `academic-contact4pages` ships `academic_contacts4pages`. Finally
 `softprops/action-gh-release` creates the release `[RELEASE] <version>` with
@@ -239,8 +239,22 @@ copies currently differ from only in the `actions/checkout` version (`v6` in the
 packages, `v4` in the template).
 
 Both publish workflows declare the `TYPO3_API_TOKEN` secret and grant
-`contents: write`; only the per-package one actually spends the token, in
+`contents: write`; only the per-package one actually spends that secret, in
 `ter:publish`.
+
+Both also set a workflow level `COMPOSER_AUTH` from `github.token`, because
+`composer global require typo3/tailor` runs on the runner host rather than in a
+container — [`Build/Scripts/runTests.sh`](../../Build/Scripts/runTests.sh) never
+sees it, so there is nothing to forward and the workflow has to carry the token
+itself. Unauthenticated it shares the 60 requests per hour and per runner IP
+that took out the pull-request pipeline (ACE-452), and a release fails as a
+whole rather than as one job out of twenty. `shivammathur/setup-php` writes the
+same credential into composer's `auth.json` on its own, but refuses to for the
+composer versions affected by `GHSA-f9f8-rm49-7jv2` and `tools: composer:v2` is
+a floating tag — so the explicit variable is what makes it version independent,
+and its `github-token` input is left alone because it already defaults to
+`github.token`. The same block sits in the root workflow, in all twelve package
+workflows and in the template; change them together.
 
 ## Pre-release checklist
 

--- a/packages/fgtclb/academic-base/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-base/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-bite-jobs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-bite-jobs/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-contact4pages/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-contact4pages/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-jobs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-jobs/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-partners/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-partners/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-persons-edit/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons-edit/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-persons-sync/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons-sync/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-persons/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-persons/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-programs/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-programs/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-projects/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-projects/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/academic-study-plan/.github/workflows/publish.yml
+++ b/packages/fgtclb/academic-study-plan/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER

--- a/packages/fgtclb/typo3-category-types/.github/workflows/publish.yml
+++ b/packages/fgtclb/typo3-category-types/.github/workflows/publish.yml
@@ -4,6 +4,28 @@ on:
     tags:
       - '*'
 
+# Composer fetches every dist archive from "api.github.com" and
+# "codeload.github.com". Unauthenticated that is 60 requests per hour and per
+# runner IP, which took out the pull request pipeline in bursts (ACE-452).
+#
+# The same limit applies to "composer global require" below, which installs
+# tailor on the runner host rather than in a container - so "runTests.sh"
+# forwards nothing to it and this workflow needs its own token.
+#
+# "setup-php" does write a "github-oauth" entry into composer's "auth.json"
+# from the token its "github-token" input already defaults to, which is why
+# this has not been observed failing. It is not something to rely on: the
+# action deliberately writes nothing for the composer versions affected by
+# GHSA-f9f8-rm49-7jv2, and "tools: composer:v2" is a floating tag that has
+# pointed into that range before. "COMPOSER_AUTH" is independent of both and
+# reaches composer directly.
+#
+# "github.token" rather than "secrets.GITHUB_TOKEN": the two are the same
+# installation token, and the "github" context is available to a workflow level
+# "env" block.
+env:
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
 jobs:
   publish:
     name: Ensure GitHub Release with extension TER artifact and publishing to TER


### PR DESCRIPTION
Second half of ACE-452. The [first half](https://github.com/fgtclb/academic-extensions/pull/512) authenticated `ci.yml` and made `runTests.sh` forward `COMPOSER_AUTH` into the containers it starts composer in. That covered the pull-request pipeline and nothing else — the release workflows install `typo3/tailor` on the runner host, outside any container, so nothing forwards a token to them.

All fourteen release workflows now set `COMPOSER_AUTH` from their own `github.token` at workflow level:

* `.github/workflows/publish.yml` — the repository root workflow
* the twelve `packages/fgtclb/*/.github/workflows/publish.yml`, split out with their package and therefore changed here, never downstream
* `Build/templates/extensions/.github/workflows/publish.yml` — the template a new extension is created from, so this does not have to be rediscovered for the next one

## This is hardening, not a repair of an observed failure

Worth stating plainly, because it is also why `shivammathur/setup-php` is left alone.

`setup-php` writes a `github-oauth` entry into composer's `auth.json` by itself, and its `github-token` input **already defaults to `github.token`** — so passing it explicitly, which is what this branch originally did, is a no-op that reads like a fix. It was removed again.

What that default does not cover is the composer versions on the action's own `composer-gh-auth-no-op` list, where it deliberately writes nothing because of [GHSA-f9f8-rm49-7jv2](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2). `tools: composer:v2` is a floating tag and pointed into that range for the whole 2.3 → 2.9.7 window. The implicit path is therefore real today and a property of a moving version; `COMPOSER_AUTH` is version independent and reaches composer directly.

## How far this is verified

Deliberately **not** by running it — there is no tag to push, and pushing one to find out is not acceptable. What was checked is what can be checked without a release:

* every workflow still parses as YAML and carries the variable;
* the twelve package workflows still share a single checksum;
* the template still differs from them in nothing but its `actions/checkout` version;
* `github.token` in a workflow-level `env` block is already proven by `ci.yml`.

## Prose

`docs/workflow/releasing.md` gains the token paragraph, and `docs/development/quality-gates.md` said *"two deviations from a plain local run"* where there have been three since the first half of this issue.

## Not done here

* `Build/templates/extensions/.github/workflows/publish.yml` still pins `actions/checkout@v4` while all twelve shipped copies use `@v6`. Pre-existing drift, unrelated to this issue, left for its own change.
* The `ghcr.io` image pulls in `runTests.sh` are host-side GitHub downloads that `COMPOSER_AUTH` cannot reach. They are not subject to the REST limit and have never failed; if they ever do, the fix is a `docker login ghcr.io`, not this variable.

Backport to `2` follows.
