### PR TITLE
[BUGFIX] ACE-461: Mount the git dir of a worktree

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -582,6 +582,37 @@ cd "$THIS_SCRIPT_DIR" || exit 1
 cd ../../ || exit 1
 ROOT_DIR="${PWD}"
 
+# Git worktree support. In a worktree ".git" is a *file* pointing at a directory
+# inside the main checkout - "gitdir: <main>/.git/worktrees/<name>" - and that
+# directory is outside "${ROOT_DIR}", so the mount below does not carry it and
+# git has no repository at all inside the container.
+#
+# The failure that produces is not git shaped and is worth naming: composer
+# cannot determine a version for the path packages without git, so the install
+# stops on the only path package that has no "branch-alias". The plugin that
+# would resolve it from the "VERSION" file, sbuerk/extended-path-repository,
+# cannot help either - composer activates only plugins already present in
+# ".Build/vendor", and a cold worktree has none.
+#
+# Mounting the *common* directory is enough for both: the worktree's own git
+# directory lives inside it, and so does the shared object store.
+GIT_COMMON_DIR=""
+if [ -f "${ROOT_DIR}/.git" ]; then
+    gitDirPointer="$(sed -n 's/^gitdir: //p' "${ROOT_DIR}/.git" | head -1)"
+    case "${gitDirPointer}" in
+        "") ;;
+        /*) ;;
+        *) gitDirPointer="${ROOT_DIR}/${gitDirPointer}" ;;
+    esac
+    if [ -n "${gitDirPointer}" ] && [ -d "${gitDirPointer}" ]; then
+        if [ -f "${gitDirPointer}/commondir" ]; then
+            GIT_COMMON_DIR="$(cd "${gitDirPointer}" && cd "$(cat commondir)" && pwd)"
+        else
+            GIT_COMMON_DIR="${gitDirPointer}"
+        fi
+    fi
+fi
+
 # Create .cache dir: composer need this.
 mkdir -p .cache/composer
 mkdir -p .Build/Web/typo3temp/var/tests
@@ -679,6 +710,14 @@ else
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     fi
+fi
+
+# Carries the git directory of a worktree into the container, see "GIT_COMMON_DIR"
+# above. Appended after the branches so it uses the same relabel suffix as the
+# "${ROOT_DIR}" mount does.
+if [ -n "${GIT_COMMON_DIR}" ]; then
+    CONTAINER_COMMON_PARAMS="${CONTAINER_COMMON_PARAMS} -v ${GIT_COMMON_DIR}:${GIT_COMMON_DIR}${CONTAINER_MOUNT_SUFFIX}"
+    CONTAINER_SIMPLE_PARAMS="${CONTAINER_SIMPLE_PARAMS} -v ${GIT_COMMON_DIR}:${GIT_COMMON_DIR}${CONTAINER_MOUNT_SUFFIX}"
 fi
 
 if [ ${PHP_XDEBUG_ON} -eq 0 ]; then

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -291,6 +291,27 @@ The workflows follow this rule literally: every job that needs a vendor tree
 runs `composerUpdate` for its own `-t`/`-p` pair first, and the `lint` job,
 which needs no vendor tree, does not run it at all — see its `lint` job.
 
+### Git worktrees
+
+A `git worktree` is a supported checkout. `runTests.sh` mounts the repository's
+common git directory alongside the working tree, because a worktree's `.git` is
+a file pointing into the main checkout and everything git needs would otherwise
+be outside the mount.
+
+What that costs is a dependency set per worktree, not per branch: `.Build/`,
+`.cache/` and `composer.lock` are all git-ignored and therefore per checkout, so
+a fresh worktree starts cold and needs its own `-s composerUpdate` for each core
+version before any suite that needs dependencies will run.
+
+Without the mount the failure is misleading — composer cannot determine a
+version for the path packages without git, so the install stops on the one path
+package that carries no `branch-alias` rather than on anything git shaped:
+
+```text
+Root composer.json requires fgtclb/academics-monorepo-shared ~3.0.0@dev,
+found fgtclb/academics-monorepo-shared[dev-main] but it does not match.
+```
+
 ## Caches: `.cache/` at the repository root
 
 Composer downloads land in `.cache/composer` and the PHPStan result cache in


### PR DESCRIPTION
`runTests.sh` mounts the checkout with `-v ${ROOT_DIR}:${ROOT_DIR}`. That is
everything git needs in a normal clone, where `.git` is a directory inside it.
In a **git worktree** `.git` is a *file* holding

```text
gitdir: <main-checkout>/.git/worktrees/<name>
```

and that directory lives in the main checkout, outside the mount — so git has no
repository at all inside the container.

### Why the symptom does not look like a git problem

Composer cannot determine a version for the path packages without git, so the
install stops on the only path package that carries no `branch-alias`:

```text
Root composer.json requires fgtclb/academics-monorepo-shared ~3.0.0@dev,
found fgtclb/academics-monorepo-shared[dev-main] but it does not match the constraint.
```

`sbuerk/extended-path-repository` would resolve that from the `VERSION` file, but
composer activates only plugins already present in `.Build/vendor`, and a cold
worktree has none — the plugin that would fix it cannot run yet.

### Impact

`-s composerUpdate` could not be used in a worktree, and with it none of the
suites that need a dependency set: `phpstan`, `unit`, `functional`, `cgl`. Only
the core-version independent node suites worked. Two branches checked out side by
side could not both be tested, and neither could several changes in parallel.

### The fix

Resolve the `gitdir:` pointer and its `commondir` file, and mount the **common**
directory at its own path. That covers both halves at once — the worktree's own
git directory lives inside it, and so does the shared object store. A normal
clone has no `.git` file, so nothing changes there and no second mount is added.
The mount is appended after the runtime branches so it inherits the same SELinux
relabel suffix the `${ROOT_DIR}` mount uses.

### Verification

Both directions, in one and the same worktree:

| Script                         | Result                                   |
|--------------------------------|------------------------------------------|
| with this change               | `composerUpdate` SUCCESS, 93 packages    |
| previous version restored      | FAILURE, exactly the constraint error above |

### Note for the portfolio

This script is shared in origin with the ones in `web-vision/deepltranslate-core`
and `fgtclb/environment-state-manager`, so the same defect is expected there.
Not touched here.
