### PR TITLE
[TASK] ACE-458: Offer every extension in the sites

### DIFF
--- a/core-13/config/sites/academics/config.yaml
+++ b/core-13/config/sites/academics/config.yaml
@@ -15,16 +15,32 @@ dependencies:
   # elements, Bootstrap 5, the RTE preset and the rest - the seed's
   # "backend_layout" values are its identifiers.
   - bootstrap-package/full
-  # The TypoScript of the academic extensions: view paths for their plugins and
-  # the plugin settings. Without it a plugin has no template root path and every
-  # action fails. Deliberately "academic-persons-default" and not
-  # "-standalone": the standalone set defines its own "page" object and would
-  # replace the theme. Each of these depends on
-  # "fgtclb/academic-base-ctype-group", which is therefore not listed here.
-  - fgtclb/academic-persons-default
+  # Every academic extension that ships a site set, by its aggregate. Since
+  # ACE-458 each extension hides its own content elements for the whole
+  # installation and re-enables them per component, so an extension that is not
+  # named here can be installed and still offer nothing an editor can place.
+  # A development instance is meant to offer everything, hence all of them.
+  #
+  # Each aggregate depends on its own component sets, so naming it enables the
+  # whole extension. Do not name component sets here by hand: the three
+  # "-content-load" sets are dependencies of their aggregates and leaving one
+  # out is a fatal error, not a degraded page - nothing else defines
+  # "styles.content.getContent" and the page templates call it through
+  # "f:cObject".
+  - fgtclb/academic-base
+  - fgtclb/academic-bite-jobs
+  - fgtclb/academic-contacts4pages
+  - fgtclb/academic-jobs
+  - fgtclb/academic-partners
+  # Deliberately the aggregate and not "fgtclb/academic-persons-standalone":
+  # the standalone set defines its own "page" object and would replace the
+  # theme. "fgtclb/academic-persons-default" is kept as a compatibility alias
+  # of this aggregate and would work as well.
+  - fgtclb/academic-persons
   - fgtclb/academic-persons-edit
   - fgtclb/academic-programs
-  - fgtclb/academic-partners
+  - fgtclb/academic-projects
+  - fgtclb/academic-study-plan
   # EXT:felogin registers its TypoScript with "includeInSiteSets = false", so
   # in a site set driven installation it arrives only through this dependency.
   - typo3/felogin

--- a/core-14/config/sites/academics/config.yaml
+++ b/core-14/config/sites/academics/config.yaml
@@ -15,16 +15,32 @@ dependencies:
   # elements, Bootstrap 5, the RTE preset and the rest - the seed's
   # "backend_layout" values are its identifiers.
   - bootstrap-package/full
-  # The TypoScript of the academic extensions: view paths for their plugins and
-  # the plugin settings. Without it a plugin has no template root path and every
-  # action fails. Deliberately "academic-persons-default" and not
-  # "-standalone": the standalone set defines its own "page" object and would
-  # replace the theme. Each of these depends on
-  # "fgtclb/academic-base-ctype-group", which is therefore not listed here.
-  - fgtclb/academic-persons-default
+  # Every academic extension that ships a site set, by its aggregate. Since
+  # ACE-458 each extension hides its own content elements for the whole
+  # installation and re-enables them per component, so an extension that is not
+  # named here can be installed and still offer nothing an editor can place.
+  # A development instance is meant to offer everything, hence all of them.
+  #
+  # Each aggregate depends on its own component sets, so naming it enables the
+  # whole extension. Do not name component sets here by hand: the three
+  # "-content-load" sets are dependencies of their aggregates and leaving one
+  # out is a fatal error, not a degraded page - nothing else defines
+  # "styles.content.getContent" and the page templates call it through
+  # "f:cObject".
+  - fgtclb/academic-base
+  - fgtclb/academic-bite-jobs
+  - fgtclb/academic-contacts4pages
+  - fgtclb/academic-jobs
+  - fgtclb/academic-partners
+  # Deliberately the aggregate and not "fgtclb/academic-persons-standalone":
+  # the standalone set defines its own "page" object and would replace the
+  # theme. "fgtclb/academic-persons-default" is kept as a compatibility alias
+  # of this aggregate and would work as well.
+  - fgtclb/academic-persons
   - fgtclb/academic-persons-edit
   - fgtclb/academic-programs
-  - fgtclb/academic-partners
+  - fgtclb/academic-projects
+  - fgtclb/academic-study-plan
   # EXT:felogin registers its TypoScript with "includeInSiteSets = false", so
   # in a site set driven installation it arrives only through this dependency.
   - typo3/felogin

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -435,6 +435,25 @@ the same relative path on both sides, because each instance bind-mounts the
 repository's `Build/` into its container
 (`core-*/.ddev/docker-compose.mounts.yaml`).
 
+### Site sets are cached, and the cache outlives a `git pull`
+
+The set definitions an installation knows are cached. After pulling a branch
+that adds, renames or repoints a site set, an instance keeps serving the
+definitions it had — even though `core-*/vendor/fgtclb/*` are **symlinks into
+`packages/`**, so the new `Configuration/Sets/` folders are already on disk.
+
+```bash
+ddev exec vendor/bin/typo3 site:sets:list      # may still show the old sets
+ddev exec vendor/bin/typo3 cache:flush
+ddev exec vendor/bin/typo3 site:sets:list      # now the current ones
+```
+
+This is worth knowing because a stale cache looks exactly like a broken
+conversion: the sets a site depends on appear not to exist, and the frontend
+loses the configuration they deliver. Flush before concluding anything. The
+same applies to `site:show`, which reads the cached definitions to resolve
+`dependencies:`.
+
 ### Seeding an instance
 
 What an instance contains is **described**, not clicked together: the seed set


### PR DESCRIPTION
Since ACE-458 cut each extension's configuration per component, a content
element is hidden for the whole installation and re-enabled by the set that
owns it. The development instances declared four extensions, so an editor could
no longer place a content element of the other six at all — installed, and
offering nothing.

Both instances now declare the aggregate of every extension that ships a site
set. An aggregate depends on its own component sets, so naming it enables the
whole extension.

## Verified in a running instance, not only in tests

| Check | Result |
|---|---|
| `fgtclb/` sets resolving | **38** (22 before R4 and R5) |
| `site:show academics` | resolves all twelve dependencies |
| Seeded plugin pages | 200 with real plugin markup — leaflet in the partners map, profile markup in the persons list |
| **Unresolved `{$…}` constants in rendered output** | **0 on every page** |

The last row is the one that matters. The restructure moved every
`constants.typoscript`, and an unresolved constant renders as its own literal
text instead of failing — so zero across every seeded page is the evidence that
both delivery paths wire up in a real installation.

Two behaviours that are correct and not regressions: `/academic-persons/detail`
returns 404 without a profile argument, and `/my-profile` returns 403 without a
frontend login.

## Choices worth reviewing

`fgtclb/academic-persons-default` is replaced by the aggregate it now delegates
to, `fgtclb/academic-persons`. The alias keeps working and is what an existing
installation has; the aggregate is what a reader should copy.
`-standalone` is still deliberately not used — it defines its own `page` object
and would replace the theme.

Component sets are deliberately **not** named here. Leaving out one of the three
`-content-load` sets is a fatal error rather than a page with an empty column —
nothing else defines `styles.content.getContent` and the page templates call it
through `f:cObject` — and depending on the aggregate cannot get that wrong.

## Also

`docs/development/environment.md` gains a short section on site set definitions
being cached. After pulling a branch that changes a set, an instance serves the
definitions it had, with the new `Configuration/Sets/` folders already on disk
because `core-*/vendor/fgtclb/*` are symlinks into `packages/`. It looks exactly
like a conversion that did not work; it is a missing `cache:flush`.

## Not in this change

The seed still has content for four extensions only. Making every extension and
every plugin available **in the seed**, in every variant, is WP2 — S2 designs
it, S3 builds it with generated images, S4 adds the second delivery variant,
S5 regenerates the committed sqlite snapshots.
