### PR TITLE
[BUGFIX] ACE-461: Mount the git dir of a worktree

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -583,6 +583,37 @@ cd "$THIS_SCRIPT_DIR" || exit 1
 cd ../../ || exit 1
 ROOT_DIR="${PWD}"
 
+# Git worktree support. In a worktree ".git" is a *file* pointing at a directory
+# inside the main checkout - "gitdir: <main>/.git/worktrees/<name>" - and that
+# directory is outside "${ROOT_DIR}", so the mount below does not carry it and
+# git has no repository at all inside the container.
+#
+# The failure that produces is not git shaped and is worth naming: composer
+# cannot determine a version for the path packages without git, so the install
+# stops on the only path package that has no "branch-alias". The plugin that
+# would resolve it from the "VERSION" file, sbuerk/extended-path-repository,
+# cannot help either - composer activates only plugins already present in
+# ".Build/vendor", and a cold worktree has none.
+#
+# Mounting the *common* directory is enough for both: the worktree's own git
+# directory lives inside it, and so does the shared object store.
+GIT_COMMON_DIR=""
+if [ -f "${ROOT_DIR}/.git" ]; then
+    gitDirPointer="$(sed -n 's/^gitdir: //p' "${ROOT_DIR}/.git" | head -1)"
+    case "${gitDirPointer}" in
+        "") ;;
+        /*) ;;
+        *) gitDirPointer="${ROOT_DIR}/${gitDirPointer}" ;;
+    esac
+    if [ -n "${gitDirPointer}" ] && [ -d "${gitDirPointer}" ]; then
+        if [ -f "${gitDirPointer}/commondir" ]; then
+            GIT_COMMON_DIR="$(cd "${gitDirPointer}" && cd "$(cat commondir)" && pwd)"
+        else
+            GIT_COMMON_DIR="${gitDirPointer}"
+        fi
+    fi
+fi
+
 # Create .cache dir: composer need this.
 mkdir -p .cache/composer
 mkdir -p .Build/Web/typo3temp/var/tests
@@ -680,6 +711,14 @@ else
         CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
         CONTAINER_SIMPLE_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
     fi
+fi
+
+# Carries the git directory of a worktree into the container, see "GIT_COMMON_DIR"
+# above. Appended after the branches so it uses the same relabel suffix as the
+# "${ROOT_DIR}" mount does.
+if [ -n "${GIT_COMMON_DIR}" ]; then
+    CONTAINER_COMMON_PARAMS="${CONTAINER_COMMON_PARAMS} -v ${GIT_COMMON_DIR}:${GIT_COMMON_DIR}${CONTAINER_MOUNT_SUFFIX}"
+    CONTAINER_SIMPLE_PARAMS="${CONTAINER_SIMPLE_PARAMS} -v ${GIT_COMMON_DIR}:${GIT_COMMON_DIR}${CONTAINER_MOUNT_SUFFIX}"
 fi
 
 if [ ${PHP_XDEBUG_ON} -eq 0 ]; then

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -300,6 +300,27 @@ The workflows follow this rule literally: every job that needs a vendor tree
 runs `composerUpdate` for its own `-t`/`-p` pair first, and the `lint` job,
 which needs no vendor tree, does not run it at all — see its `lint` job.
 
+### Git worktrees
+
+A `git worktree` is a supported checkout. `runTests.sh` mounts the repository's
+common git directory alongside the working tree, because a worktree's `.git` is
+a file pointing into the main checkout and everything git needs would otherwise
+be outside the mount.
+
+What that costs is a dependency set per worktree, not per branch: `.Build/`,
+`.cache/` and `composer.lock` are all git-ignored and therefore per checkout, so
+a fresh worktree starts cold and needs its own `-s composerUpdate` for each core
+version before any suite that needs dependencies will run.
+
+Without the mount the failure is misleading — composer cannot determine a
+version for the path packages without git, so the install stops on the one path
+package that carries no `branch-alias` rather than on anything git shaped:
+
+```text
+Root composer.json requires fgtclb/academics-monorepo-shared ~2.4.0@dev,
+found fgtclb/academics-monorepo-shared[dev-main] but it does not match.
+```
+
 ## Caches: `.cache/` at the repository root
 
 Composer downloads land in `.cache/composer` and the PHPStan result cache in


### PR DESCRIPTION
Backport of #523 to branch `2`.

In a git worktree `.git` is a *file* pointing at a directory inside the main
checkout, and that directory is outside `${ROOT_DIR}` — so the mount did not
carry it and there was no repository at all inside the container.

The failure that produces is not git shaped, which is what makes it expensive to
diagnose: composer cannot determine a version for the path packages without git,
so the install stops on the only path package that has no `branch-alias`.

```text
Root composer.json requires fgtclb/academics-monorepo-shared ~2.4.0@dev,
found fgtclb/academics-monorepo-shared[dev-main] but it does not match.
```

Mounting the *common* git directory is enough for both halves: the worktree's
own git directory lives inside it, and so does the shared object store.

## Proven both ways on this branch

```
Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
  before:  ... does not match the constraint.   (exit 1)
  after:   SUCCESS                               (exit 0)
```

## Why now

This is a prerequisite for backporting ACE-458: that work is sliced into five
rounds, each developed in a worktree of this branch, and none of them can
install dependencies until this lands.

## Difference from the `main` version

Only the documented example, which quotes this branch's constraint
(`~2.4.0@dev`) rather than `main`'s. The `docs/development/environment.md`
section is otherwise the same text.
