### PR TITLE
[BUGFIX] ACE-462: Register page types after TCA load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,13 +374,16 @@ not the Extbase one.
 
 ## Core-version-aware code (v13 vs v14)
 
-There is no `Core13/`/`Core14/` split in any academic extension yet. The two
-places that currently differ per core version are single switches on
-`(new Typo3Version())->getMajorVersion()`, both in
-`academic-base/Classes/TcaManipulator.php`:
-`addContentElementPlugin()` (the `addPlugin()` signature changed) and
-`addContentElementPluginFlexForm()` (the FlexForm `ds` shape differs and
-**neither version tolerates the other's**, see ACE-293).
+There is no `Core13/`/`Core14/` split in any academic extension yet. Every
+difference is resolved inside the file that has it, with a switch on
+`(new Typo3Version())->getMajorVersion()` — in a class, in a `Configuration/`
+file, or in an event listener. The most instructive one is
+`academic-base/Classes/TcaManipulator.php`: `addContentElementPlugin()` (the
+`addPlugin()` signature changed) and `addContentElementPluginFlexForm()` (the
+FlexForm `ds` shape differs and **neither version tolerates the other's**, see
+ACE-293). The counts per mechanism are measured in
+[Core version aware code](docs/architecture/core-version-aware-code.md) and are
+deliberately not repeated here.
 
 Keep it that way while the difference is a line or two. Reach for the folder
 split below only when a whole class has to differ — the technique can be looked

--- a/docs/architecture/core-version-aware-code.md
+++ b/docs/architecture/core-version-aware-code.md
@@ -14,14 +14,15 @@ Verified across the whole repository: no `Core13/` or `Core14/` directory
 exists under `packages/` or `packages-dev/`. Every core version difference is
 currently resolved **inside** the file that has it.
 
-Three mechanisms are in use, and they differ by *where* the difference sits —
+Four mechanisms are in use, and they differ by *where* the difference sits —
 not by preference:
 
-| Mechanism                                  | Used in                               | Count              |
-|--------------------------------------------|---------------------------------------|--------------------|
-| Version switch inside a PHP class          | `packages/fgtclb/*/Classes/`          | 1 file, 2 switches |
-| Version switch inside a configuration file | `packages/fgtclb/*/Configuration/`    | 15 files           |
-| Version dependent constant                 | `packages/fgtclb/*/EXT_CONSTANTS.php` | 2 files            |
+| Mechanism                                  | Used in                                    | Count              |
+|--------------------------------------------|--------------------------------------------|--------------------|
+| Version switch inside a PHP class          | `packages/fgtclb/*/Classes/`               | 1 file, 2 switches |
+| Version switch inside a configuration file | `packages/fgtclb/*/Configuration/`         | 12 files           |
+| Version switch inside an event listener    | `packages/fgtclb/*/Classes/EventListener/` | 3 files            |
+| Version dependent constant                 | `packages/fgtclb/*/EXT_CONSTANTS.php`      | 2 files            |
 
 All of them switch on `(new Typo3Version())->getMajorVersion()`.
 
@@ -81,7 +82,7 @@ loads". Both directions are covered by tests, see
 
 TCA, TypoScript and `ext_localconf.php` are loaded by TYPO3 from a fixed path
 and cannot be swapped per core version. A difference there has to be resolved
-in the file. 15 files under `packages/fgtclb/*/Configuration/` do this, and
+in the file. 12 files under `packages/fgtclb/*/Configuration/` do this, and
 they follow a consistent shape: build the array, adjust it at the end, return
 it. For example
 [`packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php`](../../packages/fgtclb/academic-jobs/Configuration/TCA/tx_academicjobs_domain_model_job.php)
@@ -113,15 +114,60 @@ copying:
 Dropping the option instead of guarding it is not equivalent: v14 removed it,
 but v13 still evaluates it and would search nothing without it.
 
-[`packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php`](../../packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php)
-line 62 shows the same shape for a registry call rather than an array key: v13
-has no `allowedRecordTypes` TCA option and still resolves allowed tables
-through `PageDoktypeRegistry`, whose `ext_tables.php` registration was
-deprecated in v14.3.
+### A switch inside an event listener
+
+`academic_programs`, `academic_projects` and `academic_partners` each register a
+page type, and each needs both forms of it: the TCA option `allowedRecordTypes`
+that TYPO3 v14 reads, and the `PageDoktypeRegistry` that v13 still resolves
+allowed tables through. Only the first of the two can live in
+`Configuration/TCA/Overrides/pages.php`. The second is done by a listener on
+`BootCompletedEvent`, one per extension, e.g.
+[`packages/fgtclb/academic-programs/Classes/EventListener/RegisterAcademicPageDoktype.php`](../../packages/fgtclb/academic-programs/Classes/EventListener/RegisterAcademicPageDoktype.php):
+
+```php
+public function __invoke(BootCompletedEvent $event): void
+{
+    if ((new Typo3Version())->getMajorVersion() >= 14) {
+        return;
+    }
+
+    $this->pageDoktypeRegistry->add(PageTypes::TYPE_ACADEMIC_PROGRAM, ['allowedTables' => '*']);
+}
+```
+
+**Why not in the TCA override.** On v13 the first call to
+`PageDoktypeRegistry->add()` runs `initializeTca()`, which collects every table
+declaring `security.ignorePageTypeRestriction` — `tt_content`, `sys_template`,
+`backend_layout` — from `TcaSchemaFactory` and then latches
+`$tcaHasBeenInitialized`. A TCA override runs *before*
+`TcaSchemaFactory::load()`, which `Bootstrap::init()` calls on the line right
+before it dispatches `BootCompletedEvent`, so the factory is still empty, the allow list of the `default` page type never gains
+`tt_content`, and the DataHandler refuses content elements on every standard
+page — but only while the TCA cache is cold, which is every functional test,
+every CLI import after a cache flush, and the first backend request after one
+(ACE-462). Warm, the override does not run at all and the page type is simply
+not registered, so it falls back to the `default` allow list instead of `*`.
+
+**Why not `ext_tables.php`.** That file is loaded after the TCA and would fix
+both halves — it is what `PageDoktypeRegistry`'s own class docblock suggests —
+but TYPO3 v14.3 deprecates *loading an `ext_tables.php` at all*, per extension
+and independently of its content (`ExtTablesFactory`, lines 73 and 110). Since
+the functional suites run with `failOnDeprecation`, shipping one turns the whole
+v14 suite red and writes two deprecations per request into every v14
+installation's log. `BootCompletedEvent` is dispatched one line after
+`TcaSchemaFactory::load()`, on every request and in every context, and carries
+no deprecation on either version.
+
+The v14 copy of `add()` does none of the latching; it assigns and raises the v15
+deprecation. That is why the guard is a `Typo3Version` check and not a feature
+detection: the method exists on both versions, so there is nothing to detect.
+The listener itself is registered on both versions through TYPO3's
+`#[AsEventListener]` and returns immediately on v14 — cheaper and simpler than
+making the service registration itself version aware.
 
 ### A constant, when the difference is inside an attribute argument
 
-The third mechanism exists because the other two are unavailable. PHP attribute
+The fourth mechanism exists because the other three are unavailable. PHP attribute
 arguments must be constant expressions, so a version switch cannot be written
 inside one. The Extbase `#[Cascade]` attribute takes the array form
 `['value' => 'remove']` on v13 and the plain string `'remove'` on v14, and

--- a/packages/fgtclb/academic-partners/Classes/EventListener/RegisterAcademicPageDoktype.php
+++ b/packages/fgtclb/academic-partners/Classes/EventListener/RegisterAcademicPageDoktype.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\EventListener;
+
+use FGTCLB\AcademicPartners\Enumeration\PageTypes;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Core\Event\BootCompletedEvent;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Registers the page type of this extension with the PageDoktypeRegistry for TYPO3 v13.
+ *
+ * TYPO3 v14 resolves the tables allowed on a page type from the TCA option
+ * `allowedRecordTypes`, which `Configuration/TCA/Overrides/pages.php` sets. TYPO3 v13
+ * has no such option and still asks the registry, and the registry cannot be fed from a
+ * TCA override file: on v13 the first `add()` latches an allow list collected from a
+ * `TcaSchemaFactory` that is not loaded yet while the overrides run, which costs the
+ * `default` page type its `tt_content` entry and makes the DataHandler refuse content
+ * elements on every standard page (ACE-462). This event is dispatched one line after
+ * `TcaSchemaFactory::load()` and on every request, warm cache included, which is what
+ * both halves of that defect need.
+ *
+ * The version check guards a method that exists on both versions - there is nothing to
+ * feature-detect - and calling it on v14 raises the deprecation announcing its removal
+ * in TYPO3 v15.
+ *
+ * @see \TYPO3\CMS\Core\Core\Bootstrap::init()
+ * @todo Remove once TYPO3 v13 support is dropped.
+ */
+#[AsEventListener(identifier: 'academic-partners/register-page-doktype')]
+final readonly class RegisterAcademicPageDoktype
+{
+    public function __construct(
+        private PageDoktypeRegistry $pageDoktypeRegistry,
+    ) {}
+
+    public function __invoke(BootCompletedEvent $event): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 14) {
+            return;
+        }
+
+        $this->pageDoktypeRegistry->add(PageTypes::ACADEMIC_PARTNERS, ['allowedTables' => '*']);
+    }
+}

--- a/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-partners/Configuration/TCA/Overrides/pages.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicPartners\Backend\FormEngine\CountryItems;
 use FGTCLB\AcademicPartners\Enumeration\PageTypes;
-use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -48,24 +46,15 @@ defined('TYPO3') or die;
             'types' => [
                 PageTypes::ACADEMIC_PARTNERS => [
                     'showitem' => $GLOBALS['TCA']['pages']['types'][PageRepository::DOKTYPE_DEFAULT]['showitem'],
-                    // TYPO3 v14+ resolves the tables allowed on a page type from
-                    // this TCA option (superseding the PageDoktypeRegistry below).
+                    // TYPO3 v14+ resolves the tables allowed on a page type from this
+                    // TCA option. TYPO3 v13 has no such option and needs the
+                    // PageDoktypeRegistry, which is fed by the RegisterAcademicPageDoktype
+                    // event listener - see its docblock for why it cannot happen here.
                     'allowedRecordTypes' => ['*'],
                 ],
             ],
         ]
     );
-
-    // TYPO3 v13 has no "allowedRecordTypes" TCA option yet and still resolves the
-    // allowed tables through the PageDoktypeRegistry. Registering it in
-    // ext_tables.php was deprecated in TYPO3 v14.3, hence the version-guarded call.
-    // @todo Remove once TYPO3 v13 support is dropped; keep only "allowedRecordTypes".
-    if ((new Typo3Version())->getMajorVersion() < 14) {
-        GeneralUtility::makeInstance(PageDoktypeRegistry::class)->add(
-            PageTypes::ACADEMIC_PARTNERS,
-            ['allowedTables' => '*']
-        );
-    }
 
     // Define academic partners specific columns
     $additionalTCAcolumns = [

--- a/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
+++ b/packages/fgtclb/academic-partners/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
@@ -1,0 +1,57 @@
+.. _important-ace-462-academic-partners:
+
+===========================================================
+Important: The page type is registered from a boot listener
+===========================================================
+
+Description
+===========
+
+TYPO3 v13 has no :php:`allowedRecordTypes` TCA option and resolves the tables
+allowed on a page type through :php:`PageDoktypeRegistry`. This extension
+registered its page type ``40`` there, from
+:file:`Configuration/TCA/Overrides/pages.php`.
+
+That is too early. The first call to :php:`PageDoktypeRegistry->add()` collects
+every table declaring :php:`security.ignorePageTypeRestriction` - ``tt_content``,
+``sys_template`` and ``backend_layout`` - from the :php:`TcaSchemaFactory` and
+latches the result for the rest of the request. A TCA override file runs while
+the TCA is still being assembled, before :php:`TcaSchemaFactory::load()`, so that
+factory is still empty and none of the three ever reaches the allow list of the
+``default`` page type.
+
+TYPO3 then refuses content elements on ordinary pages:
+
+..  code-block:: text
+
+    Attempt to insert record on pages:1 where table "tt_content" is not allowed
+
+This happens while the TCA cache is cold, which is every import run after a cache
+flush and the first backend request after one. Once the TCA cache is warm the
+override files are not executed at all - and then the page type of this extension
+is not registered either, and silently falls back to the allow list of the
+``default`` page type instead of allowing every record type.
+
+The registration moved to an event listener on
+:php:`\TYPO3\CMS\Core\Core\Event\BootCompletedEvent`,
+:php:`\FGTCLB\AcademicPartners\EventListener\RegisterAcademicPageDoktype`. That event
+is dispatched one line after :php:`TcaSchemaFactory::load()` and on every request,
+warm cache included, which is what both halves of the defect need. The listener
+does nothing on TYPO3 v14, where the TCA option carries the configuration and
+:php:`PageDoktypeRegistry->add()` is deprecated.
+
+Impact
+======
+
+Content elements can be created on standard pages again while the TCA cache is
+cold, and the page type ``40`` of this extension allows every record type
+while it is warm.
+
+Affected Installations
+======================
+
+All installations of this extension on TYPO3 v13. TYPO3 v14 is not affected, it
+resolves the allowed tables from TCA. Nothing has to be done beyond the usual
+cache flush after an update.
+
+.. index:: TCA, Backend, ext:academic_partners

--- a/packages/fgtclb/academic-partners/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
@@ -1,0 +1,3 @@
+be_users,,,,
+,uid,pid,username,password,admin
+,1,0,admin,"$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1

--- a/packages/fgtclb/academic-partners/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
@@ -1,0 +1,3 @@
+pages,,,,
+,uid,pid,title,slug,doktype
+,1,0,Standard page,/,1

--- a/packages/fgtclb/academic-partners/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
+++ b/packages/fgtclb/academic-partners/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPartners\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPartners\Enumeration\PageTypes;
+use FGTCLB\AcademicPartners\Tests\Functional\AbstractAcademicPartnersTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Pins how the page type of this extension reaches the PageDoktypeRegistry, and that
+ * registering it does not damage the allow list of the standard page type (ACE-462).
+ *
+ * The order of the two test methods is load-bearing, because the functional test case
+ * builds the TCA cold for its first test only and reuses the cache for every following
+ * one - which is precisely the difference the registration used to be sensitive to:
+ *
+ * - contentElementsAreAllowedOnAStandardPageWithAColdTcaCache()
+ *   runs against a cold TCA cache, the state in which "Configuration/TCA/Overrides"
+ *   files are executed. Registering the page type from there latched an allow list of
+ *   the "default" page type that was collected before the TCA was loaded, so "tt_content"
+ *   was missing from it and the DataHandler refused content elements on every standard
+ *   page.
+ * - everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache()
+ *   runs against a warm TCA cache, where the override files are not executed at all. A
+ *   page type registered from there is then simply absent and silently falls back to the
+ *   allow list of the "default" page type.
+ *
+ * Both are answered by doing the registration from a BootCompletedEvent listener, which
+ * runs after the TCA is loaded and on every request.
+ */
+final class PageDoktypeRegistrationTest extends AbstractAcademicPartnersTestCase
+{
+    /**
+     * First test of this test case, so the TCA is built cold and the TCA override files
+     * of the extension are executed.
+     */
+    #[Test]
+    public function contentElementsAreAllowedOnAStandardPageWithAColdTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('tt_content', 1),
+            'The standard page type does not allow "tt_content".'
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/pages.csv');
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                'tt_content' => [
+                    'NEW1' => [
+                        'pid' => 1,
+                        'header' => 'Created by the data handler',
+                        'CType' => 'text',
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $this->assertSame(1, $this->countContentElements());
+    }
+
+    /**
+     * Not the first test of this test case, so the TCA comes from the cache and the TCA
+     * override files of the extension are not executed.
+     *
+     * "sys_file_metadata" is asserted rather than "tt_content" because it is not part of
+     * the allow list the "default" page type falls back to, so the assertion fails when
+     * the page type is not registered at all.
+     */
+    #[Test]
+    public function everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('sys_file_metadata', PageTypes::ACADEMIC_PARTNERS),
+            'The page type of this extension does not allow every record type.'
+        );
+    }
+
+    private function countContentElements(): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder->count('uid')->from('tt_content')->executeQuery()->fetchOne();
+    }
+}

--- a/packages/fgtclb/academic-programs/Classes/EventListener/RegisterAcademicPageDoktype.php
+++ b/packages/fgtclb/academic-programs/Classes/EventListener/RegisterAcademicPageDoktype.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\EventListener;
+
+use FGTCLB\AcademicPrograms\Enumeration\PageTypes;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Core\Event\BootCompletedEvent;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Registers the page type of this extension with the PageDoktypeRegistry for TYPO3 v13.
+ *
+ * TYPO3 v14 resolves the tables allowed on a page type from the TCA option
+ * `allowedRecordTypes`, which `Configuration/TCA/Overrides/pages.php` sets. TYPO3 v13
+ * has no such option and still asks the registry, and the registry cannot be fed from a
+ * TCA override file: on v13 the first `add()` latches an allow list collected from a
+ * `TcaSchemaFactory` that is not loaded yet while the overrides run, which costs the
+ * `default` page type its `tt_content` entry and makes the DataHandler refuse content
+ * elements on every standard page (ACE-462). This event is dispatched one line after
+ * `TcaSchemaFactory::load()` and on every request, warm cache included, which is what
+ * both halves of that defect need.
+ *
+ * The version check guards a method that exists on both versions - there is nothing to
+ * feature-detect - and calling it on v14 raises the deprecation announcing its removal
+ * in TYPO3 v15.
+ *
+ * @see \TYPO3\CMS\Core\Core\Bootstrap::init()
+ * @todo Remove once TYPO3 v13 support is dropped.
+ */
+#[AsEventListener(identifier: 'academic-programs/register-page-doktype')]
+final readonly class RegisterAcademicPageDoktype
+{
+    public function __construct(
+        private PageDoktypeRegistry $pageDoktypeRegistry,
+    ) {}
+
+    public function __invoke(BootCompletedEvent $event): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 14) {
+            return;
+        }
+
+        $this->pageDoktypeRegistry->add(PageTypes::TYPE_ACADEMIC_PROGRAM, ['allowedTables' => '*']);
+    }
+}

--- a/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-programs/Configuration/TCA/Overrides/pages.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicPrograms\Enumeration\PageTypes;
-use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -47,24 +45,15 @@ defined('TYPO3') or die;
             'types' => [
                 PageTypes::TYPE_ACADEMIC_PROGRAM => [
                     'showitem' => $GLOBALS['TCA']['pages']['types'][PageRepository::DOKTYPE_DEFAULT]['showitem'],
-                    // TYPO3 v14+ resolves the tables allowed on a page type from
-                    // this TCA option (superseding the PageDoktypeRegistry below).
+                    // TYPO3 v14+ resolves the tables allowed on a page type from this
+                    // TCA option. TYPO3 v13 has no such option and needs the
+                    // PageDoktypeRegistry, which is fed by the RegisterAcademicPageDoktype
+                    // event listener - see its docblock for why it cannot happen here.
                     'allowedRecordTypes' => ['*'],
                 ],
             ],
         ]
     );
-
-    // TYPO3 v13 has no "allowedRecordTypes" TCA option yet and still resolves the
-    // allowed tables through the PageDoktypeRegistry. Registering it in
-    // ext_tables.php was deprecated in TYPO3 v14.3, hence the version-guarded call.
-    // @todo Remove once TYPO3 v13 support is dropped; keep only "allowedRecordTypes".
-    if ((new Typo3Version())->getMajorVersion() < 14) {
-        GeneralUtility::makeInstance(PageDoktypeRegistry::class)->add(
-            PageTypes::TYPE_ACADEMIC_PROGRAM,
-            ['allowedTables' => '*']
-        );
-    }
 
     // Define academic programs specific columns
     $additionalTCAcolumns = [

--- a/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
+++ b/packages/fgtclb/academic-programs/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
@@ -1,0 +1,57 @@
+.. _important-ace-462-academic-programs:
+
+===========================================================
+Important: The page type is registered from a boot listener
+===========================================================
+
+Description
+===========
+
+TYPO3 v13 has no :php:`allowedRecordTypes` TCA option and resolves the tables
+allowed on a page type through :php:`PageDoktypeRegistry`. This extension
+registered its page type ``20`` there, from
+:file:`Configuration/TCA/Overrides/pages.php`.
+
+That is too early. The first call to :php:`PageDoktypeRegistry->add()` collects
+every table declaring :php:`security.ignorePageTypeRestriction` - ``tt_content``,
+``sys_template`` and ``backend_layout`` - from the :php:`TcaSchemaFactory` and
+latches the result for the rest of the request. A TCA override file runs while
+the TCA is still being assembled, before :php:`TcaSchemaFactory::load()`, so that
+factory is still empty and none of the three ever reaches the allow list of the
+``default`` page type.
+
+TYPO3 then refuses content elements on ordinary pages:
+
+..  code-block:: text
+
+    Attempt to insert record on pages:1 where table "tt_content" is not allowed
+
+This happens while the TCA cache is cold, which is every import run after a cache
+flush and the first backend request after one. Once the TCA cache is warm the
+override files are not executed at all - and then the page type of this extension
+is not registered either, and silently falls back to the allow list of the
+``default`` page type instead of allowing every record type.
+
+The registration moved to an event listener on
+:php:`\TYPO3\CMS\Core\Core\Event\BootCompletedEvent`,
+:php:`\FGTCLB\AcademicPrograms\EventListener\RegisterAcademicPageDoktype`. That event
+is dispatched one line after :php:`TcaSchemaFactory::load()` and on every request,
+warm cache included, which is what both halves of the defect need. The listener
+does nothing on TYPO3 v14, where the TCA option carries the configuration and
+:php:`PageDoktypeRegistry->add()` is deprecated.
+
+Impact
+======
+
+Content elements can be created on standard pages again while the TCA cache is
+cold, and the page type ``20`` of this extension allows every record type
+while it is warm.
+
+Affected Installations
+======================
+
+All installations of this extension on TYPO3 v13. TYPO3 v14 is not affected, it
+resolves the allowed tables from TCA. Nothing has to be done beyond the usual
+cache flush after an update.
+
+.. index:: TCA, Backend, ext:academic_programs

--- a/packages/fgtclb/academic-programs/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
@@ -1,0 +1,3 @@
+be_users,,,,
+,uid,pid,username,password,admin
+,1,0,admin,"$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1

--- a/packages/fgtclb/academic-programs/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
@@ -1,0 +1,3 @@
+pages,,,,
+,uid,pid,title,slug,doktype
+,1,0,Standard page,/,1

--- a/packages/fgtclb/academic-programs/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
+++ b/packages/fgtclb/academic-programs/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPrograms\Tests\Functional\Tca;
+
+use FGTCLB\AcademicPrograms\Enumeration\PageTypes;
+use FGTCLB\AcademicPrograms\Tests\Functional\AbstractAcademicProgramsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Pins how the page type of this extension reaches the PageDoktypeRegistry, and that
+ * registering it does not damage the allow list of the standard page type (ACE-462).
+ *
+ * The order of the two test methods is load-bearing, because the functional test case
+ * builds the TCA cold for its first test only and reuses the cache for every following
+ * one - which is precisely the difference the registration used to be sensitive to:
+ *
+ * - contentElementsAreAllowedOnAStandardPageWithAColdTcaCache()
+ *   runs against a cold TCA cache, the state in which "Configuration/TCA/Overrides"
+ *   files are executed. Registering the page type from there latched an allow list of
+ *   the "default" page type that was collected before the TCA was loaded, so "tt_content"
+ *   was missing from it and the DataHandler refused content elements on every standard
+ *   page.
+ * - everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache()
+ *   runs against a warm TCA cache, where the override files are not executed at all. A
+ *   page type registered from there is then simply absent and silently falls back to the
+ *   allow list of the "default" page type.
+ *
+ * Both are answered by doing the registration from a BootCompletedEvent listener, which
+ * runs after the TCA is loaded and on every request.
+ */
+final class PageDoktypeRegistrationTest extends AbstractAcademicProgramsTestCase
+{
+    /**
+     * First test of this test case, so the TCA is built cold and the TCA override files
+     * of the extension are executed.
+     */
+    #[Test]
+    public function contentElementsAreAllowedOnAStandardPageWithAColdTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('tt_content', 1),
+            'The standard page type does not allow "tt_content".'
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/pages.csv');
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                'tt_content' => [
+                    'NEW1' => [
+                        'pid' => 1,
+                        'header' => 'Created by the data handler',
+                        'CType' => 'text',
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $this->assertSame(1, $this->countContentElements());
+    }
+
+    /**
+     * Not the first test of this test case, so the TCA comes from the cache and the TCA
+     * override files of the extension are not executed.
+     *
+     * "sys_file_metadata" is asserted rather than "tt_content" because it is not part of
+     * the allow list the "default" page type falls back to, so the assertion fails when
+     * the page type is not registered at all.
+     */
+    #[Test]
+    public function everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('sys_file_metadata', PageTypes::TYPE_ACADEMIC_PROGRAM),
+            'The page type of this extension does not allow every record type.'
+        );
+    }
+
+    private function countContentElements(): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder->count('uid')->from('tt_content')->executeQuery()->fetchOne();
+    }
+}

--- a/packages/fgtclb/academic-projects/Classes/EventListener/RegisterAcademicPageDoktype.php
+++ b/packages/fgtclb/academic-projects/Classes/EventListener/RegisterAcademicPageDoktype.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\EventListener;
+
+use FGTCLB\AcademicProjects\Enumeration\PageTypes;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Core\Event\BootCompletedEvent;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Registers the page type of this extension with the PageDoktypeRegistry for TYPO3 v13.
+ *
+ * TYPO3 v14 resolves the tables allowed on a page type from the TCA option
+ * `allowedRecordTypes`, which `Configuration/TCA/Overrides/pages.php` sets. TYPO3 v13
+ * has no such option and still asks the registry, and the registry cannot be fed from a
+ * TCA override file: on v13 the first `add()` latches an allow list collected from a
+ * `TcaSchemaFactory` that is not loaded yet while the overrides run, which costs the
+ * `default` page type its `tt_content` entry and makes the DataHandler refuse content
+ * elements on every standard page (ACE-462). This event is dispatched one line after
+ * `TcaSchemaFactory::load()` and on every request, warm cache included, which is what
+ * both halves of that defect need.
+ *
+ * The version check guards a method that exists on both versions - there is nothing to
+ * feature-detect - and calling it on v14 raises the deprecation announcing its removal
+ * in TYPO3 v15.
+ *
+ * @see \TYPO3\CMS\Core\Core\Bootstrap::init()
+ * @todo Remove once TYPO3 v13 support is dropped.
+ */
+#[AsEventListener(identifier: 'academic-projects/register-page-doktype')]
+final readonly class RegisterAcademicPageDoktype
+{
+    public function __construct(
+        private PageDoktypeRegistry $pageDoktypeRegistry,
+    ) {}
+
+    public function __invoke(BootCompletedEvent $event): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 14) {
+            return;
+        }
+
+        $this->pageDoktypeRegistry->add(PageTypes::TYPE_ACEDEMIC_PROJECT, ['allowedTables' => '*']);
+    }
+}

--- a/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
+++ b/packages/fgtclb/academic-projects/Configuration/TCA/Overrides/pages.php
@@ -2,9 +2,7 @@
 
 use FGTCLB\AcademicBase\TcaManipulator;
 use FGTCLB\AcademicProjects\Enumeration\PageTypes;
-use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -52,20 +50,11 @@ if (!defined('TYPO3')) {
         ]
     );
 
-    // TYPO3 v14+ resolves the tables allowed on a page type from this TCA option
-    // (superseding the PageDoktypeRegistry below).
+    // TYPO3 v14+ resolves the tables allowed on a page type from this TCA option. TYPO3
+    // v13 has no such option and needs the PageDoktypeRegistry, which is fed by the
+    // RegisterAcademicPageDoktype event listener - see its docblock for why it cannot
+    // happen here.
     $GLOBALS['TCA']['pages']['types'][PageTypes::TYPE_ACEDEMIC_PROJECT]['allowedRecordTypes'] = ['*'];
-
-    // TYPO3 v13 has no "allowedRecordTypes" TCA option yet and still resolves the
-    // allowed tables through the PageDoktypeRegistry. Registering it in
-    // ext_tables.php was deprecated in TYPO3 v14.3, hence the version-guarded call.
-    // @todo Remove once TYPO3 v13 support is dropped; keep only "allowedRecordTypes".
-    if ((new Typo3Version())->getMajorVersion() < 14) {
-        GeneralUtility::makeInstance(PageDoktypeRegistry::class)->add(
-            PageTypes::TYPE_ACEDEMIC_PROJECT,
-            ['allowedTables' => '*']
-        );
-    }
 
     $columns = [
         'tx_academicprojects_project_title' => [

--- a/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
+++ b/packages/fgtclb/academic-projects/Documentation/Changelog/2.4/Important-PageTypeRegistrationUsesABootListener.rst
@@ -1,0 +1,57 @@
+.. _important-ace-462-academic-projects:
+
+===========================================================
+Important: The page type is registered from a boot listener
+===========================================================
+
+Description
+===========
+
+TYPO3 v13 has no :php:`allowedRecordTypes` TCA option and resolves the tables
+allowed on a page type through :php:`PageDoktypeRegistry`. This extension
+registered its page type ``30`` there, from
+:file:`Configuration/TCA/Overrides/pages.php`.
+
+That is too early. The first call to :php:`PageDoktypeRegistry->add()` collects
+every table declaring :php:`security.ignorePageTypeRestriction` - ``tt_content``,
+``sys_template`` and ``backend_layout`` - from the :php:`TcaSchemaFactory` and
+latches the result for the rest of the request. A TCA override file runs while
+the TCA is still being assembled, before :php:`TcaSchemaFactory::load()`, so that
+factory is still empty and none of the three ever reaches the allow list of the
+``default`` page type.
+
+TYPO3 then refuses content elements on ordinary pages:
+
+..  code-block:: text
+
+    Attempt to insert record on pages:1 where table "tt_content" is not allowed
+
+This happens while the TCA cache is cold, which is every import run after a cache
+flush and the first backend request after one. Once the TCA cache is warm the
+override files are not executed at all - and then the page type of this extension
+is not registered either, and silently falls back to the allow list of the
+``default`` page type instead of allowing every record type.
+
+The registration moved to an event listener on
+:php:`\TYPO3\CMS\Core\Core\Event\BootCompletedEvent`,
+:php:`\FGTCLB\AcademicProjects\EventListener\RegisterAcademicPageDoktype`. That event
+is dispatched one line after :php:`TcaSchemaFactory::load()` and on every request,
+warm cache included, which is what both halves of the defect need. The listener
+does nothing on TYPO3 v14, where the TCA option carries the configuration and
+:php:`PageDoktypeRegistry->add()` is deprecated.
+
+Impact
+======
+
+Content elements can be created on standard pages again while the TCA cache is
+cold, and the page type ``30`` of this extension allows every record type
+while it is warm.
+
+Affected Installations
+======================
+
+All installations of this extension on TYPO3 v13. TYPO3 v14 is not affected, it
+resolves the allowed tables from TCA. Nothing has to be done beyond the usual
+cache flush after an update.
+
+.. index:: TCA, Backend, ext:academic_projects

--- a/packages/fgtclb/academic-projects/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/be_users.csv
@@ -1,0 +1,3 @@
+be_users,,,,
+,uid,pid,username,password,admin
+,1,0,admin,"$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1

--- a/packages/fgtclb/academic-projects/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Tca/Fixtures/PageDoktypeRegistration/pages.csv
@@ -1,0 +1,3 @@
+pages,,,,
+,uid,pid,title,slug,doktype
+,1,0,Standard page,/,1

--- a/packages/fgtclb/academic-projects/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
+++ b/packages/fgtclb/academic-projects/Tests/Functional/Tca/PageDoktypeRegistrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicProjects\Tests\Functional\Tca;
+
+use FGTCLB\AcademicProjects\Enumeration\PageTypes;
+use FGTCLB\AcademicProjects\Tests\Functional\AbstractAcademicProjectsTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Pins how the page type of this extension reaches the PageDoktypeRegistry, and that
+ * registering it does not damage the allow list of the standard page type (ACE-462).
+ *
+ * The order of the two test methods is load-bearing, because the functional test case
+ * builds the TCA cold for its first test only and reuses the cache for every following
+ * one - which is precisely the difference the registration used to be sensitive to:
+ *
+ * - contentElementsAreAllowedOnAStandardPageWithAColdTcaCache()
+ *   runs against a cold TCA cache, the state in which "Configuration/TCA/Overrides"
+ *   files are executed. Registering the page type from there latched an allow list of
+ *   the "default" page type that was collected before the TCA was loaded, so "tt_content"
+ *   was missing from it and the DataHandler refused content elements on every standard
+ *   page.
+ * - everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache()
+ *   runs against a warm TCA cache, where the override files are not executed at all. A
+ *   page type registered from there is then simply absent and silently falls back to the
+ *   allow list of the "default" page type.
+ *
+ * Both are answered by doing the registration from a BootCompletedEvent listener, which
+ * runs after the TCA is loaded and on every request.
+ */
+final class PageDoktypeRegistrationTest extends AbstractAcademicProjectsTestCase
+{
+    /**
+     * First test of this test case, so the TCA is built cold and the TCA override files
+     * of the extension are executed.
+     */
+    #[Test]
+    public function contentElementsAreAllowedOnAStandardPageWithAColdTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('tt_content', 1),
+            'The standard page type does not allow "tt_content".'
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/PageDoktypeRegistration/pages.csv');
+        $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                'tt_content' => [
+                    'NEW1' => [
+                        'pid' => 1,
+                        'header' => 'Created by the data handler',
+                        'CType' => 'text',
+                    ],
+                ],
+            ],
+            []
+        );
+        $dataHandler->process_datamap();
+
+        $this->assertSame([], $dataHandler->errorLog);
+        $this->assertSame(1, $this->countContentElements());
+    }
+
+    /**
+     * Not the first test of this test case, so the TCA comes from the cache and the TCA
+     * override files of the extension are not executed.
+     *
+     * "sys_file_metadata" is asserted rather than "tt_content" because it is not part of
+     * the allow list the "default" page type falls back to, so the assertion fails when
+     * the page type is not registered at all.
+     */
+    #[Test]
+    public function everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache(): void
+    {
+        $this->assertTrue(
+            GeneralUtility::makeInstance(PageDoktypeRegistry::class)
+                ->isRecordTypeAllowedForDoktype('sys_file_metadata', PageTypes::TYPE_ACEDEMIC_PROJECT),
+            'The page type of this extension does not allow every record type.'
+        );
+    }
+
+    private function countContentElements(): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return (int)$queryBuilder->count('uid')->from('tt_content')->executeQuery()->fetchOne();
+    }
+}


### PR DESCRIPTION
Fixes the page type registration of `academic_programs`, `academic_projects`
and `academic_partners` on **TYPO3 v13**. v14 is unaffected — it resolves the
allowed tables from the TCA option `allowedRecordTypes`.

## The defect, both halves

All three extensions called `PageDoktypeRegistry->add()` from
`Configuration/TCA/Overrides/pages.php`. That is too early on v13:

**Cold TCA cache** — the first `add()` runs `initializeTca()`, which collects
every table declaring `security.ignorePageTypeRestriction` (`tt_content`,
`sys_template`, `backend_layout`) from `TcaSchemaFactory` and then latches. A
TCA override runs before `TcaSchemaFactory::load()`, so the factory is still
empty, the `default` page type never gains `tt_content`, and the DataHandler
refuses content elements on **every standard page**:

```
Attempt to insert record on pages:1 where table "tt_content" is not allowed
```

**Warm TCA cache** — the override files are not executed at all, so the page
type is not registered and silently falls back to the `default` allow list
instead of allowing every record type. This half was not in the original
report; the tests surfaced it.

## The fix

One `BootCompletedEvent` listener per extension. `Bootstrap::init()` dispatches
that event on the line right after `TcaSchemaFactory::load()`, in every context
and on every request — which is what both halves need. It returns immediately
on v14, where `add()` raises the deprecation announcing its v15 removal. The
version guard leaves `pages.php`, which now always sets `allowedRecordTypes`;
v13 ignores it harmlessly.

### Why not `ext_tables.php`

It would run late enough, and it is what `PageDoktypeRegistry`'s own class
docblock suggests. But TYPO3 v14.3 deprecates *loading an `ext_tables.php` at
all* — per extension, independently of its content, on `require`
(`ExtTablesFactory` lines 73 and 110). Measured with the file in place:

```
Loading ext_tables.php of extension "academic_programs" has been deprecated in
TYPO3 v14.3 and will be removed in TYPO3 v15.0.
Tests: 2, Assertions: 4, Deprecations: 2.     EXIT=1
```

The suites run with `failOnDeprecation`, so it turns the whole v14 run red and
writes two deprecations per request into every v14 installation's log.

## Tests

One functional test class per extension, two methods, and their **order is
load-bearing**: `FunctionalTestCase` builds the TCA cold for the first test of
a class only, so method 1 sees a cold TCA and method 2 a warm one. The warm
method asserts `sys_file_metadata` rather than `tt_content`, because
`tt_content` would pass for the wrong reason through the `default` fallback.

Proven to fail — listener removed, `pages.php` restored, all three extensions:

```
1) …::contentElementsAreAllowedOnAStandardPageWithAColdTcaCache
   The standard page type does not allow "tt_content".
2) …::everyRecordTypeIsAllowedOnTheRegisteredPageTypeWithAWarmTcaCache
   The page type of this extension does not allow every record type.
Tests: 2, Assertions: 2, Failures: 2.
```

## Gates

| Suite | v13.4.34 | v14.3.6 |
|-------|----------|---------|
| `lintPhp` | SUCCESS | SUCCESS |
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | `[OK] No errors` | `[OK] No errors` |
| `unit` | OK (643 tests) | OK (643 tests) |
| `functional` | OK (1397 tests) | OK (1405 tests) |

Each after its own `composerUpdate`. `lintMarkdown -n` and
`checkRstRenderingAll` green as well. PHP 8.2 and SQLite only locally — the
change touches no query; CI covers 8.5 and the DBMS matrix.

## Also in here

`docs/architecture/core-version-aware-code.md` gained a section for the new
mechanism and an explicit "why not `ext_tables.php`"; its paragraph pointing at
`pages.php` line 62 was stale. Two counts corrected while there
(`Configuration/` version switches: 15 documented, 12 actual). `AGENTS.md`
claimed the only per-version switches were the two in `TcaManipulator.php`,
which was already inaccurate; it now defers to the docs page for the counts.

Resolves ACE-462.
