### PR TITLE
[BUGFIX] ACE-466: Write FlexForm items with keys

### DIFF
--- a/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicBase\Tests\Unit\Configuration;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Checks how every FlexForm shipped by the extensions of this repository declares
+ * the `items` of a select or check field.
+ *
+ * TYPO3 accepts two spellings and deprecates one of them. The positional form
+ *
+ *     <numIndex index="0" type="array">
+ *         <numIndex index="0">LLL:EXT:…:flexform.el.sortByDirection.items.asc</numIndex>
+ *         <numIndex index="1">asc</numIndex>
+ *     </numIndex>
+ *
+ * is migrated on the fly by `FlexFormTools` and reported as
+ * "uses the legacy way of defining 'items'"; the associative form
+ *
+ *     <numIndex index="0" type="array">
+ *         <label>LLL:EXT:…:flexform.el.sortByDirection.items.asc</label>
+ *         <value>asc</value>
+ *     </numIndex>
+ *
+ * is not. Both render the same select box, which is why six files kept the old
+ * one through several releases: the migration is silent unless something writes
+ * such a FlexForm while `failOnDeprecation` is on (ACE-466).
+ *
+ * The check is structural and runs without a core: it reads the XML and looks at
+ * the shape, rather than parsing the data structure through `FlexFormTools` and
+ * waiting for a deprecation. A deprecation is a moving target - it is removed in
+ * the version that removes the migration - and by then the wrong spelling stops
+ * working rather than warning.
+ *
+ * `valuePicker` items are deliberately not covered. They are a different
+ * structure with its own positional pairs, TYPO3 does not migrate them, and four
+ * FlexForms of `academic_persons` rely on them.
+ */
+final class ShippedFlexFormsTest extends UnitTestCase
+{
+    /**
+     * Directory names that are never a source: generated, installed or vendored trees.
+     *
+     * @var list<string>
+     */
+    private const SKIPPED_DIRECTORIES = [
+        '.Build',
+        '.git',
+        'Documentation-GENERATED-temp',
+        'node_modules',
+        'public',
+        'var',
+        'vendor',
+    ];
+
+    #[Test]
+    public function noShippedFlexFormDeclaresItemsInThePositionalForm(): void
+    {
+        $scanRoot = $this->determineScanRoot();
+        $files = $this->collectFlexFormFiles($scanRoot);
+
+        $this->assertNotSame([], $files, sprintf('No FlexForm found below "%s".', $scanRoot));
+
+        $failures = [];
+        foreach ($files as $file) {
+            foreach ($this->positionalItemLines($file) as $line => $text) {
+                $failures[] = sprintf(
+                    ' - %s:%d: %s',
+                    substr($file, strlen($scanRoot) + 1),
+                    $line,
+                    trim($text),
+                );
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $failures,
+            sprintf(
+                '%d item entries of the %d shipped FlexForms below "%s" use the positional form.'
+                . " Write \"<label>\" and \"<value>\" instead:\n%s",
+                count($failures),
+                count($files),
+                $scanRoot,
+                implode("\n", $failures),
+            ),
+        );
+    }
+
+    /**
+     * The lines of one file that declare an item positionally.
+     *
+     * A `<numIndex index="N" type="array">` opens an item; inside it, a nested
+     * `<numIndex>` is the positional form and a `<label>` or `<value>` is not.
+     * Anything below a `<valuePicker>` is skipped.
+     *
+     * @return array<int, string>
+     */
+    private function positionalItemLines(string $file): array
+    {
+        $found = [];
+        $valuePickerDepth = 0;
+        $inItem = false;
+
+        foreach (explode("\n", (string)file_get_contents($file)) as $index => $line) {
+            $trimmed = trim($line);
+            if (str_starts_with($trimmed, '<valuePicker')) {
+                $valuePickerDepth++;
+                continue;
+            }
+            if (str_starts_with($trimmed, '</valuePicker')) {
+                $valuePickerDepth--;
+                continue;
+            }
+            if ($valuePickerDepth > 0) {
+                continue;
+            }
+            if (preg_match('/^<numIndex index="\d+" type="array">$/', $trimmed) === 1) {
+                $inItem = true;
+                continue;
+            }
+            if ($inItem && $trimmed === '</numIndex>') {
+                $inItem = false;
+                continue;
+            }
+            if ($inItem && str_starts_with($trimmed, '<numIndex ')) {
+                $found[$index + 1] = $line;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * The whole "packages/" tree when this extension sits in one, and the extension
+     * alone when it has been split out to a repository of its own.
+     */
+    private function determineScanRoot(): string
+    {
+        $extensionRoot = dirname(__DIR__, 3);
+        $packagesRoot = dirname($extensionRoot, 2);
+
+        if (basename($packagesRoot) === 'packages' && is_dir($packagesRoot)) {
+            return $packagesRoot;
+        }
+
+        return $extensionRoot;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectFlexFormFiles(string $root): array
+    {
+        $directories = new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS);
+        $filtered = new \RecursiveCallbackFilterIterator(
+            $directories,
+            static function (\SplFileInfo $current): bool {
+                if ($current->isDir()) {
+                    return !in_array($current->getFilename(), self::SKIPPED_DIRECTORIES, true);
+                }
+
+                return strtolower($current->getExtension()) === 'xml'
+                    && str_contains($current->getPathname(), '/Configuration/FlexForms/');
+            },
+        );
+
+        $files = [];
+        foreach (new \RecursiveIteratorIterator($filtered) as $file) {
+            if ($file instanceof \SplFileInfo && $file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+        sort($files);
+
+        return $files;
+    }
+}

--- a/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core12/AcademicBiteJobsList.xml
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core12/AcademicBiteJobsList.xml
@@ -18,16 +18,16 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.list</numIndex>
-                            <numIndex index="1">List</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.list</label>
+                            <value>List</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.card</numIndex>
-                            <numIndex index="1">Card</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.card</label>
+                            <value>Card</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.table</numIndex>
-                            <numIndex index="1">Table</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.view.items.table</label>
+                            <value>Table</value>
                         </numIndex>
                     </items>
                 </config>
@@ -39,12 +39,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.ends_on</numIndex>
-                            <numIndex index="1">endsOn</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.ends_on</label>
+                            <value>endsOn</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.title</numIndex>
-                            <numIndex index="1">title</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.title</label>
+                            <value>title</value>
                         </numIndex>
                     </items>
                     <default>endsOn</default>
@@ -57,12 +57,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.asc</numIndex>
-                            <numIndex index="1">asc</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.asc</label>
+                            <value>asc</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.desc</numIndex>
-                            <numIndex index="1">desc</numIndex>
+                            <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.desc</label>
+                            <value>desc</value>
                         </numIndex>
                     </items>
                     <default>asc</default>

--- a/packages/fgtclb/academic-partners/Configuration/FlexForms/Core12/ListSettings.xml
+++ b/packages/fgtclb/academic-partners/Configuration/FlexForms/Core12/ListSettings.xml
@@ -27,24 +27,24 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.asc</numIndex>
-                            <numIndex index="1">title asc</numIndex>
+                            <label>LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.asc</label>
+                            <value>title asc</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.desc</numIndex>
-                            <numIndex index="1">title desc</numIndex>
+                            <label>LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.desc</label>
+                            <value>title desc</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update</numIndex>
-                            <numIndex index="1">lastUpdated desc</numIndex>
+                            <label>LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update</label>
+                            <value>lastUpdated desc</value>
                         </numIndex>
                         <numIndex index="3" type="array">
-                            <numIndex index="0">LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update.asc</numIndex>
-                            <numIndex index="1">lastUpdated asc</numIndex>
+                            <label>LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update.asc</label>
+                            <value>lastUpdated asc</value>
                         </numIndex>
                         <numIndex index="4" type="array">
-                            <numIndex index="0">LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.sorting.asc</numIndex>
-                            <numIndex index="1">sorting asc</numIndex>
+                            <label>LLL:EXT:academic_partners/Resources/Private/Language/locallang_be.xlf:flexform.sorting.sorting.asc</label>
+                            <value>sorting asc</value>
                         </numIndex>
                     </items>
                 </config>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
@@ -45,8 +45,8 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.groupBy.items.none</numIndex>
-                            <numIndex index="1"></numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.groupBy.items.none</label>
+                            <value></value>
                         </numIndex>
                     </items>
                     <itemsProcFunc>FGTCLB\AcademicPersons\Tca\DemandValues->getGroupByValues</itemsProcFunc>
@@ -59,8 +59,8 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.none</numIndex>
-                            <numIndex index="1"></numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortBy.items.none</label>
+                            <value></value>
                         </numIndex>
                     </items>
                     <itemsProcFunc>FGTCLB\AcademicPersons\Tca\DemandValues->getSortByValues</itemsProcFunc>
@@ -73,12 +73,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.asc</numIndex>
-                            <numIndex index="1">asc</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.asc</label>
+                            <value>asc</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.desc</numIndex>
-                            <numIndex index="1">desc</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.sortByDirection.items.desc</label>
+                            <value>desc</value>
                         </numIndex>
                     </items>
                     <default>asc</default>
@@ -91,7 +91,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.paginationEnabled.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.paginationEnabled.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>
@@ -105,7 +105,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.alphabetPaginationEnabled.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.alphabetPaginationEnabled.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>
@@ -148,7 +148,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>
@@ -162,12 +162,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
-                            <numIndex index="1">list</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</label>
+                            <value>list</value>
                         </numIndex>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
-                            <numIndex index="1">table</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</label>
+                            <value>table</value>
                         </numIndex>
                     </items>
                     <default>list</default>
@@ -180,7 +180,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.fallbackForNonTranslated.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedContracts.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedContracts.xml
@@ -45,7 +45,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>
@@ -59,12 +59,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
-                            <numIndex index="1">list</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</label>
+                            <value>list</value>
                         </numIndex>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
-                            <numIndex index="1">table</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</label>
+                            <value>table</value>
                         </numIndex>
                     </items>
                     <default>asc</default>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedProfiles.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedProfiles.xml
@@ -48,7 +48,7 @@
                     <renderType>checkboxToggle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.enabled.items.0.label</label>
                             <labelChecked>Enabled</labelChecked>
                             <labelUnchecked>Disabled</labelUnchecked>
                         </numIndex>
@@ -62,12 +62,12 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</numIndex>
-                            <numIndex index="1">list</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.list</label>
+                            <value>list</value>
                         </numIndex>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</numIndex>
-                            <numIndex index="1">table</numIndex>
+                            <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.viewMode.default.I.table</label>
+                            <value>table</value>
                         </numIndex>
                     </items>
                     <default>asc</default>

--- a/packages/fgtclb/academic-programs/Configuration/FlexForms/Core12/ProgramListSettings.xml
+++ b/packages/fgtclb/academic-programs/Configuration/FlexForms/Core12/ProgramListSettings.xml
@@ -27,24 +27,24 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.asc</numIndex>
-                            <numIndex index="1">title asc</numIndex>
+                            <label>LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.asc</label>
+                            <value>title asc</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.desc</numIndex>
-                            <numIndex index="1">title desc</numIndex>
+                            <label>LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.title.desc</label>
+                            <value>title desc</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update</numIndex>
-                            <numIndex index="1">lastUpdated desc</numIndex>
+                            <label>LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update</label>
+                            <value>lastUpdated desc</value>
                         </numIndex>
                         <numIndex index="3" type="array">
-                            <numIndex index="0">LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update.asc</numIndex>
-                            <numIndex index="1">lastUpdated asc</numIndex>
+                            <label>LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.update.asc</label>
+                            <value>lastUpdated asc</value>
                         </numIndex>
                         <numIndex index="4" type="array">
-                            <numIndex index="0">LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.sorting.asc</numIndex>
-                            <numIndex index="1">sorting asc</numIndex>
+                            <label>LLL:EXT:academic_programs/Resources/Private/Language/locallang_be.xlf:flexform.sorting.sorting.asc</label>
+                            <value>sorting asc</value>
                         </numIndex>
                     </items>
                 </config>


### PR DESCRIPTION
Six FlexForm data structures declared the `items` of a select field in the
positional form TYPO3 migrates on the fly and deprecates:

```
FlexFormTools did an on-the-fly migration of a flex form data structure. This is
deprecated and will be removed. … The TCA field uses the legacy way of defining
'items'. Please switch to associated array keys: label, value, icon, group,
description.
```

```diff
 <numIndex index="0" type="array">
-    <numIndex index="0">LLL:EXT:…:flexform.el.sortByDirection.items.asc</numIndex>
-    <numIndex index="1">asc</numIndex>
+    <label>LLL:EXT:…:flexform.el.sortByDirection.items.asc</label>
+    <value>asc</value>
 </numIndex>
```

## Scope, and why it is smaller than it looks

**Only the `Core12/` variants were affected.** Their `Core13/` counterparts were
converted at some earlier point and were already correct, so this is six files
and 60 lines, not fourteen files:

`academic-persons/…/Core12/{List,SelectedContracts,SelectedProfiles}.xml`,
`academic-bite-jobs/…/Core12/AcademicBiteJobsList.xml`,
`academic-partners/…/Core12/ListSettings.xml`,
`academic-programs/…/Core12/ProgramListSettings.xml`.

**`valuePicker` items are deliberately untouched.** They use the same positional
shape, TYPO3 does **not** migrate them, and four `academic_persons` FlexForms
rely on them — converting those would have broken working configuration. The
converter tracked `valuePicker` depth and skipped it; verified afterwards by
reading the four files.

## Why it survived several releases

Both spellings render the same select box, and the migration is silent unless
something *writes* such a FlexForm while `failOnDeprecation` is on. Nothing in
the suite did. The development seed of ACE-460 writes all of them, which is how
this surfaced: 28 deprecations on TYPO3 v12, and the seed's own tests could not
go green until this was fixed.

## The regression guard

`ShippedFlexFormsTest` in `academic-base`, a sibling of the existing
`ShippedYamlFilesTest`, scans every `Configuration/FlexForms/**.xml` below
`packages/` and reports the positional form with file and line.

It checks the **shape** rather than parsing the structure through
`FlexFormTools` and waiting for a deprecation. A deprecation is a moving target:
in the version that removes the migration, the wrong spelling stops working
rather than warning, and a test built on the warning would go quiet exactly when
it mattered.

Proven both ways on TYPO3 v12 / PHP 8.1:

* with the fix — `OK (1 test, 5 assertions)`
* with one file reverted — `16 item entries of the 16 shipped FlexForms … use
  the positional form`, naming each file and line

## Gates

| Suite | TYPO3 v12.4.45 / PHP 8.1 | TYPO3 v13.4.34 / PHP 8.2 |
|-------|--------------------------|--------------------------|
| `lintPhp` | SUCCESS | SUCCESS |
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | SUCCESS | SUCCESS |
| `unit` | SUCCESS | SUCCESS |
| `functional` | 1196 tests, 5108 assertions | 1305 tests, 5650 assertions |

Each after its own `composerUpdate`, `.cache/phpstan` wiped on every switch.

No changelog entry: the two spellings render the same select box, so there is
nothing an integrator can observe or has to act on.

Resolves ACE-466. Prerequisite for the ACE-460 seed backport.
