### PR TITLE
[BUGFIX] ACE-467: Finish the FlexForm migrations

### DIFF
--- a/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
@@ -92,6 +92,39 @@ final class ShippedFlexFormsTest extends UnitTestCase
     }
 
     /**
+     * The `<TCEforms>` wrapper below `<ROOT>` or an element is a compatibility
+     * layer TYPO3 announces as removed in v13: "It should be omitted while the
+     * underlying configuration ascends one level up." Two FlexForms of
+     * `academic_persons` carried it (ACE-467).
+     */
+    #[Test]
+    public function noShippedFlexFormWrapsItsConfigurationInTceforms(): void
+    {
+        $scanRoot = $this->determineScanRoot();
+        $files = $this->collectFlexFormFiles($scanRoot);
+
+        $failures = [];
+        foreach ($files as $file) {
+            if (str_contains((string)file_get_contents($file), '<TCEforms>')) {
+                $failures[] = ' - ' . substr($file, strlen($scanRoot) + 1);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $failures,
+            sprintf(
+                '%d of the %d shipped FlexForms below "%s" wrap their configuration in'
+                . " \"<TCEforms>\". Omit the tag and move its content one level up:\n%s",
+                count($failures),
+                count($files),
+                $scanRoot,
+                implode("\n", $failures),
+            ),
+        );
+    }
+
+    /**
      * The lines of one file that declare an item positionally.
      *
      * A `<numIndex index="N" type="array">` opens an item; inside it, a nested
@@ -104,6 +137,7 @@ final class ShippedFlexFormsTest extends UnitTestCase
     {
         $found = [];
         $valuePickerDepth = 0;
+        $inItems = false;
         $inItem = false;
 
         foreach (explode("\n", (string)file_get_contents($file)) as $index => $line) {
@@ -119,7 +153,18 @@ final class ShippedFlexFormsTest extends UnitTestCase
             if ($valuePickerDepth > 0) {
                 continue;
             }
-            if (preg_match('/^<numIndex index="\d+" type="array">$/', $trimmed) === 1) {
+            if ($trimmed === '<items>') {
+                $inItems = true;
+                continue;
+            }
+            if ($trimmed === '</items>') {
+                $inItems = false;
+                $inItem = false;
+                continue;
+            }
+            // The "type" attribute is optional and both spellings occur, so an item
+            // is recognised by where it sits rather than by how it is annotated.
+            if ($inItems && !$inItem && preg_match('/^<numIndex index="\d+"( type="array")?>$/', $trimmed) === 1) {
                 $inItem = true;
                 continue;
             }
@@ -164,8 +209,14 @@ final class ShippedFlexFormsTest extends UnitTestCase
                     return !in_array($current->getFilename(), self::SKIPPED_DIRECTORIES, true);
                 }
 
+                // Case insensitively, because the directory is not spelled the same
+                // everywhere: eleven extensions use "Configuration/FlexForms/" and
+                // "academic_jobs" uses "Configuration/Flexforms/". Matching the
+                // majority spelling exactly is how this check silently skipped that
+                // extension, and with it four data structures that needed the fix
+                // (ACE-467).
                 return strtolower($current->getExtension()) === 'xml'
-                    && str_contains($current->getPathname(), '/Configuration/FlexForms/');
+                    && str_contains(strtolower($current->getPathname()), '/configuration/flexforms/');
             },
         );
 

--- a/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core12/AcademicBiteJobsList.xml
+++ b/packages/fgtclb/academic-bite-jobs/Configuration/FlexForms/Core12/AcademicBiteJobsList.xml
@@ -72,8 +72,7 @@
                 <label>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.jobs.limit.label</label>
                 <description>LLL:EXT:academic_bite_jobs/Resources/Private/Language/locallang_be.xlf:flexform.el.jobs.limit.description</description>
                 <config>
-                    <type>input</type>
-                    <eval>int</eval>
+                    <type>number</type>
                 </config>
             </settings.jobs.limit>
         </el>

--- a/packages/fgtclb/academic-jobs/Configuration/Flexforms/Core12/PluginList.xml
+++ b/packages/fgtclb/academic-jobs/Configuration/Flexforms/Core12/PluginList.xml
@@ -10,20 +10,20 @@
                     <renderType>selectSingle</renderType>
                     <items>
                         <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.none</numIndex>
-                            <numIndex index="1">0</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.none</label>
+                            <value>0</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.job</numIndex>
-                            <numIndex index="1">1</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.job</label>
+                            <value>1</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.sidejob</numIndex>
-                            <numIndex index="1">2</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.sidejob</label>
+                            <value>2</value>
                         </numIndex>
                         <numIndex index="3" type="array">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.thesis</numIndex>
-                            <numIndex index="1">3</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang_be.xlf:tx_academicjobs_domain_model_job.jobtype.thesis</label>
+                            <value>3</value>
                         </numIndex>
                     </items>
                 </config>

--- a/packages/fgtclb/academic-jobs/Configuration/Flexforms/Core12/Plugin_NewJobForm.xml
+++ b/packages/fgtclb/academic-jobs/Configuration/Flexforms/Core12/Plugin_NewJobForm.xml
@@ -26,20 +26,20 @@
                     <default>-1</default>
                     <items>
                         <numIndex index="0">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.use_global_setting</numIndex>
-                            <numIndex index="1">-1</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.use_global_setting</label>
+                            <value>-1</value>
                         </numIndex>
                         <numIndex index="1">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_always</numIndex>
-                            <numIndex index="1">1</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_always</label>
+                            <value>1</value>
                         </numIndex>
                         <numIndex index="2">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_never</numIndex>
-                            <numIndex index="1">2</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_never</label>
+                            <value>2</value>
                         </numIndex>
                         <numIndex index="3">
-                            <numIndex index="0">LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected</numIndex>
-                            <numIndex index="1">0</numIndex>
+                            <label>LLL:EXT:academic_jobs/Resources/Private/Language/locallang.xlf:saveForm.flashMessageCreationMode.option_suppressWhenRedirectPageIsSelected</label>
+                            <value>0</value>
                         </numIndex>
                     </items>
                 </config>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedProfiles.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/SelectedProfiles.xml
@@ -1,8 +1,6 @@
 <T3DataStructure>
     <ROOT>
-        <TCEforms>
-            <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
-        </TCEforms>
+        <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
         <type>array</type>
         <el>
             <settings.detailPid>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/SelectedProfiles.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/SelectedProfiles.xml
@@ -1,8 +1,6 @@
 <T3DataStructure>
     <ROOT>
-        <TCEforms>
-            <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
-        </TCEforms>
+        <sheetTitle>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.tab.settings</sheetTitle>
         <type>array</type>
         <el>
             <settings.detailPid>


### PR DESCRIPTION
The follow-up to #540. That change converted the FlexForm `items` a scan of
`Configuration/FlexForms/` could see; four migrations TYPO3 still performs on
the fly were left, and one of them is the reason that scan missed anything.

## The four

| Migration | Where |
|-----------|-------|
| legacy positional `items` | `academic-jobs/Configuration/Flexforms/Core12/{PluginList,Plugin_NewJobForm}.xml` |
| `<TCEforms>` wrapper below `<ROOT>` | `academic-persons/Configuration/FlexForms/{Core12,Core13}/SelectedProfiles.xml` |
| `eval="int"` → `type: number` | `academic-bite-jobs/Configuration/FlexForms/Core12/AcademicBiteJobsList.xml` |

The `eval="int"` field is migrated to exactly what its `Core13` counterpart
already declares, so the two variants now differ in nothing.

**The `<TCEforms>` one is worth a second look.** TYPO3 says of it: *"This
compatibility layer will be removed in TYPO3 v13."* This branch supports v13,
so those two files were living on borrowed time quite apart from the seed.

## Two blind spots in the #540 check, both defects of the check

1. **The directory is not spelled the same everywhere.** Eleven extensions use
   `Configuration/FlexForms/`; `academic_jobs` uses `Configuration/Flexforms/`.
   `ShippedFlexFormsTest` matched the majority spelling exactly and therefore
   never looked at that extension — which is precisely where the remaining
   `items` cases were. Now matched case-insensitively.
2. **The `type="array"` attribute on an item is optional.** The check treated it
   as the marker of an item, so a legacy item written without it was invisible.
   An item is now recognised by sitting inside `<items>`, not by its annotation.

That is the uncomfortable part of #540: the test passed while covering less than
it claimed. Both gaps are closed here, and the second check makes the first one
honest rather than merely green.

## The `<TCEforms>` check is separate on purpose

It is a different mistake with a different fix, and a failure that says which
one it is saves the reader a lookup.

## Proven to fail

Each check was broken on purpose and watched fail, naming its file:

* `Plugin_NewJobForm.xml` reverted → the positional-items check reports it
* `SelectedProfiles.xml` reverted → the `<TCEforms>` check reports it

With everything in place: `OK (2 tests, 9 assertions)`.

## Gates

| Suite | TYPO3 v12.4.45 / PHP 8.1 | TYPO3 v13.4.34 / PHP 8.2 |
|-------|--------------------------|--------------------------|
| `lintPhp` | SUCCESS | SUCCESS |
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | SUCCESS | SUCCESS |
| `unit` | SUCCESS | SUCCESS |
| `functional` | 1196 tests, 5108 assertions | 1305 tests, 5650 assertions |

Each after its own `composerUpdate`, `.cache/phpstan` wiped on every switch.

No changelog entry: every one of these renders the same form field it rendered
before, so there is nothing an integrator can observe or has to act on.

Resolves ACE-467. Last prerequisite for the ACE-460 seed backport, which is
where all five deprecations were surfacing.
