### PR TITLE
[BUGFIX] ACE-464: Remove a stray FlexForm character

### DIFF
--- a/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
+++ b/packages/fgtclb/academic-base/Tests/Unit/Configuration/ShippedFlexFormsTest.php
@@ -125,6 +125,90 @@ final class ShippedFlexFormsTest extends UnitTestCase
     }
 
     /**
+     * Character data between two elements, which XML permits and TYPO3 ignores.
+     *
+     * A FlexForm is a tree of elements, so a stray character between them means
+     * exactly one thing: a typo. `academic_persons` carried a lone `s` after
+     * `</settings.organisationalUnits>` through several releases (ACE-464) - the
+     * file was well formed, the parser dropped the text node, and nothing in this
+     * repository looks at XML, so no gate ever saw it.
+     *
+     * The check is on the parsed tree rather than on the text, because that is
+     * what makes "between two elements" a decidable question.
+     */
+    #[Test]
+    public function noShippedFlexFormCarriesStrayCharacterData(): void
+    {
+        $scanRoot = $this->determineScanRoot();
+        $files = $this->collectFlexFormFiles($scanRoot);
+
+        $failures = [];
+        foreach ($files as $file) {
+            $document = new \DOMDocument();
+            $document->preserveWhiteSpace = true;
+            if (!@$document->loadXML((string)file_get_contents($file))) {
+                $failures[] = sprintf(' - %s: not well formed XML', substr($file, strlen($scanRoot) + 1));
+                continue;
+            }
+
+            foreach (self::strayTextOf($document->documentElement) as $stray) {
+                $failures[] = sprintf(
+                    ' - %s: "%s" between elements below <%s>',
+                    substr($file, strlen($scanRoot) + 1),
+                    $stray['text'],
+                    $stray['parent'],
+                );
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $failures,
+            sprintf(
+                '%d stray text nodes in the %d shipped FlexForms below "%s".'
+                . " XML allows them and TYPO3 drops them, so they are always a typo:\n%s",
+                count($failures),
+                count($files),
+                $scanRoot,
+                implode("\n", $failures),
+            ),
+        );
+    }
+
+    /**
+     * Text nodes of an element that also has element children, which is where
+     * character data can only be an accident.
+     *
+     * @return list<array{parent: string, text: string}>
+     */
+    private static function strayTextOf(?\DOMElement $element): array
+    {
+        if ($element === null) {
+            return [];
+        }
+
+        $stray = [];
+        $hasElementChild = false;
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof \DOMElement) {
+                $hasElementChild = true;
+            }
+        }
+
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof \DOMElement) {
+                $stray = array_merge($stray, self::strayTextOf($child));
+                continue;
+            }
+            if ($hasElementChild && $child instanceof \DOMText && trim($child->wholeText) !== '') {
+                $stray[] = ['parent' => $element->nodeName, 'text' => trim($child->wholeText)];
+            }
+        }
+
+        return $stray;
+    }
+
+    /**
      * The lines of one file that declare an item positionally.
      *
      * A `<numIndex index="N" type="array">` opens an item; inside it, a nested

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml
@@ -212,7 +212,7 @@
                     <maxitems>99</maxitems>
                     <size>3</size>
                 </config>
-            </settings.organisationalUnits>s
+            </settings.organisationalUnits>
             <settings.functionTypes>
                 <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.functionTypes.label</label>
                 <config>

--- a/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/List.xml
+++ b/packages/fgtclb/academic-persons/Configuration/FlexForms/Core13/List.xml
@@ -212,7 +212,7 @@
                     <maxitems>99</maxitems>
                     <size>3</size>
                 </config>
-            </settings.organisationalUnits>s
+            </settings.organisationalUnits>
             <settings.functionTypes>
                 <label>LLL:EXT:academic_persons/Resources/Private/Language/locallang_be.xlf:flexform.el.functionTypes.label</label>
                 <config>


### PR DESCRIPTION
The branch `2` half of ACE-464. The `main` half went in with the seed work
(`2735bd5bb`); this is the same stray `s` after
`</settings.organisationalUnits>` at line 215 of **both** the `Core12` and the
`Core13` variant of the `academic_persons` List FlexForm.

## Impact: none, and that is the point

XML permits character data between elements, the files are well formed (verified
by parsing them), and TYPO3's FlexForm parser drops the text node. Nothing
misbehaves. It survived several releases precisely because nothing misbehaves —
and because nothing in this repository looked at XML.

## So it gets a check, not only a fix

`ShippedFlexFormsTest` — the class ACE-466 and ACE-467 built up — gains a third
method. It walks the **parsed tree** of every shipped FlexForm and reports
character data sitting between two elements, naming the file and the element it
sits below:

```
1 stray text nodes in the 20 shipped FlexForms below "…/packages".
XML allows them and TYPO3 drops them, so they are always a typo:
 - fgtclb/academic-persons/Configuration/FlexForms/Core12/List.xml: "s" between elements below <el>
```

The check is on the parsed tree and not on the text, because that is what makes
"between two elements" a decidable question rather than a regular expression
that will be wrong on the first multi-line element.

Proven both ways: with the fix `OK (3 tests, 13 assertions)`; with one file
reverted the message above, naming the file.

## Gates

| Suite | TYPO3 v12.4.45 / PHP 8.1 | TYPO3 v13.4.34 / PHP 8.2 |
|-------|--------------------------|--------------------------|
| `lintPhp` | SUCCESS | SUCCESS |
| `cgl -n` | SUCCESS | SUCCESS |
| `phpstan` | SUCCESS | SUCCESS |
| `unit` | SUCCESS | SUCCESS |
| `functional` | 1201 tests, 5124 assertions | 1312 tests, 5666 assertions |

Each after its own `composerUpdate`, `.cache/phpstan` wiped on the switch.

No changelog entry: the change is not observable from a backend form, a frontend
rendering or an API, so there is nothing for an integrator to act on.

Resolves ACE-464 — the issue closes with this, both branches done.
