### PR TITLE
[BUGFIX] ACE-470: Limit enhancers to their own pages

### DIFF
--- a/core-12/config/sites/academics/config.yaml
+++ b/core-12/config/sites/academics/config.yaml
@@ -12,6 +12,40 @@ imports:
   - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
   - resource: 'EXT:academic_programs/Configuration/Yaml/Routes.yaml'
 
+# Bind every one of those enhancers to the pages that carry the plugin it
+# belongs to.
+#
+# Without this block TYPO3 offers all five to every page of the site, and the
+# matcher takes the first candidate route whose path matches and whose aspects
+# also resolve. "ListAndDetail.yaml" and "Detail.yaml" declare a byte identical
+# "/{profile_name}" over the same slug mapper, so the one that is imported
+# first takes every profile URL of the whole site and the other plugin never
+# receives its argument - a 404 on the dedicated detail page, from a link that
+# was generated correctly, because generation is scoped to the plugin namespace
+# being linked and is therefore not ambiguous at all (ACE-470). The two list
+# routes collide the same way and more quietly: the wrong namespace renders an
+# unfiltered list with status 200.
+#
+# The uids below are the ones the seed declares, and they are the uids of the
+# default language. Matching derives the page as "l10n_parent ?: uid", so one
+# list covers "/persons/detail" and "/de/personal/detail" alike.
+routeEnhancers:
+  # "/persons/list", "/persons/list-alphabet", "/persons/list-filtered"
+  ProfileListPlugin:
+    limitToPages: [201, 202, 203]
+  # "/persons/list-and-detail"
+  ProfileListAndDetailPlugin:
+    limitToPages: [204]
+  # "/persons/detail"
+  ProfileDetailPlugin:
+    limitToPages: [205]
+  # "/jobs/detail"
+  AcademicJobsDetailPlugin:
+    limitToPages: [233]
+  # "/programs/list", "/programs/list-preset"
+  AcademicPrograms:
+    limitToPages: [251, 252]
+
 # Site of the seeded page tree.
 #
 # "rootPageId" is 1 because the seed definition declares that uid - see

--- a/core-13/config/sites/academics-legacy/config.yaml
+++ b/core-13/config/sites/academics-legacy/config.yaml
@@ -17,6 +17,40 @@ imports:
   - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
   - resource: 'EXT:academic_programs/Configuration/Yaml/Routes.yaml'
 
+# Bind every one of those enhancers to the pages that carry the plugin it
+# belongs to.
+#
+# Without this block TYPO3 offers all five to every page of the site, and the
+# matcher takes the first candidate route whose path matches and whose aspects
+# also resolve. "ListAndDetail.yaml" and "Detail.yaml" declare a byte identical
+# "/{profile_name}" over the same slug mapper, so the one that is imported
+# first takes every profile URL of the whole site and the other plugin never
+# receives its argument - a 404 on the dedicated detail page, from a link that
+# was generated correctly, because generation is scoped to the plugin namespace
+# being linked and is therefore not ambiguous at all (ACE-470). The two list
+# routes collide the same way and more quietly: the wrong namespace renders an
+# unfiltered list with status 200.
+#
+# The uids below are the ones the seed declares, and they are the uids of the
+# default language. Matching derives the page as "l10n_parent ?: uid", so one
+# list covers "/persons/detail" and "/de/personal/detail" alike.
+routeEnhancers:
+  # "/persons/list", "/persons/list-alphabet", "/persons/list-filtered"
+  ProfileListPlugin:
+    limitToPages: [1201, 1202, 1203]
+  # "/persons/list-and-detail"
+  ProfileListAndDetailPlugin:
+    limitToPages: [1204]
+  # "/persons/detail"
+  ProfileDetailPlugin:
+    limitToPages: [1205]
+  # "/jobs/detail"
+  AcademicJobsDetailPlugin:
+    limitToPages: [1233]
+  # "/programs/list", "/programs/list-preset"
+  AcademicPrograms:
+    limitToPages: [1251, 1252]
+
 # Site of the "/legacy/" page tree - the 56 content pages of "academics",
 # delivered the way an installation that predates site sets delivers them. The
 # nine storage folders of "/data" are not mirrored: their records are shared,

--- a/core-13/config/sites/academics/config.yaml
+++ b/core-13/config/sites/academics/config.yaml
@@ -17,6 +17,40 @@ imports:
   - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
   - resource: 'EXT:academic_programs/Configuration/Yaml/Routes.yaml'
 
+# Bind every one of those enhancers to the pages that carry the plugin it
+# belongs to.
+#
+# Without this block TYPO3 offers all five to every page of the site, and the
+# matcher takes the first candidate route whose path matches and whose aspects
+# also resolve. "ListAndDetail.yaml" and "Detail.yaml" declare a byte identical
+# "/{profile_name}" over the same slug mapper, so the one that is imported
+# first takes every profile URL of the whole site and the other plugin never
+# receives its argument - a 404 on the dedicated detail page, from a link that
+# was generated correctly, because generation is scoped to the plugin namespace
+# being linked and is therefore not ambiguous at all (ACE-470). The two list
+# routes collide the same way and more quietly: the wrong namespace renders an
+# unfiltered list with status 200.
+#
+# The uids below are the ones the seed declares, and they are the uids of the
+# default language. Matching derives the page as "l10n_parent ?: uid", so one
+# list covers "/persons/detail" and "/de/personal/detail" alike.
+routeEnhancers:
+  # "/persons/list", "/persons/list-alphabet", "/persons/list-filtered"
+  ProfileListPlugin:
+    limitToPages: [201, 202, 203]
+  # "/persons/list-and-detail"
+  ProfileListAndDetailPlugin:
+    limitToPages: [204]
+  # "/persons/detail"
+  ProfileDetailPlugin:
+    limitToPages: [205]
+  # "/jobs/detail"
+  AcademicJobsDetailPlugin:
+    limitToPages: [233]
+  # "/programs/list", "/programs/list-preset"
+  AcademicPrograms:
+    limitToPages: [251, 252]
+
 # Site of the seeded page tree.
 #
 # "rootPageId" is 1 because the seed definition declares that uid - see

--- a/docs/architecture/typoscript-and-site-sets.md
+++ b/docs/architecture/typoscript-and-site-sets.md
@@ -272,6 +272,88 @@ This is a bigger trap than the double parse. It is also what an installation
 in that state recovers from by selecting the static template: the record that
 wiped the set contribution can carry the same configuration itself.
 
+## Route enhancers are not loaded by anything
+
+Five files ship route enhancers and **none of them is read by TYPO3 on its own**:
+
+| Extension           | Files                                                   |
+|---------------------|---------------------------------------------------------|
+| `academic_persons`  | `Configuration/Routes/{List,ListAndDetail,Detail}.yaml` |
+| `academic_jobs`     | `Configuration/Routes/Detail.yaml`                      |
+| `academic_programs` | `Configuration/Yaml/Routes.yaml`                        |
+
+A site configuration has to `imports:` them, or every detail page is reachable
+only through a raw `tx_…[…]` argument. All three instance site configurations
+do — `core-12/config/sites/academics/`, `core-13/config/sites/academics/` and
+`core-13/config/sites/academics-legacy/`:
+
+```yaml
+imports:
+  - resource: 'EXT:academic_persons/Configuration/Routes/List.yaml'
+  - resource: 'EXT:academic_persons/Configuration/Routes/ListAndDetail.yaml'
+  - resource: 'EXT:academic_persons/Configuration/Routes/Detail.yaml'
+  - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
+  - resource: 'EXT:academic_programs/Configuration/Yaml/Routes.yaml'
+```
+
+Not through a site set. A set may carry a `route-enhancers.yaml` only from TYPO3
+v14.1, which this branch never reaches, and the `core-12` instance has no site
+sets at all — so `imports:` is the one form that works everywhere here.
+
+### Importing is half of it — the enhancers have to be limited to their pages
+
+Importing all five is not enough, and the distinct enhancer keys do not make it
+safe. TYPO3 offers **every** enhancer of a site to **every** page unless the
+enhancer carries `limitToPages`, and `PageUriMatcher::matchCollection()` takes
+the first candidate route whose path matches *and* whose aspects resolve. The
+insertion order is the `imports:` order.
+
+Three of the five routes are declared twice, byte identical down to the mapper:
+
+| Route                       | Declared in                             |
+|-----------------------------|-----------------------------------------|
+| `/{profile_name}`           | `Detail.yaml`, `ListAndDetail.yaml`     |
+| `{localized_page}-{page}`   | `List.yaml`, `ListAndDetail.yaml`       |
+| `/{letter}`                 | `List.yaml`, `ListAndDetail.yaml`       |
+
+So the file imported first takes those URLs on every page of the site, and the
+plugin on the other page never receives its argument. That is ACE-470: the
+dedicated `/persons/detail` page answers 404 for every link the list plugins
+generate for it, in both languages and in both page trees, while
+`/persons/list-and-detail/<slug>` keeps working. Only *resolving* is ambiguous —
+generation is scoped to the plugin namespace being linked, so the links look
+right and the defect surfaces as a broken page instead.
+
+The jobs and programs enhancers are not caught by this even though
+`/{job_title}` compiles to the same greedy `.+` — an aspect variable without an
+explicit `requirements` entry always does. Their mappers read other tables, so
+a persons route that matched the path is skipped when the slug is not a profile
+slug and the matcher falls through. That is a thin guarantee, not a design.
+
+All three instance site configurations therefore pin every enhancer:
+
+```yaml
+routeEnhancers:
+  ProfileListPlugin:
+    limitToPages: [201, 202, 203]
+  ProfileListAndDetailPlugin:
+    limitToPages: [204]
+  ProfileDetailPlugin:
+    limitToPages: [205]
+  AcademicJobsDetailPlugin:
+    limitToPages: [233]
+  AcademicPrograms:
+    limitToPages: [251, 252]
+```
+
+The uids are the ones the seed declares, `+1000` in the `academics-legacy`
+site, and they are the uids of the **default language**: matching derives the
+page as `l10n_parent ?: uid`, so one list covers `/persons/detail` and
+`/de/personal/detail` alike. Generation on the other hand uses the linked page
+uid, which is the default-language uid too — naming a translated page's own uid
+would work for neither direction. `PageRouter` reads `limitToPages` identically
+on v12.4 and v13.4, so a plain list of uids is right on both.
+
 ## The integrator chapter
 
 Each converted extension documents the two mechanisms in its own

--- a/packages/fgtclb/academic-jobs/Documentation/Configuration/RouteEnhancers/Index.rst
+++ b/packages/fgtclb/academic-jobs/Documentation/Configuration/RouteEnhancers/Index.rst
@@ -50,6 +50,46 @@ the job detail plugin:
     imports:
       - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
 
+Limiting the enhancer to its page
+---------------------------------
+
+TYPO3 offers every enhancer declared in a site configuration to **every** page
+of that site unless the enhancer says otherwise, and it takes the first
+candidate route whose path matches *and* whose aspects resolve. Distinct
+enhancer keys keep the entries apart in the YAML — they are not what keeps
+their routes apart while a URL is resolved.
+
+The route of this extension is :yaml:`/{job_title}`. Its path variable comes
+from an aspect and carries no :yaml:`requirements` entry of its own, which
+makes it compile to :yaml:`.+` — a pattern that crosses slashes. What keeps it
+from answering a URL meant for another extension is only that its
+:yaml:`PersistedAliasMapper` rejects a segment which is not a job slug, so the
+candidate is skipped and the next one is tried. That is a thin guarantee: a
+slug value that exists in both tables makes the two routes compete, and the
+enhancer imported first wins.
+
+:yaml:`limitToPages` settles it by naming the pages the enhancer applies to:
+
+..  code-block:: yaml
+    :caption: config/sites/my_site/config.yaml
+
+    imports:
+      - resource: 'EXT:academic_jobs/Configuration/Routes/Detail.yaml'
+
+    routeEnhancers:
+      AcademicJobsDetailPlugin:
+        limitToPages: [17]
+
+The uid is the one of the page carrying the detail plugin, and it is the uid of
+the **default language**: matching derives the page as :php:`l10n_parent ?: uid`,
+so a single entry covers every translation of that page. Plain page uids work
+on every TYPO3 version this extension supports.
+
+In :guilabel:`academic_persons` the same mechanism is not a precaution but a
+requirement — that extension ships three enhancers whose routes overlap each
+other by construction. See `its route enhancer documentation
+<https://docs.typo3.org/p/fgtclb/academic-persons/main/en-us/Configuration/RouteEnhancers/Index.html>`__.
+
 What the URLs look like
 -----------------------
 

--- a/packages/fgtclb/academic-persons/Documentation/Changelog/2.4/Important-RouteEnhancersLimitToPages.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Changelog/2.4/Important-RouteEnhancersLimitToPages.rst
@@ -1,0 +1,87 @@
+.. _important-route-enhancers-limit-to-pages:
+
+============================================================
+Important: Route enhancers have to be limited to their pages
+============================================================
+
+Description
+===========
+
+The three route enhancers this extension ships below
+:file:`Configuration/Routes/` describe the same two views, so three of their
+routes are declared twice and are identical down to the mapper:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Route
+        -   Declared in
+    *   -   :yaml:`/{profile_name}`
+        -   :file:`Detail.yaml` and :file:`ListAndDetail.yaml`
+    *   -   :yaml:`{localized_page}-{page}`
+        -   :file:`List.yaml` and :file:`ListAndDetail.yaml`
+    *   -   :yaml:`/{letter}`
+        -   :file:`List.yaml` and :file:`ListAndDetail.yaml`
+
+TYPO3 offers every enhancer of a site to every page of that site unless the
+enhancer says otherwise, and it takes the first candidate route whose path
+matches *and* whose aspects resolve. So a site that imports more than one of
+the three files without saying where each applies gives all of those URLs to
+the file it imported first.
+
+Only resolving is ambiguous. Generating a URL is scoped to the plugin namespace
+being linked, so the links keep looking right and nothing points at the
+configuration.
+
+Impact
+======
+
+On a site that imports :file:`ListAndDetail.yaml` before :file:`Detail.yaml`,
+the page carrying the :guilabel:`Detail` plugin answers ``404`` for every link
+the list plugins generate for it — the profile argument arrives in the
+namespace of the other plugin, and :php:`ProfileController::detailAction()`
+receives nothing.
+
+The two list routes fail more quietly, and in whichever direction the import
+order points: the page number or the letter arrives in the wrong namespace, and
+the plugin renders the unfiltered first page with status ``200``.
+
+Affected Installations
+======================
+
+Installations whose site configuration imports more than one of
+:file:`List.yaml`, :file:`ListAndDetail.yaml` and :file:`Detail.yaml` — which is
+what a site showing both the separate and the combined plugin needs, and what
+the documentation of this extension recommended without further qualification
+until now.
+
+Installations that import a single one of the three files are not affected.
+
+Solution
+========
+
+Limit each enhancer to the pages that carry its plugin. With that in place the
+import order no longer matters:
+
+..  code-block:: yaml
+    :caption: config/sites/my_site/config.yaml
+
+    imports:
+      - resource: 'EXT:academic_persons/Configuration/Routes/List.yaml'
+      - resource: 'EXT:academic_persons/Configuration/Routes/ListAndDetail.yaml'
+      - resource: 'EXT:academic_persons/Configuration/Routes/Detail.yaml'
+
+    routeEnhancers:
+      ProfileListPlugin:
+        limitToPages: [12, 13]
+      ProfileListAndDetailPlugin:
+        limitToPages: [14]
+      ProfileDetailPlugin:
+        limitToPages: [15]
+
+The uids are those of the pages carrying the plugin in question, in the
+**default language**: matching derives the page as :php:`l10n_parent ?: uid`,
+so one list covers every translation of that page. Plain page uids work on
+every TYPO3 version this extension supports.
+
+.. index:: Configuration, ext:academic_persons

--- a/packages/fgtclb/academic-persons/Documentation/Configuration/RouteEnhancers/Index.rst
+++ b/packages/fgtclb/academic-persons/Documentation/Configuration/RouteEnhancers/Index.rst
@@ -45,8 +45,7 @@ What the files enhance
 Which file to import
 --------------------
 
-The three enhancers are bound to three different plugins, so they never collide
-and importing more than one is normal:
+Which of them you import follows from which plugins the site actually uses:
 
 *   A site that puts the :guilabel:`List` plugin on one page and the
     :guilabel:`Detail` plugin on another — the usual setup, where the list
@@ -55,24 +54,74 @@ and importing more than one is normal:
     :file:`Detail.yaml`.
 *   A site that puts the single :guilabel:`ListAndDetail` plugin on one page
     imports :file:`ListAndDetail.yaml` only.
-*   A site that uses both variants imports all three.
+*   A site that uses both variants imports all three, and then has to bound
+    each of them to its own pages — see the next section.
 
 The remaining plugins of this extension — :yaml:`SelectedProfiles`,
 :yaml:`SelectedContracts` and :yaml:`Card` — take no frontend arguments, so no
 enhancer is shipped for them.
 
-Importing into a site configuration
------------------------------------
+Limiting an enhancer to its pages
+---------------------------------
 
-Add the resources to the :yaml:`imports` of the site:
+An enhancer is offered to **every** page of the site unless it says otherwise,
+and TYPO3 takes the first candidate route whose path matches *and* whose
+aspects resolve. Two enhancers are not kept apart by belonging to different
+plugins, nor by carrying different keys — neither is what the matcher looks at.
+
+The three files of this extension describe the same two views, so their routes
+overlap by construction:
+
+..  list-table::
+    :header-rows: 1
+
+    *   -   Route
+        -   Declared in
+    *   -   :yaml:`/{profile_name}`
+        -   :file:`Detail.yaml` and :file:`ListAndDetail.yaml`
+    *   -   :yaml:`{localized_page}-{page}`
+        -   :file:`List.yaml` and :file:`ListAndDetail.yaml`
+    *   -   :yaml:`/{letter}`
+        -   :file:`List.yaml` and :file:`ListAndDetail.yaml`
+
+Each pair is identical down to the mapper, so importing more than one file
+without saying where it applies means the file imported first takes those URLs
+on every page of the site. The plugin on the other page then never receives its
+argument: the dedicated detail page answers ``404``, and the combined
+plugin renders the unfiltered list where a letter was asked for.
+
+Only resolving is ambiguous. Generating a URL is scoped to the plugin namespace
+being linked, so the links keep looking right, which is why this surfaces as a
+broken page rather than as a broken link.
+
+:yaml:`limitToPages` is the answer, and with it in place the import order no
+longer matters:
 
 ..  code-block:: yaml
     :caption: config/sites/my_site/config.yaml
 
     imports:
       - resource: 'EXT:academic_persons/Configuration/Routes/List.yaml'
-      - resource: 'EXT:academic_persons/Configuration/Routes/Detail.yaml'
       - resource: 'EXT:academic_persons/Configuration/Routes/ListAndDetail.yaml'
+      - resource: 'EXT:academic_persons/Configuration/Routes/Detail.yaml'
+
+    routeEnhancers:
+      ProfileListPlugin:
+        limitToPages: [12, 13]
+      ProfileListAndDetailPlugin:
+        limitToPages: [14]
+      ProfileDetailPlugin:
+        limitToPages: [15]
+
+The uids are those of the pages carrying the plugin in question, and they are
+the uids of the **default language**: matching derives the page as
+:php:`l10n_parent ?: uid`, so one list covers every translation of that page.
+Plain page uids work on every TYPO3 version this extension supports.
+
+A site that imports a single file needs no limitation for this extension, but
+adding it is still worth the two lines. What keeps a route path of the same
+shape from another extension apart is only that its mapper rejects the value —
+a slug that happens to exist in both tables is enough to make the two compete.
 
 What the URLs look like
 -----------------------

--- a/packages/fgtclb/academic-persons/Tests/Functional/Routing/Fixtures/ProfileRouteEnhancer/pluginsOnSeparatePages.csv
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Routing/Fixtures/ProfileRouteEnhancer/pluginsOnSeparatePages.csv
@@ -1,0 +1,16 @@
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/persons","Persons (List)"
+,3,1,1,0,0,0,0,0,"/team","Team (List and detail)"
+,4,1,1,0,0,0,0,0,"/profile","Profile (Detail)"
+,100,1,254,0,0,0,0,0,"/sysfolder-records","Recordcollection"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","list_type","header","pi_flexform"
+,1,2,0,0,0,0,"academicpersons_list","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,2,3,0,0,0,0,"academicpersons_listanddetail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+,3,4,0,0,0,0,"academicpersons_detail","","Profiles","<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes"" ?><T3FlexForms><data><sheet index=""sDEF""><language index=""lDEF""><field index=""settings.demand.profileList""><value index=""vDEF""></value></field><field index=""settings.fallbackForNonTranslated""><value index=""vDEF"">0</value></field></language></sheet></data></T3FlexForms>"
+"tx_academicpersons_domain_model_profile",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","first_name","last_name","slug"
+,1,100,0,0,0,0,"[EN] Max","Müllermann","max-muellermann"
+,2,100,0,0,0,0,"[EN] Horst","Huber","horst-huber"

--- a/packages/fgtclb/academic-persons/Tests/Functional/Routing/ProfileRouteEnhancerTest.php
+++ b/packages/fgtclb/academic-persons/Tests/Functional/Routing/ProfileRouteEnhancerTest.php
@@ -1,0 +1,454 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicPersons\Tests\Functional\Routing;
+
+use FGTCLB\AcademicPersons\Tests\Functional\AbstractAcademicPersonsTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Exercises the three route enhancer files shipped in `Configuration/Routes/` together.
+ *
+ * They are shipped as three files because the three plugins are three content elements,
+ * but a site that offers all three of them merges all three enhancers into one site
+ * configuration - and that is where they start to interfere. TYPO3 offers every enhancer
+ * of a site to every page of that site unless the enhancer carries `limitToPages`, and
+ * `PageUriMatcher::matchCollection()` returns the *first* candidate route whose regular
+ * expression matches and whose aspects resolve. `ListAndDetail.yaml` and `Detail.yaml`
+ * declare a byte-identical `/{profile_name}` route, backed by the same
+ * `PersistedAliasMapper` on `tx_academicpersons_domain_model_profile.slug`, so whichever
+ * of the two is merged into the site configuration first answers for both of their
+ * pages. The same holds for the `/{letter}` route that `List.yaml` and
+ * `ListAndDetail.yaml` share.
+ *
+ * Generation is not affected, because `ExtbasePluginEnhancer::enhanceForGeneration()`
+ * returns early when the parameters carry no value for *its* namespace. That asymmetry
+ * is the defect: the extension generates a speaking URL that the extension then cannot
+ * resolve back into the plugin it was generated for.
+ *
+ * The site configuration written here therefore reads the shipped files rather than
+ * inlining a copy of them, and merges them in the order they are documented in - the
+ * order is what decides the outcome, so it is spelled out in `loadShippedRouteEnhancers()`
+ * instead of being an accident of a `glob()`.
+ */
+final class ProfileRouteEnhancerTest extends AbstractAcademicPersonsTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    /**
+     * The Extbase namespaces the three enhancers derive from `extension: AcademicPersons`
+     * plus their `plugin` value: `ExtbasePluginEnhancer::__construct()` builds
+     * `'tx_' . strtolower($extension . '_' . $plugin)`. They have to be the plugin
+     * signatures `ext_localconf.php` registers, otherwise generation never enters the
+     * enhancer and silently falls back to a query string.
+     */
+    private const LIST_PLUGIN_NAMESPACE = 'tx_academicpersons_list';
+    private const LIST_AND_DETAIL_PLUGIN_NAMESPACE = 'tx_academicpersons_listanddetail';
+    private const DETAIL_PLUGIN_NAMESPACE = 'tx_academicpersons_detail';
+
+    /**
+     * The page uids of the fixture page tree, one page per plugin, mirroring the site an
+     * integrator ends up with when they use all three content elements.
+     */
+    private const LIST_PAGE = 2;
+    private const LIST_AND_DETAIL_PAGE = 3;
+    private const DETAIL_PAGE = 4;
+
+    /**
+     * A letter that no fixture last name starts with. The alphabet filter reaches the
+     * database as `last_name LIKE '<letter>%'`, and `LIKE` is case sensitive on
+     * PostgreSQL while it is not on MariaDB, MySQL and SQLite - so a letter that matches
+     * a record would assert a different result per DBMS. A letter that matches nothing
+     * everywhere still tells the two cases apart: an ignored filter renders the full
+     * list, an applied one renders an empty list.
+     */
+    private const NON_MATCHING_ALPHABET_FILTER = 'x';
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content');
+        $this->addTestExtensionsToLoad('georgringer/numbered-pagination', 'tests/plugin-templates');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    /**
+     * @param bool $limitEnhancersToTheirOwnPage Whether each enhancer is confined to the
+     *        page that carries its plugin, which is what an integrator has to add by hand:
+     *        the shipped files cannot carry page uids of an installation they do not know.
+     */
+    private function setUpTestCase(bool $limitEnhancersToTheirOwnPage): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ProfileRouteEnhancer/pluginsOnSeparatePages.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/constants.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/constants.typoscript',
+                    // Shared with the plugin rendering tests rather than copied: it turns the
+                    // alphabetical grouping of the shipped defaults off, which is what makes the
+                    // list template render the flat markup the assertions below read.
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Configuration/TypoScript/Default/setup.typoscript',
+                    'EXT:test_plugin_templates/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_persons/Tests/Functional/Plugins/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+
+        $routeEnhancers = $this->loadShippedRouteEnhancers();
+        if ($limitEnhancersToTheirOwnPage) {
+            $routeEnhancers['ProfileListPlugin']['limitToPages'] = [self::LIST_PAGE];
+            $routeEnhancers['ProfileListAndDetailPlugin']['limitToPages'] = [self::LIST_AND_DETAIL_PAGE];
+            $routeEnhancers['ProfileDetailPlugin']['limitToPages'] = [self::DETAIL_PAGE];
+        }
+
+        $this->writeSiteConfiguration(
+            identifier: 'acme',
+            site: $this->buildSiteConfiguration(
+                rootPageId: 1,
+                base: $this->frontendPluginTestBase(),
+                additionalRootConfiguration: [
+                    'routeEnhancers' => $routeEnhancers,
+                ],
+            ),
+            languages: [
+                $this->buildDefaultLanguageConfiguration(
+                    identifier: 'EN',
+                    base: '/',
+                ),
+            ],
+        );
+    }
+
+    /**
+     * Reads the three shipped files and merges them the way the documentation tells an
+     * integrator to import them: `List`, `ListAndDetail`, `Detail`.
+     *
+     * Parsed with the plain YAML parser rather than through TYPO3's `YamlFileLoader`. That
+     * loader adds `imports` resolution and placeholder substitution, neither of which the
+     * shipped files use, and it is not reachable the same way on both supported core
+     * versions: the functional test container of v12 does not publish it, and its
+     * constructor takes no logger there while v13 requires one. The point here is that the
+     * shipped files themselves are loaded, not which reader loads them.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadShippedRouteEnhancers(): array
+    {
+        $routeEnhancers = [];
+        foreach (['List', 'ListAndDetail', 'Detail'] as $fileName) {
+            $path = GeneralUtility::getFileAbsFileName(
+                sprintf('EXT:academic_persons/Configuration/Routes/%s.yaml', $fileName)
+            );
+            $configuration = Yaml::parseFile($path);
+            $this->assertIsArray($configuration, sprintf('The shipped "%s.yaml" is not a YAML mapping.', $fileName));
+
+            $shippedEnhancers = $configuration['routeEnhancers'] ?? null;
+            $this->assertIsArray(
+                $shippedEnhancers,
+                sprintf('The shipped "%s.yaml" declares no routeEnhancers.', $fileName),
+            );
+            $this->assertNotSame([], $shippedEnhancers);
+
+            // A plain merge, so a duplicate enhancer key would overwrite instead of being
+            // appended - and the assertion below states that the three keys are distinct,
+            // which is exactly why the routes collide instead of the enhancers doing so.
+            $routeEnhancers = array_merge($routeEnhancers, $shippedEnhancers);
+        }
+        $this->assertCount(3, $routeEnhancers);
+
+        /** @var array<string, array<string, mixed>> $routeEnhancers */
+        return $routeEnhancers;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function generateSpeakingUri(int $pageId, array $parameters): string
+    {
+        return (string)$this->get(SiteFinder::class)
+            ->getSiteByIdentifier('acme')
+            ->getRouter()
+            ->generateUri($pageId, $parameters);
+    }
+
+    private function generateDetailUriForDetailPlugin(int $profileUid): string
+    {
+        // No `controller`/`action` needed: `defaultController: 'Profile::detail'` of the
+        // shipped file supplies them when the parameters carry neither.
+        return $this->generateSpeakingUri(self::DETAIL_PAGE, [
+            self::DETAIL_PLUGIN_NAMESPACE => [
+                'profile' => $profileUid,
+            ],
+        ]);
+    }
+
+    private function generateDetailUriForListAndDetailPlugin(int $profileUid): string
+    {
+        // Here the pair is required: the combined plugin defaults to `Profile::list`, so
+        // without it the detail route variant is not even offered to the generator.
+        return $this->generateSpeakingUri(self::LIST_AND_DETAIL_PAGE, [
+            self::LIST_AND_DETAIL_PLUGIN_NAMESPACE => [
+                'controller' => 'Profile',
+                'action' => 'detail',
+                'profile' => $profileUid,
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function shippedRouteEnhancersDeclareTheThreePluginsOfTheExtension(): void
+    {
+        $routeEnhancers = $this->loadShippedRouteEnhancers();
+
+        $this->assertSame(
+            ['ProfileListPlugin', 'ProfileListAndDetailPlugin', 'ProfileDetailPlugin'],
+            array_keys($routeEnhancers),
+        );
+        foreach ($routeEnhancers as $identifier => $enhancer) {
+            $this->assertSame('Extbase', $enhancer['type'], $identifier);
+            $this->assertSame('AcademicPersons', $enhancer['extension'], $identifier);
+            // Without `routes` an Extbase enhancer builds no route variant at all: it is
+            // loaded, it is valid, and it does nothing.
+            $this->assertNotSame([], $enhancer['routes'] ?? [], $identifier);
+        }
+        $this->assertSame('List', $routeEnhancers['ProfileListPlugin']['plugin']);
+        $this->assertSame('ListAndDetail', $routeEnhancers['ProfileListAndDetailPlugin']['plugin']);
+        $this->assertSame('Detail', $routeEnhancers['ProfileDetailPlugin']['plugin']);
+    }
+
+    /**
+     * The mechanical reason for everything below: two enhancers of the same site declare
+     * the same route, resolved by the same aspect. Nothing distinguishes them for the
+     * matcher, so the one that is merged first wins for every page of the site.
+     */
+    #[Test]
+    public function combinedAndDetailPluginDeclareAnIdenticalProfileNameRoute(): void
+    {
+        $routeEnhancers = $this->loadShippedRouteEnhancers();
+
+        $detailRouteOfCombinedPlugin = $routeEnhancers['ProfileListAndDetailPlugin']['routes'][0];
+        $detailRouteOfDetailPlugin = $routeEnhancers['ProfileDetailPlugin']['routes'][0];
+
+        $this->assertSame('/{profile_name}', $detailRouteOfCombinedPlugin['routePath']);
+        $this->assertSame($detailRouteOfCombinedPlugin, $detailRouteOfDetailPlugin);
+        $this->assertSame(
+            $routeEnhancers['ProfileListAndDetailPlugin']['aspects']['profile_name'],
+            $routeEnhancers['ProfileDetailPlugin']['aspects']['profile_name'],
+        );
+        // The second collision, between the list plugin and the combined plugin.
+        $this->assertSame(
+            $routeEnhancers['ProfileListPlugin']['routes'][1],
+            $routeEnhancers['ProfileListAndDetailPlugin']['routes'][2],
+        );
+    }
+
+    /**
+     * Characterization test: it documents why `limitToPages` is required, it does not
+     * describe behaviour anybody wants.
+     *
+     * The detail page carries the `Detail` plugin and nothing else, and the URL below is
+     * the one the extension itself generates for it (see
+     * {@see self::speakingDetailUriIsGeneratedForTheDetailPluginWithoutLimitToPages()}).
+     * It still does not arrive: `ProfileListAndDetailPlugin` is merged before
+     * `ProfileDetailPlugin`, its identical `/{profile_name}` route matches first, and the
+     * profile is therefore handed over in the `tx_academicpersons_listanddetail` namespace.
+     * The `Detail` plugin reads `tx_academicpersons_detail`, receives nothing, and
+     * {@see \FGTCLB\AcademicPersons\Controller\ProfileController::detailAction()} answers
+     * `404` for a `null` argument.
+     *
+     * What the plugin renders instead is the error document of that response, nested into
+     * the content element - which is what this asserts, because the rendered body is the
+     * half of the outcome a functional test can see on this branch.
+     *
+     * The status code is the other half, and it is real: a browser is answered `404` here,
+     * on TYPO3 v12 as well as on v13. A functional request cannot observe it on either of
+     * them, because {@see \TYPO3\CMS\Extbase\Core\Bootstrap::handleFrontendRequest()} hands
+     * a plugin response with a status of 300 or more back to the frontend with a bare
+     * `header()` call, guarded by `headers_sent()`. That writes into the PHP output layer
+     * of the test process rather than into the response object the test gets back, so the
+     * response still says `200`. Asserting the status code is therefore not possible on
+     * either supported core version, and this test asserts the body instead.
+     *
+     * Should the profile ever start rendering here, the limitation is gone and this test
+     * is the thing to delete - not the thing to adjust.
+     */
+    #[Test]
+    public function detailPluginPageDoesNotRenderTheProfileWithoutLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: false);
+
+        $body = (string)$this->requestFrontendPage('https://www.acme.com/profile/max-muellermann')->getBody();
+
+        $this->assertStringNotContainsString('<h2>Profiledetailpage</h2>', $body);
+        $this->assertStringNotContainsString('#1: [EN] Max Müllermann', $body);
+    }
+
+    #[Test]
+    public function detailPluginPageResolvesItsOwnSpeakingUriWithLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/profile/max-muellermann');
+
+        $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        $this->assertStringContainsString('#1: [EN] Max Müllermann', $content);
+    }
+
+    /**
+     * The other half of the same site: confining the enhancers must not cost the combined
+     * plugin the detail URL it had before.
+     */
+    #[Test]
+    public function combinedPluginPageStillResolvesItsOwnSpeakingUriWithLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/team/horst-huber');
+
+        $this->assertStringContainsString('<h2>Profiledetailpage</h2>', $content);
+        $this->assertStringContainsString('#2: [EN] Horst Huber', $content);
+    }
+
+    /**
+     * Characterization test, the `/{letter}` half of the same defect.
+     *
+     * `ProfileListPlugin` is merged first and its `/{letter}` route is identical to the
+     * one of `ProfileListAndDetailPlugin`, so on the combined plugin's page the alphabet
+     * filter is delivered in the `tx_academicpersons_list` namespace. The combined plugin
+     * never sees it and renders the unfiltered list - with a letter that matches no last
+     * name at all.
+     */
+    #[Test]
+    public function alphabetFilterOfTheCombinedPluginIsIgnoredWithoutLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: false);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/team/' . self::NON_MATCHING_ALPHABET_FILTER);
+
+        $this->assertStringContainsString('<h2>Profilelist</h2>', $content);
+        $this->assertStringContainsString('[EN] Max Müllermann', $content);
+        $this->assertStringContainsString('[EN] Horst Huber', $content);
+    }
+
+    #[Test]
+    public function alphabetFilterOfTheCombinedPluginIsAppliedWithLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/team/' . self::NON_MATCHING_ALPHABET_FILTER);
+
+        // The list template renders nothing at all for an empty result, so the absence of
+        // its heading is what an applied filter looks like from the outside.
+        $this->assertStringNotContainsString('<h2>Profilelist</h2>', $content);
+        $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
+        $this->assertStringNotContainsString('[EN] Horst Huber', $content);
+    }
+
+    /**
+     * The list plugin is the one that is merged first, so its own page is the one page the
+     * collision cannot hurt - with or without `limitToPages` the filter arrives.
+     */
+    #[Test]
+    public function alphabetFilterOfTheListPluginIsAppliedWithLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        $content = $this->renderFrontendPage('https://www.acme.com/persons/' . self::NON_MATCHING_ALPHABET_FILTER);
+
+        $this->assertStringNotContainsString('<h2>Profilelist</h2>', $content);
+        $this->assertStringNotContainsString('[EN] Max Müllermann', $content);
+    }
+
+    /**
+     * The counterpart of the two `/{letter}` tests above: the filter URL an integrator sees
+     * in the alphabet navigation is a speaking one for both plugins that offer a list, and
+     * confining the enhancers does not change that.
+     */
+    #[Test]
+    public function speakingAlphabetFilterUrisAreGeneratedForBothListPlugins(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        // Neither call passes `controller`/`action`: both enhancers declare
+        // `defaultController: 'Profile::list'`, which is the pair these routes belong to.
+        $this->assertSame(
+            'https://www.acme.com/persons/' . self::NON_MATCHING_ALPHABET_FILTER,
+            $this->generateSpeakingUri(self::LIST_PAGE, [
+                self::LIST_PLUGIN_NAMESPACE => [
+                    'demand' => ['alphabetFilter' => self::NON_MATCHING_ALPHABET_FILTER],
+                ],
+            ]),
+        );
+        $this->assertSame(
+            'https://www.acme.com/team/' . self::NON_MATCHING_ALPHABET_FILTER,
+            $this->generateSpeakingUri(self::LIST_AND_DETAIL_PAGE, [
+                self::LIST_AND_DETAIL_PLUGIN_NAMESPACE => [
+                    'demand' => ['alphabetFilter' => self::NON_MATCHING_ALPHABET_FILTER],
+                ],
+            ]),
+        );
+    }
+
+    #[Test]
+    public function speakingDetailUrisAreGeneratedForBothPluginsWithLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: true);
+
+        $detailPluginUri = $this->generateDetailUriForDetailPlugin(1);
+        $combinedPluginUri = $this->generateDetailUriForListAndDetailPlugin(2);
+
+        $this->assertSame('https://www.acme.com/profile/max-muellermann', $detailPluginUri);
+        $this->assertSame('https://www.acme.com/team/horst-huber', $combinedPluginUri);
+        // The arguments went into the path, so nothing of them may be left in a query string.
+        $this->assertStringNotContainsString('?', $detailPluginUri);
+        $this->assertStringNotContainsString('?', $combinedPluginUri);
+    }
+
+    /**
+     * Generation is namespace scoped - `ExtbasePluginEnhancer::enhanceForGeneration()`
+     * returns immediately when the parameters carry no value for its own namespace - so
+     * the collision that breaks resolving leaves generation untouched.
+     *
+     * That is the asymmetry ACE-470 is about, and it is the reason the defect is not
+     * obvious: the link in the list is the correct speaking URL either way, and only
+     * following it tells the two configurations apart.
+     */
+    #[Test]
+    public function speakingDetailUriIsGeneratedForTheDetailPluginWithoutLimitToPages(): void
+    {
+        $this->setUpTestCase(limitEnhancersToTheirOwnPage: false);
+
+        $this->assertSame(
+            'https://www.acme.com/profile/max-muellermann',
+            $this->generateDetailUriForDetailPlugin(1),
+        );
+        $this->assertSame(
+            'https://www.acme.com/team/horst-huber',
+            $this->generateDetailUriForListAndDetailPlugin(2),
+        );
+    }
+}

--- a/packages/fgtclb/academic-programs/Documentation/Configuration/RouteEnhancers/Index.rst
+++ b/packages/fgtclb/academic-programs/Documentation/Configuration/RouteEnhancers/Index.rst
@@ -61,7 +61,49 @@ the program list plugin:
 
 The import is merged into the site configuration, so an installation that
 already defines other enhancers keeps them as long as no key is named
-:yaml:`AcademicPrograms` twice.
+:yaml:`AcademicPrograms` twice. That is a statement about the merge and about
+nothing else: distinct keys keep the entries, they do not keep two enhancers
+from producing routes which match the same URL.
+
+Limiting the enhancer to its page
+---------------------------------
+
+TYPO3 offers every enhancer declared in a site configuration to **every** page
+of that site unless the enhancer says otherwise, and it takes the first
+candidate route whose path matches *and* whose aspects resolve. The order the
+candidates are tried in is the order of the :yaml:`imports`.
+
+The route of this extension is comparatively hard to collide with, and that is
+owed to its mappers rather than to its key: both path variables are handled by
+a :yaml:`StaticValueMapper`, so a candidate is only accepted when the segments
+are one of the three sorting fields followed by :yaml:`asc` or :yaml:`desc`.
+Anything else is rejected and the next enhancer gets its turn. A route variable
+that is mapped less narrowly — one whose aspect comes without an explicit
+:yaml:`requirements` entry compiles to :yaml:`.+` and crosses slashes — has no
+such protection, and even here a second extension mapping values of the same
+spelling is enough to make the two compete.
+
+:yaml:`limitToPages` settles it by naming the pages the enhancer applies to:
+
+..  code-block:: yaml
+    :caption: config/sites/my_site/config.yaml
+
+    imports:
+      - resource: 'EXT:academic_programs/Configuration/Yaml/Routes.yaml'
+
+    routeEnhancers:
+      AcademicPrograms:
+        limitToPages: [23]
+
+The uid is the one of the page carrying the list plugin, and it is the uid of
+the **default language**: matching derives the page as :php:`l10n_parent ?: uid`,
+so a single entry covers every translation of that page. Plain page uids work
+on every TYPO3 version this extension supports.
+
+In :guilabel:`academic_persons` the same mechanism is not a precaution but a
+requirement — that extension ships three enhancers whose routes overlap each
+other by construction. See `its route enhancer documentation
+<https://docs.typo3.org/p/fgtclb/academic-persons/main/en-us/Configuration/RouteEnhancers/Index.html>`__.
 
 What the URLs look like
 -----------------------


### PR DESCRIPTION
Resolves ACE-470 on branch `2`. Backport of #548 (`d4ee745e5`).

## The defect, unchanged from `main`

The three route enhancer files of `EXT:academic_persons` are **byte identical**
between the branches, the plugin names are the same, and all three site
configurations of this branch import the same five files in the same order. So
the dedicated `/persons/detail` page answers 404 for every link the list plugins
generate for it, while `/persons/list-and-detail/<slug>` works.

TYPO3 offers every enhancer of a site to every page unless it carries
`limitToPages`, and `PageUriMatcher::matchCollection()` returns the first
candidate route whose path matches **and** whose aspects resolve. Three routes
are declared twice, identical down to the mapper:

| Route                     | Declared in                         |
|---------------------------|-------------------------------------|
| `/{profile_name}`         | `Detail.yaml`, `ListAndDetail.yaml` |
| `{localized_page}-{page}` | `List.yaml`, `ListAndDetail.yaml`   |
| `/{letter}`               | `List.yaml`, `ListAndDetail.yaml`   |

Generation stays correct because it is namespace scoped, which is why the links
look right and only the request is wrong.

## What differs from the `main` change

* **Three site configurations, not four.** `core-12` has one site and no
  `/legacy/` tree — that scenario exists only in the `academics-instance-sets`
  seed set, which is `core-13`'s. `core-13/config/sites/academics-legacy/` gets
  the `+1000` uids, the other two the plain ones. The uids themselves are
  identical to `main` in both seed sets.
* **The changelog entry goes to `Documentation/Changelog/2.4/`.** Its content is
  version neutral and is taken verbatim; the `Index.rst` there globs
  `Important-*`, so it needs no edit.
* **`docs/architecture/typoscript-and-site-sets.md` had no route enhancer
  chapter on this branch at all**, so the section is written rather than
  patched, and says v12.4/v13.4 where `main` says v13/v14. The
  ExpressionLanguage form of `limitToPages` is not mentioned: it is v14.2 and
  later, which this branch never reaches. Plain page uids are read identically
  by `PageRouter` on v12.4.45 and v13.4.34 — verified in both trees.
* **The functional test has one test method fewer.** On `main` the status code
  assertion is grouped `not-core-13`, because Extbase hands a plugin response of
  300 or more back with a bare `header()` call on v13 and through the
  `frontend.response.data` attribute on v14 — only v14 lets a functional request
  see it. On this branch **both** supported versions use the `header()` form
  (`Bootstrap.php:200-201` on v12.4.45, the same on v13.4), so that assertion
  could never pass here and the method is removed rather than grouped out. What
  remains asserts the rendered body, which both versions agree on, and the
  browser still answers 404.
* **The fixture CSV carries a `list_type` column**, which `main` no longer has.

The three `RouteEnhancers/Index.rst` pages were byte identical to their
pre-change state on `main`, so they are taken over unchanged.

## Not backported

ACE-471 — on TYPO3 v14 the German *selected profiles* list drops its hidden
profiles. That is a v14-only observation and this branch does not support v14.
