### PR TITLE
[TASK] Add SBOM workflow to the split packages

### DIFF
--- a/packages/fgtclb/academic-base/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-base/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-bite-jobs/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-bite-jobs/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-contact4pages/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-contact4pages/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-jobs/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-jobs/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-partners/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-partners/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-persons-edit/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-persons-edit/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-persons-sync/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-persons-sync/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-persons/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-persons/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-programs/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-programs/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-projects/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-projects/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/academic-study-plan/.github/workflows/sbom.yml
+++ b/packages/fgtclb/academic-study-plan/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+

--- a/packages/fgtclb/typo3-category-types/.github/workflows/sbom.yml
+++ b/packages/fgtclb/typo3-category-types/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+# .github/workflows/sbom.yml — thin per-repository caller.
+#
+# Pinned to @v1, a moving tag on <org>/.github that tracks the latest compatible 1.x release. That
+# means a fix to the reusable workflow reaches every caller when the tag moves, without touching
+# each repository. Pin @v1.1.0 instead where a repository must not move on its own.
+#
+# Deliberately has NO `schedule:` trigger. GitHub auto-disables scheduled workflows in repositories
+# with no activity for 60 days — already true for 58 of our 99 repos — and notifies only whoever
+# last edited the cron line. Periodic coverage is the central orchestrator's job; this workflow
+# exists to capture release-time state, which is exactly what a schedule cannot do reliably.
+name: SBOM
+
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  schedule:
+    # weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Regenerate for this ref (e.g. a release tag). Empty = current branch."
+        required: false
+        type: string
+        default: ""
+
+
+jobs:
+  sbom:
+    uses: fgtclb/.github/.github/workflows/sbom-reusable.yml@v1
+    with:
+      dry_run: false
+      target_ref: ${{ inputs.target_ref || '' }}
+    secrets:
+      DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+      DTRACK_API_URL: ${{ secrets.DTRACK_API_URL }}
+      # Composer credentials for PRIVATE dependencies. Deliberately commented out: which secret a
+      # repository holds differs, and a template that names one would silently remove the working
+      # wiring from a repository that uses the other. install-workflow.sh detects what the
+      # repository actually has and preserves whatever is already wired.
+      #
+      # Uncomment the line matching this repository's secret:
+      #
+      #   COMPOSER_AUTH holds a complete auth.json document - this is the established convention
+      #   here, and PRIVATE_PACKAGE_TOKEN is what holds it:
+      # COMPOSER_AUTH: ${{ secrets.PRIVATE_PACKAGE_TOKEN }}
+      #
+      #   COMPOSER_GITHUB_TOKEN holds a bare GitHub token, used both to rewrite SSH remotes and as
+      #   a github-oauth entry:
+      # COMPOSER_GITHUB_TOKEN: ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+


### PR DESCRIPTION
Adds `.github/workflows/sbom.yml` to each of the twelve packages under `packages/fgtclb/`, next to the `publish.yml` already there.

**Why here and not in the split repositories:** the split owns their `.github/workflows/` content, so a pull request against a split repository would be reverted by the next split.

Each workflow calls `fgtclb/.github/.github/workflows/sbom-reusable.yml@v1` — the fgtclb organisation, matching where the split repositories live. `@v1` is a moving tag, so fixes reach every package without another commit here.

### Before this runs green

- **fgtclb has no organisation secrets.** `DTRACK_API_KEY` and `DTRACK_API_URL` must be available to each split repository. The workflow's first step fails with an explicit message if either is missing, rather than part-way through.
- Every one of these packages declares two supported TYPO3 core versions, so each run produces **two** SBOM documents — one per core — uploaded as separate Dependency-Track project versions.

### Not included

`fgtclb/academic-releaser` was on the exclusion list but has **no `packages/fgtclb/` directory** — it is a standalone repository, not a split package, and its composer type is not `typo3-cms-extension`. It therefore received neither a package workflow here nor a direct deployment. Worth deciding separately.

Left unmerged for review.