### PR TITLE
[TASK] Add security policies for the packages

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-extensions") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :white_check_mark:  |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-extensions" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
-| 1.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-base/SECURITY.md
+++ b/packages/fgtclb/academic-base/SECURITY.md
@@ -12,11 +12,11 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| < 2.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -33,10 +33,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-base/SECURITY.md
+++ b/packages/fgtclb/academic-base/SECURITY.md
@@ -14,8 +14,11 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | < 2.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-base/SECURITY.md
+++ b/packages/fgtclb/academic-base/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+This product ("fgtclb/academic-base") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| < 2.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-base" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-bite-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-bite-jobs/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-bite-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-bite-jobs/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-bite-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-bite-jobs/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-bite-jobs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-bite-jobs" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-contact4pages/SECURITY.md
+++ b/packages/fgtclb/academic-contact4pages/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-contact4pages/SECURITY.md
+++ b/packages/fgtclb/academic-contact4pages/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-contact4pages/SECURITY.md
+++ b/packages/fgtclb/academic-contact4pages/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-contacts4pages") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-contacts4pages" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-jobs/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-jobs/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-jobs/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-jobs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-jobs" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-partners/SECURITY.md
+++ b/packages/fgtclb/academic-partners/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-partners/SECURITY.md
+++ b/packages/fgtclb/academic-partners/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-partners/SECURITY.md
+++ b/packages/fgtclb/academic-partners/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-partners") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-partners" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons-edit/SECURITY.md
+++ b/packages/fgtclb/academic-persons-edit/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-persons-edit/SECURITY.md
+++ b/packages/fgtclb/academic-persons-edit/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-persons-edit/SECURITY.md
+++ b/packages/fgtclb/academic-persons-edit/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons-edit") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-persons-edit" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons-sync/SECURITY.md
+++ b/packages/fgtclb/academic-persons-sync/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-persons-sync/SECURITY.md
+++ b/packages/fgtclb/academic-persons-sync/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-persons-sync/SECURITY.md
+++ b/packages/fgtclb/academic-persons-sync/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons-sync") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-persons-sync" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons/SECURITY.md
+++ b/packages/fgtclb/academic-persons/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-persons/SECURITY.md
+++ b/packages/fgtclb/academic-persons/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-persons/SECURITY.md
+++ b/packages/fgtclb/academic-persons/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-persons" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-programs/SECURITY.md
+++ b/packages/fgtclb/academic-programs/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-programs/SECURITY.md
+++ b/packages/fgtclb/academic-programs/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-programs/SECURITY.md
+++ b/packages/fgtclb/academic-programs/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-programs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-programs" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-projects/SECURITY.md
+++ b/packages/fgtclb/academic-projects/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/academic-projects/SECURITY.md
+++ b/packages/fgtclb/academic-projects/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-projects/SECURITY.md
+++ b/packages/fgtclb/academic-projects/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/academic-projects") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-projects" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-study-plan/SECURITY.md
+++ b/packages/fgtclb/academic-study-plan/SECURITY.md
@@ -12,11 +12,11 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| < 2.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -33,10 +33,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a

--- a/packages/fgtclb/academic-study-plan/SECURITY.md
+++ b/packages/fgtclb/academic-study-plan/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+This product ("fgtclb/academic-study-plan") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| < 2.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/academic-study-plan" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-study-plan/SECURITY.md
+++ b/packages/fgtclb/academic-study-plan/SECURITY.md
@@ -14,8 +14,11 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | < 2.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/typo3-category-types/SECURITY.md
+++ b/packages/fgtclb/typo3-category-types/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+This product ("fgtclb/category-types") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| 2.x            | :white_check_mark:  |
+| 1.x            | :x:                 |
+| < 1.0          | :x:                 |
+
+Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                         | Timeframe                         |
+| ----------------------------- | ---------------------------------- |
+| Acknowledgement of your report | within 1 business day (typically much faster) |
+| Status updates                | at least every 7 days until resolved |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and official distribution
+channels of "fgtclb/category-types" (e.g. TER / Packagist).
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/typo3-category-types/SECURITY.md
+++ b/packages/fgtclb/typo3-category-types/SECURITY.md
@@ -14,9 +14,12 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
+| 3.x            | :white_check_mark:  |
 | 2.x            | :white_check_mark:  |
 | 1.x            | :x:                 |
 | < 1.0          | :x:                 |
+
+The newest line listed above is under development on the default branch and has not been released yet.
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 

--- a/packages/fgtclb/typo3-category-types/SECURITY.md
+++ b/packages/fgtclb/typo3-category-types/SECURITY.md
@@ -12,12 +12,12 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 3.x            | :white_check_mark:  |
-| 2.x            | :white_check_mark:  |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
 
 The newest line listed above is under development on the default branch and has not been released yet.
 
@@ -34,10 +34,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a


### PR DESCRIPTION
Adds `SECURITY.md` to each of the twelve packages under `packages/fgtclb/`, so every split repository carries one, plus one for the monorepo itself.

**Why here:** the split owns the packages' content, so a file added directly to a split repository would be reverted by the next split.

### How the tables were derived

A major counts as supported while the newest TYPO3 version it supports is still under **regular** LTS maintenance, per get.typo3.org. TYPO3 13 (until 2027-12-31) and 14 (until 2029-06-30) qualify today; 12 ended regular maintenance on 2026-04-30 and is ELTS only.

Every package here targets TYPO3 13 and 14, so:

| Version | Supported |
| --- | --- |
| 2.x | :white_check_mark: |
| 1.x | :x: — that line targeted TYPO3 11/12 |

`academic-base` and `academic-study-plan` have only a 2.x line, so they get two rows rather than three.

Support-end date is **30 June 2029**, the end of regular TYPO3 14 LTS support. The template's "≥ 5 years from initial release" parenthetical was dropped, since the two can contradict each other and the shorter one governs.

Reports route to https://security.fgtclb.com and the manufacturer is named as FGTCLB GmbH, matching the organisation these packages are published under.

### Please check

- the composer package name in each file — `typo3-category-types` publishes as `fgtclb/category-types`, and `academic-contact4pages` as `fgtclb/academic-contacts4pages`
- whether 1.x should really be marked unsupported, or whether you still fix critical issues there

Left unmerged for review.