### PR TITLE
[TASK] Add CRA conformity documents

### DIFF
--- a/packages/fgtclb/academic-base/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-base/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Base
+**Reference:** DoC-academic_base-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Base
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_base (fgtclb/academic-base)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_base; Packagist — https://packagist.org/packages/fgtclb/academic-base
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Base, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Base is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-base/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-base/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-base/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Base
+**Referenz:** DoC-academic_base-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Base
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_base (fgtclb/academic-base)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_base; Packagist — https://packagist.org/packages/fgtclb/academic-base
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Base, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Base der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-base/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-base/README.md
+++ b/packages/fgtclb/academic-base/README.md
@@ -68,3 +68,36 @@ composer require \
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Base is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-base/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-base/SECURITY.md
+++ b/packages/fgtclb/academic-base/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+This product ("fgtclb/academic-base") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-base":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_base
+- Packagist — https://packagist.org/packages/fgtclb/academic-base
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-bite-jobs/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-bite-jobs/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Bite Jobs
+**Reference:** DoC-academic_bite_jobs-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Bite Jobs
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_bite_jobs (fgtclb/academic-bite-jobs)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_bite_jobs; Packagist — https://packagist.org/packages/fgtclb/academic-bite-jobs
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Bite Jobs, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Bite Jobs is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-bite-jobs/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-bite-jobs/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-bite-jobs/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Bite Jobs
+**Referenz:** DoC-academic_bite_jobs-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Bite Jobs
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_bite_jobs (fgtclb/academic-bite-jobs)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_bite_jobs; Packagist — https://packagist.org/packages/fgtclb/academic-bite-jobs
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Bite Jobs, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Bite Jobs der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-bite-jobs/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-bite-jobs/README.md
+++ b/packages/fgtclb/academic-bite-jobs/README.md
@@ -89,3 +89,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created the [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Bite Jobs is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-bite-jobs/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-bite-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-bite-jobs/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-bite-jobs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-bite-jobs":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_bite_jobs
+- Packagist — https://packagist.org/packages/fgtclb/academic-bite-jobs
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-contact4pages/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-contact4pages/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Contags for Pages
+**Reference:** DoC-academic_contacts4pages-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Contags for Pages
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_contacts4pages (fgtclb/academic-contacts4pages)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_contacts4pages; Packagist — https://packagist.org/packages/fgtclb/academic-contacts4pages
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Contags for Pages, version 2.4.0, as distributed via
+the TYPO3 Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Contags for Pages is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-contacts4pages/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-contact4pages/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-contact4pages/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Contags for Pages
+**Referenz:** DoC-academic_contacts4pages-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Contags for Pages
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_contacts4pages (fgtclb/academic-contacts4pages)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_contacts4pages; Packagist — https://packagist.org/packages/fgtclb/academic-contacts4pages
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Contags for Pages, Version 2.4.0, vertrieben über das
+TYPO3 Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Contags for Pages der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-contacts4pages/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-contact4pages/README.md
+++ b/packages/fgtclb/academic-contact4pages/README.md
@@ -68,3 +68,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Contags for Pages is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-contacts4pages/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-contact4pages/SECURITY.md
+++ b/packages/fgtclb/academic-contact4pages/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-contacts4pages") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-contacts4pages":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_contacts4pages
+- Packagist — https://packagist.org/packages/fgtclb/academic-contacts4pages
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-jobs/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-jobs/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Jobs
+**Reference:** DoC-academic_jobs-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Jobs
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_jobs (fgtclb/academic-jobs)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_jobs; Packagist — https://packagist.org/packages/fgtclb/academic-jobs
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Jobs, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Jobs is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-jobs/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-jobs/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-jobs/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Jobs
+**Referenz:** DoC-academic_jobs-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Jobs
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_jobs (fgtclb/academic-jobs)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_jobs; Packagist — https://packagist.org/packages/fgtclb/academic-jobs
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Jobs, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Jobs der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-jobs/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-jobs/README.md
+++ b/packages/fgtclb/academic-jobs/README.md
@@ -75,3 +75,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Jobs is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-jobs/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-jobs/SECURITY.md
+++ b/packages/fgtclb/academic-jobs/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-jobs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-jobs":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_jobs
+- Packagist — https://packagist.org/packages/fgtclb/academic-jobs
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-partners/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-partners/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Partners
+**Reference:** DoC-academic_partners-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Partners
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_partners (fgtclb/academic-partners)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_partners; Packagist — https://packagist.org/packages/fgtclb/academic-partners
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Partners, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Partners is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-partners/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-partners/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-partners/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Partners
+**Referenz:** DoC-academic_partners-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Partners
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_partners (fgtclb/academic-partners)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_partners; Packagist — https://packagist.org/packages/fgtclb/academic-partners
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Partners, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Partners der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-partners/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-partners/README.md
+++ b/packages/fgtclb/academic-partners/README.md
@@ -73,3 +73,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Partners is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-partners/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-partners/SECURITY.md
+++ b/packages/fgtclb/academic-partners/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-partners") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-partners":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_partners
+- Packagist — https://packagist.org/packages/fgtclb/academic-partners
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons-edit/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-persons-edit/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Persons Edit
+**Reference:** DoC-academic_persons_edit-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Persons Edit
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_persons_edit (fgtclb/academic-persons-edit)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_edit; Packagist — https://packagist.org/packages/fgtclb/academic-persons-edit
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Persons Edit, version 2.4.0, as distributed via the
+TYPO3 Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons Edit is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-edit/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons-edit/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-persons-edit/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Persons Edit
+**Referenz:** DoC-academic_persons_edit-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Persons Edit
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_persons_edit (fgtclb/academic-persons-edit)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_edit; Packagist — https://packagist.org/packages/fgtclb/academic-persons-edit
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Persons Edit, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Persons Edit der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-edit/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons-edit/README.md
+++ b/packages/fgtclb/academic-persons-edit/README.md
@@ -74,3 +74,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons Edit is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-edit/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-persons-edit/SECURITY.md
+++ b/packages/fgtclb/academic-persons-edit/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons-edit") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-persons-edit":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_edit
+- Packagist — https://packagist.org/packages/fgtclb/academic-persons-edit
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons-sync/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-persons-sync/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Persons Sync
+**Reference:** DoC-academic_persons_sync-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Persons Sync
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_persons_sync (fgtclb/academic-persons-sync)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_sync; Packagist — https://packagist.org/packages/fgtclb/academic-persons-sync
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Persons Sync, version 2.4.0, as distributed via the
+TYPO3 Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons Sync is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-sync/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons-sync/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-persons-sync/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Persons Sync
+**Referenz:** DoC-academic_persons_sync-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Persons Sync
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_persons_sync (fgtclb/academic-persons-sync)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_sync; Packagist — https://packagist.org/packages/fgtclb/academic-persons-sync
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Persons Sync, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Persons Sync der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-sync/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons-sync/README.md
+++ b/packages/fgtclb/academic-persons-sync/README.md
@@ -75,3 +75,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons Sync is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons-sync/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-persons-sync/SECURITY.md
+++ b/packages/fgtclb/academic-persons-sync/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons-sync") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-persons-sync":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons_sync
+- Packagist — https://packagist.org/packages/fgtclb/academic-persons-sync
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-persons/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-persons/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Persons
+**Reference:** DoC-academic_persons-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Persons
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_persons (fgtclb/academic-persons)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons; Packagist — https://packagist.org/packages/fgtclb/academic-persons
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Persons, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-persons/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Persons
+**Referenz:** DoC-academic_persons-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Persons
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_persons (fgtclb/academic-persons)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons; Packagist — https://packagist.org/packages/fgtclb/academic-persons
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Persons, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Persons der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-persons/README.md
+++ b/packages/fgtclb/academic-persons/README.md
@@ -121,3 +121,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Persons is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-persons/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-persons/SECURITY.md
+++ b/packages/fgtclb/academic-persons/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-persons") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-persons":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_persons
+- Packagist — https://packagist.org/packages/fgtclb/academic-persons
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-programs/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-programs/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: University Educational Program
+**Reference:** DoC-academic_programs-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: University Educational Program
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_programs (fgtclb/academic-programs)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_programs; Packagist — https://packagist.org/packages/fgtclb/academic-programs
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: University Educational Program, version 2.4.0, as distributed
+via the TYPO3 Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: University Educational Program is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-programs/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-programs/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-programs/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: University Educational Program
+**Referenz:** DoC-academic_programs-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: University Educational Program
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_programs (fgtclb/academic-programs)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_programs; Packagist — https://packagist.org/packages/fgtclb/academic-programs
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: University Educational Program, Version 2.4.0, vertrieben über
+das TYPO3 Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: University Educational Program der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-programs/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-programs/README.md
+++ b/packages/fgtclb/academic-programs/README.md
@@ -72,3 +72,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: University Educational Program is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-programs/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-programs/SECURITY.md
+++ b/packages/fgtclb/academic-programs/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-programs") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-programs":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_programs
+- Packagist — https://packagist.org/packages/fgtclb/academic-programs
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-projects/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-projects/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Academic Projects
+**Reference:** DoC-academic_projects-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Academic Projects
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_projects (fgtclb/academic-projects)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_projects; Packagist — https://packagist.org/packages/fgtclb/academic-projects
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Academic Projects, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Projects is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-projects/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-projects/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-projects/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Academic Projects
+**Referenz:** DoC-academic_projects-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Academic Projects
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_projects (fgtclb/academic-projects)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_projects; Packagist — https://packagist.org/packages/fgtclb/academic-projects
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Academic Projects, Version 2.4.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Academic Projects der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-projects/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-projects/README.md
+++ b/packages/fgtclb/academic-projects/README.md
@@ -82,3 +82,37 @@ documented per version in [Documentation/Changelog](./Documentation/Changelog).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Academic Projects is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-projects/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-projects/SECURITY.md
+++ b/packages/fgtclb/academic-projects/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/academic-projects") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-projects":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_projects
+- Packagist — https://packagist.org/packages/fgtclb/academic-projects
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/academic-study-plan/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/academic-study-plan/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** Academic Study Plan
+**Reference:** DoC-academic_study_plan-2.4.0
+
+## 1. Product identification
+
+- **Product name:** Academic Study Plan
+- **Type:** TYPO3 Extension
+- **Extension key / package:** academic_study_plan (fgtclb/academic-study-plan)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_study_plan; Packagist — https://packagist.org/packages/fgtclb/academic-study-plan
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+Academic Study Plan, version 2.4.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type Academic Study Plan is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-study-plan/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-study-plan/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/academic-study-plan/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** Academic Study Plan
+**Referenz:** DoC-academic_study_plan-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** Academic Study Plan
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** academic_study_plan (fgtclb/academic-study-plan)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_study_plan; Packagist — https://packagist.org/packages/fgtclb/academic-study-plan
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+Academic Study Plan, Version 2.4.0, vertrieben über das TYPO3 Extension
+Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs Academic Study Plan der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/academic-study-plan/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/academic-study-plan/README.md
+++ b/packages/fgtclb/academic-study-plan/README.md
@@ -66,3 +66,36 @@ composer require \
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type Academic Study Plan is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/academic-study-plan/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/academic-study-plan/SECURITY.md
+++ b/packages/fgtclb/academic-study-plan/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+This product ("fgtclb/academic-study-plan") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/academic-study-plan":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/academic_study_plan
+- Packagist — https://packagist.org/packages/fgtclb/academic-study-plan
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.

--- a/packages/fgtclb/typo3-category-types/EU-Declaration-of-Conformity.md
+++ b/packages/fgtclb/typo3-category-types/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** FGTCLB: Basic Typed categories
+**Reference:** DoC-category_types-2.4.0
+
+## 1. Product identification
+
+- **Product name:** FGTCLB: Basic Typed categories
+- **Type:** TYPO3 Extension
+- **Extension key / package:** category_types (fgtclb/category-types)
+- **Version:** 2.4.0 (initial issuance of this declaration)
+- **Valid for:** version 2.4.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/category_types; Packagist — https://packagist.org/packages/fgtclb/category-types
+
+## 2. Manufacturer
+
+web-vision GmbH (brand: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+FGTCLB: Basic Typed categories, version 2.4.0, as distributed via the
+TYPO3 Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Basic Typed categories is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/category-types/2.4.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/typo3-category-types/EU-Konformitaetserklaerung.md
+++ b/packages/fgtclb/typo3-category-types/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** FGTCLB: Basic Typed categories
+**Referenz:** DoC-category_types-2.4.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** FGTCLB: Basic Typed categories
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** category_types (fgtclb/category-types)
+- **Version:** 2.4.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 2.4.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/category_types; Packagist — https://packagist.org/packages/fgtclb/category-types
+
+## 2. Hersteller
+
+web-vision GmbH (Marke: FGTCLB)
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+FGTCLB: Basic Typed categories, Version 2.4.0, vertrieben über das
+TYPO3 Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs FGTCLB: Basic Typed categories der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.fgtclb.com/conformity/fgtclb/category-types/2.4.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/packages/fgtclb/typo3-category-types/README.md
+++ b/packages/fgtclb/typo3-category-types/README.md
@@ -81,3 +81,37 @@ and the `1.x` to `2.x` migration in [UPGRADE.md](./UPGRADE.md).
 This extension was created by [FGTCLB GmbH](https://www.fgtclb.com/).
 
 [Find more TYPO3 extensions we have developed](https://github.com/fgtclb/).
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.fgtclb.com) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type FGTCLB: Basic Typed categories is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.fgtclb.com/conformity/fgtclb/category-types/2.4.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/packages/fgtclb/typo3-category-types/SECURITY.md
+++ b/packages/fgtclb/typo3-category-types/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+This product ("fgtclb/category-types") is developed and maintained by FGTCLB GmbH.
+As a manufacturer of a product with digital elements under the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), we are committed to identifying,
+assessing, and remediating security vulnerabilities in this product in a
+timely manner, and to coordinating responsibly with security researchers.
+
+## Supported Versions
+
+Security updates are provided for the following versions. Versions marked
+unsupported no longer receive security fixes; please upgrade before
+reporting an issue against them.
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 3.x     | :white_check_mark: | 2029-06-30     |
+| 2.x     | :white_check_mark: | 2027-12-31     |
+| < 2.0   | :x:                | support ended  |
+
+The newest line listed above is under development on the default branch and has not been released yet.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately — **do not**
+open a public GitHub/GitLab issue.
+
+- **Report here:** https://security.fgtclb.com (our secure incident report form)
+- **Please include:** affected version(s), a description of the issue,
+  steps to reproduce or a proof of concept, and the potential impact.
+
+### What to expect
+
+| Step                                | Timeframe                                                              |
+|-------------------------------------|------------------------------------------------------------------------|
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
+| Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
+
+We coordinate the disclosure timeline with the reporter and aim for a
+resolution before any public disclosure. If you'd like credit for your
+finding, let us know how you'd like to be named; we're also happy to keep
+your report confidential if you prefer.
+
+## Safe Harbor
+
+We consider security research conducted in good faith, in accordance with
+this policy, to be authorized. We will not pursue legal action against
+researchers who:
+
+- make a genuine effort to avoid privacy violations, data destruction, and
+  service interruption during their research,
+- report a vulnerability promptly and do not exploit it beyond what is
+  necessary to demonstrate the issue,
+- do not publicly disclose the vulnerability before we have had a
+  reasonable opportunity to address it (see timeframes above).
+
+## Scope
+
+In scope: the source code, released versions, and the official distribution
+channels of "fgtclb/category-types":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/category_types
+- Packagist — https://packagist.org/packages/fgtclb/category-types
+
+Out of scope: third-party dependencies (please report those upstream, but
+feel free to let us know so we can track and update them), and
+vulnerabilities in the host application (TYPO3 core) itself
+unless directly caused by this extension.
+
+## Coordinator
+
+Vulnerability reports for this product are handled by the
+Vulnerability Coordinator team at FGTCLB GmbH,
+under the oversight of our GRC/CISO function.


### PR DESCRIPTION
Adds the CRA documents for this branch, taken verbatim from the
`wv-people/cra` repository (`main`, `18505c5`), where they were reviewed and
approved. Nothing here is authored independently of that repository — it is the
single source of truth for these files.

## What this branch gets

| Package | Version | Highest TYPO3 | End of support |
|---|---|---|---|
| `fgtclb/academic-base` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-bite-jobs` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-contacts4pages` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-jobs` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-partners` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-persons-edit` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-persons-sync` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-persons` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-programs` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-projects` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/academic-study-plan` | 2.4.0 | TYPO3 13 | 2027-12-31 |
| `fgtclb/category-types` | 2.4.0 | TYPO3 13 | 2027-12-31 |

Files added or updated under `packages/fgtclb/<package>/`:

- `SECURITY.md` — replaces the previous version. `Supported Versions` is now a
  table carrying an end-of-support date per major version, derived from the
  community-support end of the highest TYPO3 version that major supports.
- `EU-Declaration-of-Conformity.md` and `EU-Konformitaetserklaerung.md` — the
  full EU declaration of conformity under Regulation (EU) 2024/2847, English
  and German, signed under `VOLLMACHT-CISO-2026-01`.
- `README.md` — gains four sections at the end: `Supported Versions`, `Security`,
  `Simplified EU Declaration of Conformity (Annex VI)` and `License`. Existing
  content is untouched; a `License` section that already existed is kept as it is.

## Why the Annex VI section in the README

CRA Annex VI requires the simplified declaration to state the exact internet
address of the full declaration. TER and Packagist build their product pages
from `README.md`, not from `SECURITY.md`, so the README is the only place that
reaches those distribution channels.

## Scope rule

A major version is covered when the highest TYPO3 version it supports is still
in regular community support — TYPO3 13 until 2027-12-31, TYPO3 14 until
2029-06-30. TYPO3 12 went ELTS on 2026-04-30, so majors capped at 12 or below
are out of scope and get no declaration.

---

## Scope: this is phase 1

The CRA repository's `docs/TEMPLATE-README-EN.md` defines the full set of
user-information sections required by **Annex II** of Regulation (EU) 2024/2847,
and explicitly says not to drop a section merely because it is short. This pull
request deliberately covers only the part that can be generated correctly and
identically for every extension:

| Annex II | Section | Status |
|---|---|---|
| pt 2 | Reporting a vulnerability | in this PR |
| pt 6 | EU Declaration of Conformity | in this PR |
| pt 7 | Security support & update policy | in this PR |
| — | License | in this PR |
| pt 1 | Manufacturer (name, postal address, contact) | **open** |
| pt 4 (2) | Security environment & security properties | **open** |
| pt 5 | Known risks & foreseeable misuse | **open** |
| pt 8.1 | Installation & secure initial setup | **open** |
| pt 8.2 | Configuration changes & data security | **open** |
| pt 8.3 | Installing security updates | **open** |
| pt 8.4 | Uninstallation & data removal | **open** |
| pt 8.5 | Automatic security updates | **open** |
| pt 8.6 | Notes for integrators | **open** |
| pt 9 | Software Bill of Materials (SBOM) | **open** |

The open sections need per-product wording and are tracked in a separate issue
on this repository. Merging this PR does **not** make the product Annex II
complete — it establishes the reporting channel, the declaration link and the
supported-version statement, which are the parts with a hard external
dependency (the published declaration under `/conformity/`).