### PR TITLE
[BUGFIX] ACE-476: Stop leaking workspace records

### DIFF
--- a/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
+++ b/packages/fgtclb/academic-study-plan/Classes/Service/StudyPlanService.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Resource\FileRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,7 +29,10 @@ final class StudyPlanService
     {
         $context ??= GeneralUtility::makeInstance(Context::class);
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_academicstudyplan_domain_model_semester');
-        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class)->removeByType(DeletedRestriction::class);
+        $queryBuilder->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(DeletedRestriction::class)
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $this->getWorkspaceId($context)));
         $result = $queryBuilder
             ->select('*')
             ->from('tx_academicstudyplan_domain_model_semester')
@@ -42,9 +46,13 @@ final class StudyPlanService
             // Ensuring deterministic sorting behaviour
             ->addOrderBy('uid', 'ASC')
             ->executeQuery();
-        $pageRepository ??= GeneralUtility::makeInstance(PageRepository::class);
+        $pageRepository ??= GeneralUtility::makeInstance(PageRepository::class, $context);
         $semesters = [];
         while ($row = $result->fetchAssociative()) {
+            $row = $this->getWorkspaceRecord('tx_academicstudyplan_domain_model_semester', $row, $pageRepository);
+            if ($row === null) {
+                continue;
+            }
             $row = $this->getTranslatedRecord('tx_academicstudyplan_domain_model_semester', $row, $languageUid, $pageRepository);
             $row['modules'] = $this->fetchModules((int)$row['uid'], $languageUid, $pageRepository, $context);
             $semesters[] = $row;
@@ -59,7 +67,10 @@ final class StudyPlanService
     {
         $context ??= GeneralUtility::makeInstance(Context::class);
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_academicstudyplan_domain_model_module');
-        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class)->removeByType(DeletedRestriction::class);
+        $queryBuilder->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(DeletedRestriction::class)
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $this->getWorkspaceId($context)));
         $result = $queryBuilder
             ->select('*')
             ->from('tx_academicstudyplan_domain_model_module')
@@ -73,9 +84,13 @@ final class StudyPlanService
             // Ensuring deterministic sorting behaviour
             ->addOrderBy('uid', 'ASC')
             ->executeQuery();
-        $pageRepository ??= GeneralUtility::makeInstance(PageRepository::class);
+        $pageRepository ??= GeneralUtility::makeInstance(PageRepository::class, $context);
         $modules = [];
         while ($row = $result->fetchAssociative()) {
+            $row = $this->getWorkspaceRecord('tx_academicstudyplan_domain_model_module', $row, $pageRepository);
+            if ($row === null) {
+                continue;
+            }
             $row = $this->getTranslatedRecord('tx_academicstudyplan_domain_model_module', $row, $languageUid, $pageRepository);
             $row['categories'] = $this->fetchCategoriesForModule((int)$row['uid'], $languageUid, $pageRepository, $context);
             $row['audioFiles'] = $this->fetchAudioFiles((int)$row['uid']);
@@ -91,7 +106,10 @@ final class StudyPlanService
     {
         $context ??= GeneralUtility::makeInstance(Context::class);
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_academicstudyplan_domain_model_category');
-        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class)->removeByType(DeletedRestriction::class);
+        $queryBuilder->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(DeletedRestriction::class)
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $this->getWorkspaceId($context)));
         $result = $queryBuilder
             ->select('c.*')
             ->from('tx_academicstudyplan_domain_model_category', 'c')
@@ -115,6 +133,10 @@ final class StudyPlanService
         $pageRepository ??= GeneralUtility::makeInstance(PageRepository::class, $context);
         $categories = [];
         while ($row = $result->fetchAssociative()) {
+            $row = $this->getWorkspaceRecord('tx_academicstudyplan_domain_model_category', $row, $pageRepository);
+            if ($row === null) {
+                continue;
+            }
             $row = $this->getTranslatedRecord('tx_academicstudyplan_domain_model_category', $row, $languageUid, $pageRepository);
             $categories[] = $row;
         }
@@ -153,6 +175,29 @@ final class StudyPlanService
             return $row;
         }
         return $pageRepository->getLanguageOverlay($table, $row) ?? $row;
+    }
+
+    private function getWorkspaceId(Context $context): int
+    {
+        return (int)$context->getPropertyFromAspect('workspace', 'id', 0);
+    }
+
+    /**
+     * Replaces a row with its version in the current workspace, and drops it when the
+     * workspace deletes it. A no-op in the live workspace, where "versionOL()" returns
+     * immediately and the "WorkspaceRestriction" on the query has already excluded every
+     * workspace row.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>|null
+     */
+    private function getWorkspaceRecord(string $table, array $row, PageRepository $pageRepository): ?array
+    {
+        $pageRepository->versionOL($table, $row, true);
+        if (!is_array($row)) {
+            return null;
+        }
+        return $row;
     }
 
     private function getTableLanguageFieldName(string $tableName): ?string

--- a/packages/fgtclb/academic-study-plan/Documentation/Changelog/3.0/Important-StudyPlanFrontendIsWorkspaceAware.rst
+++ b/packages/fgtclb/academic-study-plan/Documentation/Changelog/3.0/Important-StudyPlanFrontendIsWorkspaceAware.rst
@@ -1,0 +1,52 @@
+.. _important-1787924557:
+
+=========================================================
+Important: The study plan frontend is now workspace aware
+=========================================================
+
+Description
+===========
+
+:php:`\FGTCLB\AcademicStudyPlan\Service\StudyPlanService` builds the queries for
+semesters, modules and categories itself. They carried no workspace constraint and
+no version overlay, with two consequences.
+
+**Unpublished drafts were served to the public.** A workspace version is an
+ordinary row in the database, told apart from a live record only by
+:sql:`t3ver_wsid`. With no condition on that column every draft was selected
+alongside the record it is a draft of, and rendered next to it — including
+records created in a workspace and never published, which have no live
+counterpart at all.
+
+**A workspace preview was not a preview.** It showed the live records and the
+workspace records together, rather than the workspace state.
+
+Both are fixed by the two pieces TYPO3 provides for it: a
+:php:`WorkspaceRestriction` on each query, which in the live workspace constrains
+to :sql:`t3ver_wsid = 0`, and :php:`PageRepository::versionOL()` on each fetched
+row, which replaces a record with its draft in a preview and drops it where the
+workspace deletes it.
+
+Impact
+======
+
+**On the live site, records disappear that should never have been there.** If a
+study plan showed duplicated or unexpected semesters, modules or categories,
+those were workspace drafts and they are gone now. No live record is affected.
+
+In a workspace preview the study plan now shows the workspace state.
+
+What still is not previewed is a **relation** changed in a workspace. Attaching
+or detaching a category from a module inside a workspace is not reflected: the
+overlay keeps the live uid of the module, so the categories are looked up
+through the live relations. The content of a record — its label, colour, note,
+credit points — is previewed correctly. Only the wiring between records is not.
+
+Affected Installations
+======================
+
+Every installation that uses workspaces for study plan content. An installation
+that never created a workspace version of a semester, module or category renders
+exactly as before.
+
+.. index:: Frontend, Database, ext:academic_study_plan

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementWorkspaceTest.php
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/AcademicStudyPlanContentElementWorkspaceTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FGTCLB\AcademicStudyPlan\Tests\Functional\ContentElement;
+
+use FGTCLB\AcademicStudyPlan\Tests\Functional\AbstractAcademicStudyPlanTestCase;
+use FGTCLB\TestingHelper\FunctionalTestCase\FrontendPluginRenderingTrait;
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\SiteHandling\SiteBasedTestTrait;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+
+/**
+ * What the `academic_study_plan` content element renders when workspace versions of its
+ * records exist (ACE-476).
+ *
+ * Before that issue `StudyPlanService` built its three queries without any
+ * `WorkspaceRestriction` and never overlaid a fetched row, with two consequences this
+ * class exists to prevent from returning: the live frontend served every unpublished
+ * draft to the public, and a workspace preview showed the live and the workspace state
+ * side by side instead of the workspace state.
+ *
+ * The fixture holds, for one live study plan: a workspace version of the semester, of
+ * the module and of the category, plus a semester that exists only in workspace 1.
+ */
+final class AcademicStudyPlanContentElementWorkspaceTest extends AbstractAcademicStudyPlanTestCase
+{
+    use FrontendPluginRenderingTrait;
+    use SiteBasedTestTrait;
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8', 'iso' => 'en', 'hrefLang' => 'en-US', 'direction' => ''],
+    ];
+
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = $this->frontendPluginTestConfiguration();
+        $this->addCoreExtensionsToLoad('typo3/cms-fluid-styled-content', 'typo3/cms-workspaces');
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/AcademicStudyPlanContentElementWorkspace/workspaceStudyPlan.csv');
+        $this->setUpFrontendRootPage(
+            pageId: 1,
+            typoScriptFiles: [
+                'constants' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                    'EXT:academic_study_plan/Configuration/TypoScript/ContentElement/constants.typoscript',
+                ],
+                'setup' => [
+                    'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                    'EXT:academic_study_plan/Configuration/TypoScript/ContentElement/setup.typoscript',
+                    'EXT:academic_study_plan/Tests/Functional/ContentElement/Fixtures/TypoScript/Setup/Rendering.typoscript',
+                ],
+            ],
+        );
+        $this->writeFrontendPluginTestSite([
+            $this->buildDefaultLanguageConfiguration(identifier: 'EN', base: '/'),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeWrittenSiteConfiguration();
+        parent::tearDown();
+    }
+
+    private function renderLive(): string
+    {
+        return $this->renderFrontendPage('https://www.acme.com/home');
+    }
+
+    private function renderInWorkspace(): string
+    {
+        return $this->renderFrontendPage(
+            'https://www.acme.com/home',
+            (new InternalRequestContext())->withBackendUserId(1)->withWorkspaceId(1),
+        );
+    }
+
+    /**
+     * Every record label the fixture can produce, in the order they sort, so an
+     * assertion states presence and absence at once and a failure prints three lines
+     * rather than the whole page.
+     *
+     * @return list<string>
+     */
+    private function renderedRecordLabels(string $content): array
+    {
+        preg_match_all('#(?:Live|Draft|Workspace Only) (?:Semester|Module|Category)#', $content, $matches);
+        $labels = array_values(array_unique($matches[0]));
+        sort($labels);
+
+        return $labels;
+    }
+
+    /**
+     * The live frontend shows the live state and nothing else.
+     *
+     * Without a condition on "t3ver_wsid" every workspace version is an ordinary row to
+     * these queries, so unpublished drafts were served to the public next to the records
+     * they are drafts of. "WorkspaceRestriction" is what excludes them: in the live
+     * workspace it constrains to "t3ver_wsid = 0".
+     */
+    #[Test]
+    public function liveFrontendRendersOnlyLiveRecords(): void
+    {
+        $this->assertSame(
+            ['Live Category', 'Live Module', 'Live Semester'],
+            $this->renderedRecordLabels($this->renderLive()),
+        );
+    }
+
+    /**
+     * A record created in a workspace and never published is not part of the live site.
+     * It carries "t3ver_wsid = 1" like any other workspace row and is excluded by the
+     * same constraint - what makes it worth its own test is that it has no live
+     * counterpart at all, so no overlay would drop it and nothing else would hide it.
+     */
+    #[Test]
+    public function liveFrontendDoesNotRenderRecordsThatExistOnlyInAWorkspace(): void
+    {
+        $this->assertNotContains('Workspace Only Semester', $this->renderedRecordLabels($this->renderLive()));
+    }
+
+    /**
+     * The other direction: a workspace preview shows the workspace state.
+     *
+     * "WorkspaceRestriction" selects the live rows plus the workspace rows that have no
+     * live counterpart, and deliberately not the plain versions - those come in through
+     * "versionOL()", which replaces a live row with its draft while keeping the live
+     * uid. So the live labels are not merely hidden here, they are overlaid.
+     */
+    #[Test]
+    public function workspacePreviewRendersTheWorkspaceState(): void
+    {
+        $this->assertSame(
+            ['Draft Category', 'Draft Module', 'Draft Semester', 'Workspace Only Semester'],
+            $this->renderedRecordLabels($this->renderInWorkspace()),
+        );
+    }
+
+    /**
+     * Whether the content element is reachable at all in a preview was the open question
+     * of ACE-476: the relations are keyed on live uids, and the workspace overlay of
+     * "tt_content" happens in the core rendering above this extension. This pins the
+     * answer instead of reasoning about it.
+     */
+    #[Test]
+    public function workspacePreviewRendersTheContentElementAtAll(): void
+    {
+        $content = $this->renderInWorkspace();
+
+        $this->assertStringContainsString('academic-study-plan', $content);
+        $this->assertStringContainsString('data-study-plan="1"', $content);
+    }
+}

--- a/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementWorkspace/workspaceStudyPlan.csv
+++ b/packages/fgtclb/academic-study-plan/Tests/Functional/ContentElement/Fixtures/AcademicStudyPlanContentElementWorkspace/workspaceStudyPlan.csv
@@ -1,0 +1,30 @@
+"be_users",
+,"uid","pid","username","password","admin"
+,1,0,"admin","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1
+"sys_workspace",
+,"uid","pid","title","deleted"
+,1,0,"Test workspace",0
+"pages",
+,"uid","pid","doktype","deleted","hidden","sys_language_uid","l10n_parent","l18n_cfg","slug","title"
+,1,0,1,0,0,0,0,0,"/","Site Root"
+,2,1,1,0,0,0,0,0,"/home","Home (EN)"
+"tt_content",
+,"uid","pid","deleted","hidden","sys_language_uid","l18n_parent","CType","header","tx_academicstudyplan_semesters","tx_academicstudyplan_footer_note"
+,1,2,0,0,0,0,"academic_study_plan","",1,"<p>All modules are subject to change.</p>"
+"tx_academicstudyplan_domain_model_semester",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","content_element","label","note","credit_points","modules","t3ver_oid","t3ver_wsid","t3ver_state","t3ver_stage"
+,1,2,0,0,0,0,1,1,"Live Semester","",30,1,0,0,0,0
+,101,2,0,0,0,0,1,1,"Draft Semester","",30,1,1,1,0,0
+,102,2,0,0,0,0,2,1,"Workspace Only Semester","",15,0,0,1,1,0
+"tx_academicstudyplan_domain_model_module",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","semester","label","note","credit_points","description","categories","t3ver_oid","t3ver_wsid","t3ver_state","t3ver_stage"
+,1,2,0,0,0,0,1,1,"Live Module","",10,"",1,0,0,0,0
+,101,2,0,0,0,0,1,1,"Draft Module","",10,"",1,1,1,0,0
+"tx_academicstudyplan_domain_model_category",
+,"uid","pid","deleted","hidden","sys_language_uid","l10n_parent","sorting","label","colour","t3ver_oid","t3ver_wsid","t3ver_state","t3ver_stage"
+,1,2,0,0,0,0,1,"Live Category","#cc0000",0,0,0,0
+,101,2,0,0,0,0,1,"Draft Category","#00cc00",1,1,0,0
+"tx_academicstudyplan_module_category_mm",
+,"uid_local","uid_foreign","sorting","sorting_foreign"
+,1,1,0,1
+,101,101,0,1


### PR DESCRIPTION
Closes ACE-476.

## The defect

`StudyPlanService` builds its three queries by hand and carried no workspace
constraint and no version overlay. That is two defects:

1. **The live frontend served every unpublished draft to the public.** A workspace
   version is an ordinary row, distinguished from a live record only by
   `t3ver_wsid`. With no condition on it, each draft was rendered next to the record
   it drafts — including records created in a workspace and never published, which
   have no live counterpart at all.
2. **A workspace preview showed live and workspace records together**, rather than
   the workspace state.

Both are reproduced by the test that comes with this, which renders one study plan
twice and asserts the set of record labels on the page. Before the fix:

```
 Expected: ['Live Category', 'Live Module', 'Live Semester']
 Actual:   ['Draft Category', 'Draft Module', 'Draft Semester',
            'Live Category', 'Live Module', 'Live Semester',
            'Workspace Only Semester']
```

## The fix

The two pieces TYPO3 provides: `WorkspaceRestriction` on each query, and
`PageRepository::versionOL()` on each fetched row. Three of the four test cases fail
without it.

## Known limitation, stated rather than hidden

A **relation** changed in a workspace is still not previewed. `versionOL()` keeps the
live uid, so a module's categories are looked up through the live MM rows. Record
*content* is previewed correctly; the wiring between records is not. This is in the
changelog entry.

## The alternative, built and measured

Replacing the hand-built queries with `PageRepository::getDefaultConstraints()` was
implemented against the same tests and also passes:

| | this PR | the alternative |
|---|---|---|
| diff | +50 / −5 | +27 / −158 |
| study-plan functional | 81 tests OK | 69 tests OK (12 reflection tests deleted with the helpers) |
| behaviour change | workspaces only | workspaces **plus** visibility |

The alternative additionally closes the missing `starttime`, `endtime` and `fe_group`
handling — but it drops the `includeDeletedRecords` support this service implements by
hand, and uses the workspace API whose own docblock says `WorkspaceRestriction` should
be used instead. Filed separately rather than carried by a leak fix.

## Verified

`lintPhp`, `cgl -n`, `phpstan`, `unit` and the full `functional` suite green on TYPO3
v13 (1430 tests) and v14 (1439 tests), each after its own `composerUpdate`, PHP 8.2.
`checkRstRenderingSingle academic-study-plan` green.
